### PR TITLE
add sampler that tracks open file descriptors

### DIFF
--- a/src/samplers/filesystem/linux/descriptors/mod.rs
+++ b/src/samplers/filesystem/linux/descriptors/mod.rs
@@ -1,0 +1,18 @@
+use crate::common::Nop;
+use crate::{distributed_slice, Config, Sampler};
+use crate::samplers::filesystem::FILESYSTEM_SAMPLERS;
+
+const NAME: &str = "filesystem_descriptors";
+
+mod procfs;
+
+use procfs::*;
+
+#[distributed_slice(FILESYSTEM_SAMPLERS)]
+fn init(config: &Config) -> Box<dyn Sampler> {
+    if let Ok(s) = Procfs::new(config) {
+        Box::new(s)
+    } else {
+        Box::new(Nop {})
+    }
+}

--- a/src/samplers/filesystem/linux/descriptors/mod.rs
+++ b/src/samplers/filesystem/linux/descriptors/mod.rs
@@ -1,6 +1,6 @@
 use crate::common::Nop;
-use crate::{distributed_slice, Config, Sampler};
 use crate::samplers::filesystem::FILESYSTEM_SAMPLERS;
+use crate::{distributed_slice, Config, Sampler};
 
 const NAME: &str = "filesystem_descriptors";
 

--- a/src/samplers/filesystem/linux/descriptors/procfs.rs
+++ b/src/samplers/filesystem/linux/descriptors/procfs.rs
@@ -1,9 +1,9 @@
-use crate::{error, Config, Sampler, Instant, Duration};
 use crate::samplers::filesystem::*;
 use crate::samplers::hwinfo::hardware_info;
+use crate::{error, Config, Duration, Instant, Sampler};
 use metriken::DynBoxedMetric;
-use metriken::MetricBuilder;
 use metriken::LazyGauge;
+use metriken::MetricBuilder;
 use std::fs::File;
 use std::io::{Read, Seek};
 

--- a/src/samplers/filesystem/linux/descriptors/procfs.rs
+++ b/src/samplers/filesystem/linux/descriptors/procfs.rs
@@ -1,0 +1,89 @@
+use crate::{error, Config, Sampler, Instant, Duration};
+use crate::samplers::filesystem::*;
+use crate::samplers::hwinfo::hardware_info;
+use metriken::DynBoxedMetric;
+use metriken::MetricBuilder;
+use metriken::LazyGauge;
+use std::fs::File;
+use std::io::{Read, Seek};
+
+use super::NAME;
+
+pub struct Procfs {
+    prev: Instant,
+    next: Instant,
+    interval: Duration,
+    file: File,
+}
+
+impl Procfs {
+    pub fn new(config: &Config) -> Result<Self, ()> {
+        // check if sampler should be enabled
+        if !config.enabled(NAME) {
+            return Err(());
+        }
+
+        let now = Instant::now();
+
+        let file = std::fs::File::open("/proc/sys/fs/file-nr").map_err(|e| {
+            error!("failed to open: {e}");
+        })?;
+
+        Ok(Self {
+            file,
+            prev: now,
+            next: now,
+            interval: config.interval(NAME),
+        })
+    }
+}
+
+impl Sampler for Procfs {
+    fn sample(&mut self) {
+        let now = Instant::now();
+
+        if now < self.next {
+            return;
+        }
+
+        let _ = self.sample_procfs();
+
+        // determine when to sample next
+        let next = self.next + self.interval;
+
+        // it's possible we fell behind
+        if next > now {
+            // if we didn't, sample at the next planned time
+            self.next = next;
+        } else {
+            // if we did, sample after the interval has elapsed
+            self.next = now + self.interval;
+        }
+
+        // mark when we last sampled
+        self.prev = now;
+    }
+}
+
+impl Procfs {
+    fn sample_procfs(&mut self) -> Result<(), std::io::Error> {
+        self.file.rewind()?;
+
+        let mut data = String::new();
+        self.file.read_to_string(&mut data)?;
+
+        let mut lines = data.lines();
+
+        if let Some(line) = lines.next() {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+
+            if parts.len() == 3 {
+                if let Ok(open) = parts[0].parse::<i64>() {
+                    FILESYSTEM_DESCRIPTORS_OPEN.set(open);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/samplers/filesystem/linux/mod.rs
+++ b/src/samplers/filesystem/linux/mod.rs
@@ -1,0 +1,3 @@
+mod descriptors;
+
+pub mod stats;

--- a/src/samplers/filesystem/linux/stats.rs
+++ b/src/samplers/filesystem/linux/stats.rs
@@ -1,0 +1,9 @@
+use crate::common::HISTOGRAM_GROUPING_POWER;
+use crate::*;
+use metriken::{metric, AtomicHistogram, Counter, Gauge, LazyCounter, LazyGauge};
+
+#[metric(
+    name = "filesystem/descriptors/open",
+    description = "The number of file descriptors currently allocated"
+)]
+pub static FILESYSTEM_DESCRIPTORS_OPEN: LazyGauge = LazyGauge::new(Gauge::default);

--- a/src/samplers/filesystem/mod.rs
+++ b/src/samplers/filesystem/mod.rs
@@ -1,0 +1,9 @@
+use crate::*;
+
+sampler!(Filesystem, "filesystem", FILESYSTEM_SAMPLERS);
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "linux")]
+pub use linux::stats::*;

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -1,7 +1,9 @@
+pub mod hwinfo;
+
 mod block_io;
 mod cpu;
 mod gpu;
-pub mod hwinfo;
+mod filesystem;
 mod memory;
 mod network;
 mod rezolus;

--- a/src/samplers/mod.rs
+++ b/src/samplers/mod.rs
@@ -2,8 +2,8 @@ pub mod hwinfo;
 
 mod block_io;
 mod cpu;
-mod gpu;
 mod filesystem;
+mod gpu;
 mod memory;
 mod network;
 mod rezolus;


### PR DESCRIPTION
Adds a sampler that tracks open file descriptors using procfs on linux.
