### PR TITLE
add support for an http_header configuration option

### DIFF
--- a/configs/example.toml
+++ b/configs/example.toml
@@ -33,7 +33,7 @@ listen = "0.0.0.0:4242"
 # reading_suffix = "count"
 
 # specify an HTTP header to be sent with each response from the stats server.
-# http_header = "Access-Control-Allow-Origin: *"
+# http_header = "Access-Control-Allow-Origin: <origin>"
 
 # Per-sampler configuration sections
 [samplers]

--- a/configs/example.toml
+++ b/configs/example.toml
@@ -32,6 +32,9 @@ listen = "0.0.0.0:4242"
 # be set to an empty string to remove the suffix entirely.
 # reading_suffix = "count"
 
+# specify an HTTP header to be sent with each response from the stats server.
+# http_header = "Access-Control-Allow-Origin: *"
+
 # Per-sampler configuration sections
 [samplers]
 

--- a/src/config/general.rs
+++ b/src/config/general.rs
@@ -23,6 +23,7 @@ pub struct General {
     fault_tolerant: AtomicBool,
     #[serde(default = "default_reading_suffix")]
     reading_suffix: String,
+    http_header: Option<String>,
 }
 
 impl General {
@@ -63,6 +64,10 @@ impl General {
             Some(&self.reading_suffix)
         }
     }
