### PR TITLE
bpf optimization scheduler sampler

### DIFF
--- a/src/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -17,7 +17,7 @@
 #define COUNTER_GROUP_WIDTH 8
 #define HISTOGRAM_BUCKETS 7424
 #define MAX_CPUS 1024
-#define MAX_TRACKED_PIDS 65536 
+#define MAX_PID 4194304
 
 #define IVCSW 0
 #define TASK_RUNNING 0
@@ -55,15 +55,15 @@ struct {
 } counters SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, MAX_TRACKED_PIDS);
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_PID);
 	__type(key, u32);
 	__type(value, u64);
 } enqueued_at SEC(".maps");
 
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, MAX_TRACKED_PIDS);
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, MAX_PID);
 	__type(key, u32);
 	__type(value, u64);
 } running_at SEC(".maps");
@@ -163,7 +163,7 @@ int handle__sched_switch(u64 *ctx)
 				__sync_fetch_and_add(cnt, 1);
 			}
 
-			bpf_map_delete_elem(&running_at, &pid);
+			*tsp = 0;
 		}
 	}
 	
@@ -185,7 +185,7 @@ int handle__sched_switch(u64 *ctx)
 			__sync_fetch_and_add(cnt, 1);
 		}
 
-		bpf_map_delete_elem(&enqueued_at, &pid);
+		*tsp = 0;
 	}
 
 	return 0;


### PR DESCRIPTION
Optimization for the scheduler sampler BPF. Replaces the hashmap for PIDs with an array to reduce lookup time at the expense of requiring additional memory. This raises the memory overhead for the BPF sampler by 64MB.

On my test system, running a compute-heavy workload. This reduces the overheads on scheduler switch and scheduler wakeup.
switch: 542ns -> 223ns
wakeup: 300ns -> 165ns