### PR TITLE
fix: bugfix for cpu sampler

### DIFF
--- a/src/samplers/cpu/perf/proc_cpuinfo.rs
+++ b/src/samplers/cpu/perf/proc_cpuinfo.rs
@@ -70,20 +70,26 @@ impl ProcCpuinfo {
         for line in lines {
             let parts: Vec<&str> = line.split_whitespace().collect();
 
+            if let Some(&"processor") = parts.first() {
+                online_cores += 1;
+            }
+
             if let (Some(&"cpu"), Some(&"MHz")) = (parts.first(), parts.get(1)) {
                 if let Some(Ok(freq)) = parts
                     .get(3)
                     .map(|v| v.parse::<f64>().map(|v| v.floor() as u64))
                 {
-                    CPU_FREQUENCY_HEATMAP.increment(now, freq, 1);
+                    let _ = CPU_FREQUENCY_HEATMAP.increment(now, freq, 1);
                     frequency += freq;
                 }
-                online_cores += 1;
             }
         }
 
         CPU_CORES.set(online_cores);
-        CPU_FREQUENCY_AVERAGE.set(frequency as i64 / online_cores);
+
+        if frequency != 0 && online_cores != 0 {
+            CPU_FREQUENCY_AVERAGE.set(frequency as i64 / online_cores);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
When we use the proc_cpuinfo sampler on systems that do not report a per processor frequency, the sampler will panic with a divide by zero.

This change fixes the logic so that we avoid a divide by zero when /proc/cpuinfo doesn't parse as we expect. It also changes the logic on how we count the number of online cores to get a count even when the system doesn't report core frequencies.
