### PR TITLE
Clean up the `systeminfo` crate

### DIFF
--- a/crates/systeminfo/src/error.rs
+++ b/crates/systeminfo/src/error.rs
@@ -1,0 +1,68 @@
+use core::fmt;
+use std::io;
+use std::path::PathBuf;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Error {
+    path: Option<PathBuf>,
+    source: ErrorSource,
+    kind: ErrorKind,
+}
+
+impl Error {
+    pub(crate) fn new(kind: ErrorKind, source: ErrorSource, path: Option<PathBuf>) -> Self {
+        Self { kind, source, path }
+    }
+
+    pub(crate) fn with_path(
+        kind: ErrorKind,
+        source: impl Into<ErrorSource>,
+        path: impl Into<PathBuf>,
+    ) -> Self {
+        Self::new(kind, source.into(), Some(path.into()))
+    }
+
+    pub(crate) fn without_path(kind: ErrorKind, source: impl Into<ErrorSource>) -> Self {
+        Self::new(kind, source.into(), None)
+    }
+
+    pub(crate) fn io(error: io::Error) -> Self {
+        Self::without_path(ErrorKind::Io, error)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ErrorSource {
+    Io(io::Error),
+    None,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ErrorKind {
+    Io,
+}
+
+impl From<io::Error> for ErrorSource {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl fmt::Display for ErrorSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => e.fmt(f),
+            Self::None => f.write_str("<no source error>"),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            ErrorKind::Io => write!(f, "io error: {}", self.source),
+        }
+    }
+}

--- a/crates/systeminfo/src/hwinfo/cpu.rs
+++ b/crates/systeminfo/src/hwinfo/cpu.rs
@@ -1,4 +1,11 @@
-use super::*;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+
+use super::util::*;
+use super::Cache;
+use crate::{Error, Result};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -43,7 +50,7 @@ impl Cpu {
 }
 
 pub fn get_cpus() -> Result<Vec<Cpu>> {
-    let mut tmp = HashMap::new();
+    let mut tmp = BTreeMap::new();
 
     // first read from /sys and build up some basic information
     let ids = read_list("/sys/devices/system/cpu/online")?;
@@ -109,63 +116,62 @@ pub fn get_cpus() -> Result<Vec<Cpu>> {
 
     // there's a lot of information that's easier to get from /proc/cpuinfo
 
-    let file = File::open("/proc/cpuinfo")?;
-    let reader = BufReader::new(file);
+    let path = "/proc/cpuinfo";
+    let file = File::open(path).map_err(|e| Error::unreadable(e, path))?;
+    let mut reader = BufReader::new(file);
 
     let mut id: Option<usize> = None;
+    let mut line = String::new();
 
-    for line in reader.lines() {
-        if line.is_err() {
-            break;
+    while reader
+        .read_line(&mut line)
+        .map_err(|e| Error::unreadable(e, path))?
+        != 0
+    {
+        let line = ClearGuard::new(&mut line);
+        let parts: Vec<&str> = line.split(':').map(|v| v.trim()).collect();
+
+        if parts.len() != 2 {
+            continue;
         }
 
-        let line = line.unwrap();
-
-        let parts: Vec<String> = line.split(':').map(|v| v.trim().to_owned()).collect();
-
-        if parts.len() == 2 {
-            match parts[0].as_str() {
-                "processor" => {
-                    if let Ok(v) = parts[1].parse() {
-                        id = Some(v);
-                    }
+        match parts[0] {
+            "processor" => {
+                if let Ok(v) = parts[1].parse() {
+                    id = Some(v);
                 }
-                "vendor_id" => {
-                    if let Some(id) = id {
-                        if let Some(cpu) = tmp.get_mut(&id) {
-                            cpu.vendor = Some(parts[1].clone());
-                        }
-                    }
-                }
-                "model name" => {
-                    if let Some(id) = id {
-                        if let Some(cpu) = tmp.get_mut(&id) {
-                            cpu.model_name = Some(parts[1].clone());
-                        }
-                    }
-                }
-                "microcode" => {
-                    if let Some(id) = id {
-                        if let Some(cpu) = tmp.get_mut(&id) {
-                            cpu.microcode = Some(parts[1].clone());
-                        }
-                    }
-                }
-                "flags" | "Features" => {
-                    if let Some(id) = id {
-                        if let Some(cpu) = tmp.get_mut(&id) {
-                            cpu.features = Some(parts[1].clone());
-                        }
-                    }
-                }
-                _ => {}
             }
+            "vendor_id" => {
+                if let Some(id) = id {
+                    if let Some(cpu) = tmp.get_mut(&id) {
+                        cpu.vendor = Some(parts[1].to_owned());
+                    }
+                }
+            }
+            "model name" => {
+                if let Some(id) = id {
+                    if let Some(cpu) = tmp.get_mut(&id) {
+                        cpu.model_name = Some(parts[1].to_owned());
+                    }
+                }
+            }
+            "microcode" => {
+                if let Some(id) = id {
+                    if let Some(cpu) = tmp.get_mut(&id) {
+                        cpu.microcode = Some(parts[1].to_owned());
+                    }
+                }
+            }
+            "flags" | "Features" => {
+                if let Some(id) = id {
+                    if let Some(cpu) = tmp.get_mut(&id) {
+                        cpu.features = Some(parts[1].to_owned());
+                    }
+                }
+            }
+            _ => (),
         }
     }
 
-    let mut ret: Vec<Cpu> = tmp.drain().map(|(_, v)| v).collect();
-
-    ret.sort_by(|a, b| a.id.cmp(&b.id));
-
-    Ok(ret)
+    Ok(tmp.into_values().collect())
 }

--- a/crates/systeminfo/src/hwinfo/memory.rs
+++ b/crates/systeminfo/src/hwinfo/memory.rs
@@ -1,4 +1,9 @@
-pub use super::*;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use super::util::*;
+use crate::{Error, Result};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -8,42 +13,48 @@ pub struct Memory {
 
 impl Memory {
     pub fn new() -> Result<Self> {
-        let file = File::open("/proc/meminfo")?;
-        let reader = BufReader::new(file);
-
-        let mut ret = Self { total_bytes: 0 };
-
-        for line in reader.lines() {
-            let line = line.unwrap();
-            if line.starts_with("MemTotal:") {
-                let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() == 3 {
-                    ret.total_bytes = parts[1].parse::<u64>().map(|v| v * 1024).map_err(|_| {
-                        std::io::Error::new(std::io::ErrorKind::InvalidData, "bad value")
-                    })?;
-                }
-            }
-        }
-
-        Ok(ret)
+        Self::from_file("/proc/meminfo")
     }
 
     pub fn node(id: usize) -> Result<Self> {
-        let file = File::open(format!("/sys/devices/system/node/node{id}/meminfo"))?;
-        let reader = BufReader::new(file);
+        Self::from_file(format!("/sys/devices/system/node/node{id}/meminfo"))
+    }
 
-        let mut ret = Self { total_bytes: 0 };
+    fn from_file(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let file = File::open(path).map_err(|e| Error::unreadable(e, path))?;
+        let mut reader = BufReader::new(file);
 
-        for line in reader.lines() {
-            let line = line.unwrap();
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() >= 4 && parts[2] == "MemTotal:" {
-                ret.total_bytes = parts[3].parse::<u64>().map(|v| v * 1024).map_err(|_| {
-                    std::io::Error::new(std::io::ErrorKind::InvalidData, "bad value")
-                })?;
+        let mut memory = Self { total_bytes: 0 };
+        let mut line = String::new();
+
+        while reader
+            .read_line(&mut line)
+            .map_err(|e| Error::unreadable(e, path))?
+            != 0
+        {
+            let line = ClearGuard::new(&mut line);
+
+            if !line.starts_with("MemTotal:") {
+                continue;
             }
+
+            let mut parts = line.split_ascii_whitespace().skip(1);
+            let Some(value) = parts.next() else {
+                continue;
+            };
+            let Some(_unit) = parts.next() else {
+                continue;
+            };
+
+            if !parts.next().is_none() {
+                continue;
+            }
+
+            let kilobytes: u64 = value.parse().map_err(|e| Error::unparseable(e, path))?;
+            memory.total_bytes = kilobytes * 1024;
         }
 
-        Ok(ret)
+        Ok(memory)
     }
 }

--- a/crates/systeminfo/src/hwinfo/mod.rs
+++ b/crates/systeminfo/src/hwinfo/mod.rs
@@ -1,25 +1,17 @@
-use serde::Serialize;
-use std::collections::HashMap;
-use std::ffi::OsStr;
-use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
-use std::io::Result;
-use std::path::Path;
-use walkdir::DirEntry;
-use walkdir::WalkDir;
+use crate::Result;
 
 mod cache;
 mod cpu;
 mod memory;
 mod net;
 mod node;
+mod util;
 
-use cache::*;
-use cpu::*;
-use memory::*;
-use net::*;
-use node::*;
+pub use self::cache::{Cache, CacheType};
+pub use self::cpu::Cpu;
+pub use self::memory::Memory;
+pub use self::net::{Interface, Queues};
+pub use self::node::Node;
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -34,80 +26,15 @@ pub struct HwInfo {
 impl HwInfo {
     pub fn new() -> Result<Self> {
         Ok(Self {
-            caches: get_caches()?,
-            cpus: get_cpus()?,
+            caches: self::cache::get_caches()?,
+            cpus: self::cpu::get_cpus()?,
             memory: Memory::new()?,
-            network: get_interfaces(),
-            nodes: get_nodes()?,
+            network: self::net::get_interfaces(),
+            nodes: self::node::get_nodes()?,
         })
     }
 
     pub fn get_cpus(&self) -> &Vec<Cpu> {
         return &self.cpus;
-    }
-}
-
-fn read_usize(path: impl AsRef<Path>) -> Result<usize> {
-    let raw = std::fs::read_to_string(path)?;
-    let raw = raw.trim();
-
-    raw.parse()
-        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "not a number"))
-}
-
-fn read_string(path: impl AsRef<Path>) -> Result<String> {
-    let raw = std::fs::read_to_string(path)?;
-    let raw = raw.trim();
-
-    Ok(raw.to_string())
-}
-
-fn read_list(path: impl AsRef<Path>) -> Result<Vec<usize>> {
-    let raw = std::fs::read_to_string(path)?;
-    parse_list(raw)
-}
-
-fn parse_list(raw: String) -> Result<Vec<usize>> {
-    let raw = raw.trim();
-    let mut ret = Vec::new();
-    let ranges: Vec<&str> = raw.split(',').collect();
-    for range in ranges {
-        let parts: Vec<&str> = range.split('-').collect();
-        if parts.len() == 1 {
-            ret.push(parts[0].parse().map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "not a number")
-            })?);
-        } else if parts.len() == 2 {
-            let start: usize = parts[0].parse().map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "not a number")
-            })?;
-            let stop: usize = parts[1].parse().map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::InvalidData, "not a number")
-            })?;
-            for i in start..=stop {
-                ret.push(i);
-            }
-        }
-    }
-
-    Ok(ret)
-}
-
-fn is_hidden(entry: &DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .map(|s| s.starts_with('.'))
-        .unwrap_or(false)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn list_parsing() {
-        let list = "0-1\r\n";
-        assert_eq!(parse_list(list.to_string()).unwrap(), vec![0, 1]);
     }
 }

