### PR TITLE
feat: add tcp packet latency sampler

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ mod bpf {
         ("block_io", "latency"),
         ("scheduler", "runqueue"),
         ("syscall", "latency"),
+        ("tcp", "packet_latency"),
         ("tcp", "receive"),
         ("tcp", "retransmit"),
         ("tcp", "traffic"),

--- a/src/common/bpf/core_fixes.h
+++ b/src/common/bpf/core_fixes.h
@@ -4,7 +4,7 @@
 #ifndef __CORE_FIXES_BPF_H
 #define __CORE_FIXES_BPF_H
 
-#include <vmlinux.h>
+#include "vmlinux.h"
 #include <bpf/bpf_core_read.h>
 
 /**

--- a/src/samplers/network/mod.rs
+++ b/src/samplers/network/mod.rs
@@ -7,9 +7,6 @@ mod stats;
 mod snmp;
 
 #[cfg(all(feature = "bpf", target_os = "linux"))]
-mod packet_latency;
-
-#[cfg(all(feature = "bpf", target_os = "linux"))]
 mod receive;
 
 #[cfg(all(feature = "bpf", target_os = "linux"))]

--- a/src/samplers/tcp/packet_latency/mod.bpf.c
+++ b/src/samplers/tcp/packet_latency/mod.bpf.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2023 Wenbo Zhang
+
+// NOTICE: this file is based off `tcppktlat.bpf.c` from the BCC project
+// <https://github.com/iovisor/bcc/> and has been modified for use within
+// Rezolus.
+
+// This BPF program probes TCP receive path gather statistics about the latency
+// from a packet being received to it being processed by the userspace
+// application.
+
+#include "../../../common/bpf/vmlinux.h"
+#include "../../../common/bpf/histogram.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#define MAX_ENTRIES	10240
+#define AF_INET		2
+
+const volatile pid_t targ_pid = 0;
+const volatile pid_t targ_tid = 0;
+const volatile __u16 targ_sport = 0;
+const volatile __u16 targ_dport = 0;
+const volatile __u64 targ_min_us = 0;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, u64);
+	__type(value, u64);
+} start SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, 7424);
+} latency SEC(".maps");
+
+static __always_inline __u64 get_sock_ident(struct sock *sk)
+{
+	return (__u64)sk;
+}
+
+static int handle_tcp_probe(struct sock *sk, struct sk_buff *skb)
+{
+	const struct inet_sock *inet = (struct inet_sock *)(sk);
+	u64 sock_ident, ts, len, doff;
+	const struct tcphdr *th;
+
+	if (targ_sport && targ_sport != BPF_CORE_READ(inet, inet_sport))
+		return 0;
+	if (targ_dport && targ_dport != BPF_CORE_READ(sk, __sk_common.skc_dport))
+		return 0;
+	th = (const struct tcphdr*)BPF_CORE_READ(skb, data);
+	doff = BPF_CORE_READ_BITFIELD_PROBED(th, doff);
+	len = BPF_CORE_READ(skb, len);
+	/* `doff * 4` means `__tcp_hdrlen` */
+	if (len <= doff * 4)
+		return 0;
+	sock_ident = get_sock_ident(sk);
+	ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&start, &sock_ident, &ts, 0);
+	return 0;
+}
+
+static int handle_tcp_rcv_space_adjust(void *ctx, struct sock *sk)
+{
+	const struct inet_sock *inet = (struct inet_sock *)(sk);
+	u64 sock_ident = get_sock_ident(sk);
+	u64 id = bpf_get_current_pid_tgid(), *tsp;
+	u32 idx;
+	u64 now, delta_ns, *cnt;
+	u32 pid = id >> 32, tid = id;
+	struct event *eventp;
+	u16 family;
+
+	tsp = bpf_map_lookup_elem(&start, &sock_ident);
+	if (!tsp)
+		return 0;
+
+	now = bpf_ktime_get_ns();
+
+	if (*tsp > now)
+		goto cleanup;
+
+	delta_ns = (now - *tsp);
+
+	idx = value_to_index(delta_ns);
+	cnt = bpf_map_lookup_elem(&latency, &idx);
+
+	if (cnt) {
+		__sync_fetch_and_add(cnt, 1);
+	}
+
+cleanup:
+	bpf_map_delete_elem(&start, &sock_ident);
+	return 0;
+}
+
+static int handle_tcp_destroy_sock(void *ctx, struct sock *sk)
+{
+	u64 sock_ident = get_sock_ident(sk);
+
+	bpf_map_delete_elem(&start, &sock_ident);
+	return 0;
+}
+
+SEC("raw_tp/tcp_probe")
+int BPF_PROG(tcp_probe, struct sock *sk, struct sk_buff *skb) {
+	return handle_tcp_probe(sk, skb);
+}
+
+SEC("raw_tp/tcp_rcv_space_adjust")
+int BPF_PROG(tcp_rcv_space_adjust, struct sock *sk)
+{
+	return handle_tcp_rcv_space_adjust(ctx, sk);
+}
+
+SEC("raw_tp/tcp_destroy_sock")
+int BPF_PROG(tcp_destroy_sock, struct sock *sk)
+{
+	return handle_tcp_destroy_sock(ctx, sk);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/samplers/tcp/packet_latency/mod.bpf.c
+++ b/src/samplers/tcp/packet_latency/mod.bpf.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2023 Wenbo Zhang
+// Copyright (c) 2023 The Rezolus Authors
 
 // NOTICE: this file is based off `tcppktlat.bpf.c` from the BCC project
 // <https://github.com/iovisor/bcc/> and has been modified for use within

--- a/src/samplers/tcp/packet_latency/mod.rs
+++ b/src/samplers/tcp/packet_latency/mod.rs
@@ -1,0 +1,119 @@
+#[distributed_slice(TCP_SAMPLERS)]
+fn init(config: &Config) -> Box<dyn Sampler> {
+    Box::new(PacketLatency::new(config))
+}
+
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/tcp_packet_latency.bpf.rs"));
+}
+
+use bpf::*;
+
+use super::stats::*;
+use super::*;
+use crate::common::bpf::*;
+
+impl GetMap for ModSkel<'_> {
+    fn map(&self, name: &str) -> &libbpf_rs::Map {
+        self.obj.map(name).unwrap()
+    }
+}
+
+/// Collects TCP packet latency stats using BPF and traces:
+/// * `tcp_destroy_sock`
+/// * `tcp_probe`
+/// * `tcp_rcv_space_adjust`
+///
+/// And produces these stats:
+/// * `tcp/receive/packet_latency`
+pub struct PacketLatency {
+    bpf: Bpf<ModSkel<'static>>,
+    counter_interval: Duration,
+    counter_next: Instant,
+    counter_prev: Instant,
+    distribution_interval: Duration,
+    distribution_next: Instant,
+    distribution_prev: Instant,
+}
+
+impl PacketLatency {
+    pub fn new(_config: &Config) -> Self {
+        let builder = ModSkelBuilder::default();
+        let mut skel = builder
+            .open()
+            .expect("failed to open bpf builder")
+            .load()
+            .expect("failed to load bpf program");
+        skel.attach().expect("failed to attach bpf");
+
+        let mut bpf = Bpf::from_skel(skel);
+
+        let mut distributions = vec![("latency", &TCP_PACKET_LATENCY)];
+
+        for (name, heatmap) in distributions.drain(..) {
+            bpf.add_distribution(name, heatmap);
+        }
+
+        Self {
+            bpf,
+            counter_interval: Duration::from_millis(10),
+            counter_next: Instant::now(),
+            counter_prev: Instant::now(),
+            distribution_interval: Duration::from_millis(50),
+            distribution_next: Instant::now(),
+            distribution_prev: Instant::now(),
+        }
+    }
+
+    pub fn refresh_counters(&mut self, now: Instant) {
+        if now < self.counter_next {
+            return;
+        }
+
+        let elapsed = (now - self.counter_prev).as_secs_f64();
+
+        self.bpf.refresh_counters(now, elapsed);
+
+        // determine when to sample next
+        let next = self.counter_next + self.counter_interval;
+
+        // check that next sample time is in the future
+        if next > now {
+            self.counter_next = next;
+        } else {
+            self.counter_next = now + self.counter_interval;
+        }
+
+        // mark when we last sampled
+        self.counter_prev = now;
+    }
+
+    pub fn refresh_distributions(&mut self, now: Instant) {
+        if now < self.distribution_next {
+            return;
+        }
+
+        self.bpf.refresh_distributions(now);
+
+        // determine when to sample next
+        let next = self.distribution_next + self.distribution_interval;
+
+        // check that next sample time is in the future
+        if next > now {
+            self.distribution_next = next;
+        } else {
+            self.distribution_next = now + self.distribution_interval;
+        }
+
+        // mark when we last sampled
+        self.distribution_prev = now;
+    }
+}
+
+impl Sampler for PacketLatency {
+    fn sample(&mut self) {
+        let now = Instant::now();
+        self.refresh_counters(now);
+        self.refresh_distributions(now);
+    }
+}

--- a/src/samplers/tcp/stats.rs
+++ b/src/samplers/tcp/stats.rs
@@ -43,3 +43,5 @@ heatmap!(
 );
 heatmap!(TCP_JITTER, "tcp/jitter");
 heatmap!(TCP_SRTT, "tcp/srtt");
+
+heatmap!(TCP_PACKET_LATENCY, "tcp/packet_latency");


### PR DESCRIPTION
Adds a TCP packet latency sampler that measures the latency from as packet being received to being handled by userspace application.
