### PR TITLE
add write permissions for packaging workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,9 @@ name: package
         description: 'Debian package release number'
         default: '1'
 
+permissions:
+  packages: write
+
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Adds write permissions for the packaging workflow so it can upload packages.
