### PR TITLE
packaging: add basic rpm packing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,13 @@ members = [
 
 [workspace.dependencies]
 systeminfo = { path = "crates/systeminfo" }
+
+[package.metadata.generate-rpm]
+auto_req = "builtin"
+assets = [
+    { source = "target/release/rezolus", dest = "/usr/bin/", mode = "755" },
+    { source = "config.toml", dest = "/etc/rezolus/", mode = "644" },
+    { source = "debian/rezolus.service", dest = "/usr/lib/systemd/system/", mode = "644" },
+]
+post_install_script = "rpm/systemd-start.sh"
+pre_uninstall_script = "rpm/systemd-stop.sh"

--- a/rpm/systemd-start.sh
+++ b/rpm/systemd-start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+systemctl enable rezolus
+systemctl start rezolus

--- a/rpm/systemd-stop.sh
+++ b/rpm/systemd-stop.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+systemctl stop rezolus
+systemctl disable rezolus


### PR DESCRIPTION
Use the cargo-generate-rpm helper crate
(https://crates.io/crates/cargo-generate-rpm) to generate
an RPM for rezolus. This crate assumes that the project
has already been built and only packages an existing binary
so that must be done before running `cargo generate-rpm`.