### PR TITLE
add more nvidia gpu stats

### DIFF
--- a/src/samplers/gpu/stats.rs
+++ b/src/samplers/gpu/stats.rs
@@ -47,6 +47,20 @@ pub static GPU_PCIE_THROUGHPUT_TX: LazyGauge = LazyGauge::new(Gauge::default);
 )]
 pub static GPU_POWER_USAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
+#[metric(
+    name = "gpu/utilization/gpu",
+    description = "The running average percentage of time the GPU was executing one or more kernels. (0-100).",
+    formatter = gpu_metric_formatter
+)]
+pub static GPU_UTILIZATION: LazyGauge = LazyGauge::new(Gauge::default);
+
+#[metric(
+    name = "gpu/utilization/memory",
+    description = "The running average percentage of time that GPU memory was being read from or written to. (0-100).",
+    formatter = gpu_metric_formatter
+)]
+pub static GPU_MEMORY_UTILIZATION: LazyGauge = LazyGauge::new(Gauge::default);
+
 /// A function to format the gpu metrics that allows for export of both total
 /// and per-GPU metrics.
 ///


### PR DESCRIPTION
Adds more nvidia gpu stats including:
- energy consumption: counter of mJ consumed
- utilization: percent utilzation for gpu and gpu memory
