### PR TITLE
split syscall sampler counts from latency

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ mod bpf {
         ("cpu", "usage"),
         ("network", "traffic"),
         ("scheduler", "runqueue"),
+        ("syscall", "counts"),
         ("syscall", "latency"),
         ("tcp", "packet_latency"),
         ("tcp", "receive"),

--- a/config.toml
+++ b/config.toml
@@ -127,8 +127,12 @@ enabled = true
 [samplers.scheduler_runqueue]
 enabled = true
 
-# BPF sampler that instruments syscall enter and exit to gather syscall counts
-# and latencies.
+# BPF sampler that instruments syscall enter to gather syscall counts.
+[samplers.syscall_counts]
+enabled = true
+
+# BPF sampler that instruments syscall enter and exit to gather syscall latency
+# distributions.
 [samplers.syscall_latency]
 enabled = true
 

--- a/src/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/samplers/syscall/linux/counts/mod.bpf.c
@@ -60,6 +60,10 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 	// update the total counter
 	cnt = bpf_map_lookup_elem(&counters, &offset);
 
+	if (cnt) {
+		__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
+	}
+
 	// for some syscalls, we track counts by "family" of syscall. check the
 	// lookup table and increment the appropriate counter
 	idx = 0;

--- a/src/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/samplers/syscall/linux/counts/mod.bpf.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Anton Protopopov
+// Copyright (c) 2023 The Rezolus Authors
+//
+// Based on syscount(8) from BCC by Sasha Goldshtein
+
+// NOTICE: this file is based off `syscount.bpf.c` from the BCC project
+// <https://github.com/iovisor/bcc/> and has been modified for use within
+// Rezolus.
+
+// This BPF program tracks syscall enter and exit to provide metrics about
+// syscall counts and latencies.
+
+#include <vmlinux.h>
+#include "../../../common/bpf/histogram.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define COUNTER_GROUP_WIDTH 8
+#define HISTOGRAM_POWER 7
+#define MAX_CPUS 1024
+#define MAX_SYSCALL_ID 1024
+#define MAX_PID 4194304
+
+// counters for syscalls
+// 0 - total
+// 1..COUNTER_GROUP_WIDTH - grouped syscalls defined in userspace in the
+//                          `syscall_lut` map
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
+} counters SEC(".maps");
+
+// provides a lookup table from syscall id to a counter index offset
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_SYSCALL_ID);
+} syscall_lut SEC(".maps");
+
+SEC("tracepoint/raw_syscalls/sys_enter")
+int sys_enter(struct trace_event_raw_sys_enter *args)
+{
+	u64 *cnt;
+	u32 offset, idx;
+
+	if (args->id < 0) {
+		return 0;
+	}
+
+	u32 syscall_id = args->id;
+	offset = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id();
+
+	// update the total counter
+	cnt = bpf_map_lookup_elem(&counters, &offset);
+
+	// for some syscalls, we track counts by "family" of syscall. check the
+	// lookup table and increment the appropriate counter
+	idx = 0;
+	if (syscall_id < MAX_SYSCALL_ID) {
+		u32 *counter_offset = bpf_map_lookup_elem(&syscall_lut, &syscall_id);
+
+		if (counter_offset && *counter_offset && *counter_offset < COUNTER_GROUP_WIDTH) {
+			idx = offset + ((u32)*counter_offset);
+			cnt = bpf_map_lookup_elem(&counters, &idx);
+
+			if (cnt) {
+				__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
+			}
+		} else {
+			// syscall counter offset was outside of the expected range
+			// this indicates that the LUT contains invalid values
+		}
+	} else {
+		// syscall id was out of the expected range
+	}
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -64,10 +64,6 @@ impl Syscall {
             "{NAME} sys_enter() BPF instruction count: {}",
             skel.progs().sys_enter().insn_cnt()
         );
-        debug!(
-            "{NAME} sys_exit() BPF instruction count: {}",
-            skel.progs().sys_exit().insn_cnt()
-        );
 
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -13,12 +13,11 @@ mod bpf {
 
 const NAME: &str = "syscall_counts";
 
-const MAX_SYSCALL_ID: usize = 1024;
-
 use bpf::*;
 
 use crate::common::bpf::*;
 use crate::common::*;
+use crate::samplers::syscall::linux::*;
 use crate::samplers::syscall::stats::*;
 use crate::samplers::syscall::*;
 
@@ -79,42 +78,7 @@ impl Syscall {
             Counter::new(&SYSCALL_SOCKET, Some(&SYSCALL_SOCKET_HISTOGRAM)),
         ];
 
-        let syscall_lut: Vec<u64> = (0..MAX_SYSCALL_ID)
-            .map(|id| {
-                if let Some(syscall_name) = syscall_numbers::native::sys_call_name(id as i64) {
-                    match syscall_name {
-                        // read related
-                        "pread64" | "preadv" | "preadv2" | "read" | "readv" | "recvfrom"
-                        | "recvmmsg" | "recvmsg" => 1,
-                        // write related
-                        "pwrite64" | "pwritev" | "pwritev2" | "sendmmsg" | "sendmsg" | "sendto"
-                        | "write" | "writev" => 2,
-                        // poll/select/epoll
-                        "epoll_create" | "epoll_create1" | "epoll_ctl" | "epoll_ctl_old"
-                        | "epoll_pwait" | "epoll_pwait2" | "epoll_wait" | "epoll_wait_old"
-                        | "poll" | "ppoll" | "ppoll_time64" | "pselect6" | "pselect6_time64"
-                        | "select" => 3,
-                        // locking
-                        "futex" => 4,
-                        // time
-                        "adjtimex" | "clock_adjtime" | "clock_getres" | "clock_gettime"
-                        | "clock_settime" | "gettimeofday" | "settimeofday" | "time" => 5,
-                        // sleep
-                        "clock_nanosleep" | "nanosleep" => 6,
-                        // socket creation and management
-                        "accept" | "bind" | "connect" | "getpeername" | "getsockname"
-                        | "getsockopt" | "listen" | "setsockopt" | "shutdown" | "socket"
-                        | "socketpair" => 7,
-                        _ => {
-                            // no group defined for these syscalls
-                            0
-                        }
-                    }
-                } else {
-                    0
-                }
-            })
-            .collect();
+        let syscall_lut = syscall_lut();
 
         let bpf = BpfBuilder::new(skel)
             .counters("counters", counters)

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -42,7 +42,6 @@ impl GetMap for ModSkel<'_> {
 pub struct Syscall {
     bpf: Bpf<ModSkel<'static>>,
     counter_interval: Interval,
-    distribution_interval: Interval,
 }
 
 impl Syscall {
@@ -90,7 +89,6 @@ impl Syscall {
         Ok(Self {
             bpf,
             counter_interval: Interval::new(now, config.interval(NAME)),
-            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
         })
     }
 

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -42,7 +42,6 @@ impl GetMap for ModSkel<'_> {
 /// * `syscall/socket/latency`
 pub struct Syscall {
     bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Interval,
     distribution_interval: Interval,
 }
 
@@ -90,7 +89,6 @@ impl Syscall {
 
         Ok(Self {
             bpf,
-            counter_interval: Interval::new(now, config.interval(NAME)),
             distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
         })
     }

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -13,12 +13,11 @@ mod bpf {
 
 const NAME: &str = "syscall_latency";
 
-const MAX_SYSCALL_ID: usize = 1024;
-
 use bpf::*;
 
 use crate::common::bpf::*;
 use crate::common::*;
+use crate::samplers::syscall::linux::*;
 use crate::samplers::syscall::stats::*;
 use crate::samplers::syscall::*;
 
@@ -73,42 +72,7 @@ impl Syscall {
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
-        let syscall_lut: Vec<u64> = (0..MAX_SYSCALL_ID)
-            .map(|id| {
-                if let Some(syscall_name) = syscall_numbers::native::sys_call_name(id as i64) {
-                    match syscall_name {
-                        // read related
-                        "pread64" | "preadv" | "preadv2" | "read" | "readv" | "recvfrom"
-                        | "recvmmsg" | "recvmsg" => 1,
-                        // write related
-                        "pwrite64" | "pwritev" | "pwritev2" | "sendmmsg" | "sendmsg" | "sendto"
-                        | "write" | "writev" => 2,
-                        // poll/select/epoll
-                        "epoll_create" | "epoll_create1" | "epoll_ctl" | "epoll_ctl_old"
-                        | "epoll_pwait" | "epoll_pwait2" | "epoll_wait" | "epoll_wait_old"
-                        | "poll" | "ppoll" | "ppoll_time64" | "pselect6" | "pselect6_time64"
-                        | "select" => 3,
-                        // locking
-                        "futex" => 4,
-                        // time
-                        "adjtimex" | "clock_adjtime" | "clock_getres" | "clock_gettime"
-                        | "clock_settime" | "gettimeofday" | "settimeofday" | "time" => 5,
-                        // sleep
-                        "clock_nanosleep" | "nanosleep" => 6,
-                        // socket creation and management
-                        "accept" | "bind" | "connect" | "getpeername" | "getsockname"
-                        | "getsockopt" | "listen" | "setsockopt" | "shutdown" | "socket"
-                        | "socketpair" => 7,
-                        _ => {
-                            // no group defined for these syscalls
-                            0
-                        }
-                    }
-                } else {
-                    0
-                }
-            })
-            .collect();
+        let syscall_lut = syscall_lut();
 
         let bpf = BpfBuilder::new(skel)
             .distribution("total_latency", &SYSCALL_TOTAL_LATENCY)

--- a/src/samplers/syscall/linux/mod.rs
+++ b/src/samplers/syscall/linux/mod.rs
@@ -3,3 +3,43 @@ mod counts;
 
 #[cfg(feature = "bpf")]
 mod latency;
+
+pub const MAX_SYSCALL_ID: usize = 1024;
+
+pub fn syscall_lut() -> Vec<u64> {
+    (0..MAX_SYSCALL_ID)
+        .map(|id| {
+            if let Some(syscall_name) = syscall_numbers::native::sys_call_name(id as i64) {
+                match syscall_name {
+                    // read related
+                    "pread64" | "preadv" | "preadv2" | "read" | "readv" | "recvfrom"
+                    | "recvmmsg" | "recvmsg" => 1,
+                    // write related
+                    "pwrite64" | "pwritev" | "pwritev2" | "sendmmsg" | "sendmsg" | "sendto"
+                    | "write" | "writev" => 2,
+                    // poll/select/epoll
+                    "epoll_create" | "epoll_create1" | "epoll_ctl" | "epoll_ctl_old"
+                    | "epoll_pwait" | "epoll_pwait2" | "epoll_wait" | "epoll_wait_old" | "poll"
+                    | "ppoll" | "ppoll_time64" | "pselect6" | "pselect6_time64" | "select" => 3,
+                    // locking
+                    "futex" => 4,
+                    // time
+                    "adjtimex" | "clock_adjtime" | "clock_getres" | "clock_gettime"
+                    | "clock_settime" | "gettimeofday" | "settimeofday" | "time" => 5,
+                    // sleep
+                    "clock_nanosleep" | "nanosleep" => 6,
+                    // socket creation and management
+                    "accept" | "bind" | "connect" | "getpeername" | "getsockname"
+                    | "getsockopt" | "listen" | "setsockopt" | "shutdown" | "socket"
+                    | "socketpair" => 7,
+                    _ => {
+                        // no group defined for these syscalls
+                        0
+                    }
+                }
+            } else {
+                0
+            }
+        })
+        .collect()
+}

--- a/src/samplers/syscall/linux/mod.rs
+++ b/src/samplers/syscall/linux/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(feature = "bpf")]
+mod counts;
+
+#[cfg(feature = "bpf")]
 mod latency;


### PR DESCRIPTION
Splits the syscall bpf sampler into two parts. One that tracks just the syscall counts and is expected to be lighter weight, and pares down the original latency sampler to just handle the latency metrics.

The intent is that for some sensitive workloads, we may be able to have syscall count tracking enabled even with the latency metrics disabled.
