### PR TITLE
fix: per-cpu frequency, ipus, ipkc metrics have wrong type

### DIFF
--- a/src/samplers/cpu/perf/mod.rs
+++ b/src/samplers/cpu/perf/mod.rs
@@ -36,6 +36,7 @@ pub struct Perf {
     interval: Duration,
     groups: Vec<PerfGroup>,
     counters: Vec<Vec<DynBoxedMetric<metriken::Counter>>>,
+    gauges: Vec<Vec<DynBoxedMetric<metriken::Gauge>>>,
 }
 
 impl Perf {
@@ -54,18 +55,18 @@ impl Perf {
 
         let mut groups = Vec::with_capacity(cpus.len());
         let mut counters = Vec::with_capacity(cpus.len());
+        let mut gauges = Vec::with_capacity(cpus.len());
 
-        let metrics = [
+        let counter_metrics = [
             "cpu/cycles",
             "cpu/instructions",
-            "cpu/ipkc",
-            "cpu/ipus",
-            "cpu/frequency",
         ];
+
+        let gauge_metrics = ["cpu/ipkc", "cpu/ipus", "cpu/frequency"];
 
         for cpu in cpus {
             counters.push(
-                metrics
+                counter_metrics
                     .iter()
                     .map(|metric| {
                         MetricBuilder::new(*metric)
@@ -78,6 +79,22 @@ impl Perf {
                     })
                     .collect(),
             );
+
+            gauges.push(
+                gauge_metrics
+                    .iter()
+                    .map(|metric| {
+                        MetricBuilder::new(*metric)
+                            .metadata("id", format!("{}", cpu.id()))
+                            .metadata("core", format!("{}", cpu.core()))
+                            .metadata("die", format!("{}", cpu.die()))
+                            .metadata("package", format!("{}", cpu.package()))
+                            .formatter(cpu_metric_formatter)
+                            .build(metriken::Gauge::new())
+                    })
+                    .collect(),
+            );
+
 
             match PerfGroup::new(cpu.id()) {
                 Ok(g) => groups.push(g),
@@ -100,6 +117,7 @@ impl Perf {
             interval: config.interval(NAME),
             groups,
             counters,
+            gauges,
         });
     }
 }
@@ -135,9 +153,10 @@ impl Sampler for Perf {
 
                 self.counters[reading.id][0].set(reading.cycles);
                 self.counters[reading.id][1].set(reading.instructions);
-                self.counters[reading.id][2].set(reading.ipkc);
-                self.counters[reading.id][3].set(reading.ipus);
-                self.counters[reading.id][4].set(reading.running_frequency_mhz);
+
+                self.gauges[reading.id][0].set(reading.ipkc as i64);
+                self.gauges[reading.id][1].set(reading.ipus as i64);
+                self.gauges[reading.id][2].set(reading.running_frequency_mhz as i64);
             }
         }
 

--- a/src/samplers/cpu/perf/mod.rs
+++ b/src/samplers/cpu/perf/mod.rs
@@ -57,10 +57,7 @@ impl Perf {
         let mut counters = Vec::with_capacity(cpus.len());
         let mut gauges = Vec::with_capacity(cpus.len());
 
-        let counter_metrics = [
-            "cpu/cycles",
-            "cpu/instructions",
-        ];
+        let counter_metrics = ["cpu/cycles", "cpu/instructions"];
 
         let gauge_metrics = ["cpu/ipkc", "cpu/ipus", "cpu/frequency"];
 
@@ -94,7 +91,6 @@ impl Perf {
                     })
                     .collect(),
             );
-
 
             match PerfGroup::new(cpu.id()) {
                 Ok(g) => groups.push(g),


### PR DESCRIPTION
The per-cpu cpu_frequency, cpu_ipus, and cpu_ipkc metrics have the wrong type. They should be gauges, but instead were counters.

This change fixes the types for those metrics so we have the right type annotations on the prometheus endpoint.
