### PR TITLE
add configurable snapshot interval

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,15 @@ listen = "0.0.0.0:4242"
 # prometheus endpoint.
 compression = false
 
+# Controls the interval between histogram snapshots. This serves as the length
+# of the window for percentile metric calculation. Windows are non-overlapping,
+# meaning that the percentile metrics will not change until the interval has
+# passed. It is recommended to match this to the scrape interval for the metrics
+# endpoints. The default is one second and should be increased if your metrics
+# system does less frequent sampling. Note: this has no impact on counters,
+# gauges, or full-distribution exposition.
+snapshot_interval = "1s"
+
 [log]
 # Controls the log level: "error", "warn", "info", "debug", "trace"
 level = "info"

--- a/config.toml
+++ b/config.toml
@@ -12,8 +12,8 @@ compression = false
 # meaning that the percentile metrics will not change until the interval has
 # passed. It is recommended to match this to the scrape interval for the metrics
 # endpoints. The default is one second and should be increased if your metrics
-# system does less frequent sampling. Note: this has no impact on counters,
-# gauges, or full-distribution exposition.
+# system does less frequent sampling. Note: this has no impact on counters or
+# gauges, as both those are read on-demand.
 snapshot_interval = "1s"
 
 [log]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -123,10 +123,7 @@ pub struct General {
 
 impl General {
     fn check(&self) {
-        match self
-            .snapshot_interval
-            .parse::<humantime::Duration>()
-        {
+        match self.snapshot_interval.parse::<humantime::Duration>() {
             Err(e) => {
                 eprintln!("snapshot interval is not valid: {e}");
                 std::process::exit(1);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -129,8 +129,8 @@ impl General {
                 std::process::exit(1);
             }
             Ok(interval) => {
-                if Duration::from_nanos(interval.as_nanos() as u64) < Duration::from_secs(1) {
-                    eprintln!("snapshot interval is too short. Minimum interval is: 1s");
+                if Duration::from_nanos(interval.as_nanos() as u64) < Duration::from_millis(100) {
+                    eprintln!("snapshot interval is too short. Minimum interval is: 100ms");
                     std::process::exit(1);
                 }
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -35,6 +35,8 @@ impl Config {
             })
             .unwrap();
 
+        config.general.check();
+
         config.prometheus().check();
 
         config.defaults.check("default");
@@ -115,9 +117,29 @@ pub struct General {
     listen: String,
     #[serde(default = "disabled")]
     compression: bool,
+    #[serde(default = "snapshot_interval")]
+    snapshot_interval: String,
 }
 
 impl General {
+    fn check(&self) {
+        match self
+            .snapshot_interval
+            .parse::<humantime::Duration>()
+        {
+            Err(e) => {
+                eprintln!("snapshot interval is not valid: {e}");
+                std::process::exit(1);
+            }
+            Ok(interval) => {
+                if Duration::from_nanos(interval.as_nanos() as u64) < Duration::from_secs(1) {
+                    eprintln!("snapshot interval is too short. Minimum interval is: 1s");
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+
     pub fn listen(&self) -> SocketAddr {
         self.listen
             .to_socket_addrs()
@@ -136,6 +158,15 @@ impl General {
 
     pub fn compression(&self) -> bool {
         self.compression
+    }
+
+    pub fn snapshot_interval(&self) -> Duration {
+        let interval = self
+            .snapshot_interval
+            .parse::<humantime::Duration>()
+            .unwrap();
+
+        Duration::from_nanos(interval.as_nanos() as u64)
     }
 }
 
@@ -230,6 +261,10 @@ pub fn interval() -> String {
 
 pub fn distribution_interval() -> String {
     "50ms".into()
+}
+
+pub fn snapshot_interval() -> String {
+    "1s".into()
 }
 
 #[derive(Deserialize, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,8 @@ fn main() {
     });
 
     // spawn thread to maintain histogram snapshots
-    rt.spawn(async {
+    let snapshot_interval = config.general().snapshot_interval();
+    rt.spawn(async move {
         loop {
             // acquire a lock and update the snapshots
             {
@@ -177,7 +178,7 @@ fn main() {
             }
 
             // delay until next update
-            tokio::time::sleep(core::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(snapshot_interval).await;
         }
     });
 


### PR DESCRIPTION
Previously the snapshot interval was fixed to be on a secondly basis. For those who scrape Rezolus at coarser intervals, it would be more appropriate to align the snapshot interval with the scrape interval so that the percentiles cover a window spanning the entire period between consecutive scrapes of the metrics endpoint.
