### PR TITLE
msgpack based exposition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,15 +1068,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1083,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +290,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,13 +346,11 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clocksource"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90cc4cec392a6d97223f008b5da7a3c2c71aa6d5ffdf0e3e14d8b2432738387"
+checksum = "129026dd5a8a9592d96916258f3a5379589e513ea5e86aeb0bd2530286e44e9e"
 dependencies = [
- "lazy_static",
  "libc",
- "mach",
  "time",
  "winapi 0.3.9",
 ]
@@ -326,6 +360,12 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -624,10 +664,11 @@ checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "histogram"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0f59c8ab5f8d1f1dd481174172ce418e2e306d665cdd8057c0bd457c447159"
+checksum = "4b634390eb8a63662e127836d4e2f26d7ae930600d4e05ee0fd85a009eeb1175"
 dependencies = [
+ "serde",
  "thiserror",
 ]
 
@@ -696,6 +737,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +790,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -854,15 +927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "metriken"
-version = "0.3.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9baea67418f728439d5a806bb1d18a4ab84a21388d768c1d400a3e6cc2dc1948"
+checksum = "9868467c2c6c455c1c7707c7eff2abd55d7ecf6a5bcc29ec7ca5cee8abdd096d"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -921,14 +985,14 @@ dependencies = [
 
 [[package]]
 name = "metriken-derive"
-version = "0.3.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1738842f3a54b57e8a665cb2f6eb5e4ad7301089a41655c2cddecf92354a4992"
+checksum = "3643374c9873e69a27e50404db6006ad09f0c1ee944e8ce928d586df077b71db"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1005,6 +1069,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,7 +1102,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1119,6 +1192,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -1259,7 +1338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -1377,7 +1465,9 @@ name = "rezolus"
 version = "3.7.1-alpha.0"
 dependencies = [
  "backtrace",
+ "chrono",
  "clap",
+ "histogram",
  "humantime",
  "lazy_static",
  "libbpf-cargo",
@@ -1392,8 +1482,10 @@ dependencies = [
  "ouroboros",
  "perf-event2",
  "ringlog",
+ "rmp-serde",
  "serde",
  "serde_json",
+ "serde_repr",
  "syscall-numbers",
  "sysconf",
  "systeminfo",
@@ -1405,15 +1497,37 @@ dependencies = [
 
 [[package]]
 name = "ringlog"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325bf804f14769bdcd0bcf437a9ac2af50d12986e969df4448205397684ca5dc"
+checksum = "0c41291385651fe8075d9eab724f7a2092076e1dc217b8ef6b0d7a22207e0669"
 dependencies = [
  "ahash",
  "clocksource",
  "log",
  "metriken",
  "mpmc",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -1532,6 +1646,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1845,7 +1970,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -1866,6 +1991,17 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -2054,6 +2190,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2285,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ humantime = "2.1.0"
 lazy_static = "1.4.0"
 libc = "0.2.147"
 linkme = "0.3.15"
-metriken = { version = "0.5.1" }
+metriken =  "0.5.1"
 memmap2 = "0.5.10"
 once_cell = "1.18.0"
 ouroboros = "0.17.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,12 @@ humantime = "2.1.0"
 lazy_static = "1.4.0"
 libc = "0.2.147"
 linkme = "0.3.15"
-metriken = "0.3.3"
+metriken = { version = "0.5.1" }
 memmap2 = "0.5.10"
 once_cell = "1.18.0"
 ouroboros = "0.17.2"
-ringlog = "0.3.2"
+ringlog = { version = "0.6.0" }
+rmp-serde = "1.1.2"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
 sysconf = "0.3.4"
@@ -32,6 +33,9 @@ tokio = { version = "1.32.0", features = ["full"] }
 toml = "0.7.6"
 walkdir = "2.3.3"
 warp = { version = "0.3.6", features = ["compression"] }
+serde_repr = "0.1.18"
+histogram = { version = "0.9.0", features = ["serde"] }
+chrono = { version = "0.4.33", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.21.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ metriken =  "0.5.1"
 memmap2 = "0.5.10"
 once_cell = "1.18.0"
 ouroboros = "0.17.2"
-ringlog = { version = "0.6.0" }
+ringlog = "0.6.0"
 rmp-serde = "1.1.2"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -348,6 +348,8 @@ mod handlers {
     }
 }
 
+/// This struct contains all the metric metadata organized by type. This allows
+/// the creation of a schema for metric storage based on this metadata alone.
 #[derive(Serialize, Deserialize)]
 pub struct Metadata {
     counters: Vec<MetricMetadata>,
@@ -365,21 +367,13 @@ impl Metadata {
     }
 }
 
+/// Contains per-metric metadata, such as the metric name.
 #[derive(Serialize, Deserialize)]
 pub struct MetricMetadata {
     name: String,
 }
 
-#[derive(Serialize, Deserialize)]
-pub enum MetricKind {
-    Counter,
-    Gauge,
-    Histogram {
-        grouping_power: u8,
-        max_value_power: u8,
-    },
-}
-
+/// Contains a snapshot of metric readings.
 #[derive(Serialize, Deserialize)]
 pub struct Readings {
     datetime: DateTime<Utc>,

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -1,9 +1,14 @@
 use crate::Arc;
 use crate::Config;
 use crate::PERCENTILES;
+use chrono::{DateTime, Utc};
 use metriken::histogram::Snapshot;
 use metriken::{AtomicHistogram, Counter, Gauge, RwLockHistogram};
-
+use rmp_serde::Serializer;
+use serde::Deserialize;
+use serde::Serialize;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 use warp::Filter;
 
 /// HTTP exposition
@@ -35,6 +40,8 @@ mod filters {
         prometheus_stats(config.clone())
             .or(human_stats())
             .or(hardware_info())
+            .or(binary_metadata())
+            .or(binary_readings())
     }
 
     /// GET /metrics
@@ -62,6 +69,22 @@ mod filters {
             .and(warp::get())
             .and_then(handlers::hwinfo)
     }
+
+    /// GET /metrics/binary/metadata
+    pub fn binary_metadata(
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        warp::path!("metrics" / "binary" / "metadata")
+            .and(warp::get())
+            .and_then(handlers::binary_metadata)
+    }
+
+    /// GET /metrics/binary/readings
+    pub fn binary_readings(
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        warp::path!("metrics" / "binary" / "readings")
+            .and(warp::get())
+            .and_then(handlers::binary_readings)
+    }
 }
 
 mod handlers {
@@ -69,7 +92,6 @@ mod handlers {
     use crate::common::HISTOGRAM_GROUPING_POWER;
     use crate::SNAPSHOTS;
     use core::convert::Infallible;
-    use std::time::UNIX_EPOCH;
 
     pub async fn prometheus_stats(config: Arc<Config>) -> Result<impl warp::Reply, Infallible> {
         let mut data = Vec::new();
@@ -248,11 +270,140 @@ mod handlers {
         Ok(content)
     }
 
+    pub async fn binary_metadata() -> Result<impl warp::Reply, Infallible> {
+        let mut metadata = Metadata::new();
+
+        for metric in &metriken::metrics() {
+            let any = match metric.as_any() {
+                Some(any) => any,
+                None => {
+                    continue;
+                }
+            };
+
+            if metric.name().starts_with("log_") {
+                continue;
+            }
+
+            if let Some(_counter) = any.downcast_ref::<Counter>() {
+                metadata.counters.push(MetricMetadata {
+                    name: metric.formatted(metriken::Format::Simple),
+                });
+            } else if let Some(_gauge) = any.downcast_ref::<Gauge>() {
+                metadata.gauges.push(MetricMetadata {
+                    name: metric.formatted(metriken::Format::Simple),
+                });
+            } else if let Some(histogram) = any.downcast_ref::<RwLockHistogram>() {
+                metadata.histograms.push((
+                    MetricMetadata {
+                        name: metric.formatted(metriken::Format::Simple),
+                    },
+                    histogram.config(),
+                ));
+            }
+        }
+
+        let mut buf = Vec::new();
+        metadata.serialize(&mut Serializer::new(&mut buf)).unwrap();
+
+        Ok(buf)
+    }
+
+    pub async fn binary_readings() -> Result<impl warp::Reply, Infallible> {
+        let mut readings = Readings::new();
+
+        for metric in &metriken::metrics() {
+            let any = match metric.as_any() {
+                Some(any) => any,
+                None => {
+                    continue;
+                }
+            };
+
+            if metric.name().starts_with("log_") {
+                continue;
+            }
+
+            if let Some(counter) = any.downcast_ref::<Counter>() {
+                readings.counters.push(counter.value());
+            } else if let Some(gauge) = any.downcast_ref::<Gauge>() {
+                readings.gauges.push(gauge.value());
+            } else if let Some(histogram) = any.downcast_ref::<RwLockHistogram>() {
+                readings.histograms.push(histogram.snapshot());
+            }
+        }
+
+        let mut buf = Vec::new();
+        readings.serialize(&mut Serializer::new(&mut buf)).unwrap();
+
+        Ok(buf)
+    }
+
     pub async fn hwinfo() -> Result<impl warp::Reply, Infallible> {
         if let Ok(hwinfo) = crate::samplers::hwinfo::hardware_info() {
             Ok(warp::reply::json(hwinfo))
         } else {
             Ok(warp::reply::json(&false))
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Metadata {
+    counters: Vec<MetricMetadata>,
+    gauges: Vec<MetricMetadata>,
+    histograms: Vec<(MetricMetadata, histogram::Config)>,
+}
+
+impl Metadata {
+    pub fn new() -> Self {
+        Self {
+            counters: Vec::new(),
+            gauges: Vec::new(),
+            histograms: Vec::new(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MetricMetadata {
+    name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram {
+        grouping_power: u8,
+        max_value_power: u8,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Readings {
+    datetime: DateTime<Utc>,
+    unix_ns: u128,
+    counters: Vec<u64>,
+    gauges: Vec<i64>,
+    histograms: Vec<Option<Snapshot>>,
+}
+
+impl Readings {
+    pub fn new() -> Self {
+        let datetime: DateTime<Utc> = Utc::now();
+
+        let unix_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        Self {
+            datetime,
+            unix_ns,
+            counters: Vec::new(),
+            gauges: Vec::new(),
+            histograms: Vec::new(),
         }
     }
 }

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -273,7 +273,13 @@ mod handlers {
     pub async fn binary_metadata() -> Result<impl warp::Reply, Infallible> {
         let mut metadata = Metadata::new();
 
-        for metric in &metriken::metrics() {
+        // TODO(bmartin): this filtering needs to be consistent between the two
+        // binary output functions. This should be factored out to guarantee
+        // consistency.
+
+        // iterate through the static metrics and build-up the metadata object
+        // NOTE: dynamic metrics are omitted from the binary outputs
+        for metric in metriken::metrics().static_metrics() {
             let any = match metric.as_any() {
                 Some(any) => any,
                 None => {
@@ -312,7 +318,13 @@ mod handlers {
     pub async fn binary_readings() -> Result<impl warp::Reply, Infallible> {
         let mut readings = Readings::new();
 
-        for metric in &metriken::metrics() {
+        // TODO(bmartin): this filtering needs to be consistent between the two
+        // binary output functions. This should be factored out to guarantee
+        // consistency.
+
+        // iterate through the static metrics and build-up the readings object
+        // NOTE: dynamic metrics are omitted from the binary outputs
+        for metric in metriken::metrics().static_metrics() {
             let any = match metric.as_any() {
                 Some(any) => any,
                 None => {

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -278,7 +278,9 @@ mod handlers {
         // consistency.
 
         // iterate through the static metrics and build-up the metadata object
-        // NOTE: dynamic metrics are omitted from the binary outputs
+        // NOTE: dynamic metrics are omitted from the binary outputs, this is to
+        // ensure that the iteration order is consistent through the lifetime of
+        // the process.
         for metric in metriken::metrics().static_metrics() {
             let any = match metric.as_any() {
                 Some(any) => any,
@@ -323,7 +325,9 @@ mod handlers {
         // consistency.
 
         // iterate through the static metrics and build-up the readings object
-        // NOTE: dynamic metrics are omitted from the binary outputs
+        // NOTE: dynamic metrics are omitted from the binary outputs, this is to
+        // ensure that the iteration order is consistent through the lifetime of
+        // the process.
         for metric in metriken::metrics().static_metrics() {
             let any = match metric.as_any() {
                 Some(any) => any,

--- a/src/samplers/block_io/mod.rs
+++ b/src/samplers/block_io/mod.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 sampler!(BlockIO, "block_io", BLOCK_IO_SAMPLERS);
 
+#[cfg(target_os = "linux")]
 mod stats;
 
 #[cfg(target_os = "linux")]

--- a/src/samplers/cpu/mod.rs
+++ b/src/samplers/cpu/mod.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 sampler!(Cpu, "cpu", CPU_SAMPLERS);
 
+#[cfg(target_os = "linux")]
 mod stats;
 
 #[cfg(target_os = "linux")]

--- a/src/samplers/gpu/mod.rs
+++ b/src/samplers/gpu/mod.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 sampler!(Gpu, "gpu", GPU_SAMPLERS);
 
+#[cfg(target_os = "linux")]
 mod stats;
 
 #[cfg(target_os = "linux")]

--- a/src/samplers/memory/linux/proc_meminfo/mod.rs
+++ b/src/samplers/memory/linux/proc_meminfo/mod.rs
@@ -22,7 +22,7 @@ pub struct ProcMeminfo {
     next: Instant,
     interval: Duration,
     file: File,
-    gauges: HashMap<&'static str, &'static Lazy<Gauge>>,
+    gauges: HashMap<&'static str, &'static Gauge>,
 }
 
 impl ProcMeminfo {
@@ -35,7 +35,7 @@ impl ProcMeminfo {
 
         let now = Instant::now();
 
-        let gauges: HashMap<&str, &Lazy<Gauge>> = HashMap::from([
+        let gauges: HashMap<&str, &Gauge> = HashMap::from([
             ("MemTotal:", &*MEMORY_TOTAL),
             ("MemFree:", &*MEMORY_FREE),
             ("MemAvailable:", &*MEMORY_AVAILABLE),

--- a/src/samplers/memory/mod.rs
+++ b/src/samplers/memory/mod.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 sampler!(Memory, "memory", MEMORY_SAMPLERS);
 
+#[cfg(target_os = "linux")]
 mod stats;
 
 #[cfg(target_os = "linux")]

--- a/src/samplers/scheduler/mod.rs
+++ b/src/samplers/scheduler/mod.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 sampler!(Scheduler, "scheduler", SCHEDULER_SAMPLERS);
 
+#[cfg(target_os = "linux")]
 mod stats;
 
 #[cfg(target_os = "linux")]

--- a/src/samplers/syscall/mod.rs
+++ b/src/samplers/syscall/mod.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 sampler!(Syscall, "syscall", SYSCALL_SAMPLERS);
 
+#[cfg(target_os = "linux")]
 mod stats;
 
 #[cfg(target_os = "linux")]

--- a/src/samplers/tcp/mod.rs
+++ b/src/samplers/tcp/mod.rs
@@ -2,6 +2,7 @@ use crate::*;
 
 sampler!(Tcp, "tcp", TCP_SAMPLERS);
 
+#[cfg(target_os = "linux")]
 mod stats;
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Adds two new HTTP endpoints `/metrics/binary/metadata` and `/metrics/binary/readings` that use msgpack to represent the metric metadata and all the current values (respectively).

Combined, this allows for more efficient scraping of the metrics, particularly when full histogram distributions are desired. These endpoints should be preferred when gathering telemetry at high resolution as they avoid duplicating metric metadata for each scrape.
