### PR TITLE
add units to metadata

### DIFF
--- a/src/samplers/block_io/stats.rs
+++ b/src/samplers/block_io/stats.rs
@@ -16,7 +16,7 @@ bpfhistogram!(
     name = "blockio/operations",
     description = "The number of completed read operations for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "read" }
+    metadata = { op = "read", unit = "operations" }
 )]
 pub static BLOCKIO_READ_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -26,7 +26,7 @@ histogram!(BLOCKIO_READ_OPS_HISTOGRAM, "blockio/read/operations");
     name = "blockio/operations",
     description = "The number of completed write operations for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "write" }
+    metadata = { op = "write", unit = "operations" }
 )]
 pub static BLOCKIO_WRITE_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -36,7 +36,7 @@ histogram!(BLOCKIO_WRITE_OPS_HISTOGRAM, "blockio/write/operations");
     name = "blockio/operations",
     description = "The number of completed discard operations for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "discard" }
+    metadata = { op = "discard", unit = "operations" }
 )]
 pub static BLOCKIO_DISCARD_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -46,7 +46,7 @@ histogram!(BLOCKIO_DISCARD_OPS_HISTOGRAM, "blockio/discard/operations");
     name = "blockio/operations",
     description = "The number of completed flush operations for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "flush" }
+    metadata = { op = "flush", unit = "operations" }
 )]
 pub static BLOCKIO_FLUSH_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -56,7 +56,7 @@ histogram!(BLOCKIO_FLUSH_OPS_HISTOGRAM, "blockio/flush/operations");
     name = "blockio/bytes",
     description = "The number of bytes read for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "read" }
+    metadata = { op = "read", unit = "bytes" }
 )]
 pub static BLOCKIO_READ_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -66,7 +66,7 @@ histogram!(BLOCKIO_READ_BYTES_HISTOGRAM, "blockio/read/bytes");
     name = "blockio/bytes",
     description = "The number of bytes written for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "write" }
+    metadata = { op = "write", unit = "bytes" }
 )]
 pub static BLOCKIO_WRITE_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -76,7 +76,7 @@ histogram!(BLOCKIO_WRITE_BYTES_HISTOGRAM, "blockio/write/bytes");
     name = "blockio/bytes",
     description = "The number of bytes discarded for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "discard" }
+    metadata = { op = "discard", unit = "bytes" }
 )]
 pub static BLOCKIO_DISCARD_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -86,7 +86,7 @@ histogram!(BLOCKIO_DISCARD_BYTES_HISTOGRAM, "blockio/discard/bytes");
     name = "blockio/bytes",
     description = "The number of bytes flushed for block devices",
     formatter = blockio_metric_formatter,
-    metadata = { op = "flush" }
+    metadata = { op = "flush", unit = "bytes" }
 )]
 pub static BLOCKIO_FLUSH_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -12,7 +12,7 @@ pub static CPU_CORES: LazyGauge = LazyGauge::new(Gauge::default);
     name = "cpu/usage",
     description = "The amount of CPU time spent waiting for IO to complete",
     formatter = cpu_metric_formatter,
