### PR TITLE
add optional compression for http exposition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +115,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +180,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -293,6 +343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +473,16 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1976,6 +2045,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
 dependencies = [
+ "async-compression",
  "bytes",
  "futures-channel",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ syscall-numbers = "3.1.0"
 tokio = { version = "1.32.0", features = ["full"] }
 toml = "0.7.6"
 walkdir = "2.3.3"
-warp = "0.3.6"
+warp = { version = "0.3.6", features = ["compression"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.21.2", optional = true }

--- a/config.toml
+++ b/config.toml
@@ -1,11 +1,19 @@
 [general]
 listen = "0.0.0.0:4242"
 
+# Controls whether gzip compression will be used for the http endpoints. This
+# can significantly reduce the payload size at the cost of some additional cpu
+# time. This is highly recommended when exposing the histograms on the
+# prometheus endpoint.
+compression = false
+
 [prometheus]
 # Controls whether the full distribution for each histogram is exposed via the
 # prometheus endpoint (`/metrics`). This adds a considerable number of time
 # series depending on the downsampling factor as each histogram bucket is
 # represented as its own time series.
+#
+# NOTE: it's recommended to enable compression when enabling this.
 histograms = false
 
 # The histogram can be downsampled for exposition to reduce the number of

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -92,6 +92,8 @@ impl Config {
 #[derive(Deserialize)]
 pub struct General {
     listen: String,
+    #[serde(default = "disabled")]
+    compression: bool,
 }
 
 impl General {
@@ -109,6 +111,10 @@ impl General {
                 std::process::exit(1);
             })
             .unwrap()
+    }
+
+    pub fn compression(&self) -> bool {
+        self.compression
     }
 }
 

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -29,6 +29,7 @@ mod filters {
         prometheus_stats(config.clone())
             .or(human_stats())
             .or(hardware_info())
+            .with(warp::filters::compression::gzip())
     }
 
     /// GET /metrics

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -8,9 +8,11 @@ use warp::Filter;
 
 /// HTTP exposition
 pub async fn http(config: Arc<Config>) {
-    let http = filters::http(config);
-
-    warp::serve(http).run(([0, 0, 0, 0], 4242)).await;
+    if config.general().compression() {
+        warp::serve(filters::http(config).with(warp::filters::compression::gzip())).run(([0, 0, 0, 0], 4242)).await;
+    } else {
+        warp::serve(filters::http(config)).run(([0, 0, 0, 0], 4242)).await;
+    }
 }
 
 mod filters {
@@ -29,7 +31,6 @@ mod filters {
         prometheus_stats(config.clone())
             .or(human_stats())
             .or(hardware_info())
-            .with(warp::filters::compression::gzip())
     }
 
     /// GET /metrics


### PR DESCRIPTION
The metrics endpoint exposes a large volume of data, particularly
when histogram exposition is enabled. This can cause a substantial
amount of bandwidth to be used, especially when sampling at high
frequency.

Fortunately, the data compresses well. This change allows opt-in
compression for the endpoints using gzip.