### PR TITLE
fix: context switch and syscall metrics

### DIFF
--- a/src/samplers/scheduler/runqueue/mod.rs
+++ b/src/samplers/scheduler/runqueue/mod.rs
@@ -54,7 +54,6 @@ impl Runqlat {
 
         let counters = vec![
             Counter::new(&SCHEDULER_IVCSW, None),
-            Counter::new(&SCHEDULER_VCSW, None),
         ];
 
         bpf.add_counters("counters", counters);

--- a/src/samplers/scheduler/runqueue/mod.rs
+++ b/src/samplers/scheduler/runqueue/mod.rs
@@ -52,9 +52,7 @@ impl Runqlat {
 
         let mut bpf = Bpf::from_skel(skel);
 
-        let counters = vec![
-            Counter::new(&SCHEDULER_IVCSW, None),
-        ];
+        let counters = vec![Counter::new(&SCHEDULER_IVCSW, None)];
 
         bpf.add_counters("counters", counters);
 

--- a/src/samplers/scheduler/stats.rs
+++ b/src/samplers/scheduler/stats.rs
@@ -15,8 +15,3 @@ counter!(
     "scheduler/context_switch/involuntary",
     "count of involuntary context switches"
 );
-counter!(
-    SCHEDULER_VCSW,
-    "scheduler/context_switch/voluntary",
-    "count of voluntary context switches"
-);

--- a/src/samplers/syscall/latency/mod.bpf.c
+++ b/src/samplers/syscall/latency/mod.bpf.c
@@ -17,11 +17,11 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
 
-#define MAX_SYSCALL_ID 1024
-#define COUNTER_GROUP_WIDTH 16
-#define MAX_CPUS 1024
-#define MAX_TRACKED_PIDS 65536 
+#define COUNTER_GROUP_WIDTH 8
 #define HISTOGRAM_BUCKETS 7424
+#define MAX_CPUS 1024
+#define MAX_SYSCALL_ID 1024
+#define MAX_TRACKED_PIDS 65536 
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);


### PR DESCRIPTION
Fixes the context switch metrics by removing the voluntary context switch counter. Previous approach was not measuring this correctly.

Cleans up the scheduler runqueue bpf to use defines for magic values.

Fixes the syscall latency bpf to use correct counter group width.
