### PR TITLE
split block_io sampler into latency and requests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ mod bpf {
     // directory.
     const SOURCES: &[(&str, &str)] = &[
         ("block_io", "latency"),
+        ("block_io", "requests"),
         ("cpu", "usage"),
         ("network", "traffic"),
         ("scheduler", "runqueue"),

--- a/config.toml
+++ b/config.toml
@@ -76,9 +76,14 @@ distribution_interval = "50ms"
 # Each sampler can then be individually configured to override the defaults. All
 # of the configuration options in the `[defaults]` section are allowed.
 
-# BPF sampler that instruments block_io request queue to measure latency and
-# size distribution.
+# BPF sampler that instruments block_io request queue to measure the request
+# latency distribution.
 [samplers.block_io_latency]
+enabled = true
+
+# BPF sampler that instruments block_io request queue to get counts of requests,
+# the number of bytes by request type, and the size distribution.
+[samplers.block_io_requests]
 enabled = true
 
 # Instruments CPU frequency, instructions, and cycles using BPF perf events or

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -73,6 +73,8 @@ impl BlockIOLatency {
             .distribution("latency", &BLOCKIO_LATENCY)
             .build();
 
+        let now = Instant::now();
+
         Ok(Self {
             bpf,
             distribution_interval:  Interval::new(now, config.distribution_interval(NAME)),

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -88,6 +88,8 @@ impl BlockIOLatency {
         self.distribution_interval.try_wait(now)?;
 
         self.bpf.refresh_distributions();
+
+        Ok(())
     }
 }
 

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -75,12 +75,7 @@ impl BlockIOLatency {
 
         Ok(Self {
             bpf,
-            counter_interval: config.interval(NAME),
-            counter_next: Instant::now(),
-            counter_prev: Instant::now(),
-            distribution_interval: config.distribution_interval(NAME),
-            distribution_next: Instant::now(),
-            distribution_prev: Instant::now(),
+            distribution_interval:  Interval::new(now, config.distribution_interval(NAME)),
         })
     }
 

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -77,7 +77,7 @@ impl BlockIOLatency {
 
         Ok(Self {
             bpf,
-            distribution_interval:  Interval::new(now, config.distribution_interval(NAME)),
+            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
         })
     }
 

--- a/src/samplers/block_io/linux/mod.rs
+++ b/src/samplers/block_io/linux/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(feature = "bpf")]
 mod latency;
+
+#[cfg(feature = "bpf")]
+mod requests;

--- a/src/samplers/block_io/linux/requests/mod.bpf.c
+++ b/src/samplers/block_io/linux/requests/mod.bpf.c
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+// Copyright (c) 2023 The Rezolus Authors
+
+#include <vmlinux.h>
+#include "../../../common/bpf/histogram.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+extern int LINUX_KERNEL_VERSION __kconfig;
+
+#define COUNTER_GROUP_WIDTH 8
+#define HISTOGRAM_POWER 7
+#define MAX_CPUS 1024
+
+#define REQ_OP_BITS	8
+#define REQ_OP_MASK	((1 << REQ_OP_BITS) - 1)
+#define REQ_FLAG_BITS	24
+
+#define REQ_OP_READ 0
+#define REQ_OP_WRITE 1
+#define REQ_OP_FLUSH 2
+#define REQ_OP_DISCARD 3
+
+// counters
+// 0 - read ops
+// 1 - write ops
+// 2 - flush ops
+// 3 - discard ops
+// 4 - read bytes
+// 5 - write bytes
+// 6 - flush bytes
+// 7 - discard bytes
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
+} counters SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, 7424);
+} size SEC(".maps");
+
+static int handle_block_rq_complete(struct request *rq, int error, unsigned int nr_bytes)
+{
+	u64 delta, *tsp, *cnt;
+	u32 idx;
+	unsigned int cmd_flags;
+
+	cmd_flags = BPF_CORE_READ(rq, cmd_flags);
+
+	idx = cmd_flags & REQ_OP_MASK;
+
+    if (idx < COUNTER_GROUP_WIDTH / 2) {
+        idx = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id() + idx;
+        cnt = bpf_map_lookup_elem(&counters, &idx);
+
+		if (cnt) {
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
+		}
+
+		idx = idx + COUNTER_GROUP_WIDTH / 2;
+		cnt = bpf_map_lookup_elem(&counters, &idx);
+
+		if (cnt) {
+			__atomic_fetch_add(cnt, nr_bytes, __ATOMIC_RELAXED);
+		}
+
+		idx = value_to_index(nr_bytes, HISTOGRAM_POWER);
+		cnt = bpf_map_lookup_elem(&size, &idx);
+
+		if (cnt) {
+			__atomic_fetch_add(cnt, 1, __ATOMIC_RELAXED);
+		}
+    }
+
+	return 0;
+}
+
+SEC("raw_tp/block_rq_complete")
+int BPF_PROG(block_rq_complete, struct request *rq, int error, unsigned int nr_bytes)
+{
+	return handle_block_rq_complete(rq, error, nr_bytes);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -1,6 +1,6 @@
 #[distributed_slice(BLOCK_IO_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    if let Ok(s) = BlockIOLatency::new(config) {
+    if let Ok(s) = BlockIOCounts::new(config) {
         Box::new(s)
     } else {
         Box::new(Nop {})
@@ -8,10 +8,10 @@ fn init(config: &Config) -> Box<dyn Sampler> {
 }
 
 mod bpf {
-    include!(concat!(env!("OUT_DIR"), "/block_io_latency.bpf.rs"));
+    include!(concat!(env!("OUT_DIR"), "/block_io_requests.bpf.rs"));
 }
 
-static NAME: &str = "block_io_latency";
+static NAME: &str = "block_io_requests";
 
 use bpf::*;
 
@@ -26,20 +26,24 @@ impl GetMap for ModSkel<'_> {
     }
 }
 
