### PR TITLE
Fix packaging release workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -216,16 +216,17 @@ jobs:
 
           url="$(echo '${{ github.event.release.upload_url }}' | sed -e 's/{.*}//g')"
 
-          for artifact in target/debian/**; do
+          for artifact in target/debian/**/*; do
             name="$(basename "$artifact")"
-            distro="$(echo "$artifact" | cut -d _ -f 1)"
-            release="$(echo "$artifact" | cut -d _ -f 2)"
-
+            directory="$(basename "$(dirname "$artifact")")"
+        
+            release="$(echo "$directory" | cut -d _ -f 2)"
+        
             curl -L -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "Content-Type: application/octet-stream" \
               -H "X-Github-Api-Version: 2022-11-28" \
-              "$url?name=$distro-$release-$artifact" \
+              "$url?name=${release}_${name}" \
               --data-binary "@$artifact"
           done


### PR DESCRIPTION
The artifact upload job was attempting to upload folders since the folder structure was different from what it thought it was. This resulted in no artifacts being uploaded. I've changed things here to fix naming and actually upload the debs.

I have also manually uploaded the artifacts for the previous release.