### PR TITLE
fix: report memory usage gauges in bytes

### DIFF
--- a/src/common/bpf/mod.rs
+++ b/src/common/bpf/mod.rs
@@ -3,6 +3,7 @@ use metriken::DynBoxedMetric;
 use metriken::RwLockHistogram;
 use ouroboros::*;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd};
+use std::sync::Arc;
 
 pub use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,10 +2,9 @@
 pub mod bpf;
 
 pub mod classic;
+pub mod units;
 
 mod nop;
-
-use std::sync::Arc;
 
 use metriken::AtomicHistogram;
 use metriken::LazyCounter;

--- a/src/common/units.rs
+++ b/src/common/units.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code)]
+
+// Time units with base unit as nanoseconds
+pub const SECONDS: u64 = 1_000 * MILLISECONDS;
+pub const MILLISECONDS: u64 = 1_000 * MICROSECONDS; 
+pub const MICROSECONDS: u64 = 1_000 * NANOSECONDS;
+pub const NANOSECONDS: u64 = 1;
+
+// Data (IEC) with base unit as bytes - typically used for memory
+pub const KIBIBYTES: u64 = 1024 * BYTES;
+pub const BYTES: u64 = 1;

--- a/src/common/units.rs
+++ b/src/common/units.rs
@@ -2,7 +2,7 @@
 
 // Time units with base unit as nanoseconds
 pub const SECONDS: u64 = 1_000 * MILLISECONDS;
-pub const MILLISECONDS: u64 = 1_000 * MICROSECONDS; 
+pub const MILLISECONDS: u64 = 1_000 * MICROSECONDS;
 pub const MICROSECONDS: u64 = 1_000 * NANOSECONDS;
 pub const NANOSECONDS: u64 = 1;
 

--- a/src/samplers/memory/linux/proc_meminfo/mod.rs
+++ b/src/samplers/memory/linux/proc_meminfo/mod.rs
@@ -1,4 +1,5 @@
 use crate::common::Nop;
+use crate::common::units::KIBIBYTES;
 use crate::samplers::memory::stats::*;
 use crate::samplers::memory::*;
 use metriken::{Gauge, Lazy};
@@ -99,7 +100,7 @@ impl ProcMeminfo {
 
             if let Some(gauge) = self.gauges.get_mut(*parts.first().unwrap()) {
                 if let Some(Ok(v)) = parts.get(1).map(|v| v.parse::<i64>()) {
-                    gauge.set(v);
+                    gauge.set(v * KIBIBYTES as i64);
                 }
             }
         }

--- a/src/samplers/memory/linux/proc_meminfo/mod.rs
+++ b/src/samplers/memory/linux/proc_meminfo/mod.rs
@@ -1,5 +1,5 @@
-use crate::common::Nop;
 use crate::common::units::KIBIBYTES;
+use crate::common::Nop;
 use crate::samplers::memory::stats::*;
 use crate::samplers::memory::*;
 use metriken::{Gauge, Lazy};

--- a/src/samplers/rezolus/rusage/mod.rs
+++ b/src/samplers/rezolus/rusage/mod.rs
@@ -2,10 +2,7 @@ use super::stats::*;
 use super::*;
 use crate::common::Counter;
 use crate::common::Nop;
-
-const S: u64 = 1_000_000_000;
-const US: u64 = 1_000;
-const KB: i64 = 1024;
+use crate::common::units::{SECONDS, MICROSECONDS, KIBIBYTES};
 
 #[distributed_slice(REZOLUS_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
@@ -104,13 +101,13 @@ impl Rusage {
         if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut rusage) } == 0 {
             self.ru_utime.set(
                 elapsed,
-                rusage.ru_utime.tv_sec as u64 * S + rusage.ru_utime.tv_usec as u64 * US,
+                rusage.ru_utime.tv_sec as u64 * SECONDS + rusage.ru_utime.tv_usec as u64 * MICROSECONDS,
             );
             self.ru_stime.set(
                 elapsed,
-                rusage.ru_stime.tv_sec as u64 * S + rusage.ru_stime.tv_usec as u64 * US,
+                rusage.ru_stime.tv_sec as u64 * SECONDS + rusage.ru_stime.tv_usec as u64 * MICROSECONDS,
             );
-            RU_MAXRSS.set(rusage.ru_maxrss * KB);
+            RU_MAXRSS.set(rusage.ru_maxrss * KIBIBYTES as i64);
             RU_MINFLT.set(rusage.ru_minflt as u64);
             RU_MAJFLT.set(rusage.ru_majflt as u64);
             RU_INBLOCK.set(rusage.ru_inblock as u64);

--- a/src/samplers/rezolus/rusage/mod.rs
+++ b/src/samplers/rezolus/rusage/mod.rs
@@ -1,8 +1,8 @@
 use super::stats::*;
 use super::*;
+use crate::common::units::{KIBIBYTES, MICROSECONDS, SECONDS};
 use crate::common::Counter;
 use crate::common::Nop;
-use crate::common::units::{SECONDS, MICROSECONDS, KIBIBYTES};
 
 #[distributed_slice(REZOLUS_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
@@ -101,11 +101,13 @@ impl Rusage {
         if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut rusage) } == 0 {
             self.ru_utime.set(
                 elapsed,
-                rusage.ru_utime.tv_sec as u64 * SECONDS + rusage.ru_utime.tv_usec as u64 * MICROSECONDS,
+                rusage.ru_utime.tv_sec as u64 * SECONDS
+                    + rusage.ru_utime.tv_usec as u64 * MICROSECONDS,
             );
             self.ru_stime.set(
                 elapsed,
-                rusage.ru_stime.tv_sec as u64 * SECONDS + rusage.ru_stime.tv_usec as u64 * MICROSECONDS,
+                rusage.ru_stime.tv_sec as u64 * SECONDS
+                    + rusage.ru_stime.tv_usec as u64 * MICROSECONDS,
             );
             RU_MAXRSS.set(rusage.ru_maxrss * KIBIBYTES as i64);
             RU_MINFLT.set(rusage.ru_minflt as u64);


### PR DESCRIPTION
Currently, the metadata units and actual measurement units for the memory usage gauges (`memory/total`, `memory/free`, ...) do not agree.

This change updates the sampler so that the gauges are properly reported in bytes.

While this is more disruptive than changing the unit metadata, this approach leads to better consistency across our units of measurement.
