### PR TITLE
bugfix: incorrect calculation of histogram snapshot delta

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,8 +52,9 @@ impl Snapshots {
 
         for (name, previous) in &self.previous {
             if let Some(histogram) = current.get(name).cloned() {
-                let _ = histogram.wrapping_sub(previous);
-                delta.insert(name.to_string(), histogram);
+                if let Ok(d) = histogram.wrapping_sub(previous) {
+                    delta.insert(name.to_string(), d);
+                }
             }
         }
 


### PR DESCRIPTION
Introduced in #156

We are incorrectly throwing away the delta instead of storing it. This results in the running percentiles being reported instead of delta percentiles.

This change stores the delta instead of throwing it away.
