### PR TITLE
cpu: convert metrics to use attribute macros

### DIFF
--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -19,7 +19,7 @@ pub static CPU_USAGE_IO_WAIT: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu/usage/io_wait",
-    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    description = "Distribution of rate of CPU usage from sample to sample",
     metadata = { unit = "nanoseconds/second" }
 )]
 pub static CPU_USAGE_IO_WAIT_HISTOGRAM: AtomicHistogram =
@@ -35,7 +35,7 @@ pub static CPU_USAGE_IRQ: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu/usage/irq",
-    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    description = "Distribution of rate of CPU usage from sample to sample",
     metadata = { unit = "nanoseconds/second" }
 )]
 pub static CPU_USAGE_IRQ_HISTOGRAM: AtomicHistogram =
@@ -51,7 +51,7 @@ pub static CPU_USAGE_SOFTIRQ: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu/usage/softirq",
-    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    description = "Distribution of rate of CPU usage from sample to sample",
     metadata = { unit = "nanoseconds/second" }
 )]
 pub static CPU_USAGE_SOFTIRQ_HISTOGRAM: AtomicHistogram =
@@ -67,7 +67,7 @@ pub static CPU_USAGE_STEAL: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu/usage/steal",
-    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    description = "Distribution of rate of CPU usage from sample to sample",
     metadata = { unit = "nanoseconds/second" }
 )]
 pub static CPU_USAGE_STEAL_HISTOGRAM: AtomicHistogram =
@@ -83,7 +83,7 @@ pub static CPU_USAGE_GUEST: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu/usage/guest",
-    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    description = "Distribution of rate of CPU usage from sample to sample",
     metadata = { unit = "nanoseconds/second" }
 )]
 pub static CPU_USAGE_GUEST_HISTOGRAM: AtomicHistogram =
@@ -99,7 +99,7 @@ pub static CPU_USAGE_GUEST_NICE: LazyCounter = LazyCounter::new(Counter::default
 
 #[metric(
     name = "cpu/usage/guest_nice",
-    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    description = "Distribution of rate of CPU usage from sample to sample",
     metadata = { unit = "nanoseconds/second" }
 )]
 pub static CPU_USAGE_GUEST_NICE_HISTOGRAM: AtomicHistogram =
@@ -133,7 +133,7 @@ pub static CPU_IPKC_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "cpu/ipkc",
-    description = "Distribution of instruction retirement rates across the past snapshot interval",
+    description = "Distribution of instruction retirement rates from sample to sample",
     metadata = { unit = "instructions/kilocycle" }
 )]
 pub static CPU_IPKC_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
@@ -146,7 +146,7 @@ pub static CPU_IPUS_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "cpu/ipus",
-    description = "Distribution of instruction retirement rates across the past snapshot interval",
+    description = "Distribution of instruction retirement rates from sample to sample",
     metadata = { unit = "instructions/microsecond" }
 )]
 pub static CPU_IPUS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
@@ -165,7 +165,7 @@ pub static CPU_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "cpu/frequency",
-    description = "Distribution of instantaneous CPU frequencies sampled across the past snapshot interval",
+    description = "Distribution of CPU frequencies from sample to sample",
     metadata = { unit = "megahertz" }
 )]
 pub static CPU_FREQUENCY_HISTOGRAM: AtomicHistogram =

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -1,6 +1,7 @@
 use super::super::stats::*;
+use crate::common::HISTOGRAM_GROUPING_POWER;
 use crate::*;
-use metriken::{metric, Counter, Gauge, LazyCounter, LazyGauge};
+use metriken::{metric, AtomicHistogram, Counter, Gauge, LazyCounter, LazyGauge};
 
 #[metric(
     name = "cpu/cores",
@@ -16,7 +17,13 @@ pub static CPU_CORES: LazyGauge = LazyGauge::new(Gauge::default);
 )]
 pub static CPU_USAGE_IO_WAIT: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_IO_WAIT_HISTOGRAM, "cpu/usage/io_wait");
+#[metric(
+    name = "cpu/usage/io_wait",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_IO_WAIT_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -26,7 +33,13 @@ histogram!(CPU_USAGE_IO_WAIT_HISTOGRAM, "cpu/usage/io_wait");
 )]
 pub static CPU_USAGE_IRQ: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_IRQ_HISTOGRAM, "cpu/usage/irq");
+#[metric(
+    name = "cpu/usage/irq",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_IRQ_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -36,7 +49,13 @@ histogram!(CPU_USAGE_IRQ_HISTOGRAM, "cpu/usage/irq");
 )]
 pub static CPU_USAGE_SOFTIRQ: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_SOFTIRQ_HISTOGRAM, "cpu/usage/softirq");
