### PR TITLE
add config options to disable bpf samplers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,6 +52,10 @@ histogram_grouping_power = 4
 # collection for that sampler. Setting the default to false requires that
 # individual sampler configs are used to opt-in to collection.
 enabled = true
+# Controls whether BPF sampler will be used. When a metric can be collected
+# without BPF, that sampler will be used instead. Otherwise, the sampler will
+# effectively be disabled.
+bpf = true
 # The collection interval for counter and gauge based metrics. Shorter intervals
 # allow for more accurately capturing bursts in the related percentile metrics.
 interval = "10ms"
@@ -73,9 +77,11 @@ enabled = true
 [samplers.cpu_perf]
 enabled = true
 
-# Instruments CPU usage by state by reading /proc/stat
-[samplers.cpu_proc_stat]
+# Instruments CPU usage by state with BPF or by reading /proc/stat on linux
+# On macos host_processor_info() is used
+[samplers.cpu_usage]
 enabled = true
+bpf = true
 
 # Produces various nVIDIA specific GPU metrics using NVML
 [samplers.gpu_nvidia]
@@ -87,6 +93,14 @@ enabled = true
 
 # Memory NUMA metrics from /proc/vmstat
 [samplers.memory_vmstat]
+enabled = true
+
+# Produces network interface statistics from /sys/class/net for TX/RX errors
+[samplers.network_interfaces]
+enabled = true
+
+# Produces network traffic statistics using BPF
+[samplers.network_traffic]
 enabled = true
 
 # Sample resource utilization for Rezolus itself
@@ -126,11 +140,8 @@ enabled = true
 [samplers.tcp_retransmit]
 enabled = true
 
-# TCP sampler that reads from /proc/snmp
-[samplers.tcp_snmp]
-enabled = true
-
-# BPF sampler that probes TCP send and receive paths to instrument tx/rx size
-# distribution, bytes, and packets.
+# Samples TCP traffic using either a BPF sampler or /proc/net/snmp to provide
+# metrics for TX/RX bytes and packets
 [samplers.tcp_traffic]
 enabled = true
+bpf = true

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -83,6 +83,13 @@ impl Config {
             .unwrap_or(self.defaults.enabled())
     }
 
+    pub fn bpf(&self, name: &str) -> bool {
+        self.samplers
+            .get(name)
+            .map(|c| c.bpf())
+            .unwrap_or(self.defaults.bpf())
+    }
+
     pub fn interval(&self, name: &str) -> Duration {
         self.samplers
             .get(name)
@@ -224,6 +231,8 @@ pub fn distribution_interval() -> String {
 pub struct SamplerConfig {
     #[serde(default = "enabled")]
     enabled: bool,
+    #[serde(default = "enabled")]
+    bpf: bool,
     #[serde(default = "interval")]
     interval: String,
     #[serde(default = "distribution_interval")]
@@ -234,6 +243,7 @@ impl Default for SamplerConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            use_bpf: true,
             interval: interval(),
             distribution_interval: distribution_interval(),
         }
@@ -266,6 +276,10 @@ impl SamplerConfig {
 
     pub fn enabled(&self) -> bool {
         self.enabled
+    }
+
+    pub fn bpf(&self) -> bool {
+        self.bpf
     }
 
     pub fn interval(&self) -> Duration {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -66,16 +66,6 @@ impl Config {
         &self.prometheus
     }
 
-    #[cfg(feature = "bpf")]
-    pub fn bpf(&self) -> bool {
-        true
-    }
-
-    #[cfg(not(feature = "bpf"))]
-    pub fn bpf(&self) -> bool {
-        false
-    }
-
     pub fn enabled(&self, name: &str) -> bool {
         self.samplers
             .get(name)
@@ -243,7 +233,7 @@ impl Default for SamplerConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            use_bpf: true,
+            bpf: true,
             interval: interval(),
             distribution_interval: distribution_interval(),
         }

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -47,7 +47,7 @@ pub struct Biolat {
 impl Biolat {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -45,6 +45,11 @@ pub struct CpuUsage {
 const IDLE_CPUTIME_INDEX: usize = 5;
 impl CpuUsage {
     pub fn new(config: &Config) -> Result<Self, ()> {
+        // check if sampler should be enabled
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
+            return Err(());
+        }
+
         let builder = ModSkelBuilder::default();
         let mut skel = builder
             .open()

--- a/src/samplers/network/linux/traffic/bpf.rs
+++ b/src/samplers/network/linux/traffic/bpf.rs
@@ -36,7 +36,7 @@ pub struct NetworkTraffic {
 impl NetworkTraffic {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 

--- a/src/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/samplers/scheduler/linux/runqueue/mod.rs
@@ -45,7 +45,7 @@ pub struct Runqlat {
 impl Runqlat {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -44,7 +44,7 @@ pub struct Syscall {
 impl Syscall {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 

--- a/src/samplers/tcp/linux/packet_latency/mod.rs
+++ b/src/samplers/tcp/linux/packet_latency/mod.rs
@@ -42,7 +42,7 @@ pub struct PacketLatency {
 impl PacketLatency {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 

--- a/src/samplers/tcp/linux/receive/mod.rs
+++ b/src/samplers/tcp/linux/receive/mod.rs
@@ -41,7 +41,7 @@ pub struct Receive {
 impl Receive {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 

--- a/src/samplers/tcp/linux/retransmit/mod.rs
+++ b/src/samplers/tcp/linux/retransmit/mod.rs
@@ -40,7 +40,7 @@ pub struct Retransmit {
 impl Retransmit {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 

--- a/src/samplers/tcp/linux/traffic/bpf.rs
+++ b/src/samplers/tcp/linux/traffic/bpf.rs
@@ -38,7 +38,7 @@ pub struct TcpTraffic {
 impl TcpTraffic {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 


### PR DESCRIPTION
Adds config options to enable/disable bpf samplers. This can be set on a per-sampler basis, or globally, and enables better control when a sampler can get some data without bpf.