--- a/crates/systeminfo/src/hwinfo/net.rs
+++ b/crates/systeminfo/src/hwinfo/net.rs
@@ -1,4 +1,9 @@
-use super::*;
+use std::ffi::OsStr;
+
+use walkdir::WalkDir;
+
+use super::util::*;
+use crate::{Error, Result};
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -20,9 +25,7 @@ pub struct Queues {
 }
 
 fn get_interface(name: &OsStr) -> Result<Option<Interface>> {
-    let name = name.to_str().ok_or_else(|| {
-        std::io::Error::new(std::io::ErrorKind::InvalidData, "bad interface name")
-    })?;
+    let name = name.to_str().ok_or_else(Error::invalid_interface_name)?;
 
     // skip any that aren't "up"
     let operstate = read_string(format!("/sys/class/net/{name}/operstate"))?;

--- a/crates/systeminfo/src/hwinfo/node.rs
+++ b/crates/systeminfo/src/hwinfo/node.rs
@@ -1,4 +1,6 @@
-use super::*;
+use super::memory::Memory;
+use super::util::*;
+use crate::Result;
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/systeminfo/src/hwinfo/util.rs
+++ b/crates/systeminfo/src/hwinfo/util.rs
@@ -1,0 +1,111 @@
+use std::ops::{Deref, DerefMut};
+use std::path::Path;
+
+use walkdir::DirEntry;
+
+use crate::{Error, Result};
+
+pub(crate) fn read_usize(path: impl AsRef<Path>) -> Result<usize> {
+    let path = path.as_ref();
+
+    let raw = std::fs::read_to_string(path).map_err(|e| Error::unreadable(e, path))?;
+    let raw = raw.trim();
+
+    raw.parse().map_err(|e| Error::unparseable(e, path))
+}
+
+pub(crate) fn read_string(path: impl AsRef<Path>) -> Result<String> {
+    let path = path.as_ref();
+
+    let raw = std::fs::read_to_string(path).map_err(|e| Error::unreadable(e, path))?;
+    let raw = raw.trim();
+
+    Ok(raw.to_string())
+}
+
+pub(crate) fn read_list(path: impl AsRef<Path>) -> Result<Vec<usize>> {
+    let path = path.as_ref();
+    let raw = std::fs::read_to_string(path).map_err(|e| Error::unreadable(e, path))?;
+    parse_list(&raw, path)
+}
+
+fn parse_list(raw: &str, path: &Path) -> Result<Vec<usize>> {
+    let raw = raw.trim();
+    let mut ret = Vec::new();
+
+    for range in raw.split(',') {
+        let mut parts = range.split('-');
+
+        let first: Option<usize> = parts
+            .next()
+            .map(|text| text.parse())
+            .transpose()
+            .map_err(|e| Error::unparseable(e, path))?;
+        let second: Option<usize> = parts
+            .next()
+            .map(|text| text.parse())
+            .transpose()
+            .map_err(|e| Error::unparseable(e, path))?;
+
+        if parts.next().is_some() {
+            // The line is invalid, skip it.
+            continue;
+        }
+
+        match (first, second) {
+            (Some(value), None) => ret.push(value),
+            (Some(start), Some(stop)) => ret.extend(start..=stop),
+            _ => continue,
+        }
+    }
+
+    Ok(ret)
+}
+
+pub(crate) fn is_hidden(entry: &DirEntry) -> bool {
+    entry
+        .file_name()
+        .to_str()
+        .map(|s| s.starts_with('.'))
+        .unwrap_or(false)
+}
+
+/// Guard which clears the contained string upon drop.
+pub(crate) struct ClearGuard<'a>(&'a mut String);
+
+impl<'a> ClearGuard<'a> {
+    pub fn new(value: &'a mut String) -> Self {
+        Self(value)
+    }
+}
+
+impl<'a> Drop for ClearGuard<'a> {
+    fn drop(&mut self) {
+        self.0.clear();
+    }
+}
+
+impl<'a> Deref for ClearGuard<'a> {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for ClearGuard<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_parsing() {
+        let list = "0-1\r\n";
+        assert_eq!(parse_list(list, "/test/case".as_ref()).unwrap(), vec![0, 1]);
+    }
+}

