### PR TITLE
chore: change dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
         patterns:
           - "*"
     open-pull-requests-limit: 10
-    versioning-strategy: auto
+    versioning-strategy: lockfile-only
     allow:
       - dependency-type: all


### PR DESCRIPTION
Change dependabot config to set the versioning strategy to lockfile only. This should avoid breaking updates from 0.x -> 0.y for our dependencies.
