### PR TITLE
tcp traffic: refactoring

### DIFF
--- a/src/samplers/tcp/linux/mod.rs
+++ b/src/samplers/tcp/linux/mod.rs
@@ -1,5 +1,5 @@
 mod connection_state;
-mod snmp;
+mod traffic;
 
 #[cfg(feature = "bpf")]
 mod packet_latency;
@@ -10,5 +10,3 @@ mod receive;
 #[cfg(feature = "bpf")]
 mod retransmit;
 
-#[cfg(feature = "bpf")]
-mod traffic;

--- a/src/samplers/tcp/linux/mod.rs
+++ b/src/samplers/tcp/linux/mod.rs
@@ -9,4 +9,3 @@ mod receive;
 
 #[cfg(feature = "bpf")]
 mod retransmit;
-

--- a/src/samplers/tcp/linux/traffic/bpf.rs
+++ b/src/samplers/tcp/linux/traffic/bpf.rs
@@ -1,0 +1,137 @@
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/tcp_traffic.bpf.rs"));
+}
+
+use super::NAME;
+
+use bpf::*;
+
+use crate::common::bpf::*;
+use crate::common::*;
+use crate::samplers::tcp::stats::*;
+use crate::samplers::tcp::*;
+
+impl GetMap for ModSkel<'_> {
+    fn map(&self, name: &str) -> &libbpf_rs::Map {
+        self.obj.map(name).unwrap()
+    }
+}
+
+/// Collects TCP Traffic stats using BPF and traces:
+/// * `tcp_sendmsg`
+/// * `tcp_cleanup_rbuf`
+///
+/// And produces these stats:
+/// * `tcp/receive/bytes`
+/// * `tcp/receive/segments`
+/// * `tcp/receive/size`
+/// * `tcp/transmit/bytes`
+/// * `tcp/transmit/segments`
+/// * `tcp/transmit/size`
+pub struct TcpTraffic {
+    bpf: Bpf<ModSkel<'static>>,
+    counter_interval: Duration,
+    counter_next: Instant,
+    counter_prev: Instant,
+    distribution_interval: Duration,
+    distribution_next: Instant,
+    distribution_prev: Instant,
+}
+
+impl TcpTraffic {
+    pub fn new(config: &Config) -> Result<Self, ()> {
+        // check if sampler should be enabled
+        if !config.enabled(NAME) {
+            return Err(());
+        }
+
+        let builder = ModSkelBuilder::default();
+        let mut skel = builder
+            .open()
+            .map_err(|e| error!("failed to open bpf builder: {e}"))?
+            .load()
+            .map_err(|e| error!("failed to load bpf program: {e}"))?;
+
+        skel.attach()
+            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
+
+        let mut bpf = Bpf::from_skel(skel);
+
+        let counters = vec![
+            Counter::new(&TCP_RX_BYTES, Some(&TCP_RX_BYTES_HISTOGRAM)),
+            Counter::new(&TCP_TX_BYTES, Some(&TCP_TX_BYTES_HISTOGRAM)),
+            Counter::new(&TCP_RX_SEGMENTS, Some(&TCP_RX_SEGMENTS_HISTOGRAM)),
+            Counter::new(&TCP_TX_SEGMENTS, Some(&TCP_TX_SEGMENTS_HISTOGRAM)),
+        ];
+
+        bpf.add_counters("counters", counters);
+
+        let mut distributions = vec![("rx_size", &TCP_RX_SIZE), ("tx_size", &TCP_TX_SIZE)];
+
+        for (name, histogram) in distributions.drain(..) {
+            bpf.add_distribution(name, histogram);
+        }
+
+        Ok(Self {
+            bpf,
+            counter_interval: config.interval(NAME),
+            counter_next: Instant::now(),
+            counter_prev: Instant::now(),
+            distribution_interval: config.distribution_interval(NAME),
+            distribution_next: Instant::now(),
+            distribution_prev: Instant::now(),
+        })
+    }
+
+    pub fn refresh_counters(&mut self, now: Instant) {
+        if now < self.counter_next {
+            return;
+        }
+
+        let elapsed = (now - self.counter_prev).as_secs_f64();
+
+        self.bpf.refresh_counters(elapsed);
+
+        // determine when to sample next
+        let next = self.counter_next + self.counter_interval;
+
+        // check that next sample time is in the future
+        if next > now {
+            self.counter_next = next;
+        } else {
+            self.counter_next = now + self.counter_interval;
+        }
+
+        // mark when we last sampled
+        self.counter_prev = now;
+    }
+
+    pub fn refresh_distributions(&mut self, now: Instant) {
+        if now < self.distribution_next {
+            return;
+        }
+
+        self.bpf.refresh_distributions();
+
+        // determine when to sample next
+        let next = self.distribution_next + self.distribution_interval;
+
+        // check that next sample time is in the future
+        if next > now {
+            self.distribution_next = next;
+        } else {
+            self.distribution_next = now + self.distribution_interval;
+        }
+
+        // mark when we last sampled
+        self.distribution_prev = now;
+    }
+}
+
+impl Sampler for TcpTraffic {
+    fn sample(&mut self) {
+        let now = Instant::now();
+        self.refresh_counters(now);
+        self.refresh_distributions(now);
+    }
+}

