### PR TITLE
fix(workflow): add libelf to packaging prereq install

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y curl build-essential pkg-config libssl-dev jq debhelper lsb-release \
-            cmake libclang-dev clang
+            cmake libclang-dev clang libelf-dev
 
       - name: install rust
         shell: bash


### PR DESCRIPTION
The packaging workflow is missing libelf-dev package which is required when building Rezolus with BPF support.
