### PR TITLE
bpf: use relaxed atomics

### DIFF
--- a/src/samplers/block_io/linux/latency/mod.bpf.c
+++ b/src/samplers/block_io/linux/latency/mod.bpf.c
@@ -96,14 +96,14 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
         cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 
 		idx = idx + COUNTER_GROUP_WIDTH / 2;
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, nr_bytes);
+			__atomic_fetch_add(cnt, nr_bytes, __ATOMIC_RELAXED);
 		}
     }
 
@@ -111,7 +111,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 	cnt = bpf_map_lookup_elem(&size, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 	tsp = bpf_map_lookup_elem(&start, &rq);
@@ -126,7 +126,7 @@ static int handle_block_rq_complete(struct request *rq, int error, unsigned int 
 		cnt = bpf_map_lookup_elem(&latency, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 	}
 

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -42,7 +42,7 @@ int account_delta(u64 delta, u32 usage_idx)
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__atomic_fetch_and_add(cnt, delta, __ATOMIC_RELAXED);
+			__atomic_fetch_add(cnt, delta, __ATOMIC_RELAXED);
 		}
 	}
 

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -42,7 +42,7 @@ int account_delta(u64 delta, u32 usage_idx)
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, delta);
+			__atomic_fetch_and_add(cnt, delta, __ATOMIC_RELAXED);
 		}
 	}
 

--- a/src/samplers/network/linux/traffic/mod.bpf.c
+++ b/src/samplers/network/linux/traffic/mod.bpf.c
@@ -51,14 +51,14 @@ int BPF_PROG(netif_receive_skb, struct sk_buff *skb)
 	cnt = bpf_map_lookup_elem(&counters, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 	idx = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id() + RX_BYTES;
 	cnt = bpf_map_lookup_elem(&counters, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, len);
+		__atomic_fetch_add(cnt, len, __ATOMIC_RELAXED);
 	}
 
 	return 0;
@@ -85,14 +85,14 @@ int BPF_PROG(tcp_cleanup_rbuf, struct sk_buff *skb, struct net_device *dev, void
 	cnt = bpf_map_lookup_elem(&counters, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 	idx = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id() + TX_BYTES;
 	cnt = bpf_map_lookup_elem(&counters, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, len);
+		__atomic_fetch_add(cnt, len, __ATOMIC_RELAXED);
 	}
 
 	return 0;

--- a/src/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -171,7 +171,7 @@ int handle__sched_switch(u64 *ctx)
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 
 		pid = prev->pid;
@@ -188,7 +188,7 @@ int handle__sched_switch(u64 *ctx)
 			idx = value_to_index(delta_ns, HISTOGRAM_POWER);
 			cnt = bpf_map_lookup_elem(&running, &idx);
 			if (cnt) {
-				__sync_fetch_and_add(cnt, 1);
+				__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 			}
 
 			*tsp = 0;
@@ -218,7 +218,7 @@ int handle__sched_switch(u64 *ctx)
 		idx = value_to_index(delta_ns, HISTOGRAM_POWER);
 		cnt = bpf_map_lookup_elem(&runqlat, &idx);
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 
 		*tsp = 0;
@@ -236,7 +236,7 @@ int handle__sched_switch(u64 *ctx)
 				idx = value_to_index(offcpu_ns, HISTOGRAM_POWER);
 				cnt = bpf_map_lookup_elem(&offcpu, &idx);
 				if (cnt) {
-					__sync_fetch_and_add(cnt, 1);
+					__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 				}
 			}
 

--- a/src/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/samplers/syscall/linux/latency/mod.bpf.c
@@ -149,7 +149,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 	cnt = bpf_map_lookup_elem(&counters, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 	// for some syscalls, we track counts by "family" of syscall. check the
@@ -163,7 +163,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 			cnt = bpf_map_lookup_elem(&counters, &idx);
 
 			if (cnt) {
-				__sync_fetch_and_add(cnt, 1);
+				__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 			}
 		} else {
 			// syscall counter offset was outside of the expected range
@@ -194,7 +194,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 	cnt = bpf_map_lookup_elem(&total_latency, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 	// increment latency histogram for the syscall family
@@ -229,7 +229,7 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 		}
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 	}
 

--- a/src/samplers/tcp/linux/packet_latency/mod.bpf.c
+++ b/src/samplers/tcp/linux/packet_latency/mod.bpf.c
@@ -89,7 +89,7 @@ static int handle_tcp_rcv_space_adjust(void *ctx, struct sock *sk)
 	cnt = bpf_map_lookup_elem(&latency, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 cleanup:

--- a/src/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/samplers/tcp/linux/receive/mod.bpf.c
@@ -55,7 +55,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	cnt = bpf_map_lookup_elem(&srtt, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 	// NOTE: mdev is stored as 4x the value in microseconds but we want to
@@ -66,7 +66,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	cnt = bpf_map_lookup_elem(&jitter, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, 1);
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 	}
 
 	return 0;

--- a/src/samplers/tcp/linux/retransmit/mod.bpf.c
+++ b/src/samplers/tcp/linux/retransmit/mod.bpf.c
@@ -28,7 +28,7 @@ int BPF_KPROBE(tcp_retransmit_skb, struct sock *sk, struct sk_buff *skb, int seg
 	cnt = bpf_map_lookup_elem(&counters, &idx);
 
 	if (cnt) {
-		__sync_fetch_and_add(cnt, segs);
+		__atomic_fetch_add(cnt, segs, __ATOMIC_RELAXED);
 	}
 
 	return 0;

--- a/src/samplers/tcp/linux/traffic/mod.bpf.c
+++ b/src/samplers/tcp/linux/traffic/mod.bpf.c
@@ -71,42 +71,42 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, (u64) size);
+			__atomic_fetch_add(cnt, (u64) size, __ATOMIC_RELAXED);
 		}
 
 		idx = value_to_index((u64) size, HISTOGRAM_POWER);
 		cnt = bpf_map_lookup_elem(&rx_size, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 
 		idx = 8 * bpf_get_smp_processor_id() + TCP_RX_PACKETS;
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 	} else {
 		idx = 8 * bpf_get_smp_processor_id() + TCP_TX_BYTES;
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, (u64) size);
+			__atomic_fetch_add(cnt, (u64) size, __ATOMIC_RELAXED);
 		}
 
 		idx = value_to_index((u64) size, HISTOGRAM_POWER);
 		cnt = bpf_map_lookup_elem(&tx_size, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 
 		idx = 8 * bpf_get_smp_processor_id() + TCP_TX_PACKETS;
 		cnt = bpf_map_lookup_elem(&counters, &idx);
 
 		if (cnt) {
-			__sync_fetch_and_add(cnt, 1);
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
 		}
 	}
 


### PR DESCRIPTION
Replace all `__sync_fetch_and_add` with `__atomic_fetch_add` with relaxed ordering in the BPF code.