### PR TITLE
rename GPU utilization stats

### DIFF
--- a/src/samplers/gpu/nvidia/mod.rs
+++ b/src/samplers/gpu/nvidia/mod.rs
@@ -140,12 +140,10 @@ impl Nvidia {
                     .build(metriken::Gauge::new()),
                 gpu_utilization: MetricBuilder::new("gpu/utilization")
                     .metadata("id", format!("{}", device))
-                    .metadata("type", "gpu")
                     .formatter(gpu_metric_formatter)
                     .build(metriken::Gauge::new()),
-                memory_utilization: MetricBuilder::new("gpu/utilization")
+                memory_utilization: MetricBuilder::new("gpu/memory_utilization")
                     .metadata("id", format!("{}", device))
-                    .metadata("type", "memory")
                     .formatter(gpu_metric_formatter)
                     .build(metriken::Gauge::new()),
             });

--- a/src/samplers/gpu/stats.rs
+++ b/src/samplers/gpu/stats.rs
@@ -55,7 +55,7 @@ pub static GPU_POWER_USAGE: LazyGauge = LazyGauge::new(Gauge::default);
 pub static GPU_UTILIZATION: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
-    name = "gpu/utilization/memory",
+    name = "gpu/memory_utilization",
     description = "The running average percentage of time that GPU memory was being read from or written to. (0-100).",
     formatter = gpu_metric_formatter
 )]


### PR DESCRIPTION
Rename the GPU utilization stats for better clarity.
