### PR TITLE
blockio: use attribute macros for all metrics

### DIFF
--- a/src/samplers/block_io/stats.rs
+++ b/src/samplers/block_io/stats.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::common::HISTOGRAM_GROUPING_POWER;
+use crate::*;
 use metriken::*;
 
 #[metric(
@@ -29,7 +29,8 @@ pub static BLOCKIO_READ_OPS: LazyCounter = LazyCounter::new(Counter::default);
     description = "Distribution of blockio read operation rates across the past snapshot interval",
     metadata = { unit = "operations/second" }
 )]
-pub static BLOCKIO_READ_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_READ_OPS_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",
@@ -44,7 +45,8 @@ pub static BLOCKIO_WRITE_OPS: LazyCounter = LazyCounter::new(Counter::default);
     description = "Distribution of blockio write operation rates across the past snapshot interval",
     metadata = { unit = "operations/second" }
 )]
-pub static BLOCKIO_WRITE_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_WRITE_OPS_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",
@@ -59,7 +61,8 @@ pub static BLOCKIO_DISCARD_OPS: LazyCounter = LazyCounter::new(Counter::default)
     description = "Distribution of blockio discard operation rates across the past snapshot interval",
     metadata = { unit = "operations/second" }
 )]
-pub static BLOCKIO_DISCARD_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_DISCARD_OPS_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",
@@ -74,7 +77,8 @@ pub static BLOCKIO_FLUSH_OPS: LazyCounter = LazyCounter::new(Counter::default);
     description = "Distribution of blockio flush operation rates across the past snapshot interval",
     metadata = { unit = "operations/second" }
 )]
-pub static BLOCKIO_FLUSH_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_FLUSH_OPS_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -89,7 +93,8 @@ pub static BLOCKIO_READ_BYTES: LazyCounter = LazyCounter::new(Counter::default);
     description = "Distribution of blockio read throughput across the past snapshot interval",
     metadata = { unit = "bytes/second" }
 )]
-pub static BLOCKIO_READ_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_READ_BYTES_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -104,7 +109,8 @@ pub static BLOCKIO_WRITE_BYTES: LazyCounter = LazyCounter::new(Counter::default)
     description = "Distribution of blockio write throughput across the past snapshot interval",
     metadata = { unit = "bytes/second" }
 )]
-pub static BLOCKIO_WRITE_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_WRITE_BYTES_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -119,7 +125,8 @@ pub static BLOCKIO_DISCARD_BYTES: LazyCounter = LazyCounter::new(Counter::defaul
     description = "Distribution of blockio discard throughput across the past snapshot interval",
     metadata = { unit = "bytes/second" }
 )]
-pub static BLOCKIO_DISCARD_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_DISCARD_BYTES_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -134,7 +141,8 @@ pub static BLOCKIO_FLUSH_BYTES: LazyCounter = LazyCounter::new(Counter::default)
     description = "Distribution of blockio flush throughput across the past snapshot interval",
     metadata = { unit = "bytes/second" }
 )]
-pub static BLOCKIO_FLUSH_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_FLUSH_BYTES_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 /// A function to format the blockio metrics that allows for export of ops and
 /// byte counters by operation type.

--- a/src/samplers/block_io/stats.rs
+++ b/src/samplers/block_io/stats.rs
@@ -26,7 +26,7 @@ pub static BLOCKIO_READ_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio/read/operations",
-    description = "Distribution of blockio read operation rates across the past snapshot interval",
+    description = "Distribution of blockio read operation rates from sample to sample",
     metadata = { unit = "operations/second" }
 )]
 pub static BLOCKIO_READ_OPS_HISTOGRAM: AtomicHistogram =
@@ -42,7 +42,7 @@ pub static BLOCKIO_WRITE_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio/write/operations",
-    description = "Distribution of blockio write operation rates across the past snapshot interval",
+    description = "Distribution of blockio write operation rates from sample to sample",
     metadata = { unit = "operations/second" }
 )]
 pub static BLOCKIO_WRITE_OPS_HISTOGRAM: AtomicHistogram =
