### PR TITLE
feat: add per-cpu metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "heatmap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5215fe8c60b67071fb8d7fe407631449641f2010152db16088c05ae00a00c2"
+checksum = "fdeff4026a4e69d8ae19b51fa661841da47c3448ba67ad44affe893a2c985e31"
 dependencies = [
  "clocksource",
  "histogram",
@@ -514,9 +514,9 @@ checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "histogram"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9ff99982ffdd3056847e7dd1f3e6ceae8826fb0af27d91f29cb7b119820177"
+checksum = "d0978bb4ae7b21dded5037bc688271ec01443b6eb2c7713aad75fce2cf670923"
 dependencies = [
  "thiserror",
 ]
@@ -811,23 +811,24 @@ dependencies = [
 
 [[package]]
 name = "metriken"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ec8699ded843c60ea478d0c41583b447700524f93d5c74bfb1edf8347fd6d"
+checksum = "b9d170fab855458882d2086de239300a0ea4d5ef457afed89bebfe0257f87bdf"
 dependencies = [
- "clocksource",
  "heatmap",
+ "histogram",
  "linkme",
  "metriken-derive",
  "once_cell",
  "parking_lot",
+ "phf",
 ]
 
 [[package]]
 name = "metriken-derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e58941ebb3d827378ea64a769df9cf65e47f75d78227969d70431c19578e5dc"
+checksum = "0213a7a12e01c66357d1f3491e2d7d74b2373540ea0a4bfd928a4c0e5e02f432"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1065,6 +1066,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "ringlog"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82db4b27000bac41d738972779f440ed6176ebe82c935b736594eff989aa60f1"
+checksum = "c90d3d1e4db43daedfdae26373e7b4cb4f56b26f217fc8f661e4f439827b4a46"
 dependencies = [
  "ahash",
  "clocksource",
@@ -1418,6 +1461,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2.141"
 libbpf-rs = { version = "0.19.1", optional = true }
 libbpf-sys = { version = "1.1.1", optional = true }
 linkme = "0.3.9"
-metriken = "0.1.3"
+metriken = "0.2.0"
 memmap2 = "0.5.10"
 once_cell = "1.17.1"
 ouroboros = "0.15.6"
@@ -23,7 +23,7 @@ serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 sysconf = "0.3.4"
 syscall-numbers = "3.0.0"
-ringlog = "0.1.1"
+ringlog = "0.2.0"
 tokio = { version = "1.27.0", features = ["full"] }
 toml = "0.7.3"
 walkdir = "2.3.3"

--- a/src/common/bpf/distribution.rs
+++ b/src/common/bpf/distribution.rs
@@ -23,11 +23,11 @@ pub struct Distribution<'a> {
     _map: &'a libbpf_rs::Map,
     mmap: memmap2::MmapMut,
     prev: [u64; HISTOGRAM_BUCKETS],
-    heatmap: &'static LazyHeatmap,
+    heatmap: &'static Heatmap,
 }
 
 impl<'a> Distribution<'a> {
-    pub fn new(map: &'a libbpf_rs::Map, heatmap: &'static LazyHeatmap) -> Self {
+    pub fn new(map: &'a libbpf_rs::Map, heatmap: &'static Heatmap) -> Self {
         let fd = map.fd();
         let file = unsafe { std::fs::File::from_raw_fd(fd as _) };
         let mmap = unsafe {
@@ -65,7 +65,7 @@ impl<'a> Distribution<'a> {
 
             if delta > 0 {
                 let value = key_to_value(idx as u64);
-                self.heatmap.increment(now, value as _, delta as _);
+                let _ = self.heatmap.add(now, value as _, delta as _);
             }
         }
     }

--- a/src/common/bpf/mod.rs
+++ b/src/common/bpf/mod.rs
@@ -80,7 +80,7 @@ impl<T: 'static + GetMap> Bpf<T> {
         })
     }
 
-    pub fn add_distribution(&mut self, name: &str, heatmap: &'static LazyHeatmap) {
+    pub fn add_distribution(&mut self, name: &str, heatmap: &'static Heatmap) {
         self.with_mut(|this| {
             this.distributions
                 .push(Distribution::new(this.skel.map(name), heatmap));

--- a/src/samplers/cpu/perf/proc_cpuinfo.rs
+++ b/src/samplers/cpu/perf/proc_cpuinfo.rs
@@ -79,7 +79,7 @@ impl ProcCpuinfo {
                     .get(3)
                     .map(|v| v.parse::<f64>().map(|v| v.floor() as u64))
                 {
-                    let _ = CPU_FREQUENCY_HEATMAP.increment(now, freq, 1);
+                    let _ = CPU_FREQUENCY_HEATMAP.increment(now, freq);
                     frequency += freq;
                 }
             }

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -1,89 +1,225 @@
 use crate::*;
+use metriken::{metric, Counter, Format, Gauge, LazyCounter, LazyGauge, MetricEntry};
 
-counter_with_heatmap!(CPU_USAGE_USER, CPU_USAGE_USER_HEATMAP, "cpu/usage/user");
-counter_with_heatmap!(CPU_USAGE_NICE, CPU_USAGE_NICE_HEATMAP, "cpu/usage/nice");
-counter_with_heatmap!(
-    CPU_USAGE_SYSTEM,
-    CPU_USAGE_SYSTEM_HEATMAP,
-    "cpu/usage/system"
-);
-counter_with_heatmap!(CPU_USAGE_IDLE, CPU_USAGE_IDLE_HEATMAP, "cpu/usage/idle");
-counter_with_heatmap!(
-    CPU_USAGE_IO_WAIT,
-    CPU_USAGE_IO_WAIT_HEATMAP,
-    "cpu/usage/io_wait"
-);
-counter_with_heatmap!(CPU_USAGE_IRQ, CPU_USAGE_IRQ_HEATMAP, "cpu/usage/irq");
-counter_with_heatmap!(
-    CPU_USAGE_SOFTIRQ,
-    CPU_USAGE_SOFTIRQ_HEATMAP,
-    "cpu/usage/softirq"
-);
-counter_with_heatmap!(CPU_USAGE_STEAL, CPU_USAGE_STEAL_HEATMAP, "cpu/usage/steal");
-counter_with_heatmap!(CPU_USAGE_GUEST, CPU_USAGE_GUEST_HEATMAP, "cpu/usage/guest");
-counter_with_heatmap!(
-    CPU_USAGE_GUEST_NICE,
-    CPU_USAGE_GUEST_NICE_HEATMAP,
-    "cpu/usage/guest_nice"
-);
+#[metric(
+    name = "cpu/cores",
+    description = "The total number of logical cores that are currently online"
+)]
+pub static CPU_CORES: LazyGauge = LazyGauge::new(Gauge::default);
 
-gauge!(
-    CPU_CORES,
-    "cpu/cores",
-    "the count of logical cores that are online"
-);
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent executing normal tasks is user mode",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "user" }
+)]
+pub static CPU_USAGE_USER: LazyCounter = LazyCounter::new(Counter::default);
 
-counter!(
-    CPU_CYCLES,
-    "cpu/cycles",
-    "total executed CPU cycles on all CPUs"
-);
-counter!(
-    CPU_INSTRUCTIONS,
-    "cpu/instructions",
-    "total retired instructions on all CPUs"
-);
+heatmap!(CPU_USAGE_USER_HEATMAP, "cpu/usage/user");
 
-gauge!(
-    CPU_PERF_GROUPS_ACTIVE,
-    "cpu/perf_groups/active",
-    "the number of active perf groups"
-);
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent executing low priority tasks in user mode",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "nice" }
+)]
+pub static CPU_USAGE_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
-gauge!(
-    CPU_IPKC_AVERAGE,
-    "cpu/ipkc/average",
-    "average IPKC (Instructions Per Thousand Cycles): SUM(IPKC_CPU0...N)/N)"
-);
+heatmap!(CPU_USAGE_NICE_HEATMAP, "cpu/usage/nice");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent executing tasks in kernel mode",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "system" }
+)]
+pub static CPU_USAGE_SYSTEM: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_SYSTEM_HEATMAP, "cpu/usage/system");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent idle",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "idle" }
+)]
+pub static CPU_USAGE_IDLE: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_IDLE_HEATMAP, "cpu/usage/idle");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent waiting for IO to complete",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "io_wait" }
+)]
+pub static CPU_USAGE_IO_WAIT: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_IO_WAIT_HEATMAP, "cpu/usage/io_wait");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent servicing interrupts",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "irq" }
+)]
+pub static CPU_USAGE_IRQ: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_IRQ_HEATMAP, "cpu/usage/irq");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent servicing softirqs",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "softirq" }
+)]
+pub static CPU_USAGE_SOFTIRQ: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_SOFTIRQ_HEATMAP, "cpu/usage/softirq");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time stolen by the hypervisor",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "steal" }
+)]
+pub static CPU_USAGE_STEAL: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_STEAL_HEATMAP, "cpu/usage/steal");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent running a virtual CPU for a guest",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "guest" }
+)]
+pub static CPU_USAGE_GUEST: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_GUEST_HEATMAP, "cpu/usage/guest");
+
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent running a virtual CPU for a guest in low priority mode",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "guest_nice" }
+)]
+pub static CPU_USAGE_GUEST_NICE: LazyCounter = LazyCounter::new(Counter::default);
+
+heatmap!(CPU_USAGE_GUEST_NICE_HEATMAP, "cpu/usage/guest_nice");
+
+#[metric(
+    name = "cpu/cycles",
+    description = "The number of elapsed CPU cycles",
+    formatter = cpu_metric_formatter
+)]
+pub static CPU_CYCLES: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "cpu/instructions",
+    description = "The number of instructions retired",
+    formatter = cpu_metric_formatter
+)]
+pub static CPU_INSTRUCTIONS: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "cpu/perf_groups/active",
+    description = "The number of currently active perf event groups"
+)]
+pub static CPU_PERF_GROUPS_ACTIVE: LazyGauge = LazyGauge::new(Gauge::default);
+
+#[metric(
+    name = "cpu/ipkc/average",
+    description = "Average IPKC (instructions per thousand cycles): SUM(IPKC_CPU0...N)/N)"
+)]
+pub static CPU_IPKC_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
+
 heatmap!(
     CPU_IPKC_HEATMAP,
     "cpu/ipkc",
     "distribution of per-CPU IPKC (Instructions Per Thousand Cycles)"
 );
 
