### PR TITLE
add fallback for net traffic sampler

### DIFF
--- a/src/samplers/network/linux/interfaces/mod.rs
+++ b/src/samplers/network/linux/interfaces/mod.rs
@@ -1,15 +1,15 @@
-use crate::common::{Interval, Nop};
-use crate::samplers::hwinfo::hardware_info;
-use crate::samplers::network::stats::*;
-use crate::samplers::network::*;
-use metriken::Counter;
-use std::fs::File;
-use std::io::Read;
-use std::io::Seek;
+use crate::samplers::network::linux::*;
 
 #[distributed_slice(NETWORK_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    if let Ok(s) = Interfaces::new(config) {
+    let metrics = vec![
+        (&NETWORK_RX_CRC_ERRORS, "rx_crc_errors"),
+        (&NETWORK_RX_DROPPED, "rx_dropped"),
+        (&NETWORK_RX_MISSED_ERRORS, "rx_missed_errors"),
+        (&NETWORK_TX_DROPPED, "tx_dropped"),
+    ];
+
+    if let Ok(s) = SysfsNetSampler::new(config, NAME, metrics) {
         Box::new(s)
     } else {
         Box::new(Nop::new(config))
@@ -17,88 +17,3 @@ fn init(config: &Config) -> Box<dyn Sampler> {
 }
 
 const NAME: &str = "network_interfaces";
-
-pub struct Interfaces {
-    interval: Interval,
-    stats: Vec<(&'static Lazy<Counter>, &'static str, HashMap<String, File>)>,
-}
-
-impl Interfaces {
-    pub fn new(config: &Config) -> Result<Self, ()> {
-        // check if sampler should be enabled
-        if !config.enabled(NAME) {
-            return Err(());
-        }
-
-        let hwinfo = hardware_info().map_err(|e| {
-            error!("failed to load hardware info: {e}");
-        })?;
-
-        let mut metrics = vec![
-            (&NETWORK_RX_CRC_ERRORS, "rx_crc_errors"),
-            (&NETWORK_RX_DROPPED, "rx_dropped"),
-            (&NETWORK_RX_MISSED_ERRORS, "rx_missed_errors"),
-            (&NETWORK_TX_DROPPED, "tx_dropped"),
-        ];
-
-        let mut stats = Vec::new();
-        let mut d = String::new();
-
-        for (counter, stat) in metrics.drain(..) {
-            let mut if_stats = HashMap::new();
-
-            for interface in &hwinfo.network {
-                if interface.driver.is_none() {
-                    continue;
-                }
-
-                if let Ok(mut f) = std::fs::File::open(&format!(
-                    "/sys/class/net/{}/statistics/{stat}",
-                    interface.name
-                )) {
-                    if f.read_to_string(&mut d).is_ok() && d.parse::<u64>().is_ok() {
-                        if_stats.insert(interface.name.to_string(), f);
-                    }
-                }
-            }
-
-            stats.push((counter, stat, if_stats));
-        }
-
-        Ok(Self {
-            stats,
-            interval: Interval::new(Instant::now(), config.interval(NAME)),
-        })
-    }
-}
-
-impl Sampler for Interfaces {
-    fn sample(&mut self) {
-        if self.interval.try_wait(Instant::now()).is_err() {
-            return;
-        }
-
-        let mut data = String::new();
-
-        'outer: for (counter, _stat, ref mut if_stats) in &mut self.stats {
-            let mut sum = 0;
-
-            for file in if_stats.values_mut() {
-                if file.rewind().is_ok() {
-                    if let Err(e) = file.read_to_string(&mut data) {
-                        error!("error reading: {e}");
-                        continue 'outer;
-                    }
-
-                    if let Ok(v) = data.parse::<u64>() {
-                        sum += v;
-                    } else {
-                        continue 'outer;
-                    }
-                }
-            }
-
-            counter.set(sum);
-        }
-    }
-}

--- a/src/samplers/network/linux/mod.rs
+++ b/src/samplers/network/linux/mod.rs
@@ -1,2 +1,97 @@
+use crate::common::{Interval, Nop};
+use crate::samplers::hwinfo::hardware_info;
+use crate::samplers::network::stats::*;
+use crate::samplers::network::*;
+use metriken::Counter;
+use std::fs::File;
+use std::io::Read;
+use std::io::Seek;
+
 mod interfaces;
 mod traffic;
