### PR TITLE
fix: change kprobe for cpu usage

### DIFF
--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -44,8 +44,8 @@ int account_delta(u64 delta, u32 usage_idx)
 	return 0;
 }
 
-SEC("kprobe/__cgroup_account_cputime_field")
-int BPF_KPROBE(cgroup_account_cputime_field_kprobe, void *task, u32 index, u64 delta)
+SEC("kprobe/cpuacct_account_field")
+int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 {
 	if (index == 3) {
 		return 0;


### PR DESCRIPTION
Change the kprobe for CPU usage to probe the cpu accounting function instead of the cgroup accounting function. This addresses an issue where all CPU time is reported as idle on some systems.

Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

Solution

Describe the modifications you've done.

Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.
