### PR TITLE
fix panic when no perf groups can be read during sampling

### DIFF
--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -167,15 +167,18 @@ impl Sampler for Perf {
             }
         }
 
-        // we increase the total cycles executed in the last sampling period instead of using the cycle perf event value to handle offlined CPUs.
-        CPU_CYCLES.add(total_cycles);
-        CPU_INSTRUCTIONS.add(total_instructions);
-        CPU_PERF_GROUPS_ACTIVE.set(nr_active_groups as i64);
-        CPU_IPKC_AVERAGE.set((avg_ipkc / nr_active_groups) as i64);
-        CPU_IPUS_AVERAGE.set((avg_ipus / nr_active_groups) as i64);
-        CPU_BASE_FREQUENCY_AVERAGE.set((avg_base_frequency / nr_active_groups) as i64);
-        CPU_FREQUENCY_AVERAGE.set((avg_running_frequency / nr_active_groups) as i64);
-        CPU_CORES.set(nr_active_groups as _);
+        if nr_active_groups > 0 {
+            // we increase the total cycles executed in the last sampling period
+            // instead of using the cycle perf event value to handle offlined CPUs.
+            CPU_CYCLES.add(total_cycles);
+            CPU_INSTRUCTIONS.add(total_instructions);
+            CPU_PERF_GROUPS_ACTIVE.set(nr_active_groups as i64);
+            CPU_IPKC_AVERAGE.set((avg_ipkc / nr_active_groups) as i64);
+            CPU_IPUS_AVERAGE.set((avg_ipus / nr_active_groups) as i64);
+            CPU_BASE_FREQUENCY_AVERAGE.set((avg_base_frequency / nr_active_groups) as i64);
+            CPU_FREQUENCY_AVERAGE.set((avg_running_frequency / nr_active_groups) as i64);
+            CPU_CORES.set(nr_active_groups as _);
+        }
 
         // determine when to sample next
         let next = self.next + self.interval;


### PR DESCRIPTION
Fixes a panic when no perf groups can be read during sampling. This condition results in a divide-by-zero error.

We skip the calculations and metrics updates when the number of active perf groups is zero during any sampling period.