+
+pub struct SysfsNetSampler {
+    interval: Interval,
+    stats: Vec<(&'static Lazy<Counter>, &'static str, HashMap<String, File>)>,
+}
+
+impl SysfsNetSampler {
+    pub fn new(
+        config: &Config,
+        name: &str,
+        mut metrics: Vec<(&'static Lazy<Counter>, &'static str)>,
+    ) -> Result<Self, ()> {
+        // check if sampler should be enabled
+        if !config.enabled(name) {
+            return Err(());
+        }
+
+        let hwinfo = hardware_info().map_err(|e| {
+            error!("failed to load hardware info: {e}");
+        })?;
+
+        let mut stats = Vec::new();
+        let mut data = String::new();
+
+        for (counter, stat) in metrics.drain(..) {
+            let mut if_stats = HashMap::new();
+
+            for interface in &hwinfo.network {
+                if interface.driver.is_none() {
+                    continue;
+                }
+
+                if let Ok(mut f) = std::fs::File::open(&format!(
+                    "/sys/class/net/{}/statistics/{stat}",
+                    interface.name
+                )) {
+                	data.clear();
+
+                    if f.read_to_string(&mut data).is_ok() && data.trim_end().parse::<u64>().is_ok() {
+                        if_stats.insert(interface.name.to_string(), f);
+                    }
+                }
+            }
+
+            stats.push((counter, stat, if_stats));
+        }
+
+        Ok(Self {
+            stats,
+            interval: Interval::new(Instant::now(), config.interval(name)),
+        })
+    }
+}
+
+impl Sampler for SysfsNetSampler {
+    fn sample(&mut self) {
+        if self.interval.try_wait(Instant::now()).is_err() {
+            return;
+        }
+
+        let mut data = String::new();
+
+        'outer: for (counter, _stat, ref mut if_stats) in &mut self.stats {
+            let mut sum = 0;
+
+            for file in if_stats.values_mut() {
+                if file.rewind().is_ok() {
+                	data.clear();
+
+                    if let Err(e) = file.read_to_string(&mut data) {
+                        error!("error reading: {e}");
+                        continue 'outer;
+                    }
+
+                    if let Ok(v) = data.trim_end().parse::<u64>() {
+                        sum += v;
+                    } else {
+                        continue 'outer;
+                    }
+                }
+            }
+
+            counter.set(sum);
+        }
+    }
+}

--- a/src/samplers/network/linux/mod.rs
+++ b/src/samplers/network/linux/mod.rs
@@ -45,9 +45,10 @@ impl SysfsNetSampler {
                     "/sys/class/net/{}/statistics/{stat}",
                     interface.name
                 )) {
-                	data.clear();
+                    data.clear();
 
-                    if f.read_to_string(&mut data).is_ok() && data.trim_end().parse::<u64>().is_ok() {
+                    if f.read_to_string(&mut data).is_ok() && data.trim_end().parse::<u64>().is_ok()
+                    {
                         if_stats.insert(interface.name.to_string(), f);
                     }
                 }
@@ -76,7 +77,7 @@ impl Sampler for SysfsNetSampler {
 
             for file in if_stats.values_mut() {
                 if file.rewind().is_ok() {
-                	data.clear();
+                    data.clear();
 
                     if let Err(e) = file.read_to_string(&mut data) {
                         error!("error reading: {e}");

--- a/src/samplers/network/linux/traffic/mod.rs
+++ b/src/samplers/network/linux/traffic/mod.rs
@@ -1,5 +1,4 @@
-use crate::common::Nop;
-use crate::samplers::network::*;
+use crate::samplers::network::linux::*;
 
 const NAME: &str = "network_traffic";
 
@@ -16,12 +15,34 @@ fn init(config: &Config) -> Box<dyn Sampler> {
     if let Ok(s) = NetworkTraffic::new(config) {
         Box::new(s)
     } else {
-        Box::new(Nop {})
+        let metrics = vec![
+            (&NETWORK_RX_BYTES, "rx_bytes"),
+            (&NETWORK_RX_PACKETS, "rx_packets"),
+            (&NETWORK_TX_BYTES, "tx_bytes"),
+            (&NETWORK_TX_PACKETS, "tx_packets"),
+        ];
+
+        if let Ok(s) = SysfsNetSampler::new(config, NAME, metrics) {
+            Box::new(s)
+        } else {
+            Box::new(Nop::new(config))
+        }
     }
 }
 
 #[cfg(not(feature = "bpf"))]
 #[distributed_slice(NETWORK_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    Box::new(Nop {})
+    let metrics = vec![
+        (&NETWORK_RX_BYTES, "rx_bytes"),
+        (&NETWORK_RX_PACKETS, "rx_packets"),
+        (&NETWORK_TX_BYTES, "tx_bytes"),
+        (&NETWORK_TX_PACKETS, "tx_packets"),
+    ];
+
+    if let Ok(s) = SysfsNetSampler::new(config, NAME, metrics) {
+        Box::new(s)
+    } else {
+        Box::new(Nop::new(config))
+    }
 }

--- a/src/samplers/tcp/linux/traffic/bpf.rs
+++ b/src/samplers/tcp/linux/traffic/bpf.rs
@@ -68,7 +68,7 @@ impl TcpTraffic {
             Counter::new(&TCP_TX_PACKETS, Some(&TCP_TX_PACKETS_HISTOGRAM)),
         ];
 
-        let mut bpf = BpfBuilder::new(skel)
+        let bpf = BpfBuilder::new(skel)
             .counters("counters", counters)
             .distribution("rx_size", &TCP_RX_SIZE)
             .distribution("tx_size", &TCP_TX_SIZE)


### PR DESCRIPTION
Adds a fallback network traffic sampler that reads from sysfs when BPF is disabled or not available.
