### PR TITLE
change: move hardware info into lazy static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,7 @@ dependencies = [
  "backtrace",
  "clap 4.1.8",
  "clocksource",
+ "lazy_static",
  "libbpf-cargo",
  "libbpf-rs",
  "libbpf-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "High resolution systems performance telemetry agent"
 backtrace = "0.3.67"
 clap = "4.1.4"
 clocksource = "0.6.0"
+lazy_static = "1.4.0"
 libc = "0.2.141"
 libbpf-rs = { version = "0.19.1", optional = true }
 libbpf-sys = { version = "1.1.1", optional = true }

--- a/src/samplers/hwinfo/mod.rs
+++ b/src/samplers/hwinfo/mod.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -21,6 +22,14 @@ use memory::*;
 use net::*;
 use node::*;
 
+lazy_static! {
+    pub static ref HWINFO: Result<Hwinfo> = Hwinfo::new();
+}
+
+pub fn hardware_info() -> std::result::Result<&'static Hwinfo, &'static std::io::Error> {
+    HWINFO.as_ref()
+}
+
 #[derive(Serialize)]
 pub struct Hwinfo {
     caches: Vec<Vec<Cache>>,
@@ -31,7 +40,7 @@ pub struct Hwinfo {
 }
 
 impl Hwinfo {
-    pub fn new() -> Result<Self> {
+    fn new() -> Result<Self> {
         Ok(Self {
             caches: get_caches()?,
             cpus: get_cpus()?,


### PR DESCRIPTION
Moves the hardware info into a lazy static so it can be reused in exposition and other samplers without calling the constructor each time.
