### PR TITLE
fix: per core cycle and instruction counters incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- CPU per core cycle and instruction counters were incorrect. The system totals
+  reflected the appropriate value. (# ?)
+
 ### Added
 
 - Allow setting the metric snapshot interval to better address cases where

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,7 +1531,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rezolus"
-version = "3.17.1-alpha.1"
+version = "3.17.1-alpha.2"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.17.1-alpha.1"
+version = "3.17.1-alpha.2"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.17.1-alpha.1"
+version = "3.17.1-alpha.2"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -143,10 +143,10 @@ impl Sampler for Perf {
                     CPU_FREQUENCY_HISTOGRAM.increment(reading.running_frequency_mhz.unwrap_or(0));
 
                 if let Some(c) = reading.cycles {
-                    self.counters[reading.cpu][0].set(c);
+                    self.counters[reading.cpu][0].add(c);
                 }
                 if let Some(c) = reading.instructions {
-                    self.counters[reading.cpu][1].set(c);
+                    self.counters[reading.cpu][1].add(c);
                 }
 
                 if let Some(c) = reading.ipkc {


### PR DESCRIPTION
Per core cycle and instruction counters were incorrectly being set to show the delta from the previous value instead of incrementing the value of the counter. This resulted in incorrect metrics being exposed for per-core level only. System total counts were using the correct logic and were unaffected by this bug.
