### PR TITLE
feat(sampler): change CPU features from a string to an array

### DIFF
--- a/crates/systeminfo/src/hwinfo/cpu.rs
+++ b/crates/systeminfo/src/hwinfo/cpu.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -26,7 +27,7 @@ pub struct Cpu {
     pub microcode: Option<String>,
     pub vendor: Option<String>,
     pub model_name: Option<String>,
-    pub features: Option<Vec<String>>,
+    pub features: Option<HashSet<String>>,
 
     pub caches: Vec<Cache>,
 }

--- a/crates/systeminfo/src/hwinfo/cpu.rs
+++ b/crates/systeminfo/src/hwinfo/cpu.rs
@@ -26,7 +26,7 @@ pub struct Cpu {
     pub microcode: Option<String>,
     pub vendor: Option<String>,
     pub model_name: Option<String>,
-    pub features: Option<String>,
+    pub features: Option<Vec<String>>,
 
     pub caches: Vec<Cache>,
 }
@@ -165,7 +165,12 @@ pub fn get_cpus() -> Result<Vec<Cpu>> {
             "flags" | "Features" => {
                 if let Some(id) = id {
                     if let Some(cpu) = tmp.get_mut(&id) {
-                        cpu.features = Some(parts[1].to_owned());
+                        cpu.features = Some(
+                            parts[1]
+                                .split_ascii_whitespace()
+                                .map(|s| s.to_owned())
+                                .collect(),
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Currently, systeminfo stores the CPU features as a giant string. Semantically, though, it's an array of strings and it would be more useful to have the data representation reflect that.
