### PR TITLE
fix: look for rezolus in `/usr/bin` instead of `/usr/local/bin` in systemd service file

### DIFF
--- a/debian/rezolus.service
+++ b/debian/rezolus.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 User=root
 Group=root
-ExecStart=/usr/local/bin/rezolus /etc/rezolus/config.toml
+ExecStart=/usr/bin/rezolus /etc/rezolus/config.toml
 KillMode=control-group
 Restart=on-failure
 

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,6 @@ endif
 	dh $@
 
 override_dh_auto_clean:
-	@
 
 override_dh_auto_build:
 	cargo build --profile ${PROFILE} --bins


### PR DESCRIPTION
The service file has `/usr/local/bin/rezolus` but the deb installs the rezolus binary at `/usr/bin/rezolus`. This likely worked fine when testing on a server that had a previous manual install of rezolus in `/usr/local/bin` but doesn't work when installing anywhere else.