@@ -58,7 +58,7 @@ pub static BLOCKIO_DISCARD_OPS: LazyCounter = LazyCounter::new(Counter::default)
 
 #[metric(
     name = "blockio/discard/operations",
-    description = "Distribution of blockio discard operation rates across the past snapshot interval",
+    description = "Distribution of blockio discard operation rates from sample to sample",
     metadata = { unit = "operations/second" }
 )]
 pub static BLOCKIO_DISCARD_OPS_HISTOGRAM: AtomicHistogram =
@@ -74,7 +74,7 @@ pub static BLOCKIO_FLUSH_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio/flush/operations",
-    description = "Distribution of blockio flush operation rates across the past snapshot interval",
+    description = "Distribution of blockio flush operation rates from sample to sample",
     metadata = { unit = "operations/second" }
 )]
 pub static BLOCKIO_FLUSH_OPS_HISTOGRAM: AtomicHistogram =
@@ -90,7 +90,7 @@ pub static BLOCKIO_READ_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio/read/bytes",
-    description = "Distribution of blockio read throughput across the past snapshot interval",
+    description = "Distribution of blockio read throughput from sample to sample",
     metadata = { unit = "bytes/second" }
 )]
 pub static BLOCKIO_READ_BYTES_HISTOGRAM: AtomicHistogram =
@@ -106,7 +106,7 @@ pub static BLOCKIO_WRITE_BYTES: LazyCounter = LazyCounter::new(Counter::default)
 
 #[metric(
     name = "blockio/write/bytes",
-    description = "Distribution of blockio write throughput across the past snapshot interval",
+    description = "Distribution of blockio write throughput from sample to sample",
     metadata = { unit = "bytes/second" }
 )]
 pub static BLOCKIO_WRITE_BYTES_HISTOGRAM: AtomicHistogram =
@@ -122,7 +122,7 @@ pub static BLOCKIO_DISCARD_BYTES: LazyCounter = LazyCounter::new(Counter::defaul
 
 #[metric(
     name = "blockio/discard/bytes",
-    description = "Distribution of blockio discard throughput across the past snapshot interval",
+    description = "Distribution of blockio discard throughput from sample to sample",
     metadata = { unit = "bytes/second" }
 )]
 pub static BLOCKIO_DISCARD_BYTES_HISTOGRAM: AtomicHistogram =
@@ -138,7 +138,7 @@ pub static BLOCKIO_FLUSH_BYTES: LazyCounter = LazyCounter::new(Counter::default)
 
 #[metric(
     name = "blockio/flush/bytes",
-    description = "Distribution of blockio flush throughput across the past snapshot interval",
+    description = "Distribution of blockio flush throughput from sample to sample",
     metadata = { unit = "bytes/second" }
 )]
 pub static BLOCKIO_FLUSH_BYTES_HISTOGRAM: AtomicHistogram =

--- a/src/samplers/block_io/stats.rs
+++ b/src/samplers/block_io/stats.rs
@@ -1,16 +1,20 @@
 use crate::*;
+use crate::common::HISTOGRAM_GROUPING_POWER;
 use metriken::*;
 
-bpfhistogram!(
-    BLOCKIO_LATENCY,
-    "blockio/latency",
-    "distribution of block IO latencies"
-);
-bpfhistogram!(
-    BLOCKIO_SIZE,
-    "blockio/size",
-    "distribution of block IO sizes"
-);
+#[metric(
+    name = "blockio/latency",
+    description = "Distribution of blockio operation latency in nanoseconds",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static BLOCKIO_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio/size",
+    description = "Distribution of blockio operation sizes in bytes",
+    metadata = { unit = "bytes" }
+)]
+pub static BLOCKIO_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",
@@ -20,7 +24,12 @@ bpfhistogram!(
 )]
 pub static BLOCKIO_READ_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_READ_OPS_HISTOGRAM, "blockio/read/operations");