-gauge!(
-    CPU_IPUS_AVERAGE,
-    "cpu/ipus/average",
-    "average IPUS (Instructions Per Microsecond): SUM(IPUS_CPU0...N)/N"
-);
+#[metric(
+    name = "cpu/ipus/average",
+    description = "Average IPUS (instructions per microsecond): SUM(IPUS_CPU0...N)/N)"
+)]
+pub static CPU_IPUS_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
+
 heatmap!(
     CPU_IPUS_HEATMAP,
     "cpu/ipus",
-    "distribution of per-CPU IPUS (Instructions Per Microsecond)"
+    "Distribution of per-CPU IPUS (Instructions Per Microsecond)"
 );
 
-gauge!(
-    CPU_BASE_FREQUENCY_AVERAGE,
-    "cpu/base_frequency/average",
-    "average base CPU frequency"
-);
-gauge!(
-    CPU_FREQUENCY_AVERAGE,
-    "cpu/frequency/average",
-    "average running CPU frequency: SUM(RUNNING_FREQUENCY_CPU0...N)/N"
-);
+#[metric(
+    name = "cpu/base_frequency/average",
+    description = "Average base CPU frequency (MHz)"
+)]
+pub static CPU_BASE_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
+
+#[metric(
+    name = "cpu/frequency/average",
+    description = "Average running CPU frequency (MHz): SUM(RUNNING_FREQUENCY_CPU0...N)/N"
+)]
+pub static CPU_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
+
 heatmap!(
     CPU_FREQUENCY_HEATMAP,
     "cpu/frequency",
-    "distribution of the per-CPU running frequencies"
+    "Distribution of the per-CPU running frequencies"
 );
