### PR TITLE
bump dependency versions in manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
@@ -1033,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668934cb4bd14f41e8d98a447ee237c76fc19ef0b935d5127026121a096ea86e"
+checksum = "0fa6cd31e1dcdad522b4599076c96b3a26973fe32ff36f32000dbcd90e16d460"
 dependencies = [
  "chrono",
  "histogram 0.10.0",
@@ -1213,9 +1228,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "ouroboros"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ba07320d39dfea882faa70554b4bd342a5f273ed59ba7c1c6b4c840492c954"
+checksum = "97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -1224,13 +1239,14 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
+checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error",
+ "itertools",
  "proc-macro2",
+ "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.48",
 ]
@@ -1299,7 +1315,7 @@ dependencies = [
  "bitflags 2.4.2",
  "c-enum 0.1.2",
  "libc",
- "memmap2 0.9.3",
+ "memmap2 0.9.4",
  "perf-event-data",
  "perf-event-open-sys2",
 ]
@@ -1416,36 +1432,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1540,7 +1545,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "linkme",
- "memmap2 0.5.10",
+ "memmap2 0.9.4",
  "metriken 0.6.0",
  "metriken-exposition",
  "num_cpus",
@@ -1675,18 +1680,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2009,14 +2014,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -2035,10 +2040,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2049,7 +2052,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.6",
 ]
 
 [[package]]
@@ -2481,6 +2497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wrapcenum-derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2516,12 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,34 +13,34 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 systeminfo = { workspace = true }
 
-backtrace = "0.3.69"
-clap = "4.3.24"
+backtrace = "0.3.71"
+chrono = { version = "0.4.38", features = ["serde"] }
+clap = "4.5.4"
+histogram = { version = "0.10.0", features = ["serde"] }
 humantime = "2.1.0"
 lazy_static = "1.4.0"
-libc = "0.2.147"
-linkme = "0.3.15"
+libc = "0.2.153"
+linkme = "0.3.25"
 metriken =  "0.6.0"
-metriken-exposition = { version = "0.5.0", features = ["serde", "msgpack"] }
-memmap2 = "0.5.10"
+metriken-exposition = { version = "0.6.1", features = ["serde", "msgpack"] }
+memmap2 = "0.9.4"
 num_cpus = "1.16.0"
 once_cell = "1.18.0"
-ouroboros = "0.17.2"
+ouroboros = "0.18.3"
 ringlog = "0.6.0"
-serde = { version = "1.0.185", features = ["derive"] }
+serde = { version = "1.0.198", features = ["derive"] }
+serde_repr = "0.1.19"
 sysconf = "0.3.4"
-syscall-numbers = "3.1.0"
-tokio = { version = "1.32.0", features = ["full"] }
-toml = "0.7.6"
-walkdir = "2.3.3"
-warp = { version = "0.3.6", features = ["compression"] }
-serde_repr = "0.1.18"
-histogram = { version = "0.10.0", features = ["serde"] }
-chrono = { version = "0.4.33", features = ["serde"] }
+syscall-numbers = "3.1.1"
+tokio = { version = "1.37.0", features = ["full"] }
+toml = "0.8.12"
+walkdir = "2.5.0"
+warp = { version = "0.3.7", features = ["compression"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.21.2", optional = true }
 libbpf-sys = { version = "1.2.1", optional = true }
-perf-event2 = "0.7.0"
+perf-event2 = "0.7.2"
 nvml-wrapper = "0.9.0"
 
 [target.'cfg(target_os = "linux")'.build-dependencies]


### PR DESCRIPTION
Bumps dependency versions in the manifest for all crates except those for BPF and nvml support.