-    metadata = { state = "io_wait" }
+    metadata = { state = "io_wait", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_IO_WAIT: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -22,7 +22,7 @@ histogram!(CPU_USAGE_IO_WAIT_HISTOGRAM, "cpu/usage/io_wait");
     name = "cpu/usage",
     description = "The amount of CPU time spent servicing interrupts",
     formatter = cpu_metric_formatter,
-    metadata = { state = "irq" }
+    metadata = { state = "irq", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_IRQ: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -32,7 +32,7 @@ histogram!(CPU_USAGE_IRQ_HISTOGRAM, "cpu/usage/irq");
     name = "cpu/usage",
     description = "The amount of CPU time spent servicing softirqs",
     formatter = cpu_metric_formatter,
-    metadata = { state = "softirq" }
+    metadata = { state = "softirq", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_SOFTIRQ: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -42,7 +42,7 @@ histogram!(CPU_USAGE_SOFTIRQ_HISTOGRAM, "cpu/usage/softirq");
     name = "cpu/usage",
     description = "The amount of CPU time stolen by the hypervisor",
     formatter = cpu_metric_formatter,
-    metadata = { state = "steal" }
+    metadata = { state = "steal", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_STEAL: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -52,7 +52,7 @@ histogram!(CPU_USAGE_STEAL_HISTOGRAM, "cpu/usage/steal");
     name = "cpu/usage",
     description = "The amount of CPU time spent running a virtual CPU for a guest",
     formatter = cpu_metric_formatter,
-    metadata = { state = "guest" }
+    metadata = { state = "guest", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_GUEST: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -62,7 +62,7 @@ histogram!(CPU_USAGE_GUEST_HISTOGRAM, "cpu/usage/guest");
     name = "cpu/usage",
     description = "The amount of CPU time spent running a virtual CPU for a guest in low priority mode",
     formatter = cpu_metric_formatter,
-    metadata = { state = "guest_nice" }
+    metadata = { state = "guest_nice", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_GUEST_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -71,14 +71,16 @@ histogram!(CPU_USAGE_GUEST_NICE_HISTOGRAM, "cpu/usage/guest_nice");
 #[metric(
     name = "cpu/cycles",
     description = "The number of elapsed CPU cycles",
-    formatter = cpu_metric_formatter
+    formatter = cpu_metric_formatter,
+    metadata = { unit = "cycles" }
 )]
 pub static CPU_CYCLES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu/instructions",
     description = "The number of instructions retired",
-    formatter = cpu_metric_formatter
+    formatter = cpu_metric_formatter,
+    metadata = { unit = "instructions" }
 )]
 pub static CPU_INSTRUCTIONS: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -90,7 +92,8 @@ pub static CPU_PERF_GROUPS_ACTIVE: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "cpu/ipkc/average",
-    description = "Average IPKC (instructions per thousand cycles): SUM(IPKC_CPU0...N)/N)"
+    description = "Average IPKC (instructions per thousand cycles): SUM(IPKC_CPU0...N)/N)",
+    metadata = { unit = "instructions/kilocycle" }
 )]
 pub static CPU_IPKC_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
@@ -102,7 +105,8 @@ histogram!(
 
 #[metric(
     name = "cpu/ipus/average",
-    description = "Average IPUS (instructions per microsecond): SUM(IPUS_CPU0...N)/N)"
+    description = "Average IPUS (instructions per microsecond): SUM(IPUS_CPU0...N)/N)",
+    metadata = { unit = "instructions/microsecond" }
 )]
 pub static CPU_IPUS_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
@@ -114,13 +118,15 @@ histogram!(
 
 #[metric(
     name = "cpu/base_frequency/average",
-    description = "Average base CPU frequency (MHz)"
+    description = "Average base CPU frequency (MHz)",
+    metadata = { unit = "megahertz" }
 )]
 pub static CPU_BASE_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "cpu/frequency/average",
-    description = "Average running CPU frequency (MHz): SUM(RUNNING_FREQUENCY_CPU0...N)/N"
+    description = "Average running CPU frequency (MHz): SUM(RUNNING_FREQUENCY_CPU0...N)/N",
+    metadata = { unit = "megahertz" }
 )]
 pub static CPU_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -5,7 +5,7 @@ use metriken::{metric, Counter, Format, LazyCounter, MetricEntry};
     name = "cpu/usage",
     description = "The amount of CPU time spent executing normal tasks is user mode",
     formatter = cpu_metric_formatter,
