### PR TITLE
network: convert metrics to use attribute macro

### DIFF
--- a/src/samplers/network/stats.rs
+++ b/src/samplers/network/stats.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::common::HISTOGRAM_GROUPING_POWER;
+use crate::*;
 use metriken::{metric, AtomicHistogram, Counter, Gauge, LazyCounter, LazyGauge};
 
 #[metric(

--- a/src/samplers/network/stats.rs
+++ b/src/samplers/network/stats.rs
@@ -11,7 +11,7 @@ pub static NETWORK_RX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network/receive/bytes",
-    description = "Distribution of network receive throughput across the past snapshot interval",
+    description = "Distribution of network receive throughput from sample to sample",
     metadata = { unit = "bytes/second" }
 )]
 pub static NETWORK_RX_BYTES_HISTOGRAM: AtomicHistogram =
@@ -26,7 +26,7 @@ pub static NETWORK_RX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network/receive/packets",
-    description = "Distribution of network receive packet rate across the past snapshot interval",
+    description = "Distribution of network receive packet rate from sample to sample",
     metadata = { unit = "packets/second" }
 )]
 pub static NETWORK_RX_PACKETS_HISTOGRAM: AtomicHistogram =
@@ -41,7 +41,7 @@ pub static NETWORK_TX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network/transmit/bytes",
-    description = "Distribution of network transmit throughput across the past snapshot interval",
+    description = "Distribution of network transmit throughput from sample to sample",
     metadata = { unit = "bytes/second" }
 )]
 pub static NETWORK_TX_BYTES_HISTOGRAM: AtomicHistogram =
@@ -56,7 +56,7 @@ pub static NETWORK_TX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network/transmit/packets",
-    description = "Distribution of network transmit packet rate across the past snapshot interval",
+    description = "Distribution of network transmit packet rate from sample to sample",
     metadata = { unit = "packets/second" }
 )]
 pub static NETWORK_TX_PACKETS_HISTOGRAM: AtomicHistogram =

--- a/src/samplers/network/stats.rs
+++ b/src/samplers/network/stats.rs
@@ -1,28 +1,63 @@
 use crate::*;
-use metriken::metric;
+use crate::common::HISTOGRAM_GROUPING_POWER;
+use metriken::{metric, AtomicHistogram, Counter, Gauge, LazyCounter, LazyGauge};
 
-counter_with_histogram!(
-    NETWORK_RX_BYTES,
-    NETWORK_RX_BYTES_HISTOGRAM,
-    "network/receive/bytes",
-    "number of bytes received"
-);
-counter_with_histogram!(
-    NETWORK_RX_PACKETS,
-    NETWORK_RX_PACKETS_HISTOGRAM,
-    "network/receive/frames",
-    "number of packets received"
-);
+#[metric(
+    name = "network/receive/bytes",
+    description = "The number of bytes received over the network",
+    metadata = { unit = "bytes" }
+)]
+pub static NETWORK_RX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
-counter_with_histogram!(
-    NETWORK_TX_BYTES,
-    NETWORK_TX_BYTES_HISTOGRAM,
-    "network/transmit/bytes",
-    "number of bytes transmitted"
-);
-counter_with_histogram!(
-    NETWORK_TX_PACKETS,
-    NETWORK_TX_PACKETS_HISTOGRAM,
-    "network/transmit/packets",
-    "number of packets transmitted"
-);
+#[metric(
+    name = "network/receive/bytes",
+    description = "Distribution of network receive throughput across the past snapshot interval",
+    metadata = { unit = "bytes/second" }
+)]
+pub static NETWORK_RX_BYTES_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "network/receive/packets",
+    description = "The number of packets received over the network",
+    metadata = { unit = "packets" }
+)]
+pub static NETWORK_RX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "network/receive/packets",
+    description = "Distribution of network receive packet rate across the past snapshot interval",
+    metadata = { unit = "packets/second" }
+)]
+pub static NETWORK_RX_PACKETS_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "network/transmit/bytes",
+    description = "The number of bytes transmitted over the network",
+    metadata = { unit = "bytes" }
+)]
+pub static NETWORK_TX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "network/transmit/bytes",
+    description = "Distribution of network transmit throughput across the past snapshot interval",
+    metadata = { unit = "bytes/second" }
+)]
+pub static NETWORK_TX_BYTES_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "network/transmit/packets",
+    description = "The number of packets transmitted over the network",
+    metadata = { unit = "packets" }
+)]
+pub static NETWORK_TX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "network/transmit/packets",
+    description = "Distribution of network transmit packet rate across the past snapshot interval",
+    metadata = { unit = "packets/second" }
+)]
+pub static NETWORK_TX_PACKETS_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);


### PR DESCRIPTION
Converts all network metrics to use the attribute macro