+
+/// A function to format the cpu metrics that allows for export of both total
+/// and per-CPU metrics.
+///
+/// For the `Simple` format, the metrics will be formatted according to the
+/// a pattern which depends on the metric metadata:
+/// `{name}/cpu{id}` eg: `cpu/frequency/cpu0`
+/// `{name}/total` eg: `cpu/cycles/total`
+/// `{name}/{state}/cpu{id}` eg: `cpu/usage/user/cpu0`
+/// `{name}/{state}/total` eg: `cpu/usage/user/total`
+///
+/// For the `Prometheus` format, if the metric has an `id` set in the metadata,
+/// the metric name is left as-is. Otherwise, `/total` is appended. Note: we
+/// rely on the exposition logic to convert the `/`s to `_`s in the metric name.
+pub fn cpu_metric_formatter(metric: &MetricEntry, format: Format) -> String {
+    match format {
+        Format::Simple => {
+            let name = if let Some(state) = metric.metadata().get("state") {
+                format!("{}/{state}", metric.name())
+            } else {
+                metric.name().to_string()
+            };
+
+            if metric.metadata().contains_key("id") {
+                format!(
+                    "{name}/cpu{}",
+                    metric.metadata().get("id").unwrap_or("unknown"),
+                )
+            } else {
+                format!("{name}/total",)
+            }
+        }
+        Format::Prometheus => {
+            let metadata: Vec<String> = metric
+                .metadata()
+                .iter()
+                .map(|(key, value)| format!("{key}=\"{value}\""))
+                .collect();
+            let metadata = metadata.join(", ");
+
+            let name = if metric.metadata().contains_key("id") {
+                metric.name().to_string()
+            } else {
+                format!("{}/total", metric.name())
+            };
+
+            if metadata.is_empty() {
+                name
+            } else {
+                format!("{}{{{metadata}}}", name)
+            }
+        }
+        _ => metriken::default_formatter(metric, format),
+    }
+}