--- a/crates/systeminfo/src/lib.rs
+++ b/crates/systeminfo/src/lib.rs
@@ -1,9 +1,6 @@
 //! Gather a comprehensive description of the current system.
 //!
 
-use crate::error::{ErrorKind, ErrorSource};
-use std::io;
-
 #[macro_use]
 extern crate serde;
 
@@ -26,7 +23,7 @@ pub struct SystemInfo {
 impl SystemInfo {
     pub fn new() -> Result<Self> {
         Ok(Self {
-            hwinfo: crate::hwinfo::HwInfo::new().map_err(Error::io)?,
+            hwinfo: crate::hwinfo::HwInfo::new()?,
         })
     }
 }

--- a/crates/systeminfo/src/lib.rs
+++ b/crates/systeminfo/src/lib.rs
@@ -1,15 +1,19 @@
 //! Gather a comprehensive description of the current system.
 //!
 
+use crate::error::{ErrorKind, ErrorSource};
 use std::io;
 
 #[macro_use]
 extern crate serde;
 
+mod error;
 pub mod hwinfo;
 
+pub use crate::error::{Error, Result};
+
 /// Read the [`SystemInfo`] for the current system.
-pub fn systeminfo() -> io::Result<SystemInfo> {
+pub fn systeminfo() -> Result<SystemInfo> {
     SystemInfo::new()
 }
 
@@ -20,9 +24,9 @@ pub struct SystemInfo {
 }
 
 impl SystemInfo {
-    pub fn new() -> io::Result<Self> {
+    pub fn new() -> Result<Self> {
         Ok(Self {
-            hwinfo: crate::hwinfo::HwInfo::new()?,
+            hwinfo: crate::hwinfo::HwInfo::new().map_err(Error::io)?,
         })
     }
 }

--- a/src/samplers/hwinfo/mod.rs
+++ b/src/samplers/hwinfo/mod.rs
@@ -4,7 +4,8 @@ use lazy_static::lazy_static;
 use systeminfo::hwinfo::HwInfo;
 
 lazy_static! {
-    pub static ref HWINFO: io::Result<HwInfo> = HwInfo::new();
+    pub static ref HWINFO: io::Result<HwInfo> = HwInfo::new() //
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
 }
 
 pub fn hardware_info() -> std::result::Result<&'static HwInfo, &'static std::io::Error> {


### PR DESCRIPTION
The goal with this PR is to take the crate from being a bunch of code that was just copied out of rezolus and to turn it into a usable library.

Here's the various changes included:
- Iterating over files line-by-line now re-uses the string instead of creating a new one for each line
- I have removed several temporary vectors that could be replaced with iterators
- The library now has a proper error type, although error messages could probably be a bit better still.
- I have replaced all the confusing `use super::*` imports with ones that are actually specific to the current module.
- The various helper functions have been moved into their own module and out of `hwinfo/mod.rs`