### PR TITLE
feat: add a gauge to capture the number of online logical cpu cores

### DIFF
--- a/src/samplers/cpu/proc_cpuinfo/mod.rs
+++ b/src/samplers/cpu/proc_cpuinfo/mod.rs
@@ -64,6 +64,8 @@ impl ProcCpuinfo {
         let mut data = String::new();
         self.file.read_to_string(&mut data)?;
 
+        let mut online_cores = 0;
+
         let lines = data.lines();
 
         for line in lines {
@@ -76,8 +78,11 @@ impl ProcCpuinfo {
                 {
                     CPU_FREQUENCY.increment(now, freq, 1);
                 }
+                online_cores += 1;
             }
         }
+
+        CPU_CORES.set(online_cores);
 
         Ok(())
     }

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -33,7 +33,11 @@ heatmap!(
     "distribution of instantaneous CPU frequencies"
 );
 
-gauge!(CPU_CORES, "cpu/cores", "the count of logical cores that are online");
+gauge!(
+    CPU_CORES,
+    "cpu/cores",
+    "the count of logical cores that are online"
+);
 
 counter!(CPU_CYCLES, "cpu/cycles");
 counter!(CPU_INSTRUCTIONS, "cpu/instructions");

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -33,5 +33,7 @@ heatmap!(
     "distribution of instantaneous CPU frequencies"
 );
 
+gauge!(CPU_CORES, "cpu/cores", "the count of logical cores that are online");
+
 counter!(CPU_CYCLES, "cpu/cycles");
 counter!(CPU_INSTRUCTIONS, "cpu/instructions");


### PR DESCRIPTION
Adds a gauge to export the number of online logical cpu cores and adds it into the proc_cpuinfo sampler.
