### PR TITLE
add off-cpu time distribution

### DIFF
--- a/src/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/samplers/scheduler/linux/runqueue/mod.rs
@@ -72,6 +72,7 @@ impl Runqlat {
         let mut distributions = vec![
             ("runqlat", &SCHEDULER_RUNQUEUE_LATENCY),
             ("running", &SCHEDULER_RUNNING),
+            ("offcpu", &SCHEDULER_OFFCPU),
         ];
 
         for (name, histogram) in distributions.drain(..) {

--- a/src/samplers/scheduler/stats.rs
+++ b/src/samplers/scheduler/stats.rs
@@ -18,6 +18,13 @@ pub static SCHEDULER_RUNQUEUE_LATENCY: RwLockHistogram =
 pub static SCHEDULER_RUNNING: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
+    name = "scheduler/offcpu",
+    description = "Distribution of the amount of time tasks were off-CPU",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SCHEDULER_OFFCPU: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
     name = "scheduler/context_switch/involuntary",
     description = "The number of involuntary context switches"
 )]


### PR DESCRIPTION
Adds a distribution that tracks the amount of time tasks spent off-CPU, not including runqueue wait.
