### PR TITLE
syscall: migrate to attribute macro for metrics

### DIFF
--- a/src/samplers/syscall/stats.rs
+++ b/src/samplers/syscall/stats.rs
@@ -1,5 +1,7 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, AtomicHistogram, Counter, Format, LazyCounter, MetricEntry, RwLockHistogram};
+use metriken::{
+    metric, AtomicHistogram, Counter, Format, LazyCounter, MetricEntry, RwLockHistogram,
+};
 
 #[metric(
     name = "syscall/total",

--- a/src/samplers/syscall/stats.rs
+++ b/src/samplers/syscall/stats.rs
@@ -1,5 +1,5 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, AtomicHistogram, Counter, Format, LazyCounter, MetricEntry};
+use metriken::{metric, AtomicHistogram, Counter, Format, LazyCounter, MetricEntry, RwLockHistogram};
 
 #[metric(
     name = "syscall/total",

--- a/src/samplers/syscall/stats.rs
+++ b/src/samplers/syscall/stats.rs
@@ -1,90 +1,186 @@
-use crate::*;
+use crate::common::HISTOGRAM_GROUPING_POWER;
+use metriken::{metric, AtomicHistogram, Counter, Format, LazyCounter, MetricEntry};
 
-counter_with_histogram!(
-    SYSCALL_TOTAL,
-    SYSCALL_TOTAL_HISTOGRAM,
-    "syscall/total",
-    "tracks total syscalls"
-);
-counter_with_histogram!(
-    SYSCALL_READ,
-    SYSCALL_READ_HISTOGRAM,
-    "syscall/read",
-    "tracks read related syscalls (read, recvfrom, ...)"
-);
-counter_with_histogram!(
-    SYSCALL_WRITE,
-    SYSCALL_WRITE_HISTOGRAM,
-    "syscall/write",
-    "tracks write related syscalls (write, sendto, ...)"
-);
-counter_with_histogram!(
-    SYSCALL_POLL,
-    SYSCALL_POLL_HISTOGRAM,
-    "syscall/poll",
-    "tracks poll related syscalls (poll, select, epoll, ...)"
-);
-counter_with_histogram!(
-    SYSCALL_LOCK,
-    SYSCALL_LOCK_HISTOGRAM,
-    "syscall/lock",
-    "tracks lock related syscalls (futex)"
-);
-counter_with_histogram!(
-    SYSCALL_TIME,
-    SYSCALL_TIME_HISTOGRAM,
-    "syscall/time",
-    "tracks time related syscalls (clock_gettime, clock_settime, clock_getres, ...)"
-);
-counter_with_histogram!(
-    SYSCALL_SLEEP,
-    SYSCALL_SLEEP_HISTOGRAM,
-    "syscall/sleep",
-    "tracks sleep related syscalls (nanosleep, clock_nanosleep)"
-);
-counter_with_histogram!(
-    SYSCALL_SOCKET,
-    SYSCALL_SOCKET_HISTOGRAM,
-    "syscall/socket",
-    "tracks socket related syscalls (accept, connect, bind, setsockopt, ...)"
-);
-bpfhistogram!(
-    SYSCALL_TOTAL_LATENCY,
-    "syscall/total/latency",
-    "latency of all syscalls"
-);
-bpfhistogram!(
-    SYSCALL_READ_LATENCY,
-    "syscall/read/latency",
-    "latency of read related syscalls (read, recvfrom, ...)"
-);
-bpfhistogram!(
-    SYSCALL_WRITE_LATENCY,
-    "syscall/write/latency",
-    "latency of write related syscalls (write, sendto, ...)"
-);
-bpfhistogram!(
-    SYSCALL_POLL_LATENCY,
-    "syscall/poll/latency",
-    "latency of poll related syscalls (poll, select, epoll, ...)"
-);
-bpfhistogram!(
-    SYSCALL_LOCK_LATENCY,
-    "syscall/lock/latency",
-    "latency of lock related syscalls (futex)"
-);
-bpfhistogram!(
-    SYSCALL_TIME_LATENCY,
-    "syscall/time/latency",
-    "latency of time related syscalls (clock_gettime, clock_settime, clock_getres, ...)"
-);
-bpfhistogram!(
-    SYSCALL_SLEEP_LATENCY,
-    "syscall/sleep/latency",
-    "latency of sleep related syscalls (nanosleep, clock_nanosleep)"
-);
-bpfhistogram!(
-    SYSCALL_SOCKET_LATENCY,
-    "syscall/socket/latency",
-    "latency of socket related syscalls (accept, connect, bind, setsockopt, ...)"
-);
+#[metric(
+    name = "syscall/total",
+    description = "The total number of syscalls",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_TOTAL: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/total",
+    description = "Distribution of the total rate of syscalls across the past snapshot interval",
+    metadata = { unit = "syscalls/second" }
+)]
+pub static SYSCALL_TOTAL_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/total/latency",
+    description = "Distribution of the latency for all syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_TOTAL_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/read",
+    description = "The number of read related syscalls (read, recvfrom, ...)",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_READ: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/read",
+    description = "Distribution of the rate of read related syscalls across the past snapshot interval",
+    metadata = { unit = "syscalls/second" }
+)]
+pub static SYSCALL_READ_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/read/latency",
+    description = "Distribution of the latency for read related syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_READ_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/write",
+    description = "The number of write related syscalls (write, sendto, ...)",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_WRITE: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/write",
+    description = "Distribution of the rate of write related syscalls across the past snapshot interval",
+    metadata = { unit = "sycalls/second" }
+)]
+pub static SYSCALL_WRITE_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/write/latency",
+    description = "Distribution of the latency for write related syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_WRITE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/poll",
+    description = "The number of poll related syscalls (poll, select, epoll, ...)",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_POLL: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/poll",
+    description = "Distribution of the rate of poll related syscalls across the past snapshot interval",
+    metadata = { unit = "sycalls/second" }
+)]
+pub static SYSCALL_POLL_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/poll/latency",
+    description = "Distribution of the latency for poll related syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_POLL_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/lock",
+    description = "The number of lock related syscalls (futex, ...)",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_LOCK: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/lock",
+    description = "Distribution of the rate of lock related syscalls across the past snapshot interval",
+    metadata = { unit = "sycalls/second" }
+)]
+pub static SYSCALL_LOCK_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/lock/latency",
+    description = "Distribution of the latency for lock related syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_LOCK_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/time",
+    description = "The number of time related syscalls (clock_gettime, clock_settime, clock_getres, ...)",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/time",
+    description = "Distribution of the rate of time related syscalls across the past snapshot interval",
+    metadata = { unit = "sycalls/second" }
+)]
+pub static SYSCALL_TIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/time/latency",
+    description = "Distribution of the latency for time related syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_TIME_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/sleep",
+    description = "The number of sleep related syscalls (nanosleep, clock_nanosleep, ...)",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_SLEEP: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/sleep",
+    description = "Distribution of the rate of sleep related syscalls across the past snapshot interval",
+    metadata = { unit = "sycalls/second" }
+)]
+pub static SYSCALL_SLEEP_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/sleep/latency",
+    description = "Distribution of the latency for sleep related syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_SLEEP_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/socket",
+    description = "The number of socket related syscalls (accept, connect, bind, setsockopt, ...)",
+    metadata = { unit = "syscalls" }
+)]
+pub static SYSCALL_SOCKET: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall/socket",
+    description = "Distribution of the rate of socket related syscalls across the past snapshot interval",
+    metadata = { unit = "sycalls/second" }
+)]
+pub static SYSCALL_SOCKET_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "syscall/socket/latency",
+    description = "Distribution of the latency for socket related syscalls",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SYSCALL_SOCKET_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);