-/// Collects Scheduler Runqueue Latency stats using BPF and traces:
-/// * `block_rq_insert`
-/// * `block_rq_issue`
+/// Collects BlockIO stats using BPF and traces:
 /// * `block_rq_complete`
 ///
 /// And produces these stats:
-/// * `blockio/latency`
+/// * `blockio/*/operations`
+/// * `blockio/*/bytes`
 /// * `blockio/size`
-pub struct BlockIOLatency {
+pub struct BlockIORequests {
     bpf: Bpf<ModSkel<'static>>,
-    distribution_interval: Interval,
+    counter_interval: Duration,
+    counter_next: Instant,
+    counter_prev: Instant,
+    distribution_interval: Duration,
+    distribution_next: Instant,
+    distribution_prev: Instant,
 }
 
-impl BlockIOLatency {
+impl BlockIORequests {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
         if !(config.enabled(NAME) && config.bpf(NAME)) {
@@ -54,14 +58,6 @@ impl BlockIOLatency {
             .map_err(|e| error!("failed to load bpf program: {e}"))?;
 
         debug!(
-            "{NAME} block_rq_insert() BPF instruction count: {}",
-            skel.progs().block_rq_insert().insn_cnt()
-        );
-        debug!(
-            "{NAME} block_rq_issue() BPF instruction count: {}",
-            skel.progs().block_rq_issue().insn_cnt()
-        );
-        debug!(
             "{NAME} block_rq_complete() BPF instruction count: {}",
             skel.progs().block_rq_complete().insn_cnt()
         );
@@ -69,8 +65,23 @@ impl BlockIOLatency {
         skel.attach()
             .map_err(|e| error!("failed to attach bpf program: {e}"))?;
 
+        let counters = vec![
+            Counter::new(&BLOCKIO_READ_OPS, Some(&BLOCKIO_READ_OPS_HISTOGRAM)),
+            Counter::new(&BLOCKIO_WRITE_OPS, Some(&BLOCKIO_WRITE_OPS_HISTOGRAM)),
+            Counter::new(&BLOCKIO_FLUSH_OPS, Some(&BLOCKIO_FLUSH_OPS_HISTOGRAM)),
+            Counter::new(&BLOCKIO_DISCARD_OPS, Some(&BLOCKIO_DISCARD_OPS_HISTOGRAM)),
+            Counter::new(&BLOCKIO_READ_BYTES, Some(&BLOCKIO_READ_BYTES_HISTOGRAM)),
+            Counter::new(&BLOCKIO_WRITE_BYTES, Some(&BLOCKIO_WRITE_BYTES_HISTOGRAM)),
+            Counter::new(&BLOCKIO_FLUSH_BYTES, Some(&BLOCKIO_FLUSH_BYTES_HISTOGRAM)),
+            Counter::new(
+                &BLOCKIO_DISCARD_BYTES,
+                Some(&BLOCKIO_DISCARD_BYTES_HISTOGRAM),
+            ),
+        ];
+
         let bpf = BpfBuilder::new(skel)
-            .distribution("latency", &BLOCKIO_LATENCY)
+            .counters("counters", counters)
+            .distribution("size", &BLOCKIO_SIZE)
             .build();
 
         Ok(Self {
@@ -84,6 +95,12 @@ impl BlockIOLatency {
         })
     }
 
+    pub fn refresh_counters(&mut self, now: Instant) {
+        let elapsed = self.counter_interval.try_wait(now)?;
+
+        self.bpf.refresh_counters(elapsed);
+    }
+
     pub fn refresh_distributions(&mut self, now: Instant) -> Result<(), ()> {
         self.distribution_interval.try_wait(now)?;
 
@@ -91,9 +108,10 @@ impl BlockIOLatency {
     }
 }
 
-impl Sampler for BlockIOLatency {
+impl Sampler for BlockIORequests {
     fn sample(&mut self) {
         let now = Instant::now();
-        let _ = self.refresh_distributions(now);
+        self.refresh_counters(now);
+        self.refresh_distributions(now);
     }
 }

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -84,8 +84,8 @@ impl BlockIORequests {
 
         Ok(Self {
             bpf,
-            counter_interval:  Interval::new(now, config.interval(NAME)),
-            distribution_interval:  Interval::new(now, config.distribution_interval(NAME)),
+            counter_interval: Interval::new(now, config.interval(NAME)),
+            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
         })
     }
 

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -99,12 +99,16 @@ impl BlockIORequests {
         let elapsed = self.counter_interval.try_wait(now)?;
 
         self.bpf.refresh_counters(elapsed);
+
+        Ok(())
     }
 
     pub fn refresh_distributions(&mut self, now: Instant) -> Result<(), ()> {
         self.distribution_interval.try_wait(now)?;
 
         self.bpf.refresh_distributions();
+
+        Ok(())
     }
 }
 

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -109,7 +109,7 @@ impl BlockIORequests {
 impl Sampler for BlockIORequests {
     fn sample(&mut self) {
         let now = Instant::now();
-        self.refresh_counters(now);
-        self.refresh_distributions(now);
+        let _ = self.refresh_counters(now);
+        let _ = self.refresh_distributions(now);
     }
 }

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -80,6 +80,8 @@ impl BlockIORequests {
             .distribution("size", &BLOCKIO_SIZE)
             .build();
 
+        let now = Instant::now();
+
         Ok(Self {
             bpf,
             counter_interval:  Interval::new(now, config.interval(NAME)),
@@ -87,7 +89,7 @@ impl BlockIORequests {
         })
     }
 
-    pub fn refresh_counters(&mut self, now: Instant) {
+    pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
         self.bpf.refresh_counters(elapsed);

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -1,6 +1,6 @@
 #[distributed_slice(BLOCK_IO_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    if let Ok(s) = BlockIOCounts::new(config) {
+    if let Ok(s) = BlockIORequests::new(config) {
         Box::new(s)
     } else {
         Box::new(Nop {})
@@ -35,12 +35,8 @@ impl GetMap for ModSkel<'_> {
 /// * `blockio/size`
 pub struct BlockIORequests {
     bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Duration,
-    counter_next: Instant,
-    counter_prev: Instant,
-    distribution_interval: Duration,
-    distribution_next: Instant,
-    distribution_prev: Instant,
+    counter_interval: Interval,
+    distribution_interval: Interval,
 }
 
 impl BlockIORequests {
@@ -86,12 +82,8 @@ impl BlockIORequests {
 
         Ok(Self {
             bpf,
-            counter_interval: config.interval(NAME),
-            counter_next: Instant::now(),
-            counter_prev: Instant::now(),
-            distribution_interval: config.distribution_interval(NAME),
-            distribution_next: Instant::now(),
-            distribution_prev: Instant::now(),
+            counter_interval:  Interval::new(now, config.interval(NAME)),
+            distribution_interval:  Interval::new(now, config.distribution_interval(NAME)),
         })
     }
 


### PR DESCRIPTION
Splits the block_io BPF sampler into two parts. One which tracks request latency only and the other which tracks request counts, number of bytes, and the size distribution.