+
+    pub fn http_header(&self) -> Option<String> {
+        self.http_header.clone()
+    }
 }
 
 impl Default for General {
@@ -75,6 +80,7 @@ impl Default for General {
             window: default_window(),
             fault_tolerant: default_fault_tolerant(),
             reading_suffix: default_reading_suffix(),
+            http_header: None,
         }
     }
 }

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use std::net::SocketAddr;
+
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -16,18 +17,25 @@ pub struct Http {
     snapshot: MetricsSnapshot,
     server: Server,
     updated: Instant,
+    header: Option<tiny_http::Header>,
 }
 
 impl Http {
-    pub fn new(address: SocketAddr, metrics: Arc<Metrics>, count_label: Option<&str>) -> Self {
+    pub fn new(config: Arc<Config>, metrics: Arc<Metrics>, ) -> Self {
+        let address = config.listen().expect("no listen address");
         let server = tiny_http::Server::http(address);
         if server.is_err() {
             fatal!("Failed to open {} for HTTP Stats listener", address);
         }
+        let count_label = config.general().reading_suffix();
+        let header = config.general().http_header()
+            .map(|s| tiny_http::Header::from_str(&s).expect("invalid HTTP header")); 
+
         Self {
             snapshot: MetricsSnapshot::new(metrics, count_label),
             server: server.unwrap(),
             updated: Instant::now(),
+            header,
         }
     }
 
@@ -40,37 +48,49 @@ impl Http {
             let url = request.url();
             let parts: Vec<&str> = url.split('?').collect();
             let url = parts[0];
+
             match request.method() {
-                Method::Get => match url {
-                    "/" => {
-                        debug!("Serving GET on index");
-                        let _ = request.respond(Response::from_string(format!(
-                            "Welcome to {}\nVersion: {}\n",
-                            crate::config::NAME,
-                            crate::config::VERSION,
-                        )));
+                Method::Get => { 
+                    let content = match url {
+                        "/" => {
+                            debug!("Serving GET on index");
+                            format!(
+                                "Welcome to {}\nVersion: {}\n",
+                                crate::config::NAME,
+                                crate::config::VERSION,
+                            )
+                        }
+                        "/metrics" => {
+                            debug!("Serving Prometheus compatible stats");
+                            self.snapshot.prometheus()
+                        }
+                        "/metrics.json" | "/vars.json" | "/admin/metrics.json" => {
+                            debug!("Serving machine readable stats");
+                            self.snapshot.json(false)
+                        }
+                        "/vars" => {
+                            debug!("Serving human readable stats");
+                            self.snapshot.human()
+                        }
+                        url => {
+                            debug!("GET on non-existent url: {}", url);
+                            debug!("Serving machine readable stats");
+                            self.snapshot.json(false)
+                        }
+                    };
+                    let mut response = Response::from_string(content);
+                    if let Some(header) = &self.header {
+                        response = response.with_header(header.clone())
                     }
-                    "/metrics" => {
-                        debug!("Serving Prometheus compatible stats");
-                        let _ = request.respond(Response::from_string(self.snapshot.prometheus()));
-                    }
-                    "/metrics.json" | "/vars.json" | "/admin/metrics.json" => {
-                        debug!("Serving machine readable stats");
-                        let _ = request.respond(Response::from_string(self.snapshot.json(false)));
-                    }
-                    "/vars" => {
-                        debug!("Serving human readable stats");
-                        let _ = request.respond(Response::from_string(self.snapshot.human()));
-                    }
-                    url => {
-                        debug!("GET on non-existent url: {}", url);
-                        debug!("Serving machine readable stats");
-                        let _ = request.respond(Response::from_string(self.snapshot.json(false)));
-                    }
+                    let _ = request.respond(response);
                 },
                 method => {
                     debug!("unsupported request method: {}", method);
-                    let _ = request.respond(Response::empty(404));
+                    let mut response = Response::empty(404);
+                    if let Some(header) = &self.header {
+                        response = response.with_header(header.clone())
+                    }
+                    let _ = request.respond(response);
                 }
             }
         }

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -21,15 +20,17 @@ pub struct Http {
 }
 
 impl Http {
-    pub fn new(config: Arc<Config>, metrics: Arc<Metrics>, ) -> Self {
+    pub fn new(config: Arc<Config>, metrics: Arc<Metrics>) -> Self {
         let address = config.listen().expect("no listen address");
         let server = tiny_http::Server::http(address);
         if server.is_err() {
             fatal!("Failed to open {} for HTTP Stats listener", address);
         }
         let count_label = config.general().reading_suffix();
-        let header = config.general().http_header()
-            .map(|s| tiny_http::Header::from_str(&s).expect("invalid HTTP header")); 
+        let header = config
+            .general()
+            .http_header()
+            .map(|s| tiny_http::Header::from_str(&s).expect("invalid HTTP header"));
 
         Self {
             snapshot: MetricsSnapshot::new(metrics, count_label),
@@ -50,7 +51,7 @@ impl Http {
             let url = parts[0];
 
             match request.method() {
-                Method::Get => { 
+                Method::Get => {
                     let content = match url {
                         "/" => {
                             debug!("Serving GET on index");
@@ -83,7 +84,7 @@ impl Http {
                         response = response.with_header(header.clone())
                     }
                     let _ = request.respond(response);
-                },
+                }
                 method => {
                     debug!("unsupported request method: {}", method);
                     let mut response = Response::empty(404);

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,10 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     debug!("beginning stats exposition");
-    let mut http = exposition::Http::new(
-        config.clone(),
-        metrics,
-    );
+    let mut http = exposition::Http::new(config.clone(), metrics);
 
     while runnable.load(Ordering::Relaxed) {
         clocksource::refresh_clock();

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,9 +114,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     debug!("beginning stats exposition");
     let mut http = exposition::Http::new(
-        config.listen().expect("no listen address"),
+        config.clone(),
         metrics,
-        config.general().reading_suffix(),
     );
 
     while runnable.load(Ordering::Relaxed) {


### PR DESCRIPTION
This option is intended to allow [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests to the stats server.

I implemented an option for adding a single HTTP header rather than multiple because I don't think we need more than one right now and because I wasn't sure how to best support a "one or many" configuration style. I found [this](https://docs.rs/serde_with/latest/serde_with/struct.OneOrMany.html) but it looks like using it would add a dependency. Happy to make a change to that if needed.

There's also the matter of supporting preflight [OPTIONS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS) requests, but I think we can get away without needing to support them for now since the incoming requests will be [simple requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests) that don't trigger a preflight check.

I tested that the header is correctly added to a GET request with `curl`:

```
% curl -i 'http://0.0.0.0:4242/'
HTTP/1.1 200 OK
Server: tiny-http (Rust)
Date: Tue, 31 Jan 2023 18:26:31 GMT
Content-Type: text/plain; charset=UTF-8
Access-Control-Allow-Origin: *
Content-Length: 43

Welcome to rezolus
Version: 2.16.4-alpha.0
```