### PR TITLE
Revert "cleanup snapshotting within rezolus (#156)"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,17 +2,15 @@ use backtrace::Backtrace;
 use clap::{Arg, Command};
 use linkme::distributed_slice;
 use metriken::Lazy;
-use metriken_exposition::HistogramSnapshot;
 use ringlog::*;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::SystemTime;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::RwLock;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-type HistogramSnapshots = HashMap<String, HistogramSnapshot>;
+type HistogramSnapshots = HashMap<String, metriken::histogram::Snapshot>;
 
 static SNAPSHOTS: Lazy<Arc<RwLock<Snapshots>>> =
     Lazy::new(|| Arc::new(RwLock::new(Snapshots::new())));
@@ -20,7 +18,7 @@ static SNAPSHOTS: Lazy<Arc<RwLock<Snapshots>>> =
 pub struct Snapshots {
     timestamp: SystemTime,
     previous: HistogramSnapshots,
-    delta: HistogramSnapshots,
+    deltas: HistogramSnapshots,
 }
 
 impl Default for Snapshots {
@@ -31,34 +29,76 @@ impl Default for Snapshots {
 
 impl Snapshots {
     pub fn new() -> Self {
-        let snapshot = metriken_exposition::Snapshotter::default().snapshot();
+        let timestamp = SystemTime::now();
 
-        let previous: HistogramSnapshots = snapshot.histograms.into_iter().collect();
-        let delta = previous.clone();
+        let mut current = HashMap::new();
+
+        for metric in metriken::metrics().iter() {
+            let any = if let Some(any) = metric.as_any() {
+                any
+            } else {
+                continue;
+            };
+
+            let key = metric.name().to_string();
+
+            let snapshot = if let Some(histogram) = any.downcast_ref::<metriken::AtomicHistogram>()
+            {
+                histogram.snapshot()
+            } else if let Some(histogram) = any.downcast_ref::<metriken::RwLockHistogram>() {
+                histogram.snapshot()
+            } else {
+                None
+            };
+
+            if let Some(snapshot) = snapshot {
+                current.insert(key, snapshot);
+            }
+        }
+
+        let deltas = current.clone();
 
         Self {
-            timestamp: snapshot.systemtime,
-            previous,
-            delta,
+            timestamp,
+            previous: current,
+            deltas,
         }
     }
 
     pub fn update(&mut self) {
-        let snapshot = metriken_exposition::Snapshotter::default().snapshot();
-        self.timestamp = snapshot.systemtime;
+        self.timestamp = SystemTime::now();
 
-        let current: HistogramSnapshots = snapshot.histograms.into_iter().collect();
-        let mut delta = HistogramSnapshots::new();
+        let mut current = HashMap::new();
 
-        for (name, previous) in &self.previous {
-            if let Some(histogram) = current.get(name).cloned() {
-                let _ = histogram.wrapping_sub(previous);
-                delta.insert(name.to_string(), histogram);
+        for metric in metriken::metrics().iter() {
+            let any = if let Some(any) = metric.as_any() {
+                any
+            } else {
+                continue;
+            };
+
+            let key = metric.name().to_string();
+
+            let snapshot = if let Some(histogram) = any.downcast_ref::<metriken::AtomicHistogram>()
+            {
+                histogram.snapshot()
+            } else if let Some(histogram) = any.downcast_ref::<metriken::RwLockHistogram>() {
+                histogram.snapshot()
+            } else {
+                None
+            };
+
+            if let Some(snapshot) = snapshot {
+                if let Some(previous) = self.previous.get(&key) {
+                    self.deltas
+                        .insert(key.clone(), snapshot.wrapping_sub(previous).unwrap());
+                }
+
+                current.insert(key, snapshot);
             }
         }
 
         self.previous = current;
-        self.delta = delta;
     }
 }
 


### PR DESCRIPTION
This reverts commit dd9e7bcd7d6054da683bb48e1c3c28f3d6cadddc.

Problem

This commit introduces a bug which causes summary stats (percentiles) to be incorrect. Instead of reflecting the percentile between two snapshots, they reflect the running percentile across the process lifetime.
