### PR TITLE
filter out the atomic histograms again

### DIFF
--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -259,7 +259,17 @@ mod handlers {
 
     pub async fn msgpack() -> Result<impl warp::Reply, Infallible> {
         let snapshot = SnapshotterBuilder::new()
-            .filter(|metric| !metric.name().starts_with("log_"))
+            .filter(|metric| {
+                if let Some(m) = metric.as_any() {
+                    if m.downcast_ref::<AtomicHistogram>().is_some() {
+                        false
+                    } else {
+                        !metric.name().starts_with("log_")
+                    }
+                } else {
+                    false
+                }
+            })
             .build()
             .snapshot();
 


### PR DESCRIPTION
Missed filtering of the atomic histograms in #154 

This PR adds the proper filtering so they are omitted from the msgpack endpoint.