+#[metric(
+    name = "blockio/read/operations",
+    description = "Distribution of blockio read operation rates across the past snapshot interval",
+    metadata = { unit = "operations/second" }
+)]
+pub static BLOCKIO_READ_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",
@@ -30,7 +39,12 @@ histogram!(BLOCKIO_READ_OPS_HISTOGRAM, "blockio/read/operations");
 )]
 pub static BLOCKIO_WRITE_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_WRITE_OPS_HISTOGRAM, "blockio/write/operations");
+#[metric(
+    name = "blockio/write/operations",
+    description = "Distribution of blockio write operation rates across the past snapshot interval",
+    metadata = { unit = "operations/second" }
+)]
+pub static BLOCKIO_WRITE_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",
@@ -40,7 +54,12 @@ histogram!(BLOCKIO_WRITE_OPS_HISTOGRAM, "blockio/write/operations");
 )]
 pub static BLOCKIO_DISCARD_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_DISCARD_OPS_HISTOGRAM, "blockio/discard/operations");
+#[metric(
+    name = "blockio/discard/operations",
+    description = "Distribution of blockio discard operation rates across the past snapshot interval",
+    metadata = { unit = "operations/second" }
+)]
+pub static BLOCKIO_DISCARD_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",
@@ -50,7 +69,12 @@ histogram!(BLOCKIO_DISCARD_OPS_HISTOGRAM, "blockio/discard/operations");
 )]
 pub static BLOCKIO_FLUSH_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_FLUSH_OPS_HISTOGRAM, "blockio/flush/operations");
+#[metric(
+    name = "blockio/flush/operations",
+    description = "Distribution of blockio flush operation rates across the past snapshot interval",
+    metadata = { unit = "operations/second" }
+)]
+pub static BLOCKIO_FLUSH_OPS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -60,7 +84,12 @@ histogram!(BLOCKIO_FLUSH_OPS_HISTOGRAM, "blockio/flush/operations");
 )]
 pub static BLOCKIO_READ_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_READ_BYTES_HISTOGRAM, "blockio/read/bytes");
+#[metric(
+    name = "blockio/read/bytes",
+    description = "Distribution of blockio read throughput across the past snapshot interval",
+    metadata = { unit = "bytes/second" }
+)]
+pub static BLOCKIO_READ_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -70,7 +99,12 @@ histogram!(BLOCKIO_READ_BYTES_HISTOGRAM, "blockio/read/bytes");
 )]
 pub static BLOCKIO_WRITE_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_WRITE_BYTES_HISTOGRAM, "blockio/write/bytes");
+#[metric(
+    name = "blockio/write/bytes",
+    description = "Distribution of blockio write throughput across the past snapshot interval",
+    metadata = { unit = "bytes/second" }
+)]
+pub static BLOCKIO_WRITE_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -80,7 +114,12 @@ histogram!(BLOCKIO_WRITE_BYTES_HISTOGRAM, "blockio/write/bytes");
 )]
 pub static BLOCKIO_DISCARD_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_DISCARD_BYTES_HISTOGRAM, "blockio/discard/bytes");
+#[metric(
+    name = "blockio/discard/bytes",
+    description = "Distribution of blockio discard throughput across the past snapshot interval",
+    metadata = { unit = "bytes/second" }
+)]
+pub static BLOCKIO_DISCARD_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/bytes",
@@ -90,7 +129,12 @@ histogram!(BLOCKIO_DISCARD_BYTES_HISTOGRAM, "blockio/discard/bytes");
 )]
 pub static BLOCKIO_FLUSH_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(BLOCKIO_FLUSH_BYTES_HISTOGRAM, "blockio/flush/bytes");
+#[metric(
+    name = "blockio/flush/bytes",
+    description = "Distribution of blockio flush throughput across the past snapshot interval",
+    metadata = { unit = "bytes/second" }
+)]
+pub static BLOCKIO_FLUSH_BYTES_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 /// A function to format the blockio metrics that allows for export of ops and
 /// byte counters by operation type.


### PR DESCRIPTION
Updates the blockio metrics to use atrribute macros for all metric definitions. Adds unit metadata for those metrics.
