### PR TITLE
Add github actions job to upload deb packages as release artifacts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -196,3 +196,36 @@ jobs:
             gcloud artifacts apt upload "$release" --source "$artifact"
             echo "::endgroup::"
           done
+
+  upload-release-artifacts:
+    if: ${{ github.event_name == 'release' }}
+    runs-on: ubuntu-latest
+    needs:
+      - build-deb
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          path: target/debian/
+
+      - name: upload packages
+        shell: bash
+        run: |
+          set -x
+          shopt -s nullglob
+
+          url="$(echo '${{ github.event.release.upload_url }}' | sed -e 's/{.*}//g')"
+
+          for artifact in target/debian/**; do
+            name="$(basename "$artifact")"
+            distro="$(echo "$artifact" | cut -d _ -f 1)"
+            release="$(echo "$artifact" | cut -d _ -f 2)"
+
+            curl -L -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Content-Type: application/octet-stream" \
+              -H "X-Github-Api-Version: 2022-11-28" \
+              "$url?name=$distro-$release-$artifact" \
+              --data-binary "@$artifact"
+          done

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -51,7 +51,6 @@ jobs:
           - { distro: ubuntu, release: bionic  } # LTS until Apr 2028
           - { distro: ubuntu, release: focal   } # LTS until Apr 2030
           - { distro: ubuntu, release: jammy   } # LTS until Apr 2032
-          - { distro: ubuntu, release: kinetic } # Previous release
           - { distro: ubuntu, release: lunar   } # Current release
       fail-fast: false
     env:


### PR DESCRIPTION
It's looking like I'll need this pretty soon within systemslab (mostly to have binaries to download for the development cluster). The body of the step is copied from the systemslab git commit history so it should just work.