### PR TITLE
feat: track latencies for syscall famlies

### DIFF
--- a/src/samplers/syscall/latency/mod.rs
+++ b/src/samplers/syscall/latency/mod.rs
@@ -128,7 +128,16 @@ impl Syscall {
 
         bpf.add_counters("counters", counters);
 
-        let mut distributions = vec![("total_latency", &SYSCALL_TOTAL_LATENCY)];
+        let mut distributions = vec![
+            ("total_latency", &SYSCALL_TOTAL_LATENCY),
+            ("read_latency", &SYSCALL_READ_LATENCY),
+            ("write_latency", &SYSCALL_WRITE_LATENCY),
+            ("poll_latency", &SYSCALL_POLL_LATENCY),
+            ("lock_latency", &SYSCALL_LOCK_LATENCY),
+            ("time_latency", &SYSCALL_TIME_LATENCY),
+            ("sleep_latency", &SYSCALL_SLEEP_LATENCY),
+            ("socket_latency", &SYSCALL_SOCKET_LATENCY),
+        ];
 
         for (name, histogram) in distributions.drain(..) {
             bpf.add_distribution(name, histogram);

--- a/src/samplers/syscall/stats.rs
+++ b/src/samplers/syscall/stats.rs
@@ -53,3 +53,38 @@ bpfhistogram!(
     "syscall/total/latency",
     "latency of all syscalls"
 );
+bpfhistogram!(
+    SYSCALL_READ_LATENCY,
+    "syscall/read/latency",
+    "latency of read related syscalls (read, recvfrom, ...)"
+);
+bpfhistogram!(
+    SYSCALL_WRITE_LATENCY,
+    "syscall/write/latency",
+    "latency of write related syscalls (write, sendto, ...)"
+);
+bpfhistogram!(
+    SYSCALL_POLL_LATENCY,
+    "syscall/poll/latency",
+    "latency of poll related syscalls (poll, select, epoll, ...)"
+);
+bpfhistogram!(
+    SYSCALL_LOCK_LATENCY,
+    "syscall/lock/latency",
+    "latency of lock related syscalls (futex)"
+);
+bpfhistogram!(
+    SYSCALL_TIME_LATENCY,
+    "syscall/time/latency",
+    "latency of time related syscalls (clock_gettime, clock_settime, clock_getres, ...)"
+);
+bpfhistogram!(
+    SYSCALL_SLEEP_LATENCY,
+    "syscall/sleep/latency",
+    "latency of sleep related syscalls (nanosleep, clock_nanosleep)"
+);
+bpfhistogram!(
+    SYSCALL_SOCKET_LATENCY,
+    "syscall/socket/latency",
+    "latency of socket related syscalls (accept, connect, bind, setsockopt, ...)"
+);


### PR DESCRIPTION
Add latency distributions for each syscall family so we can better
understand the latencies for common syscalls for a given workload.
