### PR TITLE
add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# ignore these vendored files in language statistics
+src/common/bpf/aarch64/vmlinux.h linguist-vendored
+src/common/bpf/x86_64/vmlinux.h linguist-vendored


### PR DESCRIPTION
Add a gitattributes file that marks the vendored vmlinux.h files so that they are excluded from the language statistics displayed on GitHub.