-    metadata = { state = "user" }
+    metadata = { state = "user", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_USER: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -15,7 +15,7 @@ histogram!(CPU_USAGE_USER_HISTOGRAM, "cpu/usage/user");
     name = "cpu/usage",
     description = "The amount of CPU time spent executing low priority tasks in user mode",
     formatter = cpu_metric_formatter,
-    metadata = { state = "nice" }
+    metadata = { state = "nice", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -25,7 +25,7 @@ histogram!(CPU_USAGE_NICE_HISTOGRAM, "cpu/usage/nice");
     name = "cpu/usage",
     description = "The amount of CPU time spent executing tasks in kernel mode",
     formatter = cpu_metric_formatter,
-    metadata = { state = "system" }
+    metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_SYSTEM: LazyCounter = LazyCounter::new(Counter::default);
 
@@ -35,7 +35,7 @@ histogram!(CPU_USAGE_SYSTEM_HISTOGRAM, "cpu/usage/system");
     name = "cpu/usage",
     description = "The amount of CPU time spent idle",
     formatter = cpu_metric_formatter,
-    metadata = { state = "idle" }
+    metadata = { state = "idle", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_IDLE: LazyCounter = LazyCounter::new(Counter::default);
 

--- a/src/samplers/gpu/stats.rs
+++ b/src/samplers/gpu/stats.rs
@@ -4,7 +4,7 @@ use metriken::{metric, Format, Gauge, LazyGauge, MetricEntry};
     name = "gpu/memory",
     description = "The total amount of GPU memory free.",
     formatter = gpu_metric_formatter,
-    metadata = { state = "free" }
+    metadata = { state = "free", unit = "bytes" }
 )]
 pub static GPU_MEMORY_FREE: LazyGauge = LazyGauge::new(Gauge::default);
 
@@ -12,7 +12,7 @@ pub static GPU_MEMORY_FREE: LazyGauge = LazyGauge::new(Gauge::default);
     name = "gpu/memory",
     description = "The total amount of GPU memory used.",
     formatter = gpu_metric_formatter,
-    metadata = { state = "used" }
+    metadata = { state = "used", unit = "bytes" }
 )]
 pub static GPU_MEMORY_USED: LazyGauge = LazyGauge::new(Gauge::default);
 
@@ -20,7 +20,7 @@ pub static GPU_MEMORY_USED: LazyGauge = LazyGauge::new(Gauge::default);
     name = "gpu/pcie/bandwidth",
     description = "The total PCIe bandwidth in Bytes/s.",
     formatter = gpu_metric_formatter,
-    metadata = { direction = "receive" }
+    metadata = { direction = "receive", unit = "bytes/second" }
 )]
 pub static GPU_PCIE_BANDWIDTH: LazyGauge = LazyGauge::new(Gauge::default);
 
@@ -28,7 +28,7 @@ pub static GPU_PCIE_BANDWIDTH: LazyGauge = LazyGauge::new(Gauge::default);
     name = "gpu/pcie/throughput",
     description = "The current PCIe throughput in Bytes/s.",
     formatter = gpu_metric_formatter,
-    metadata = { direction = "receive" }
+    metadata = { direction = "receive", unit = "bytes/second" }
 )]
 pub static GPU_PCIE_THROUGHPUT_RX: LazyGauge = LazyGauge::new(Gauge::default);
 
@@ -36,28 +36,31 @@ pub static GPU_PCIE_THROUGHPUT_RX: LazyGauge = LazyGauge::new(Gauge::default);
     name = "gpu/pcie/throughput",
     description = "The current PCIe throughput in Bytes/s.",
     formatter = gpu_metric_formatter,
-    metadata = { direction = "transmit" }
+    metadata = { direction = "transmit", unit = "bytes/second" }
 )]
 pub static GPU_PCIE_THROUGHPUT_TX: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "gpu/power/usage",
     description = "The current power usage in milliwatts (mW).",
-    formatter = gpu_metric_formatter
+    formatter = gpu_metric_formatter,
+    metadata = { unit = "milliwatts" }
 )]
 pub static GPU_POWER_USAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "gpu/utilization/gpu",
     description = "The running average percentage of time the GPU was executing one or more kernels. (0-100).",
-    formatter = gpu_metric_formatter
+    formatter = gpu_metric_formatter,
+    metadata = { unit = "percentage" }
 )]
 pub static GPU_UTILIZATION: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "gpu/memory_utilization",
     description = "The running average percentage of time that GPU memory was being read from or written to. (0-100).",
-    formatter = gpu_metric_formatter
+    formatter = gpu_metric_formatter,
+    metadata = { unit = "percentage" }
 )]
 pub static GPU_MEMORY_UTILIZATION: LazyGauge = LazyGauge::new(Gauge::default);
 


### PR DESCRIPTION
Add units to metadata for all metrics that use the attribute macros.

Metrics that use the declarative macros are not covered in this PR.
