### PR TITLE
userspace counter improvements

### DIFF
--- a/src/common/counter.rs
+++ b/src/common/counter.rs
@@ -1,0 +1,49 @@
+use metriken::AtomicHistogram;
+use metriken::LazyCounter;
+
+/// A `Counter` is a wrapper type that enables us to automatically calculate
+/// percentiles for secondly rates between subsequent counter observations.
+///
+/// To do this, it contains the current reading, previous reading, and
+/// optionally a histogram to store rate observations.
+pub struct Counter {
+    counter: &'static LazyCounter,
+    histogram: Option<&'static AtomicHistogram>,
+}
+
+impl Counter {
+    /// Construct a new counter that wraps a `metriken` counter and optionally a
+    /// `metriken` histogram.
+    pub fn new(counter: &'static LazyCounter, histogram: Option<&'static AtomicHistogram>) -> Self {
+        Self { counter, histogram }
+    }
+
+    /// Updates the counter by setting it to a new value. If this counter has a
+    /// histogram it also calculates a secondly rate since the last reading
+    /// and increments the histogram.
+    pub fn set(&mut self, elapsed: f64, value: u64) -> u64 {
+        if let Some(histogram) = self.histogram {
+            if let Some(previous) =
+                metriken::Lazy::<metriken::Counter>::get(self.counter).map(|c| c.value())
+            {
+                let delta = value.wrapping_sub(previous);
+
+                let _ = histogram.increment((delta as f64 / elapsed) as _);
+            }
+        }
+
+        self.counter.set(value)
+    }
+
+    /// Updates the counter by incrementing it by some value. If this counter
+    /// has a histogram, it normalizes the increment to a secondly rate and
+    /// increments the histogram too.
+    #[allow(dead_code)]
+    pub fn add(&mut self, elapsed: f64, delta: u64) -> u64 {
+        if let Some(histogram) = self.histogram {
+            let _ = histogram.increment((delta as f64 / elapsed) as _);
+        }
+
+        self.counter.add(delta)
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,58 +4,15 @@ pub mod bpf;
 pub mod classic;
 pub mod units;
 
+mod counter;
 mod interval;
 mod nop;
 
-use metriken::AtomicHistogram;
-use metriken::LazyCounter;
-
+pub use counter::Counter;
 pub use interval::Interval;
 pub use nop::Nop;
 
 pub const HISTOGRAM_GROUPING_POWER: u8 = 7;
-
-/// A `Counter` is a wrapper type that enables us to automatically calculate
-/// percentiles for secondly rates between subsequent counter observations.
-///
-/// To do this, it contains the current reading, previous reading, and
-/// optionally a histogram to store rate observations.
-pub struct Counter {
-    previous: Option<u64>,
-    counter: &'static LazyCounter,
-    histogram: Option<&'static AtomicHistogram>,
-}
-
-impl Counter {
-    /// Construct a new counter that wraps a `metriken` counter and optionally a
-    /// `metriken` histogram.
-    pub fn new(counter: &'static LazyCounter, histogram: Option<&'static AtomicHistogram>) -> Self {
-        Self {
-            previous: None,
-            counter,
-            histogram,
-        }
-    }
-
-    /// Updates the counter by setting the current value to a new value. If this
-    /// counter has a histogram it also calculates the rate since the last reading
-    /// and increments the histogram.
-    pub fn set(&mut self, elapsed: f64, value: u64) {
-        if let Some(previous) = self.previous {
-            let delta = value.wrapping_sub(previous);
-            self.counter.add(delta);
-            if let Some(histogram) = self.histogram {
-                let _ = histogram.increment((delta as f64 / elapsed) as _);
-            }
-        }
-
-        self.previous = Some(value);
-    }
-
-    pub fn value(&self) -> u64 {
-        self.counter.value()
-    }
-}
 
 #[macro_export]
 #[rustfmt::skip]


### PR DESCRIPTION
Changes the internal behavior of the userspace counter wrapper that is used to increment both a counter and histogram. This brings the behavior more in-line with how the underlying Metriken counters work and removes the potential footguns around previous value tracking.
