### PR TITLE
add cpu busy time

### DIFF
--- a/src/common/bpf/counters.rs
+++ b/src/common/bpf/counters.rs
@@ -49,13 +49,6 @@ impl PercpuCounters {
         }
     }
 
-    /// Adds the provided delta to a counter for this CPU
-    pub fn add(&self, cpu: usize, idx: usize, delta: u64) {
-        if let Some(Some(counter)) = self.inner.get(cpu).map(|v| v.get(idx)) {
-            counter.add(delta);
-        }
-    }
-
     /// Returns the sum of all the counters for this CPU
     pub fn sum(&self, cpu: usize) -> Option<u64> {
         self.inner

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -51,6 +51,10 @@ impl Counter {
 
         self.previous = Some(value);
     }
+
+    pub fn value(&self) -> u64 {
+        self.counter.value()
+    }
 }
 
 #[macro_export]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -48,6 +48,7 @@ impl Counter {
                 let _ = histogram.increment((delta as f64 / elapsed) as _);
             }
         }
+
         self.previous = Some(value);
     }
 }

--- a/src/exposition/http.rs
+++ b/src/exposition/http.rs
@@ -102,6 +102,10 @@ mod handlers {
                 continue;
             }
 
+            if name == "cpu/usage" && metric.metadata().get("state") == Some("busy") {
+                continue;
+            }
+
             if let Some(counter) = any.downcast_ref::<Counter>() {
                 if metric.metadata().is_empty() {
                     data.push(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,14 @@
-use crate::common::Counter;
 use backtrace::Backtrace;
 use clap::{Arg, Command};
 use linkme::distributed_slice;
-use metriken::metric;
-use metriken::Lazy;
-use metriken::LazyCounter;
+use metriken::{metric, Lazy, LazyCounter};
 use metriken_exposition::Histogram;
 use ringlog::*;
+use tokio::sync::RwLock;
+
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::SystemTime;
-use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use std::time::{Duration, Instant, SystemTime};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -68,13 +68,15 @@ impl OnlineCores {
     }
 
     pub fn refresh(&mut self) -> Result<(), ()> {
-        self.file.rewind()
+        self.file
+            .rewind()
             .map_err(|e| error!("failed to seek to start of file: {e}"))?;
 
         let mut count = 0;
         let mut raw = String::new();
 
-        let _ = self.file
+        let _ = self
+            .file
             .read_to_string(&mut raw)
             .map_err(|e| error!("failed to read file: {e}"))?;
 
@@ -144,8 +146,8 @@ impl CpuUsage {
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
-        let online_cores = OnlineCores::new()
-            .map_err(|_| error!("couldn't determine number of online cores"))?;
+        let online_cores =
+            OnlineCores::new().map_err(|_| error!("couldn't determine number of online cores"))?;
 
         let cpus = match hardware_info() {
             Ok(hwinfo) => hwinfo.get_cpus(),

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -9,7 +9,7 @@ use super::NAME;
 
 use std::io::{Read, Seek};
 
-use metriken::MetricBuilder;
+use metriken::{DynBoxedMetric, MetricBuilder};
 
 use bpf::*;
 
@@ -33,8 +33,10 @@ impl GetMap for ModSkel<'_> {
 pub struct CpuUsage {
     bpf: Bpf<ModSkel<'static>>,
     percpu_counters: Arc<PercpuCounters>,
-    sum_prev: u64,
-    percpu_sum_prev: Vec<u64>,
+    total_busy: Counter,
+    total_idle: Counter,
+    percpu_busy: Vec<DynBoxedMetric<metriken::Counter>>,
+    percpu_idle: Vec<DynBoxedMetric<metriken::Counter>>,
     counter_interval: Interval,
     distribution_interval: Interval,
     online_cores: usize,
@@ -42,7 +44,6 @@ pub struct CpuUsage {
     online_cores_interval: Interval,
 }
 
-const IDLE_CPUTIME_INDEX: usize = 5;
 impl CpuUsage {
     pub fn new(config: &Config) -> Result<Self, ()> {
         let builder = ModSkelBuilder::default();
@@ -77,14 +78,14 @@ impl CpuUsage {
             Counter::new(&CPU_USAGE_SYSTEM, Some(&CPU_USAGE_SYSTEM_HISTOGRAM)),
             Counter::new(&CPU_USAGE_SOFTIRQ, Some(&CPU_USAGE_SOFTIRQ_HISTOGRAM)),
             Counter::new(&CPU_USAGE_IRQ, Some(&CPU_USAGE_IRQ_HISTOGRAM)),
-            Counter::new(&CPU_USAGE_IDLE, Some(&CPU_USAGE_IDLE_HISTOGRAM)),
-            Counter::new(&CPU_USAGE_IO_WAIT, Some(&CPU_USAGE_IO_WAIT_HISTOGRAM)),
             Counter::new(&CPU_USAGE_STEAL, Some(&CPU_USAGE_STEAL_HISTOGRAM)),
             Counter::new(&CPU_USAGE_GUEST, Some(&CPU_USAGE_GUEST_HISTOGRAM)),
             Counter::new(&CPU_USAGE_GUEST_NICE, Some(&CPU_USAGE_GUEST_NICE_HISTOGRAM)),
         ];
 
         let mut percpu_counters = PercpuCounters::default();
+        let mut percpu_busy = Vec::new();
+        let mut percpu_idle = Vec::new();
 
         let states = [
             "user",
@@ -92,8 +93,6 @@ impl CpuUsage {
             "system",
             "softirq",
             "irq",
-            "idle",
-            "io_wait",
             "steal",
             "guest",
             "guest_nice",
@@ -113,6 +112,26 @@ impl CpuUsage {
                         .build(metriken::Counter::new()),
                 );
             }
+            percpu_busy.push(
+                MetricBuilder::new("cpu/usage")
+                    .metadata("id", format!("{}", cpu.id()))
+                    .metadata("core", format!("{}", cpu.core()))
+                    .metadata("die", format!("{}", cpu.die()))
+                    .metadata("package", format!("{}", cpu.package()))
+                    .metadata("state", "busy")
+                    .formatter(cpu_metric_formatter)
+                    .build(metriken::Counter::new()),
+            );
+            percpu_idle.push(
+                MetricBuilder::new("cpu/usage")
+                    .metadata("id", format!("{}", cpu.id()))
+                    .metadata("core", format!("{}", cpu.core()))
+                    .metadata("die", format!("{}", cpu.die()))
+                    .metadata("package", format!("{}", cpu.package()))
+                    .metadata("state", "idle")
+                    .formatter(cpu_metric_formatter)
+                    .build(metriken::Counter::new()),
+            );
         }
 
         let percpu_counters = Arc::new(percpu_counters);
@@ -125,11 +144,13 @@ impl CpuUsage {
 
         Ok(Self {
             bpf,
-            percpu_counters,
-            sum_prev: 0,
-            percpu_sum_prev: vec![0; cpus.len()],
             counter_interval: Interval::new(now, config.interval(NAME)),
             distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
+            total_busy: Counter::new(&CPU_USAGE_BUSY, Some(&CPU_USAGE_BUSY_HISTOGRAM)),
+            total_idle: Counter::new(&CPU_USAGE_IDLE, Some(&CPU_USAGE_IDLE_HISTOGRAM)),
+            percpu_counters,
+            percpu_busy,
+            percpu_idle,
             online_cores,
             online_cores_file,
             online_cores_interval: Interval::new(now, ONLINE_CORES_REFRESH),
@@ -142,33 +163,33 @@ impl CpuUsage {
         // refresh the counters from the kernel-space counters
         self.bpf.refresh_counters(elapsed);
 
-        // get the new sum of all the counters
-        let sum_now: u64 = sum();
+        // update busy time metric
+        let busy: u64 = busy();
+        let busy_prev = CPU_USAGE_BUSY.value();
+        let busy_delta = busy.wrapping_sub(busy_prev);
+        self.total_busy.set(elapsed.as_secs_f64(), busy);
 
-        // get the number of nanoseconds in busy time, since idle hasn't been
-        // incremented, the busy time is the difference between our prev and
-        // current sums
-        let busy_delta = sum_now.wrapping_sub(self.sum_prev);
-
-        // idle time delta is `cores * elapsed - busy_delta`
-        let idle_delta = self.online_cores as u64 * elapsed.as_nanos() as u64 - busy_delta;
-
-        // update the idle time metrics
-        CPU_USAGE_IDLE.add(idle_delta);
-        let _ = CPU_USAGE_IDLE_HISTOGRAM.increment(idle_delta);
+        // calculate the idle time elapsed since last sample, update metric
+        let idle_prev = CPU_USAGE_IDLE.value();
+        let idle_delta =
+            (self.online_cores as u64 * elapsed.as_nanos() as u64).saturating_sub(busy_delta);
+        self.total_idle
+            .set(elapsed.as_secs_f64(), idle_prev.wrapping_add(idle_delta));
 
         // do the same for percpu counters
-        for (cpu, sum_prev) in self.percpu_sum_prev.iter_mut().enumerate() {
-            let sum_now: u64 = self.percpu_counters.sum(cpu).unwrap_or(0);
-            let busy_delta = sum_now.wrapping_sub(*sum_prev);
-            let idle_delta = elapsed.as_nanos() as u64 - busy_delta;
-            self.percpu_counters
-                .add(cpu, IDLE_CPUTIME_INDEX, idle_delta);
-            *sum_prev += busy_delta + idle_delta;
-        }
+        for (cpu, (busy_counter, idle_counter)) in self
+            .percpu_busy
+            .iter_mut()
+            .zip(self.percpu_idle.iter_mut())
+            .enumerate()
+        {
+            let busy: u64 = self.percpu_counters.sum(cpu).unwrap_or(0);
+            let busy_prev = busy_counter.set(busy);
+            let busy_delta = busy.wrapping_sub(busy_prev);
 
-        // update the previous sums
-        self.sum_prev += busy_delta + idle_delta;
+            let idle_delta = (elapsed.as_nanos() as u64).saturating_sub(busy_delta);
+            idle_counter.add(idle_delta);
+        }
 
         Ok(())
     }
@@ -191,15 +212,13 @@ impl CpuUsage {
     }
 }
 
-fn sum() -> u64 {
+fn busy() -> u64 {
     [
         &CPU_USAGE_USER,
         &CPU_USAGE_NICE,
         &CPU_USAGE_SYSTEM,
         &CPU_USAGE_SOFTIRQ,
         &CPU_USAGE_IRQ,
-        &CPU_USAGE_IDLE,
-        &CPU_USAGE_IO_WAIT,
         &CPU_USAGE_STEAL,
         &CPU_USAGE_GUEST,
         &CPU_USAGE_GUEST_NICE,

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -62,9 +62,9 @@ impl OnlineCores {
             file,
         };
 
-        let _ = online_cores.refresh();
+        let _ = online_cores.refresh()?;
 
-        online_cores
+        Ok(online_cores)
     }
 
     pub fn refresh(&mut self) -> Result<(), ()> {
@@ -117,6 +117,8 @@ impl OnlineCores {
         }
 
         self.count = count;
+
+        Ok(())
     }
 }
 

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -12,7 +12,6 @@
 
 #define IDLE_STAT_INDEX 5
 #define IOWAIT_STAT_INDEX 6
-#define TOTAL_STATES 10
 
 // cpu usage stat index (https://elixir.bootlin.com/linux/v6.9-rc4/source/include/linux/kernel_stat.h#L20)
 // 0 - user

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -7,11 +7,12 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 
-#define COUNTER_GROUP_WIDTH 16
+#define COUNTER_GROUP_WIDTH 8
 #define MAX_CPUS 1024
 
 #define IDLE_STAT_INDEX 5
 #define IOWAIT_STAT_INDEX 6
+#define TOTAL_STATES 10
 
 // cpu usage stat index (https://elixir.bootlin.com/linux/v6.9-rc4/source/include/linux/kernel_stat.h#L20)
 // 0 - user
@@ -19,11 +20,11 @@
 // 2 - system
 // 3 - softirq
 // 4 - irq
-// 5 - idle - *NOTE* this will not increment. User-space must calculate it
-// 6 - iowait
-// 7 - steal
-// 8 - guest
-// 9 - guest_nice
+//   - idle - *NOTE* this will not increment. User-space must calculate it. This index is skipped
+//   - iowait - *NOTE* this will not increment. This index is skipped
+// 5 - steal
+// 6 - guest
+// 7 - guest_nice
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(map_flags, BPF_F_MMAPABLE);
@@ -37,11 +38,13 @@ int account_delta(u64 delta, u32 usage_idx)
 	u64 *cnt;
 	u32 idx;
 
-	idx = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id() + usage_idx;
-	cnt = bpf_map_lookup_elem(&counters, &idx);
+	if (usage_idx < COUNTER_GROUP_WIDTH) {
+		idx = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id() + usage_idx;
+		cnt = bpf_map_lookup_elem(&counters, &idx);
 
-	if (cnt) {
-		__sync_fetch_and_add(cnt, delta);
+		if (cnt) {
+			__sync_fetch_and_add(cnt, delta);
+		}
 	}
 
 	return 0;
@@ -56,7 +59,14 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 		return 0;
 	}
 
-	return account_delta(delta, index);
+	// we pack the counters by skipping over the index values for idle and iowait
+	// this prevents having those counters mapped to non-incrementing values in
+	// this BPF program
+	if (index < IDLE_STAT_INDEX) {
+		return account_delta(delta, index);
+	} else {
+		return account_delta(delta, index - 2);
+	}
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/samplers/cpu/linux/usage/proc_stat.rs
+++ b/src/samplers/cpu/linux/usage/proc_stat.rs
@@ -8,6 +8,9 @@ use std::io::{Read, Seek};
 
 use super::NAME;
 
+const CPU_IDLE_FIELD_INDEX: usize = 3;
+const CPU_IO_WAIT_FIELD_INDEX: usize = 4;
+
 pub struct ProcStat {
     interval: Interval,
     nanos_per_tick: u64,
@@ -138,7 +141,7 @@ impl ProcStat {
 
                 for (field, counter) in self.total_counters.iter_mut().enumerate() {
                     if let Some(Ok(v)) = parts.get(field + 1).map(|v| v.parse::<u64>()) {
-                        if field < 2 || field > 4 {
+                        if field != CPU_IDLE_FIELD_INDEX && field != CPU_IO_WAIT_FIELD_INDEX {
                             busy = busy.wrapping_add(v);
                         }
                         counter.set(elapsed, v.wrapping_mul(self.nanos_per_tick));
@@ -153,7 +156,7 @@ impl ProcStat {
 
                     for (field, counter) in self.percpu_counters[id].iter_mut().enumerate() {
                         if let Some(Ok(v)) = parts.get(field + 1).map(|v| v.parse::<u64>()) {
-                            if field < 2 || field > 4 {
+                            if field != CPU_IDLE_FIELD_INDEX && field != CPU_IO_WAIT_FIELD_INDEX {
                                 busy = busy.wrapping_add(v);
                             }
                             counter.set(v.wrapping_mul(self.nanos_per_tick));

--- a/src/samplers/cpu/macos/usage/mod.rs
+++ b/src/samplers/cpu/macos/usage/mod.rs
@@ -1,7 +1,6 @@
 use crate::common::{Counter, Interval, Nop};
 use crate::samplers::cpu::*;
 use crate::{distributed_slice, Config, Sampler};
-use core::time::Duration;
 use libc::mach_port_t;
 use metriken::{DynBoxedMetric, MetricBuilder};
 use ringlog::error;
@@ -98,6 +97,7 @@ impl CpuUsage {
         let mut total_system = 0;
         let mut total_idle = 0;
         let mut total_nice = 0;
+        let mut total_busy = 0;
 
         if libc::host_processor_info(
             self.port,
@@ -124,22 +124,26 @@ impl CpuUsage {
                     .offset((cpu as i32 * libc::CPU_STATE_MAX + libc::CPU_STATE_NICE) as isize)
                     as u64)
                     .wrapping_mul(self.nanos_per_tick);
+                let busy = user.wrapping_add(system.wrapping_add(idle));
 
                 self.counters_percpu[cpu as usize][0].set(user);
                 self.counters_percpu[cpu as usize][1].set(nice);
                 self.counters_percpu[cpu as usize][2].set(system);
                 self.counters_percpu[cpu as usize][3].set(idle);
+                self.counters_percpu[cpu as usize][4].set(busy);
 
                 total_user += user;
                 total_system += system;
                 total_idle += idle;
                 total_nice += nice;
+                total_busy += busy;
             }
 
             self.counters_total[0].set(elapsed, total_user);
             self.counters_total[1].set(elapsed, total_nice);
             self.counters_total[2].set(elapsed, total_system);
             self.counters_total[3].set(elapsed, total_idle);
+            self.counters_total[4].set(elapsed, total_busy);
         } else {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/src/samplers/cpu/macos/usage/mod.rs
+++ b/src/samplers/cpu/macos/usage/mod.rs
@@ -124,7 +124,7 @@ impl CpuUsage {
                     .offset((cpu as i32 * libc::CPU_STATE_MAX + libc::CPU_STATE_NICE) as isize)
                     as u64)
                     .wrapping_mul(self.nanos_per_tick);
-                let busy = user.wrapping_add(system.wrapping_add(idle));
+                let busy = user.wrapping_add(system.wrapping_add(nice));
 
                 self.counters_percpu[cpu as usize][0].set(user);
                 self.counters_percpu[cpu as usize][1].set(nice);

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -65,6 +65,22 @@ pub static CPU_USAGE_IDLE: LazyCounter = LazyCounter::new(Counter::default);
 pub static CPU_USAGE_IDLE_HISTOGRAM: AtomicHistogram =
     AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
+#[metric(
+    name = "cpu/usage",
+    description = "The amount of CPU time spent busy",
+    formatter = cpu_metric_formatter,
+    metadata = { state = "busy", unit = "nanoseconds" }
+)]
+pub static CPU_USAGE_BUSY: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "cpu/usage/busy",
+    description = "Distribution of rate of CPU usage across the past snapshot interval",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static CPU_USAGE_BUSY_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
 /// A function to format the cpu metrics that allows for export of both total
 /// and per-CPU metrics.
 ///


### PR DESCRIPTION
Adds metrics for cpu busy time to make cpu utilization easier to calculate. This metric is not exported in the prometheus exposition because all the non-idle states can be trivially summed. However, for users of other metrics systems or consumers of the raw msgpack output, it can be more convenient to work with just busy and idle times and not worry about enumerating and summing the various other states.
