### PR TITLE
fix TCP segment metrics

### DIFF
--- a/src/samplers/tcp/snmp/mod.rs
+++ b/src/samplers/tcp/snmp/mod.rs
@@ -7,10 +7,7 @@ use std::fs::File;
 
 #[distributed_slice(TCP_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    // if we have bpf enabled, we don't need to run this sampler at all
-    if config.bpf() {
-        Box::new(Nop::new(config))
-    } else if let Ok(s) = Snmp::new(config) {
+    if let Ok(s) = Snmp::new(config) {
         Box::new(s)
     } else {
         Box::new(Nop::new(config))

--- a/src/samplers/tcp/stats.rs
+++ b/src/samplers/tcp/stats.rs
@@ -12,16 +12,29 @@ counter_with_histogram!(
     "number of bytes received over TCP"
 );
 counter_with_histogram!(
+    TCP_RX_READ,
+    TCP_RX_READ_HISTOGRAM,
+    "tcp/receive/read",
+    "number of reads from the TCP socket buffers after reassembly"
+);
+counter_with_histogram!(
     TCP_RX_SEGMENTS,
     TCP_RX_SEGMENTS_HISTOGRAM,
     "tcp/receive/segments",
     "number of TCP segments received"
 );
+
 counter_with_histogram!(
     TCP_TX_BYTES,
     TCP_TX_BYTES_HISTOGRAM,
     "tcp/transmit/bytes",
     "number of bytes transmitted over TCP"
+);
+counter_with_histogram!(
+    TCP_TX_SEND,
+    TCP_TX_SEND_HISTOGRAM,
+    "tcp/transmit/send",
+    "number of TCP sends before fragmentation"
 );
 counter_with_histogram!(
     TCP_TX_SEGMENTS,
@@ -135,12 +148,12 @@ pub static TCP_CONN_STATE_NEW_SYN_RECV: LazyGauge = LazyGauge::new(Gauge::defaul
 bpfhistogram!(
     TCP_RX_SIZE,
     "tcp/receive/size",
-    "distribution of receive segment sizes"
+    "distribution of logical receive sizes after reassembly"
 );
 bpfhistogram!(
     TCP_TX_SIZE,
     "tcp/transmit/size",
-    "distribution of transmit segment sizes"
+    "distribution of logical send sizes before fragmentation"
 );
 bpfhistogram!(TCP_JITTER, "tcp/jitter");
 bpfhistogram!(TCP_SRTT, "tcp/srtt");


### PR DESCRIPTION
Fixes #123 by using /proc/net/snmp to report TCP in/out segments and renaming the eBPF metrics so we can continue to report logical sends/recvs before fragmentation and after reassembly respectively.