--- a/src/samplers/tcp/linux/traffic/mod.rs
+++ b/src/samplers/tcp/linux/traffic/mod.rs
@@ -1,146 +1,40 @@
+use crate::common::Nop;
+use crate::samplers::tcp::*;
+
+const NAME: &str = "tcp_traffic";
+
+#[cfg(feature = "bpf")]
+mod bpf;
+
+mod proc;
+
+#[cfg(feature = "bpf")]
+use bpf::*;
+
+use proc::*;
+
+#[cfg(feature = "bpf")]
 #[distributed_slice(TCP_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    if let Ok(s) = Traffic::new(config) {
+    // try to initialize the bpf based sampler
+    if let Ok(s) = TcpTraffic::new(config) {
+        Box::new(s)
+    // try to fallback to the /proc/net/snmp based sampler if there was an error
+    } else if let Ok(s) = ProcNetSnmp::new(config) {
         Box::new(s)
     } else {
         Box::new(Nop {})
     }
 }
 
-mod bpf {
-    include!(concat!(env!("OUT_DIR"), "/tcp_traffic.bpf.rs"));
-}
-
-const NAME: &str = "tcp_traffic";
-
-use bpf::*;
-
-use crate::common::bpf::*;
-use crate::common::*;
-use crate::samplers::tcp::stats::*;
-use crate::samplers::tcp::*;
-
-impl GetMap for ModSkel<'_> {
-    fn map(&self, name: &str) -> &libbpf_rs::Map {
-        self.obj.map(name).unwrap()
-    }
-}
-
-/// Collects TCP Traffic stats using BPF and traces:
-/// * `tcp_sendmsg`
-/// * `tcp_cleanup_rbuf`
-///
-/// And produces these stats:
-/// * `tcp/receive/bytes`
-/// * `tcp/receive/segments`
-/// * `tcp/receive/size`
-/// * `tcp/transmit/bytes`
-/// * `tcp/transmit/segments`
-/// * `tcp/transmit/size`
-pub struct Traffic {
-    bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Duration,
-    counter_next: Instant,
-    counter_prev: Instant,
-    distribution_interval: Duration,
-    distribution_next: Instant,
-    distribution_prev: Instant,
-}
-
-impl Traffic {
-    pub fn new(config: &Config) -> Result<Self, ()> {
-        // check if sampler should be enabled
-        if !config.enabled(NAME) {
-            return Err(());
-        }
-
-        let builder = ModSkelBuilder::default();
-        let mut skel = builder
-            .open()
-            .map_err(|e| error!("failed to open bpf builder: {e}"))?
-            .load()
-            .map_err(|e| error!("failed to load bpf program: {e}"))?;
-
-        skel.attach()
-            .map_err(|e| error!("failed to attach bpf program: {e}"))?;
-
-        let mut bpf = Bpf::from_skel(skel);
-
-        let counters = vec![
-            Counter::new(&TCP_RX_BYTES, Some(&TCP_RX_BYTES_HISTOGRAM)),
-            Counter::new(&TCP_TX_BYTES, Some(&TCP_TX_BYTES_HISTOGRAM)),
-            Counter::new(&TCP_RX_SEGMENTS, Some(&TCP_RX_SEGMENTS_HISTOGRAM)),
-            Counter::new(&TCP_TX_SEGMENTS, Some(&TCP_TX_SEGMENTS_HISTOGRAM)),
-        ];
-
-        bpf.add_counters("counters", counters);
-
-        let mut distributions = vec![("rx_size", &TCP_RX_SIZE), ("tx_size", &TCP_TX_SIZE)];
-
-        for (name, histogram) in distributions.drain(..) {
-            bpf.add_distribution(name, histogram);
-        }
-
-        Ok(Self {
-            bpf,
-            counter_interval: config.interval(NAME),
-            counter_next: Instant::now(),
-            counter_prev: Instant::now(),
-            distribution_interval: config.distribution_interval(NAME),
-            distribution_next: Instant::now(),
-            distribution_prev: Instant::now(),
-        })
-    }
-
-    pub fn refresh_counters(&mut self, now: Instant) {
-        if now < self.counter_next {
-            return;
-        }
-
-        let elapsed = (now - self.counter_prev).as_secs_f64();
-
-        self.bpf.refresh_counters(elapsed);
-
-        // determine when to sample next
-        let next = self.counter_next + self.counter_interval;
-
-        // check that next sample time is in the future
-        if next > now {
-            self.counter_next = next;
-        } else {
-            self.counter_next = now + self.counter_interval;
-        }
-
-        // mark when we last sampled
-        self.counter_prev = now;
-    }
-
-    pub fn refresh_distributions(&mut self, now: Instant) {
-        if now < self.distribution_next {
-            return;
-        }
-
-        self.bpf.refresh_distributions();
-
-        // determine when to sample next
-        let next = self.distribution_next + self.distribution_interval;
-
-        // check that next sample time is in the future
-        if next > now {
-            self.distribution_next = next;
-        } else {
-            self.distribution_next = now + self.distribution_interval;
-        }
-
-        // mark when we last sampled
-        self.distribution_prev = now;
-    }
-}
-
-impl Sampler for Traffic {
-    fn sample(&mut self) {
-        let now = Instant::now();
-        self.refresh_counters(now);
-        self.refresh_distributions(now);
+#[cfg(not(feature = "bpf"))]
+#[distributed_slice(CPU_SAMPLERS)]
+fn init(config: &Config) -> Box<dyn Sampler> {
+    // try to use the /proc/net/snmp based sampler since BPF was not enabled for
+    // this build
+    if let Ok(s) = ProcNetSnmp::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
     }
 }

--- a/src/samplers/tcp/linux/traffic/mod.rs
+++ b/src/samplers/tcp/linux/traffic/mod.rs
@@ -28,7 +28,7 @@ fn init(config: &Config) -> Box<dyn Sampler> {
 }
 
 #[cfg(not(feature = "bpf"))]
-#[distributed_slice(CPU_SAMPLERS)]
+#[distributed_slice(TCP_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
     // try to use the /proc/net/snmp based sampler since BPF was not enabled for
     // this build

--- a/src/samplers/tcp/linux/traffic/proc.rs
+++ b/src/samplers/tcp/linux/traffic/proc.rs
@@ -1,22 +1,12 @@
 use crate::common::classic::NestedMap;
 use crate::common::Counter;
-use crate::common::Nop;
 use crate::samplers::tcp::stats::*;
 use crate::samplers::tcp::*;
 use std::fs::File;
 
-#[distributed_slice(TCP_SAMPLERS)]
-fn init(config: &Config) -> Box<dyn Sampler> {
-    if let Ok(s) = Snmp::new(config) {
-        Box::new(s)
-    } else {
-        Box::new(Nop::new(config))
-    }
-}
+use super::NAME;
 
-const NAME: &str = "tcp_snmp";
-
-pub struct Snmp {
+pub struct ProcNetSnmp {
     prev: Instant,
     next: Instant,
     interval: Duration,
@@ -24,7 +14,7 @@ pub struct Snmp {
     counters: Vec<(Counter, &'static str, &'static str)>,
 }
 
-impl Snmp {
+impl ProcNetSnmp {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
         if !config.enabled(NAME) {
@@ -56,7 +46,7 @@ impl Snmp {
     }
 }
 
-impl Sampler for Snmp {
+impl Sampler for ProcNetSnmp {
     fn sample(&mut self) {
         let now = Instant::now();
 


### PR DESCRIPTION
Refactoring of the TCP traffic sampler to combine the the /proc/net/snmp and
BPF based traffic samplers into a single sampler.
