### PR TITLE
fix: online cores function in usage sampler

### DIFF
--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -273,11 +273,6 @@ fn online_cores(file: &mut std::fs::File) -> Result<usize, ()> {
     for range in raw.split(',') {
         let mut parts = range.split('-');
 
-        if parts.next().is_some() {
-            // The line is invalid, report error
-            return Err(error!("invalid content in file"));
-        }
-
         let first: Option<usize> = parts
             .next()
             .map(|text| text.parse())
@@ -288,6 +283,11 @@ fn online_cores(file: &mut std::fs::File) -> Result<usize, ()> {
             .map(|text| text.parse())
             .transpose()
             .map_err(|e| error!("couldn't parse: {e}"))?;
+
+        if parts.next().is_some() {
+            // The line is invalid, report error
+            return Err(error!("invalid content in file"));
+        }
 
         match (first, second) {
             (Some(_value), None) => {


### PR DESCRIPTION
The online cores function doesn't properly handle a cpu list containing just a single CPU.

The cause is the validation line belongs after taking the first two elements of the range. This was mistakenly moved forward in an attempt to stop the parsing if the line was invalid.
