### PR TITLE
fix: histogram mmap length check

### DIFF
--- a/src/common/bpf/distribution.rs
+++ b/src/common/bpf/distribution.rs
@@ -52,10 +52,12 @@ impl<'a> Distribution<'a> {
 
         let (_prefix, buckets, _suffix) = unsafe { self.mmap.align_to::<u64>() };
 
-        if buckets.len() == HISTOGRAM_BUCKETS {
-            let _ = self.histogram.update_from(&buckets);
+        let expected_len = HISTOGRAM_PAGES * PAGE_SIZE / 8;
+
+        if buckets.len() == expected_len {
+            let _ = self.histogram.update_from(&buckets[0..HISTOGRAM_BUCKETS]);
         } else {
-            warn!("mmap region misaligned or did not have expected number of values");
+            warn!("mmap region misaligned or did not have expected number of values {} != {expected_len}", buckets.len());
 
             self.buffer.resize(HISTOGRAM_BUCKETS, 0);
 


### PR DESCRIPTION
The length check of the mmap'd histogram buckets used the exact number of buckets in the histogram. This number needs to be rounded up to match the next full page size.

Instead of using the `HISTOGRAM_BUCKETS` const, we use the `HISTOGRAM_PAGES` and `PAGE_SIZE` to validate the length of the mmap'd buckets.

This results in the fast path being used.
