### PR TITLE
fix: fix BPF samplers with clang 11

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,14 +30,14 @@ mod bpf {
             #[cfg(target_arch = "x86_64")]
             SkeletonBuilder::new()
                 .source(&src)
-                .clang_args("-I src/common/bpf/x86_64")
+                .clang_args("-I src/common/bpf/x86_64 -fno-unwind-tables")
                 .build_and_generate(&tgt)
                 .unwrap();
 
             #[cfg(target_arch = "aarch64")]
             SkeletonBuilder::new()
                 .source(&src)
-                .clang_args("-I src/common/bpf/aarch64")
+                .clang_args("-I src/common/bpf/aarch64 -fno-unwind-tables")
                 .build_and_generate(&tgt)
                 .unwrap();
 

--- a/src/samplers/block_io/latency/mod.rs
+++ b/src/samplers/block_io/latency/mod.rs
@@ -1,6 +1,10 @@
 #[distributed_slice(BLOCK_IO_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    Box::new(Biolat::new(config))
+    if let Ok(s) = Biolat::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
+    }
 }
 
 mod bpf {
@@ -12,6 +16,7 @@ use bpf::*;
 use super::stats::*;
 use super::*;
 use crate::common::bpf::*;
+use crate::common::*;
 
 impl GetMap for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
@@ -38,16 +43,15 @@ pub struct Biolat {
 }
 
 impl Biolat {
-    pub fn new(_config: &Config) -> Self {
+    pub fn new(_config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
-        let mut skel = builder
+        llet mut skel = builder
             .open()
-            .expect("failed to open bpf builder")
+            .map_err(|e| error!("failed to open bpf builder: {e}"))?
             .load()
-            .expect("failed to load bpf program");
-        skel.attach().expect("failed to attach bpf");
+            .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        let mut bpf = Bpf::from_skel(skel);
+        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut distributions = vec![("latency", &BLOCKIO_LATENCY), ("size", &BLOCKIO_SIZE)];
 
@@ -55,7 +59,7 @@ impl Biolat {
             bpf.add_distribution(name, heatmap);
         }
 
-        Self {
+        Ok(Self {
             bpf,
             counter_interval: Duration::from_millis(10),
             counter_next: Instant::now(),
@@ -63,7 +67,7 @@ impl Biolat {
             distribution_interval: Duration::from_millis(50),
             distribution_next: Instant::now(),
             distribution_prev: Instant::now(),
-        }
+        })
     }
 
     pub fn refresh_counters(&mut self, now: Instant) {

--- a/src/samplers/block_io/latency/mod.rs
+++ b/src/samplers/block_io/latency/mod.rs
@@ -51,7 +51,8 @@ impl Biolat {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 

--- a/src/samplers/block_io/latency/mod.rs
+++ b/src/samplers/block_io/latency/mod.rs
@@ -45,13 +45,15 @@ pub struct Biolat {
 impl Biolat {
     pub fn new(_config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
-        llet mut skel = builder
+        let mut skel = builder
             .open()
             .map_err(|e| error!("failed to open bpf builder: {e}"))?
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
         skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+
+        let mut bpf = Bpf::from_skel(skel);
 
         let mut distributions = vec![("latency", &BLOCKIO_LATENCY), ("size", &BLOCKIO_SIZE)];
 

--- a/src/samplers/scheduler/runqueue/mod.rs
+++ b/src/samplers/scheduler/runqueue/mod.rs
@@ -53,7 +53,8 @@ impl Runqlat {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 

--- a/src/samplers/scheduler/runqueue/mod.rs
+++ b/src/samplers/scheduler/runqueue/mod.rs
@@ -1,6 +1,10 @@
 #[distributed_slice(SCHEDULER_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    Box::new(Runqlat::new(config))
+    if let Ok(s) = Runqlat::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
+    }
 }
 
 mod bpf {
@@ -41,14 +45,15 @@ pub struct Runqlat {
 }
 
 impl Runqlat {
-    pub fn new(_config: &Config) -> Self {
+    pub fn new(_config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
         let mut skel = builder
             .open()
-            .expect("failed to open bpf builder")
+            .map_err(|e| error!("failed to open bpf builder: {e}"))?
             .load()
-            .expect("failed to load bpf program");
-        skel.attach().expect("failed to attach bpf");
+            .map_err(|e| error!("failed to load bpf program: {e}"))?;
+
+        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 
@@ -65,7 +70,7 @@ impl Runqlat {
             bpf.add_distribution(name, heatmap);
         }
 
-        Self {
+        Ok(Self {
             bpf,
             counter_interval: Duration::from_millis(10),
             counter_next: Instant::now(),
@@ -73,7 +78,7 @@ impl Runqlat {
             distribution_interval: Duration::from_millis(50),
             distribution_next: Instant::now(),
             distribution_prev: Instant::now(),
-        }
+        })
     }
 
     pub fn refresh_counters(&mut self, now: Instant) {

--- a/src/samplers/syscall/latency/mod.rs
+++ b/src/samplers/syscall/latency/mod.rs
@@ -1,6 +1,10 @@
 #[distributed_slice(SYSCALL_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    Box::new(Syscall::new(config))
+    if let Ok(s) = Syscall::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
+    }
 }
 
 mod bpf {
@@ -40,16 +44,15 @@ pub struct Syscall {
 }
 
 impl Syscall {
-    pub fn new(_config: &Config) -> Self {
+    pub fn new(_config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
         let mut skel = builder
             .open()
-            .expect("failed to open bpf builder")
+            .map_err(|e| error!("failed to open bpf builder: {e}"))?
             .load()
-            .expect("failed to load bpf program");
-        skel.attach().expect("failed to attach bpf");
+            .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        let mut bpf = Bpf::from_skel(skel);
+        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let fd = bpf.map("syscall_lut").as_fd().as_raw_fd();
         let file = unsafe { std::fs::File::from_raw_fd(fd as _) };
@@ -121,7 +124,7 @@ impl Syscall {
             bpf.add_distribution(name, heatmap);
         }
 
-        Self {
+        Ok(Self {
             bpf,
             counter_interval: Duration::from_millis(10),
             counter_next: Instant::now(),
@@ -129,7 +132,7 @@ impl Syscall {
             distribution_interval: Duration::from_millis(50),
             distribution_next: Instant::now(),
             distribution_prev: Instant::now(),
-        }
+        })
     }
 
     pub fn refresh_counters(&mut self, now: Instant) {

--- a/src/samplers/syscall/latency/mod.rs
+++ b/src/samplers/syscall/latency/mod.rs
@@ -52,7 +52,8 @@ impl Syscall {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 

--- a/src/samplers/syscall/latency/mod.rs
+++ b/src/samplers/syscall/latency/mod.rs
@@ -54,6 +54,8 @@ impl Syscall {
 
         skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
+        let mut bpf = Bpf::from_skel(skel);
+
         let fd = bpf.map("syscall_lut").as_fd().as_raw_fd();
         let file = unsafe { std::fs::File::from_raw_fd(fd as _) };
         let mut syscall_lut = unsafe {

--- a/src/samplers/tcp/packet_latency/mod.rs
+++ b/src/samplers/tcp/packet_latency/mod.rs
@@ -16,6 +16,7 @@ use bpf::*;
 use super::stats::*;
 use super::*;
 use crate::common::bpf::*;
+use crate::common::*;
 
 impl GetMap for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {

--- a/src/samplers/tcp/packet_latency/mod.rs
+++ b/src/samplers/tcp/packet_latency/mod.rs
@@ -50,7 +50,8 @@ impl PacketLatency {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 

--- a/src/samplers/tcp/packet_latency/mod.rs
+++ b/src/samplers/tcp/packet_latency/mod.rs
@@ -51,6 +51,8 @@ impl PacketLatency {
 
         skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
+        let mut bpf = Bpf::from_skel(skel);
+
         let mut distributions = vec![("latency", &TCP_PACKET_LATENCY)];
 
         for (name, heatmap) in distributions.drain(..) {

--- a/src/samplers/tcp/receive/mod.rs
+++ b/src/samplers/tcp/receive/mod.rs
@@ -49,7 +49,8 @@ impl Receive {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 

--- a/src/samplers/tcp/receive/mod.rs
+++ b/src/samplers/tcp/receive/mod.rs
@@ -1,6 +1,10 @@
 #[distributed_slice(TCP_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    Box::new(Receive::new(config))
+    if let Ok(s) = Receive::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
+    }
 }
 
 mod bpf {
@@ -36,14 +40,15 @@ pub struct Receive {
 }
 
 impl Receive {
-    pub fn new(_config: &Config) -> Self {
+    pub fn new(_config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
         let mut skel = builder
             .open()
-            .expect("failed to open bpf builder")
+            .map_err(|e| error!("failed to open bpf builder: {e}"))?
             .load()
-            .expect("failed to load bpf program");
-        skel.attach().expect("failed to attach bpf");
+            .map_err(|e| error!("failed to load bpf program: {e}"))?;
+
+        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 
@@ -53,7 +58,7 @@ impl Receive {
             bpf.add_distribution(name, heatmap);
         }
 
-        Self {
+        Ok(Self {
             bpf,
             counter_interval: Duration::from_millis(10),
             counter_next: Instant::now(),
@@ -61,7 +66,7 @@ impl Receive {
             distribution_interval: Duration::from_millis(50),
             distribution_next: Instant::now(),
             distribution_prev: Instant::now(),
-        }
+        })
     }
 
     pub fn refresh_counters(&mut self, now: Instant) {

--- a/src/samplers/tcp/receive/mod.rs
+++ b/src/samplers/tcp/receive/mod.rs
@@ -16,6 +16,7 @@ use bpf::*;
 use super::stats::*;
 use super::*;
 use crate::common::bpf::*;
+use crate::common::*;
 
 impl GetMap for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {

--- a/src/samplers/tcp/retransmit/mod.rs
+++ b/src/samplers/tcp/retransmit/mod.rs
@@ -48,7 +48,8 @@ impl Retransmit {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 

--- a/src/samplers/tcp/retransmit/mod.rs
+++ b/src/samplers/tcp/retransmit/mod.rs
@@ -1,6 +1,10 @@
 #[distributed_slice(TCP_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    Box::new(Retransmit::new(config))
+    if let Ok(s) = Retransmit::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
+    }
 }
 
 mod bpf {
@@ -36,14 +40,15 @@ pub struct Retransmit {
 }
 
 impl Retransmit {
-    pub fn new(_config: &Config) -> Self {
+    pub fn new(_config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
         let mut skel = builder
             .open()
-            .expect("failed to open bpf builder")
+            .map_err(|e| error!("failed to open bpf builder: {e}"))?
             .load()
-            .expect("failed to load bpf program");
-        skel.attach().expect("failed to attach bpf");
+            .map_err(|e| error!("failed to load bpf program: {e}"))?;
+
+        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 
@@ -54,7 +59,7 @@ impl Retransmit {
 
         bpf.add_counters("counters", counters);
 
-        Self {
+        Ok(Self {
             bpf,
             counter_interval: Duration::from_millis(10),
             counter_next: Instant::now(),
@@ -62,7 +67,7 @@ impl Retransmit {
             distribution_interval: Duration::from_millis(50),
             distribution_next: Instant::now(),
             distribution_prev: Instant::now(),
-        }
+        })
     }
 
     pub fn refresh_counters(&mut self, now: Instant) {

--- a/src/samplers/tcp/traffic/mod.rs
+++ b/src/samplers/tcp/traffic/mod.rs
@@ -1,6 +1,10 @@
 #[distributed_slice(TCP_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    Box::new(Traffic::new(config))
+    if let Ok(s) = Traffic::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
+    }
 }
 
 mod bpf {
@@ -42,14 +46,15 @@ pub struct Traffic {
 }
 
 impl Traffic {
-    pub fn new(_config: &Config) -> Self {
+    pub fn new(_config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
         let mut skel = builder
             .open()
-            .expect("failed to open bpf builder")
+            .map_err(|e| error!("failed to open bpf builder: {e}"))?
             .load()
-            .expect("failed to load bpf program");
-        skel.attach().expect("failed to attach bpf");
+            .map_err(|e| error!("failed to load bpf program: {e}"))?;
+
+        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 
@@ -68,7 +73,7 @@ impl Traffic {
             bpf.add_distribution(name, heatmap);
         }
 
-        Self {
+        Ok(Self {
             bpf,
             counter_interval: Duration::from_millis(10),
             counter_next: Instant::now(),
@@ -76,7 +81,7 @@ impl Traffic {
             distribution_interval: Duration::from_millis(50),
             distribution_next: Instant::now(),
             distribution_prev: Instant::now(),
-        }
+        })
     }
 
     pub fn refresh_counters(&mut self, now: Instant) {

--- a/src/samplers/tcp/traffic/mod.rs
+++ b/src/samplers/tcp/traffic/mod.rs
@@ -54,7 +54,8 @@ impl Traffic {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        skel.attach().map_err(|e| error!("failed to attach bpf program: {e}"))?;
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
         let mut bpf = Bpf::from_skel(skel);
 


### PR DESCRIPTION
Problem

Changes in libbpf result in binaries being generated with relocations in
the STT_SECTION. This is not compatible with clang 11 which is found
on Amazon Linux 2. 

Solution

Add `-fno-unwind-tables` to generate binaries which are compatible.

More defensive BPF program loading.

Result

Restore compatibility with clang 11
