### PR TITLE
scheduler: migrate metrics to attribute macro

### DIFF
--- a/src/samplers/scheduler/stats.rs
+++ b/src/samplers/scheduler/stats.rs
@@ -1,17 +1,24 @@
+use crate::common::HISTOGRAM_GROUPING_POWER;
 use crate::*;
+use metriken::{metric, Conter, LazyCounter, RwLockHistogram};
 
-bpfhistogram!(
-    SCHEDULER_RUNQUEUE_LATENCY,
-    "scheduler/runqueue/latency",
-    "distribution of task wait times in the runqueue"
-);
-bpfhistogram!(
-    SCHEDULER_RUNNING,
-    "scheduler/running",
-    "distribution of task on-cpu time"
-);
-counter!(
-    SCHEDULER_IVCSW,
-    "scheduler/context_switch/involuntary",
-    "count of involuntary context switches"
-);
+#[metric(
+    name = "scheduler/runqueue/latency",
+    description = "Distribution of the amount of time tasks were waiting in the runqueue",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SCHEDULER_RUNQUEUE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "scheduler/running",
+    description = "Distribution of the amount of time tasks were on-CPU",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SCHEDULER_RUNNING: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "scheduler/context_switch/involuntary",
+    description = "The number of involuntary context switches"
+)]
+pub static SCHEDULER_IVCSW: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/samplers/scheduler/stats.rs
+++ b/src/samplers/scheduler/stats.rs
@@ -1,6 +1,6 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
 use crate::*;
-use metriken::{metric, Conter, LazyCounter, RwLockHistogram};
+use metriken::{metric, Counter, LazyCounter, RwLockHistogram};
 
 #[metric(
     name = "scheduler/runqueue/latency",


### PR DESCRIPTION
Migrate the scheduler metrics to use the attribute macro
