### PR TITLE
feat: enable bpf by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ clap = "4.1.4"
 clocksource = "0.6.0"
 lazy_static = "1.4.0"
 libc = "0.2.141"
-libbpf-rs = { version = "0.19.1", optional = true }
-libbpf-sys = { version = "1.1.1", optional = true }
 linkme = "0.3.9"
 metriken = "0.1.3"
 memmap2 = "0.5.10"
@@ -30,15 +28,17 @@ walkdir = "2.3.3"
 warp = "0.3.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+libbpf-rs = { version = "0.19.1", optional = true }
+libbpf-sys = { version = "1.1.1", optional = true }
 perf-event2 = "0.6.3"
 nvml-wrapper = "0.9.0"
 
-[build-dependencies]
+[target.'cfg(target_os = "linux")'.build-dependencies]
 libbpf-cargo = { version = "0.13.1", optional = true }
 
 [features]
 all = ["bpf"]
-default = []
+default = ["bpf"]
 bpf = ["libbpf-cargo","libbpf-rs","libbpf-sys"]
 
 [profile.bench]

--- a/README.md
+++ b/README.md
@@ -56,18 +56,24 @@ started with Rust.
 
 ### Build Dependencies
 
-For a default build of Rezolus, in addition to the rust toolchain, you will
+A default build of Rezolus that targets Linux systems will have BPF support
+enabled by default. For this build, in addition to the rust toolchain, you will
 need:
 
 * clang >= 11.0
-
-To build with eBPF support, the following additional dependencies are required:
-
 * libelf-dev >= 0.183
 * make >= 4.3
 * pkg-config >= 0.29.2
 
-Debian and Ubuntu users can install all the required dependencies with:
+When building for non-Linux systems or without the default features to disable
+the `bpf` feature, the only dependencies aside from the rust toolchain are:
+
+To build with eBPF support, the following additional dependencies are required:
+
+* clang >= 11.0
+
+Debian and Ubuntu users can install all the required dependencies for a default
+build with:
 
 ```bash
 sudo apt install clang libelf-dev make pkg-config

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 fn main() {
-    #[cfg(feature = "bpf")]
+    #[cfg(all(feature = "bpf", target_os = "linux"))]
     bpf::generate();
 }
 
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod bpf {
     use libbpf_cargo::SkeletonBuilder;
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 pub mod bpf;
 
 pub mod classic;

--- a/src/samplers/block_io/mod.rs
+++ b/src/samplers/block_io/mod.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 sampler!(BlockIO, "block_io", BLOCK_IO_SAMPLERS);
 
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod latency;
 
 mod stats;

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -4,5 +4,5 @@ sampler!(Scheduler, "scheduler", SCHEDULER_SAMPLERS);
 
 mod stats;
 
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod runqueue;

--- a/src/samplers/syscall/mod.rs
+++ b/src/samplers/syscall/mod.rs
@@ -4,5 +4,5 @@ sampler!(Syscall, "syscall", SYSCALL_SAMPLERS);
 
 mod stats;
 
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod latency;

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -6,11 +6,11 @@ mod stats;
 
 mod snmp;
 
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod receive;
 
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod retransmit;
 
-#[cfg(feature = "bpf")]
+#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod traffic;


### PR DESCRIPTION
Makes the bpf dependencies linux specific and enables the bpf feature by default.

Change all bpf feature gates within the code to include the target_os to prevent issues when building on non-linux systems with the default feature set
