### PR TITLE
fix percpu idle accounting

### DIFF
--- a/src/common/bpf/counters.rs
+++ b/src/common/bpf/counters.rs
@@ -58,7 +58,9 @@ impl PercpuCounters {
 
     /// Returns the sum of all the counters for this CPU
     pub fn sum(&self, cpu: usize) -> Option<u64> {
-        self.inner.get(cpu).map(|v| v.iter().map(|v| v.value()).sum())
+        self.inner
+            .get(cpu)
+            .map(|v| v.iter().map(|v| v.value()).sum())
     }
 }
 

--- a/src/common/bpf/mod.rs
+++ b/src/common/bpf/mod.rs
@@ -73,7 +73,7 @@ impl<T: 'static + GetMap> Bpf<T> {
         &mut self,
         name: &str,
         counters: Vec<Counter>,
-        percpu_counters: PercpuCounters,
+        percpu_counters: Arc<PercpuCounters>,
     ) {
         self.with_mut(|this| {
             this.counters.push(Counters::new(

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,6 +5,8 @@ pub mod classic;
 
 mod nop;
 
+use std::sync::Arc;
+
 use metriken::AtomicHistogram;
 use metriken::LazyCounter;
 pub use nop::Nop;


### PR DESCRIPTION
#176 did not fix the per-cpu idle time metrics.

This PR addresses the per-cpu idle time accounting.
