### PR TITLE
fix bpf checks for start time syscall and scheduler

### DIFF
--- a/src/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -155,7 +155,7 @@ int handle__sched_switch(u64 *ctx)
 
 		// calculate how long it was running, increment running histogram
 		tsp = bpf_map_lookup_elem(&running_at, &pid);
-		if (tsp) {
+		if (tsp && *tsp) {
 			delta_ns = ts - *tsp;
 			u32 idx = value_to_index(delta_ns);
 			cnt = bpf_map_lookup_elem(&running, &idx);
@@ -177,7 +177,7 @@ int handle__sched_switch(u64 *ctx)
 
 	// calculate how long it was enqueued, increment running histogram
 	tsp = bpf_map_lookup_elem(&enqueued_at, &pid);
-	if (tsp) {
+	if (tsp && *tsp) {
 		delta_ns = ts - *tsp;
 		u32 idx = value_to_index(delta_ns);
 		cnt = bpf_map_lookup_elem(&runqlat, &idx);

--- a/src/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/samplers/syscall/linux/latency/mod.bpf.c
@@ -177,7 +177,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 	start_ts = bpf_map_lookup_elem(&start, &tid);
 
 	// possible we missed the start
-	if (!start_ts) {
+	if (!start_ts || *start_ts == 0) {
 		return 0;
 	}
 


### PR DESCRIPTION
Introduced in #193 and #195 we don't check if the start timestamp is zero. This can result in missed start events causing incorrect latencies to be inserted into the histogram.

This change addresses the new bugs by checking if the start ts is zero.