+#[metric(
+    name = "cpu/usage/softirq",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_SOFTIRQ_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -46,7 +65,13 @@ histogram!(CPU_USAGE_SOFTIRQ_HISTOGRAM, "cpu/usage/softirq");
 )]
 pub static CPU_USAGE_STEAL: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_STEAL_HISTOGRAM, "cpu/usage/steal");
+#[metric(
+    name = "cpu/usage/steal",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_STEAL_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -56,7 +81,13 @@ histogram!(CPU_USAGE_STEAL_HISTOGRAM, "cpu/usage/steal");
 )]
 pub static CPU_USAGE_GUEST: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_GUEST_HISTOGRAM, "cpu/usage/guest");
+#[metric(
+    name = "cpu/usage/guest",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_GUEST_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -66,7 +97,13 @@ histogram!(CPU_USAGE_GUEST_HISTOGRAM, "cpu/usage/guest");
 )]
 pub static CPU_USAGE_GUEST_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_GUEST_NICE_HISTOGRAM, "cpu/usage/guest_nice");
+#[metric(
+    name = "cpu/usage/guest_nice",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_GUEST_NICE_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/cycles",
@@ -94,11 +131,12 @@ pub static CPU_PERF_GROUPS_ACTIVE: LazyGauge = LazyGauge::new(Gauge::default);
 )]
 pub static CPU_IPKC_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
-histogram!(
-    CPU_IPKC_HISTOGRAM,
-    "cpu/ipkc",
-    "distribution of per-CPU IPKC (Instructions Per Thousand Cycles)"
-);
+#[metric(
+    name = "cpu/ipkc",
+    description = "Distribution of instruction retirement rates across the past snapshot interval",
+    metadata = { unit = "instructions/kilocycle" }
+)]
+pub static CPU_IPKC_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/ipus/average",
@@ -106,11 +144,12 @@ histogram!(
 )]
 pub static CPU_IPUS_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
-histogram!(
-    CPU_IPUS_HISTOGRAM,
-    "cpu/ipus",
-    "Distribution of per-CPU IPUS (Instructions Per Microsecond)"
-);
+#[metric(
+    name = "cpu/ipus",
+    description = "Distribution of instruction retirement rates across the past snapshot interval",
+    metadata = { unit = "instructions/microsecond" }
+)]
+pub static CPU_IPUS_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/base_frequency/average",
@@ -124,8 +163,10 @@ pub static CPU_BASE_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default
 )]
 pub static CPU_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
 
-histogram!(
-    CPU_FREQUENCY_HISTOGRAM,
-    "cpu/frequency",
-    "Distribution of the per-CPU running frequencies"
-);
+#[metric(
+    name = "cpu/frequency",
+    description = "Distribution of instantaneous CPU frequencies sampled across the past snapshot interval",
+    metadata = { unit = "megahertz" }
+)]
+pub static CPU_FREQUENCY_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -1,5 +1,5 @@
-use crate::*;
-use metriken::{metric, Counter, Format, LazyCounter, MetricEntry};
+use crate::common::HISTOGRAM_GROUPING_POWER;
+use metriken::{metric, AtomicHistogram, Counter, Format, LazyCounter, MetricEntry};
 
 #[metric(
     name = "cpu/usage",
@@ -9,7 +9,13 @@ use metriken::{metric, Counter, Format, LazyCounter, MetricEntry};
 )]
 pub static CPU_USAGE_USER: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_USER_HISTOGRAM, "cpu/usage/user");
+#[metric(
+    name = "cpu/usage/user",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_USER_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -19,7 +25,13 @@ histogram!(CPU_USAGE_USER_HISTOGRAM, "cpu/usage/user");
 )]
 pub static CPU_USAGE_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_NICE_HISTOGRAM, "cpu/usage/nice");
+#[metric(
+    name = "cpu/usage/nice",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_NICE_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -29,7 +41,13 @@ histogram!(CPU_USAGE_NICE_HISTOGRAM, "cpu/usage/nice");
 )]
 pub static CPU_USAGE_SYSTEM: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_SYSTEM_HISTOGRAM, "cpu/usage/system");
+#[metric(
+    name = "cpu/usage/system",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_SYSTEM_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "cpu/usage",
@@ -39,7 +57,13 @@ histogram!(CPU_USAGE_SYSTEM_HISTOGRAM, "cpu/usage/system");
 )]
 pub static CPU_USAGE_IDLE: LazyCounter = LazyCounter::new(Counter::default);
 
-histogram!(CPU_USAGE_IDLE_HISTOGRAM, "cpu/usage/idle");
+#[metric(
+    name = "cpu/usage/idle",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_IDLE_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 /// A function to format the cpu metrics that allows for export of both total
 /// and per-CPU metrics.


### PR DESCRIPTION
Convert the CPU metrics to us attribute macros instead of the declarative macros.
