### PR TITLE
refactor bpf histogram indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -1433,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
@@ -1580,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
+checksum = "938a142ab806f18b88a97b0dea523d39e0fd730a064b035726adcfc58a8a5188"
 dependencies = [
  "byteorder",
  "rmp",
@@ -1608,9 +1608,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.4.2",
  "errno 0.3.8",
@@ -1700,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -1754,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -1892,18 +1892,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2333,11 +2333,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
 dependencies = [
- "winapi 0.3.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/common/bpf/histogram.h
+++ b/src/common/bpf/histogram.h
@@ -212,7 +212,7 @@ static u32 clz(u64 value) {
 //
 // See the indexing logic here:
 // https://github.com/pelikan-io/rustcommon/blob/main/histogram/src/config.rs
-static u32 value_to_index(u8 grouping_power, u64 value) {
+static u32 value_to_index(u64 value, u8 grouping_power) {
     if (value < (2 << grouping_power)) {
         return value;
     } else {

--- a/src/common/bpf/histogram.h
+++ b/src/common/bpf/histogram.h
@@ -1,15 +1,15 @@
 // Helpers for converting values to histogram indices. 
 
+#define HISTOGRAM_BUCKETS_POW_4 976
+#define HISTOGRAM_BUCKETS_POW_5 1920
+#define HISTOGRAM_BUCKETS_POW_6 3776
+#define HISTOGRAM_BUCKETS_POW_7 7424
+
 // Function to count leading zeros, since we cannot use the builtin CLZ from
 // within BPF. But since we also can't loop, this is implemented as a binary
-// search with a maximum of 6 branches.
+// search with a maximum of 6 branches. 
 static u32 clz(u64 value) {
     u32 count = 0;
-
-    // quick return if value is 0
-    if (!value) {
-        return 64;
-    }
 
     // binary search to find number of leading zeros
     if (value & 0xFFFFFFFF00000000) {
@@ -203,25 +203,79 @@ static u32 clz(u64 value) {
     } else {
         return 63;
     }
+
+    return 64;
 }
 
 // base-2 histogram indexing function that is compatible with Rust `histogram`
-// crate for m = 0, r = 8, n = 64 this gives us the ability to store counts for
-// values from 1 -> u64::MAX and uses 7424 buckets per histogram, which occupies
-// 58KB of space in kernelspace (where we use 64bit counters)
-static u32 value_to_index(u64 value) {
-    if (value == 0) {
-        return 0;
-    }
-
-    u64 h = 63 - clz(value);
-    // h < r
-    if (h < 8) {
+// crate with grouping power = 4. This uses 2 pages (8KB) in kernel space and
+// 7.6KB in user space and has a relative error of 6.25%
+//
+// See the indexing logic here:
+// https://github.com/pelikan-io/rustcommon/blob/main/histogram/src/config.rs
+static u32 value_to_index4(u64 value) {
+    if (value < 32) {
         return value;
     } else {
-        // d = h - r + 1
-        u64 d = h - 7;
-        // ((d + 1) * G + ((value - (1 << h)) >> (m + d)))
-        return ((d + 1) * 128) + ((value - (1 << h)) >> d);
+        u64 power = 63 - clz(value);
+        u64 bin = power - 3;
+        u64 offset = (value - (1 << power)) >> (power - 4);
+
+        return (bin * 16 + offset);
+    }
+}
+
+// base-2 histogram indexing function that is compatible with Rust `histogram`
+// crate with grouping power = 5. This uses 4 pages (16KB) in kernel space and
+// 15KB in user space and has a relative error of 3.13%
+//
+// See the indexing logic here:
+// https://github.com/pelikan-io/rustcommon/blob/main/histogram/src/config.rs
+static u32 value_to_index5(u64 value) {
+    if (value < 64) {
+        return value;
+    } else {
+        u64 power = 63 - clz(value);
+        u64 bin = power - 4;
+        u64 offset = (value - (1 << power)) >> (power - 5);
+
+        return (bin * 32 + offset);
+    }
+}
+
+// base-2 histogram indexing function that is compatible with Rust `histogram`
+// crate with grouping power = 5. This uses 4 pages (16KB) in kernel space and
+// 15KB in user space and has a relative error of 3.13%
+//
+// See the indexing logic here:
+// https://github.com/pelikan-io/rustcommon/blob/main/histogram/src/config.rs
+static u32 value_to_index6(u64 value) {
+    if (value < 128) {
+        return value;
+    } else {
+        u64 power = 63 - clz(value);
+        u64 bin = power - 5;
+        u64 offset = (value - (1 << power)) >> (power - 6);
+
+        return (bin * 64 + offset);
+    }
+}
+
+
+// base-2 histogram indexing function that is compatible with Rust `histogram`
+// crate with grouping power = 7. This uses 15 pages (60KB) in kernel space and
+// 58KB in user space per histogram with a relative error of 0.781%
+//
+// See the indexing logic here:
+// https://github.com/pelikan-io/rustcommon/blob/main/histogram/src/config.rs
+static u32 value_to_index7(u64 value) {
+    if (value < 256) {
+        return value;
+    } else {
+        u64 power = 63 - clz(value);
+        u64 bin = power - 6;
+        u64 offset = (value - (1 << power)) >> (power - 7);
+
+        return (bin * 128 + offset);
     }
 }

--- a/src/samplers/block_io/linux/latency/mod.bpf.c
+++ b/src/samplers/block_io/linux/latency/mod.bpf.c
@@ -107,7 +107,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 		}
     }
 
-	idx = value_to_index(HISTOGRAM_POWER, nr_bytes);
+	idx = value_to_index(nr_bytes, HISTOGRAM_POWER);
 	cnt = bpf_map_lookup_elem(&size, &idx);
 
 	if (cnt) {
@@ -122,7 +122,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 	if (*tsp <= ts) {
 		delta = ts - *tsp;
 
-		idx = value_to_index(HISTOGRAM_POWER, delta);
+		idx = value_to_index(delta, HISTOGRAM_POWER);
 		cnt = bpf_map_lookup_elem(&latency, &idx);
 
 		if (cnt) {

--- a/src/samplers/block_io/linux/latency/mod.bpf.c
+++ b/src/samplers/block_io/linux/latency/mod.bpf.c
@@ -11,6 +11,7 @@
 extern int LINUX_KERNEL_VERSION __kconfig;
 
 #define COUNTER_GROUP_WIDTH 8
+#define HISTOGRAM_POWER 7
 #define MAX_CPUS 1024
 
 #define REQ_OP_BITS	8
@@ -106,7 +107,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 		}
     }
 
-	idx = value_to_index7(nr_bytes);
+	idx = value_to_index(HISTOGRAM_POWER, nr_bytes);
 	cnt = bpf_map_lookup_elem(&size, &idx);
 
 	if (cnt) {
@@ -121,7 +122,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 	if (*tsp <= ts) {
 		delta = ts - *tsp;
 
-		idx = value_to_index7(delta);
+		idx = value_to_index(HISTOGRAM_POWER, delta);
 		cnt = bpf_map_lookup_elem(&latency, &idx);
 
 		if (cnt) {

--- a/src/samplers/block_io/linux/latency/mod.bpf.c
+++ b/src/samplers/block_io/linux/latency/mod.bpf.c
@@ -106,7 +106,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 		}
     }
 
-	idx = value_to_index(nr_bytes);
+	idx = value_to_index7(nr_bytes);
 	cnt = bpf_map_lookup_elem(&size, &idx);
 
 	if (cnt) {
@@ -121,7 +121,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 	if (*tsp <= ts) {
 		delta = ts - *tsp;
 
-		idx = value_to_index(delta);
+		idx = value_to_index7(delta);
 		cnt = bpf_map_lookup_elem(&latency, &idx);
 
 		if (cnt) {

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -58,9 +58,18 @@ impl Biolat {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} block_rq_insert() BPF instruction count: {}", skel.progs().block_rq_insert().insn_cnt());
-        debug!("{NAME} block_rq_issue() BPF instruction count: {}", skel.progs().block_rq_issue().insn_cnt());
-        debug!("{NAME} block_rq_complete() BPF instruction count: {}", skel.progs().block_rq_complete().insn_cnt());
+        debug!(
+            "{NAME} block_rq_insert() BPF instruction count: {}",
+            skel.progs().block_rq_insert().insn_cnt()
+        );
+        debug!(
+            "{NAME} block_rq_issue() BPF instruction count: {}",
+            skel.progs().block_rq_issue().insn_cnt()
+        );
+        debug!(
+            "{NAME} block_rq_complete() BPF instruction count: {}",
+            skel.progs().block_rq_complete().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -56,7 +56,10 @@ impl CpuUsage {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} cpuacct_account_field() BPF instruction count: {}", skel.progs().cpuacct_account_field_kprobe().insn_cnt());
+        debug!(
+            "{NAME} cpuacct_account_field() BPF instruction count: {}",
+            skel.progs().cpuacct_account_field_kprobe().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/network/linux/traffic/bpf.rs
+++ b/src/samplers/network/linux/traffic/bpf.rs
@@ -50,8 +50,14 @@ impl NetworkTraffic {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} netif_receive_skb() BPF instruction count: {}", skel.progs().netif_receive_skb().insn_cnt());
-        debug!("{NAME} tcp_cleanup_rbuf() BPF instruction count: {}", skel.progs().tcp_cleanup_rbuf().insn_cnt());
+        debug!(
+            "{NAME} netif_receive_skb() BPF instruction count: {}",
+            skel.progs().netif_receive_skb().insn_cnt()
+        );
+        debug!(
+            "{NAME} tcp_cleanup_rbuf() BPF instruction count: {}",
+            skel.progs().tcp_cleanup_rbuf().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -185,7 +185,7 @@ int handle__sched_switch(u64 *ctx)
 			delta_ns = ts - *tsp;
 
 			// update histogram
-			idx = value_to_index(HISTOGRAM_POWER, delta_ns);
+			idx = value_to_index(delta_ns, HISTOGRAM_POWER);
 			cnt = bpf_map_lookup_elem(&running, &idx);
 			if (cnt) {
 				__sync_fetch_and_add(cnt, 1);
@@ -215,7 +215,7 @@ int handle__sched_switch(u64 *ctx)
 		delta_ns = ts - *tsp;
 
 		// update the histogram
-		idx = value_to_index(HISTOGRAM_POWER, delta_ns);
+		idx = value_to_index(delta_ns, HISTOGRAM_POWER);
 		cnt = bpf_map_lookup_elem(&runqlat, &idx);
 		if (cnt) {
 			__sync_fetch_and_add(cnt, 1);
@@ -233,7 +233,7 @@ int handle__sched_switch(u64 *ctx)
 				offcpu_ns = offcpu_ns - delta_ns;
 
 				// update the histogram
-				idx = value_to_index(HISTOGRAM_POWER, offcpu_ns);
+				idx = value_to_index(offcpu_ns, HISTOGRAM_POWER);
 				cnt = bpf_map_lookup_elem(&offcpu, &idx);
 				if (cnt) {
 					__sync_fetch_and_add(cnt, 1);

--- a/src/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -15,6 +15,7 @@
 #include <bpf/bpf_helpers.h>
 
 #define COUNTER_GROUP_WIDTH 8
+#define HISTOGRAM_POWER 7
 #define MAX_CPUS 1024
 #define MAX_PID 4194304
 
@@ -184,7 +185,7 @@ int handle__sched_switch(u64 *ctx)
 			delta_ns = ts - *tsp;
 
 			// update histogram
-			idx = value_to_index7(delta_ns);
+			idx = value_to_index(HISTOGRAM_POWER, delta_ns);
 			cnt = bpf_map_lookup_elem(&running, &idx);
 			if (cnt) {
 				__sync_fetch_and_add(cnt, 1);
@@ -214,7 +215,7 @@ int handle__sched_switch(u64 *ctx)
 		delta_ns = ts - *tsp;
 
 		// update the histogram
-		idx = value_to_index7(delta_ns);
+		idx = value_to_index(HISTOGRAM_POWER, delta_ns);
 		cnt = bpf_map_lookup_elem(&runqlat, &idx);
 		if (cnt) {
 			__sync_fetch_and_add(cnt, 1);
@@ -232,7 +233,7 @@ int handle__sched_switch(u64 *ctx)
 				offcpu_ns = offcpu_ns - delta_ns;
 
 				// update the histogram
-				idx = value_to_index7(offcpu_ns);
+				idx = value_to_index(HISTOGRAM_POWER, offcpu_ns);
 				cnt = bpf_map_lookup_elem(&offcpu, &idx);
 				if (cnt) {
 					__sync_fetch_and_add(cnt, 1);

--- a/src/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/samplers/scheduler/linux/runqueue/mod.rs
@@ -60,9 +60,18 @@ impl Runqlat {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} handle__sched_wakeup() BPF instruction count: {}", skel.progs().handle__sched_wakeup().insn_cnt());
-        debug!("{NAME} handle__sched_wakeup_new() BPF instruction count: {}", skel.progs().handle__sched_wakeup_new().insn_cnt());
-        debug!("{NAME} handle__sched_switch() BPF instruction count: {}", skel.progs().handle__sched_switch().insn_cnt());
+        debug!(
+            "{NAME} handle__sched_wakeup() BPF instruction count: {}",
+            skel.progs().handle__sched_wakeup().insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_wakeup_new() BPF instruction count: {}",
+            skel.progs().handle__sched_wakeup_new().insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_switch() BPF instruction count: {}",
+            skel.progs().handle__sched_switch().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/samplers/syscall/linux/latency/mod.bpf.c
@@ -18,7 +18,7 @@
 #include <bpf/bpf_core_read.h>
 
 #define COUNTER_GROUP_WIDTH 8
-#define HISTOGRAM_BUCKETS 7424
+#define HISTOGRAM_POWER 7
 #define MAX_CPUS 1024
 #define MAX_SYSCALL_ID 1024
 #define MAX_PID 4194304
@@ -188,7 +188,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 	*start_ts = 0;
 
 	// calculate the histogram index for this latency value
-	idx = value_to_index7(lat);
+	idx = value_to_index(HISTOGRAM_POWER, lat);
 
 	// update the total latency histogram
 	cnt = bpf_map_lookup_elem(&total_latency, &idx);

--- a/src/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/samplers/syscall/linux/latency/mod.bpf.c
@@ -48,7 +48,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } total_latency SEC(".maps");
 
 struct {
@@ -56,7 +56,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } read_latency SEC(".maps");
 
 struct {
@@ -64,7 +64,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } write_latency SEC(".maps");
 
 struct {
@@ -72,7 +72,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } poll_latency SEC(".maps");
 
 struct {
@@ -80,7 +80,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } lock_latency SEC(".maps");
 
 struct {
@@ -88,7 +88,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } time_latency SEC(".maps");
 
 struct {
@@ -96,7 +96,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } sleep_latency SEC(".maps");
 
 struct {
@@ -104,7 +104,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } socket_latency SEC(".maps");
 
 // provides a lookup table from syscall id to a counter index offset
@@ -188,7 +188,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 	*start_ts = 0;
 
 	// calculate the histogram index for this latency value
-	idx = value_to_index(lat);
+	idx = value_to_index7(lat);
 
 	// update the total latency histogram
 	cnt = bpf_map_lookup_elem(&total_latency, &idx);

--- a/src/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/samplers/syscall/linux/latency/mod.bpf.c
@@ -188,7 +188,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 	*start_ts = 0;
 
 	// calculate the histogram index for this latency value
-	idx = value_to_index(HISTOGRAM_POWER, lat);
+	idx = value_to_index(lat, HISTOGRAM_POWER);
 
 	// update the total latency histogram
 	cnt = bpf_map_lookup_elem(&total_latency, &idx);

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -59,8 +59,14 @@ impl Syscall {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} sys_enter() BPF instruction count: {}", skel.progs().sys_enter().insn_cnt());
-        debug!("{NAME} sys_exit() BPF instruction count: {}", skel.progs().sys_exit().insn_cnt());
+        debug!(
+            "{NAME} sys_enter() BPF instruction count: {}",
+            skel.progs().sys_enter().insn_cnt()
+        );
+        debug!(
+            "{NAME} sys_exit() BPF instruction count: {}",
+            skel.progs().sys_exit().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/tcp/linux/packet_latency/mod.bpf.c
+++ b/src/samplers/tcp/linux/packet_latency/mod.bpf.c
@@ -32,7 +32,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, 7424);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } latency SEC(".maps");
 
 static __always_inline __u64 get_sock_ident(struct sock *sk)
@@ -83,7 +83,7 @@ static int handle_tcp_rcv_space_adjust(void *ctx, struct sock *sk)
 
 	delta_ns = (now - *tsp);
 
-	idx = value_to_index(delta_ns);
+	idx = value_to_index7(delta_ns);
 	cnt = bpf_map_lookup_elem(&latency, &idx);
 
 	if (cnt) {

--- a/src/samplers/tcp/linux/packet_latency/mod.bpf.c
+++ b/src/samplers/tcp/linux/packet_latency/mod.bpf.c
@@ -85,7 +85,7 @@ static int handle_tcp_rcv_space_adjust(void *ctx, struct sock *sk)
 
 	delta_ns = (now - *tsp);
 
-	idx = value_to_index(HISTOGRAM_POWER, delta_ns);
+	idx = value_to_index(delta_ns, HISTOGRAM_POWER);
 	cnt = bpf_map_lookup_elem(&latency, &idx);
 
 	if (cnt) {

--- a/src/samplers/tcp/linux/packet_latency/mod.bpf.c
+++ b/src/samplers/tcp/linux/packet_latency/mod.bpf.c
@@ -16,6 +16,8 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 
+#define HISTOGRAM_POWER 7
+
 #define MAX_ENTRIES	10240
 #define AF_INET		2
 #define NO_EXIST    1
@@ -83,7 +85,7 @@ static int handle_tcp_rcv_space_adjust(void *ctx, struct sock *sk)
 
 	delta_ns = (now - *tsp);
 
-	idx = value_to_index7(delta_ns);
+	idx = value_to_index(HISTOGRAM_POWER, delta_ns);
 	cnt = bpf_map_lookup_elem(&latency, &idx);
 
 	if (cnt) {

--- a/src/samplers/tcp/linux/packet_latency/mod.rs
+++ b/src/samplers/tcp/linux/packet_latency/mod.rs
@@ -57,9 +57,18 @@ impl PacketLatency {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} tcp_probe() BPF instruction count: {}", skel.progs().tcp_probe().insn_cnt());
-        debug!("{NAME} tcp_rcv_space_adjust() BPF instruction count: {}", skel.progs().tcp_rcv_space_adjust().insn_cnt());
-        debug!("{NAME} tcp_destroy_sock() BPF instruction count: {}", skel.progs().tcp_destroy_sock().insn_cnt());
+        debug!(
+            "{NAME} tcp_probe() BPF instruction count: {}",
+            skel.progs().tcp_probe().insn_cnt()
+        );
+        debug!(
+            "{NAME} tcp_rcv_space_adjust() BPF instruction count: {}",
+            skel.progs().tcp_rcv_space_adjust().insn_cnt()
+        );
+        debug!(
+            "{NAME} tcp_destroy_sock() BPF instruction count: {}",
+            skel.progs().tcp_destroy_sock().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/samplers/tcp/linux/receive/mod.bpf.c
@@ -16,6 +16,8 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
 
+#define HISTOGRAM_POWER 7
+
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(map_flags, BPF_F_MMAPABLE);
@@ -49,7 +51,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	// record nanoseconds.
 	srtt_ns = 1000 * (u64) srtt_us >> 3;
 
-	idx = value_to_index7(srtt_ns);
+	idx = value_to_index(HISTOGRAM_POWER, srtt_ns);
 	cnt = bpf_map_lookup_elem(&srtt, &idx);
 
 	if (cnt) {
@@ -60,7 +62,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	// record nanoseconds.
 	mdev_ns = 1000 * (u64) mdev_us >> 2;
 
-	idx = value_to_index7(mdev_ns);
+	idx = value_to_index(HISTOGRAM_POWER, mdev_ns);
 	cnt = bpf_map_lookup_elem(&jitter, &idx);
 
 	if (cnt) {

--- a/src/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/samplers/tcp/linux/receive/mod.bpf.c
@@ -21,7 +21,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, 7424);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } jitter SEC(".maps");
 
 struct {
@@ -29,7 +29,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, 7424);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } srtt SEC(".maps");
 
 SEC("kprobe/tcp_rcv_established")
@@ -49,7 +49,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	// record nanoseconds.
 	srtt_ns = 1000 * (u64) srtt_us >> 3;
 
-	idx = value_to_index(srtt_ns);
+	idx = value_to_index7(srtt_ns);
 	cnt = bpf_map_lookup_elem(&srtt, &idx);
 
 	if (cnt) {
@@ -60,7 +60,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	// record nanoseconds.
 	mdev_ns = 1000 * (u64) mdev_us >> 2;
 
-	idx = value_to_index(mdev_ns);
+	idx = value_to_index7(mdev_ns);
 	cnt = bpf_map_lookup_elem(&jitter, &idx);
 
 	if (cnt) {

--- a/src/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/samplers/tcp/linux/receive/mod.bpf.c
@@ -51,7 +51,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	// record nanoseconds.
 	srtt_ns = 1000 * (u64) srtt_us >> 3;
 
-	idx = value_to_index(HISTOGRAM_POWER, srtt_ns);
+	idx = value_to_index(srtt_ns, HISTOGRAM_POWER);
 	cnt = bpf_map_lookup_elem(&srtt, &idx);
 
 	if (cnt) {
@@ -62,7 +62,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	// record nanoseconds.
 	mdev_ns = 1000 * (u64) mdev_us >> 2;
 
-	idx = value_to_index(HISTOGRAM_POWER, mdev_ns);
+	idx = value_to_index(mdev_ns, HISTOGRAM_POWER);
 	cnt = bpf_map_lookup_elem(&jitter, &idx);
 
 	if (cnt) {

--- a/src/samplers/tcp/linux/receive/mod.rs
+++ b/src/samplers/tcp/linux/receive/mod.rs
@@ -56,7 +56,10 @@ impl Receive {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} tcp_rcv() BPF instruction count: {}", skel.progs().tcp_rcv_kprobe().insn_cnt());
+        debug!(
+            "{NAME} tcp_rcv() BPF instruction count: {}",
+            skel.progs().tcp_rcv_kprobe().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/tcp/linux/retransmit/mod.rs
+++ b/src/samplers/tcp/linux/retransmit/mod.rs
@@ -55,7 +55,10 @@ impl Retransmit {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} tcp_retransmit_skb() BPF instruction count: {}", skel.progs().tcp_retransmit_skb().insn_cnt());
+        debug!(
+            "{NAME} tcp_retransmit_skb() BPF instruction count: {}",
+            skel.progs().tcp_retransmit_skb().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/tcp/linux/traffic/bpf.rs
+++ b/src/samplers/tcp/linux/traffic/bpf.rs
@@ -52,8 +52,14 @@ impl TcpTraffic {
             .load()
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
-        debug!("{NAME} tcp_sendmsg() BPF instruction count: {}", skel.progs().tcp_sendmsg().insn_cnt());
-        debug!("{NAME} tcp_cleanup_rbuf() BPF instruction count: {}", skel.progs().tcp_cleanup_rbuf().insn_cnt());
+        debug!(
+            "{NAME} tcp_sendmsg() BPF instruction count: {}",
+            skel.progs().tcp_sendmsg().insn_cnt()
+        );
+        debug!(
+            "{NAME} tcp_cleanup_rbuf() BPF instruction count: {}",
+            skel.progs().tcp_cleanup_rbuf().insn_cnt()
+        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/tcp/linux/traffic/mod.bpf.c
+++ b/src/samplers/tcp/linux/traffic/mod.bpf.c
@@ -16,6 +16,8 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
 
+#define HISTOGRAM_POWER 7
+
 /* Taken from kernel include/linux/socket.h. */
 #define AF_INET		2	/* Internet IP Protocol 	*/
 #define AF_INET6	10	/* IP version 6			*/
@@ -72,7 +74,7 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 			__sync_fetch_and_add(cnt, (u64) size);
 		}
 
-		idx = value_to_index7((u64) size);
+		idx = value_to_index(HISTOGRAM_POWER, (u64) size);
 		cnt = bpf_map_lookup_elem(&rx_size, &idx);
 
 		if (cnt) {
@@ -93,7 +95,7 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 			__sync_fetch_and_add(cnt, (u64) size);
 		}
 
-		idx = value_to_index7((u64) size);
+		idx = value_to_index(HISTOGRAM_POWER, (u64) size);
 		cnt = bpf_map_lookup_elem(&tx_size, &idx);
 
 		if (cnt) {

--- a/src/samplers/tcp/linux/traffic/mod.bpf.c
+++ b/src/samplers/tcp/linux/traffic/mod.bpf.c
@@ -39,7 +39,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, 7424);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } rx_size SEC(".maps");
 
 struct {
@@ -47,7 +47,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, 7424);
+	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
 } tx_size SEC(".maps");
 
 static int probe_ip(bool receiving, struct sock *sk, size_t size)
@@ -72,7 +72,7 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 			__sync_fetch_and_add(cnt, (u64) size);
 		}
 
-		idx = value_to_index((u64) size);
+		idx = value_to_index7((u64) size);
 		cnt = bpf_map_lookup_elem(&rx_size, &idx);
 
 		if (cnt) {
@@ -93,7 +93,7 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 			__sync_fetch_and_add(cnt, (u64) size);
 		}
 
-		idx = value_to_index((u64) size);
+		idx = value_to_index7((u64) size);
 		cnt = bpf_map_lookup_elem(&tx_size, &idx);
 
 		if (cnt) {

--- a/src/samplers/tcp/linux/traffic/mod.bpf.c
+++ b/src/samplers/tcp/linux/traffic/mod.bpf.c
@@ -74,7 +74,7 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 			__sync_fetch_and_add(cnt, (u64) size);
 		}
 
-		idx = value_to_index(HISTOGRAM_POWER, (u64) size);
+		idx = value_to_index((u64) size, HISTOGRAM_POWER);
 		cnt = bpf_map_lookup_elem(&rx_size, &idx);
 
 		if (cnt) {
@@ -95,7 +95,7 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 			__sync_fetch_and_add(cnt, (u64) size);
 		}
 
-		idx = value_to_index(HISTOGRAM_POWER, (u64) size);
+		idx = value_to_index((u64) size, HISTOGRAM_POWER);
 		cnt = bpf_map_lookup_elem(&tx_size, &idx);
 
 		if (cnt) {


### PR DESCRIPTION
The previous BPF histogram indexing was based on a reduction of the algorithm in an older version of the histogram crate that had both an a and b component. The latest histogram crate replaced those with a single grouping power.

This change brings the indexing more in-line with the Rust version. Specific reductions and optimizations are made based on the specific values that we use throughout Rezolus.