--- a/src/samplers/gpu/nvidia/mod.rs
+++ b/src/samplers/gpu/nvidia/mod.rs
@@ -85,7 +85,7 @@ impl Nvidia {
                 if let Ok(power_usage) = device.power_usage() {
                     // current power usage in mW
                     GPU_POWER_USAGE.set(power_usage as _);
-                    GPU_POWER_USAGE_HEATMAP.increment(now, power_usage as _, 1);
+                    let _ = GPU_POWER_USAGE_HEATMAP.increment(now, power_usage as _);
                 }
 
                 /*
@@ -95,7 +95,7 @@ impl Nvidia {
                 if let Ok(temperature) = device.temperature(TemperatureSensor::Gpu) {
                     // current die temperature in C
                     GPU_TEMPERATURE.set(temperature as _);
-                    GPU_TEMPERATURE_HEATMAP.increment(now, temperature as _, 1);
+                    let _ = GPU_TEMPERATURE_HEATMAP.increment(now, temperature as _);
                 }
 
                 /*
@@ -105,21 +105,15 @@ impl Nvidia {
                 if let Ok(pcie_throughput_rx) = device.pcie_throughput(PcieUtilCounter::Receive) {
                     // current pcie receive throughput scaled to Bytes/s
                     GPU_PCIE_THROUGHPUT_RX.set(pcie_throughput_rx as i64 * KB);
-                    GPU_PCIE_THROUGHPUT_RX_HEATMAP.increment(
-                        now,
-                        (pcie_throughput_rx as i64 * KB) as _,
-                        1,
-                    );
+                    let _ = GPU_PCIE_THROUGHPUT_RX_HEATMAP
+                        .increment(now, (pcie_throughput_rx as i64 * KB) as _);
                 }
 
                 if let Ok(pcie_throughput_tx) = device.pcie_throughput(PcieUtilCounter::Send) {
                     // current pcie transmit throughput scaled to Bytes/s
                     GPU_PCIE_THROUGHPUT_TX.set(pcie_throughput_tx as i64 * KB);
-                    GPU_PCIE_THROUGHPUT_TX_HEATMAP.increment(
-                        now,
-                        (pcie_throughput_tx as i64 * KB) as _,
-                        1,
-                    );
+                    let _ = GPU_PCIE_THROUGHPUT_TX_HEATMAP
+                        .increment(now, (pcie_throughput_tx as i64 * KB) as _);
                 }
 
                 if let Ok(link_width) = device.current_pcie_link_width() {
@@ -138,11 +132,8 @@ impl Nvidia {
                         if pcie_link_bandwidth > 0 {
                             // current device pcie bandwidth scaled to Bytes/s
                             GPU_PCIE_BANDWIDTH.set(pcie_link_bandwidth * link_width as i64);
-                            GPU_PCIE_BANDWIDTH_HEATMAP.increment(
-                                now,
-                                (pcie_link_bandwidth * link_width as i64) as _,
-                                1,
-                            );
+                            let _ = GPU_PCIE_BANDWIDTH_HEATMAP
+                                .increment(now, (pcie_link_bandwidth * link_width as i64) as _);
                         }
                     }
                 }
@@ -157,57 +148,62 @@ impl Nvidia {
                     GPU_MEMORY_TOTAL.set(memory_info.total as _);
                     GPU_MEMORY_USED.set(memory_info.used as _);
 
-                    GPU_MEMORY_FREE_HEATMAP.increment(now, memory_info.free as _, 1);
-                    GPU_MEMORY_TOTAL_HEATMAP.increment(now, memory_info.total as _, 1);
-                    GPU_MEMORY_USED_HEATMAP.increment(now, memory_info.used as _, 1);
+                    let _ = GPU_MEMORY_FREE_HEATMAP.increment(now, memory_info.free as _);
+                    let _ = GPU_MEMORY_TOTAL_HEATMAP.increment(now, memory_info.total as _);
+                    let _ = GPU_MEMORY_USED_HEATMAP.increment(now, memory_info.used as _);
                 }
 
                 if let Ok(frequency) = device.clock_info(Clock::Graphics) {
                     // current clock frequency scaled to Hz
                     GPU_CLOCK_GRAPHICS.set(frequency as i64 * MHZ);
-                    GPU_CLOCK_GRAPHICS_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ =
+                        GPU_CLOCK_GRAPHICS_HEATMAP.increment(now, (frequency as i64 * MHZ) as _);
                 }
 
                 if let Ok(frequency) = device.clock_info(Clock::SM) {
                     // current clock frequency scaled to Hz
                     GPU_CLOCK_COMPUTE.set(frequency as i64 * MHZ);
-                    GPU_CLOCK_COMPUTE_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ = GPU_CLOCK_COMPUTE_HEATMAP.increment(now, (frequency as i64 * MHZ) as _);
                 }
 
                 if let Ok(frequency) = device.clock_info(Clock::Memory) {
                     // current clock frequency scaled to Hz
                     GPU_CLOCK_MEMORY.set(frequency as i64 * MHZ);
-                    GPU_CLOCK_MEMORY_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ = GPU_CLOCK_MEMORY_HEATMAP.increment(now, (frequency as i64 * MHZ) as _);
                 }
 
                 if let Ok(frequency) = device.clock_info(Clock::Video) {
                     // current clock frequency scaled to Hz
                     GPU_CLOCK_VIDEO.set(frequency as i64 * MHZ);
-                    GPU_CLOCK_VIDEO_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ = GPU_CLOCK_VIDEO_HEATMAP.increment(now, (frequency as i64 * MHZ) as _);
                 }
 
                 if let Ok(frequency) = device.max_clock_info(Clock::Graphics) {
                     // max clock frequency scaled to Hz
                     GPU_MAX_CLOCK_GRAPHICS.set(frequency as i64 * MHZ);
-                    GPU_MAX_CLOCK_GRAPHICS_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ = GPU_MAX_CLOCK_GRAPHICS_HEATMAP
+                        .increment(now, (frequency as i64 * MHZ) as _);
                 }
 
                 if let Ok(frequency) = device.max_clock_info(Clock::SM) {
                     // max clock frequency scaled to Hz
                     GPU_MAX_CLOCK_COMPUTE.set(frequency as i64 * MHZ);
-                    GPU_MAX_CLOCK_COMPUTE_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ =
+                        GPU_MAX_CLOCK_COMPUTE_HEATMAP.increment(now, (frequency as i64 * MHZ) as _);
                 }
 
                 if let Ok(frequency) = device.max_clock_info(Clock::Memory) {
                     // max clock frequency scaled to Hz
                     GPU_MAX_CLOCK_MEMORY.set(frequency as i64 * MHZ);
-                    GPU_MAX_CLOCK_MEMORY_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ =
+                        GPU_MAX_CLOCK_MEMORY_HEATMAP.increment(now, (frequency as i64 * MHZ) as _);
                 }
 
                 if let Ok(frequency) = device.max_clock_info(Clock::Video) {
                     // max clock frequency scaled to Hz
                     GPU_MAX_CLOCK_VIDEO.set(frequency as i64 * MHZ);
-                    GPU_MAX_CLOCK_VIDEO_HEATMAP.increment(now, (frequency as i64 * MHZ) as _, 1);
+                    let _ =
+                        GPU_MAX_CLOCK_VIDEO_HEATMAP.increment(now, (frequency as i64 * MHZ) as _);
                 }
             }
         }

--- a/src/samplers/hwinfo/cpu.rs
+++ b/src/samplers/hwinfo/cpu.rs
@@ -24,8 +24,20 @@ pub struct Cpu {
 }
 
 impl Cpu {
-    pub fn get_cpuid(&self) -> usize {
-        return self.id;
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    pub fn core(&self) -> usize {
+        self.core_id
+    }
+
+    pub fn die(&self) -> usize {
+        self.die_id
+    }
+
+    pub fn package(&self) -> usize {
+        self.package_id
     }
 }
 

--- a/src/samplers/memory/proc_meminfo/mod.rs
+++ b/src/samplers/memory/proc_meminfo/mod.rs
@@ -1,8 +1,6 @@
-use crate::common::LazyGauge;
-use metriken::MetricInstance;
-
 use super::stats::*;
 use super::*;
+use metriken::LazyGauge;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Seek};
@@ -18,7 +16,7 @@ pub struct ProcMeminfo {
     next: Instant,
     interval: Duration,
     file: File,
-    gauges: HashMap<&'static str, &'static MetricInstance<LazyGauge>>,
+    gauges: HashMap<&'static str, &'static LazyGauge>,
 }
 
 impl ProcMeminfo {


### PR DESCRIPTION
Adds per-CPU metrics to the CPU sampler. This allows us to export telemetry for each logical core independently.

Updates the metriken library to 0.2.0 to support the changes.
