### PR TITLE
fix cpu usage idle time accounting

### DIFF
--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -14,7 +14,7 @@
 // 0 - user
 // 1 - nice
 // 2 - system
-// 3 - idle
+// 3 - idle - *NOTE* this will not increment. User-space must calculate it
 // 4 - iowait
 // 5 - irq
 // 6 - softirq
@@ -47,6 +47,10 @@ int account_delta(u64 delta, u32 usage_idx)
 SEC("kprobe/__cgroup_account_cputime_field")
 int BPF_KPROBE(cgroup_account_cputime_field_kprobe, void *task, u32 index, u64 delta)
 {
+	if (index == 3) {
+		return 0;
+	}
+
 	return account_delta(delta, index);
 }
 


### PR DESCRIPTION
Adds a probe for cpu idle time so it is accounted for when the BPF sampler is used for cpu usage.

Fixes #174 