### PR TITLE
rezolus: use attribute macros for rezolus process metrics

### DIFF
--- a/src/samplers/rezolus/rusage/mod.rs
+++ b/src/samplers/rezolus/rusage/mod.rs
@@ -111,17 +111,10 @@ impl Rusage {
                 rusage.ru_stime.tv_sec as u64 * S + rusage.ru_stime.tv_usec as u64 * US,
             );
             RU_MAXRSS.set(rusage.ru_maxrss * KB);
-            RU_IXRSS.set(rusage.ru_ixrss * KB);
-            RU_IDRSS.set(rusage.ru_idrss * KB);
-            RU_ISRSS.set(rusage.ru_isrss * KB);
             RU_MINFLT.set(rusage.ru_minflt as u64);
             RU_MAJFLT.set(rusage.ru_majflt as u64);
-            RU_NSWAP.set(rusage.ru_nswap as u64);
             RU_INBLOCK.set(rusage.ru_inblock as u64);
             RU_OUBLOCK.set(rusage.ru_oublock as u64);
-            RU_MSGSND.set(rusage.ru_msgsnd as u64);
-            RU_MSGRCV.set(rusage.ru_msgrcv as u64);
-            RU_NSIGNALS.set(rusage.ru_nsignals as u64);
             RU_NVCSW.set(rusage.ru_nvcsw as u64);
             RU_NIVCSW.set(rusage.ru_nivcsw as u64);
         }

--- a/src/samplers/rezolus/stats.rs
+++ b/src/samplers/rezolus/stats.rs
@@ -1,37 +1,75 @@
-use crate::*;
+use crate::common::HISTOGRAM_GROUPING_POWER;
+use metriken::{metric, AtomicHistogram, Counter, Gauge, LazyCounter, LazyGauge};
 
-counter_with_histogram!(
-    RU_UTIME,
-    RU_UTIME_HISTOGRAM,
-    "rezolus/cpu/usage/user",
-    "The amount of CPU time Rezolus was executing in user mode"
-);
-counter_with_histogram!(
-    RU_STIME,
-    RU_STIME_HISTOGRAM,
-    "rezolus/cpu/usage/system",
-    "The amount of CPU time Rezolus was executing in system mode"
-);
+#[metric(
+    name = "rezolus/cpu/usage/user",
+    description = "The amount of CPU time Rezolus was executing in user mode",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static RU_UTIME: LazyCounter = LazyCounter::new(Counter::default);
 
-gauge!(
-    RU_MAXRSS,
-    "rezolus/memory/usage/resident_set_size",
-    "The total amount of memory allocated by Rezolus"
-);
-gauge!(RU_IXRSS, "rezolus/memory/usage/shared_memory_size");
-gauge!(RU_IDRSS, "rezolus/memory/usage/data_size");
-gauge!(RU_ISRSS, "rezolus/memory/usage/stack_size");
-counter!(RU_MINFLT, "rezolus/memory/page/reclaims");
-counter!(RU_MAJFLT, "rezolus/memory/page/faults");
-counter!(RU_NSWAP, "rezolus/memory/swapped");
+#[metric(
+    name = "rezolus/cpu/usage/user",
+    description = "Distribution of the rate of CPU usage for Rezolus executing in user mode",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static RU_UTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
-counter!(RU_INBLOCK, "rezolus/io/block/reads");
-counter!(RU_OUBLOCK, "rezolus/io/block/writes");
+#[metric(
+    name = "rezolus/cpu/usage/system",
+    description = "The amount of CPU time Rezolus was executing in system mode",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static RU_STIME: LazyCounter = LazyCounter::new(Counter::default);
 
-counter!(RU_MSGSND, "rezolus/messages/sentg");
-counter!(RU_MSGRCV, "rezolus/messages/received");
+#[metric(
+    name = "rezolus/cpu/usage/system",
+    description = "Distribution of the rate of CPU usage for Rezolus executing in system mode",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static RU_STIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
-counter!(RU_NSIGNALS, "rezolus/signals/received");
+#[metric(
+    name = "rezolus/memory/usage/resident_set_size",
+    description = "The total amount of memory allocated by Rezolus",
+    metadata = { unit = "bytes" }
+)]
+pub static RU_MAXRSS: LazyGauge = LazyGauge::new(Gauge::default);
 
-counter!(RU_NVCSW, "rezolus/context_switch/voluntary");
-counter!(RU_NIVCSW, "rezolus/context_switch/involuntary");
+#[metric(
+    name = "rezolus/memory/page/reclaims",
+    description = "The number of page faults which were serviced by reclaiming a page"
+)]
+pub static RU_MINFLT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus/memory/page/faults",
+    description = "The number of page faults which required an I/O operation"
+)]
+pub static RU_MAJFLT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus/blockio/read",
+    description = "The number of reads from the filesystem",
+    metadata = { unit = "operations" }
+)]
+pub static RU_INBLOCK: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus/blockio/write",
+    description = "The number of writes to the filesystem",
+    metadata = { unit = "operations" }
+)]
+pub static RU_OUBLOCK: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus/context_switch/voluntary",
+    description = "The number of voluntary context switches"
+)]
+pub static RU_NVCSW: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus/context_switch/involuntary",
+    description = "The number of involuntary context switches"
+)]
+pub static RU_NIVCSW: LazyCounter = LazyCounter::new(Counter::default);


### PR DESCRIPTION
Switch to using the attribute macros for Rezolus process metrics.

Removes several metrics which are unused on linux systems.