--- a/src/samplers/syscall/stats.rs
+++ b/src/samplers/syscall/stats.rs
@@ -12,7 +12,7 @@ pub static SYSCALL_TOTAL: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/total",
-    description = "Distribution of the total rate of syscalls across the past snapshot interval",
+    description = "Distribution of the total rate of syscalls from sample to sample",
     metadata = { unit = "syscalls/second" }
 )]
 pub static SYSCALL_TOTAL_HISTOGRAM: AtomicHistogram =
@@ -35,7 +35,7 @@ pub static SYSCALL_READ: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/read",
-    description = "Distribution of the rate of read related syscalls across the past snapshot interval",
+    description = "Distribution of the rate of read related syscalls from sample to sample",
     metadata = { unit = "syscalls/second" }
 )]
 pub static SYSCALL_READ_HISTOGRAM: AtomicHistogram =
@@ -58,7 +58,7 @@ pub static SYSCALL_WRITE: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/write",
-    description = "Distribution of the rate of write related syscalls across the past snapshot interval",
+    description = "Distribution of the rate of write related syscalls from sample to sample",
     metadata = { unit = "sycalls/second" }
 )]
 pub static SYSCALL_WRITE_HISTOGRAM: AtomicHistogram =
@@ -81,7 +81,7 @@ pub static SYSCALL_POLL: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/poll",
-    description = "Distribution of the rate of poll related syscalls across the past snapshot interval",
+    description = "Distribution of the rate of poll related syscalls from sample to sample",
     metadata = { unit = "sycalls/second" }
 )]
 pub static SYSCALL_POLL_HISTOGRAM: AtomicHistogram =
@@ -104,7 +104,7 @@ pub static SYSCALL_LOCK: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/lock",
-    description = "Distribution of the rate of lock related syscalls across the past snapshot interval",
+    description = "Distribution of the rate of lock related syscalls from sample to sample",
     metadata = { unit = "sycalls/second" }
 )]
 pub static SYSCALL_LOCK_HISTOGRAM: AtomicHistogram =
@@ -127,7 +127,7 @@ pub static SYSCALL_TIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/time",
-    description = "Distribution of the rate of time related syscalls across the past snapshot interval",
+    description = "Distribution of the rate of time related syscalls from sample to sample",
     metadata = { unit = "sycalls/second" }
 )]
 pub static SYSCALL_TIME_HISTOGRAM: AtomicHistogram =
@@ -150,7 +150,7 @@ pub static SYSCALL_SLEEP: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/sleep",
-    description = "Distribution of the rate of sleep related syscalls across the past snapshot interval",
+    description = "Distribution of the rate of sleep related syscalls from sample to sample",
     metadata = { unit = "sycalls/second" }
 )]
 pub static SYSCALL_SLEEP_HISTOGRAM: AtomicHistogram =
@@ -173,7 +173,7 @@ pub static SYSCALL_SOCKET: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "syscall/socket",
-    description = "Distribution of the rate of socket related syscalls across the past snapshot interval",
+    description = "Distribution of the rate of socket related syscalls from sample to sample",
     metadata = { unit = "sycalls/second" }
 )]
 pub static SYSCALL_SOCKET_HISTOGRAM: AtomicHistogram =


### PR DESCRIPTION
Migrates the syscall samplers to the attribute macro for metrics.
