### PR TITLE
fix configuration logic

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,16 +72,22 @@ distribution_interval = "50ms"
 [samplers.block_io_latency]
 enabled = true
 
-# Instruments CPU frequency, instructions, and cycles using perf events with
-# fallback to instrumenting frequency only via /proc/cpuinfo
+# Instruments CPU frequency, instructions, and cycles using BPF perf events or
+# frequency only via /proc/cpuinfo
 [samplers.cpu_perf]
 enabled = true
+bpf = true
 
 # Instruments CPU usage by state with BPF or by reading /proc/stat on linux
 # On macos host_processor_info() is used
 [samplers.cpu_usage]
 enabled = true
 bpf = true
+
+# Instruments the number of currently open file descriptors using
+# /proc/sys/fs/file-nr
+[samplers.filesystem_descriptors]
+enabled = true
 
 # Produces various nVIDIA specific GPU metrics using NVML
 [samplers.gpu_nvidia]

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -40,7 +40,7 @@ pub struct Perf {
 impl Perf {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
-        if !config.enabled(NAME) {
+        if !(config.enabled(NAME) && config.bpf(NAME)) {
             return Err(());
         }
 


### PR DESCRIPTION
Previously, when a sampler config section is partially defined, it inherits all defaults in the code as opposed to the defaults provided in the config. This means that the configurations may sometimes need to be overly verbose.

This change addresses the logic in the config module such that all sampler config fields are optional and inherit from the config defaults and then the coded defaults. This brings the behavior in-line with expectations.

Also fixes the cpu perf sampler initialization to allow running without BPF perf events being enabled.