### PR TITLE
Update the index of CPU usage counters to match cpu_usage_stat

### DIFF
--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -46,6 +46,7 @@ pub struct CpuUsage {
     online_cores_next: Instant,
 }
 
+const IDLE_CPUTIME_INDEX: usize = 3;
 impl CpuUsage {
     pub fn new(config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
@@ -90,10 +91,10 @@ impl CpuUsage {
             "user",
             "nice",
             "system",
+            "softirq",
+            "irq",
             "idle",
             "io_wait",
-            "irq",
-            "softirq",
             "steal",
             "guest",
             "guest_nice",
@@ -176,7 +177,8 @@ impl CpuUsage {
             let sum_now: u64 = self.percpu_counters.sum(cpu).unwrap_or(0);
             let busy_delta = sum_now.wrapping_sub(*sum_prev);
             let idle_delta = elapsed.as_nanos() as u64 - busy_delta;
-            self.percpu_counters.add(cpu, 3, idle_delta);
+            self.percpu_counters
+                .add(cpu, IDLE_CPUTIME_INDEX, idle_delta);
             *sum_prev += busy_delta + idle_delta;
         }
 

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -46,7 +46,7 @@ pub struct CpuUsage {
     online_cores_next: Instant,
 }
 
-const IDLE_CPUTIME_INDEX: usize = 3;
+const IDLE_CPUTIME_INDEX: usize = 5;
 impl CpuUsage {
     pub fn new(config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
@@ -76,10 +76,10 @@ impl CpuUsage {
             Counter::new(&CPU_USAGE_USER, Some(&CPU_USAGE_USER_HISTOGRAM)),
             Counter::new(&CPU_USAGE_NICE, Some(&CPU_USAGE_NICE_HISTOGRAM)),
             Counter::new(&CPU_USAGE_SYSTEM, Some(&CPU_USAGE_SYSTEM_HISTOGRAM)),
+            Counter::new(&CPU_USAGE_SOFTIRQ, Some(&CPU_USAGE_SOFTIRQ_HISTOGRAM)),
+            Counter::new(&CPU_USAGE_IRQ, Some(&CPU_USAGE_IRQ_HISTOGRAM)),
             Counter::new(&CPU_USAGE_IDLE, Some(&CPU_USAGE_IDLE_HISTOGRAM)),
             Counter::new(&CPU_USAGE_IO_WAIT, Some(&CPU_USAGE_IO_WAIT_HISTOGRAM)),
-            Counter::new(&CPU_USAGE_IRQ, Some(&CPU_USAGE_IRQ_HISTOGRAM)),
-            Counter::new(&CPU_USAGE_SOFTIRQ, Some(&CPU_USAGE_SOFTIRQ_HISTOGRAM)),
             Counter::new(&CPU_USAGE_STEAL, Some(&CPU_USAGE_STEAL_HISTOGRAM)),
             Counter::new(&CPU_USAGE_GUEST, Some(&CPU_USAGE_GUEST_HISTOGRAM)),
             Counter::new(&CPU_USAGE_GUEST_NICE, Some(&CPU_USAGE_GUEST_NICE_HISTOGRAM)),
@@ -246,10 +246,10 @@ fn sum() -> u64 {
         &CPU_USAGE_USER,
         &CPU_USAGE_NICE,
         &CPU_USAGE_SYSTEM,
+        &CPU_USAGE_SOFTIRQ,
+        &CPU_USAGE_IRQ,
         &CPU_USAGE_IDLE,
         &CPU_USAGE_IO_WAIT,
-        &CPU_USAGE_IRQ,
-        &CPU_USAGE_SOFTIRQ,
         &CPU_USAGE_STEAL,
         &CPU_USAGE_GUEST,
         &CPU_USAGE_GUEST_NICE,

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -49,7 +49,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 {
   // ignore both the idle and the iowait counting since both count the idle time
   // https://elixir.bootlin.com/linux/v6.9-rc4/source/kernel/sched/cputime.c#L227
-	if (index == 4 || index == 5) {
+	if (index == 5 || index == 6) {
 		return 0;
 	}
 

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -10,6 +10,9 @@
 #define COUNTER_GROUP_WIDTH 16
 #define MAX_CPUS 1024
 
+#define IDLE_STAT_INDEX 5
+#define IOWAIT_STAT_INDEX 6
+
 // cpu usage stat index (https://elixir.bootlin.com/linux/v6.9-rc4/source/include/linux/kernel_stat.h#L20)
 // 0 - user
 // 1 - nice
@@ -49,7 +52,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 {
   // ignore both the idle and the iowait counting since both count the idle time
   // https://elixir.bootlin.com/linux/v6.9-rc4/source/kernel/sched/cputime.c#L227
-	if (index == 5 || index == 6) {
+	if (index == IDLE_STAT_INDEX || index == IOWAIT_STAT_INDEX) {
 		return 0;
 	}
 

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -10,14 +10,14 @@
 #define COUNTER_GROUP_WIDTH 16
 #define MAX_CPUS 1024
 
-// counters for cpu usage
+// cpu usage stat index (https://elixir.bootlin.com/linux/v6.9-rc4/source/include/linux/kernel_stat.h#L20)
 // 0 - user
 // 1 - nice
 // 2 - system
-// 3 - idle - *NOTE* this will not increment. User-space must calculate it
-// 4 - iowait
-// 5 - irq
-// 6 - softirq
+// 3 - softirq
+// 4 - irq
+// 5 - idle - *NOTE* this will not increment. User-space must calculate it
+// 6 - iowait
 // 7 - steal
 // 8 - guest
 // 9 - guest_nice
@@ -47,7 +47,9 @@ int account_delta(u64 delta, u32 usage_idx)
 SEC("kprobe/cpuacct_account_field")
 int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 {
-	if (index == 3) {
+  // ignore both the idle and the iowait counting since both count the idle time
+  // https://elixir.bootlin.com/linux/v6.9-rc4/source/kernel/sched/cputime.c#L227
+	if (index == 4 || index == 5) {
 		return 0;
 	}
 


### PR DESCRIPTION
The [cpu_usage_stat](https://elixir.bootlin.com/linux/v6.9-rc4/C/ident/cpu_usage_stat) index is different to the order in /proc/stat. This PR updates the index.

Both of [CPUTIME_IDLE](https://elixir.bootlin.com/linux/v6.9-rc4/C/ident/CPUTIME_IDLE) and [CPUTIME_IOWAIT](https://elixir.bootlin.com/linux/v6.9-rc4/C/ident/CPUTIME_IOWAIT) are idle time, so ignore both of them in counting.
