### PR TITLE
disable cargo-audit in CI

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -62,20 +62,21 @@ jobs:
       with:
         sarif_file: clippy.sarif
 
-  audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: check-ubuntu-latest
-          save-if: false
-      - uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-audit
-          args: --locked
-      - run: |
-          cargo audit
+  # TODO(bmartin): re-enable audit check (#302)
+  # audit:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         shared-key: check-ubuntu-latest
+  #         save-if: false
+  #     - uses: baptiste0928/cargo-install@v1
+  #       with:
+  #         crate: cargo-audit
+  #         args: --locked
+  #     - run: |
+  #         cargo audit
       
   rustfmt:
     name: rustfmt
@@ -155,7 +156,6 @@ jobs:
       - rustfmt
       - clippy
       - clippy-upload
-      - audit
 
     steps:
       - name: no-op


### PR DESCRIPTION
Disables cargo-audit in CI due to failures since Rust 1.80 (#302)
