### PR TITLE
add sampler runtime metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "clap",
+ "clocksource",
  "histogram",
  "humantime",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 toml = "0.8.13"
 walkdir = "2.5.0"
 warp = { version = "0.3.7", features = ["compression"] }
+clocksource = "0.8.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.21.2", optional = true }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,6 +8,7 @@ mod counter;
 mod interval;
 mod nop;
 
+pub use clocksource::precise::UnixInstant;
 pub use counter::Counter;
 pub use interval::Interval;
 pub use nop::Nop;

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -93,6 +93,14 @@ impl BlockIOLatency {
 impl Sampler for BlockIOLatency {
     fn sample(&mut self) {
         let now = Instant::now();
-        let _ = self.refresh_distributions(now);
+
+        if self.refresh_distributions(now).is_ok() {
+            let elapsed = now.elapsed().as_nanos() as u64;
+
+            METADATA_BLOCKIO_LATENCY_COLLECTED_AT
+                .set(UnixInstant::EPOCH.elapsed().as_nanos() - elapsed);
+            METADATA_BLOCKIO_LATENCY_RUNTIME.add(elapsed);
+            let _ = METADATA_BLOCKIO_LATENCY_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
     }
 }

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -92,6 +92,8 @@ impl BlockIORequests {
     pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
+        METADATA_BLOCKIO_REQUESTS_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
         self.bpf.refresh_counters(elapsed);
 
         Ok(())
@@ -109,7 +111,12 @@ impl BlockIORequests {
 impl Sampler for BlockIORequests {
     fn sample(&mut self) {
         let now = Instant::now();
-        let _ = self.refresh_counters(now);
-        let _ = self.refresh_distributions(now);
+
+        if self.refresh_counters(now).is_ok() || self.refresh_distributions(now).is_ok() {
+            let elapsed = now.elapsed().as_nanos() as u64;
+
+            METADATA_BLOCKIO_REQUESTS_RUNTIME.add(elapsed);
+            let _ = METADATA_BLOCKIO_REQUESTS_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
     }
 }

--- a/src/samplers/block_io/stats.rs
+++ b/src/samplers/block_io/stats.rs
@@ -2,6 +2,50 @@ use crate::common::HISTOGRAM_GROUPING_POWER;
 use metriken::*;
 
 #[metric(
+    name = "metadata/blockio_latency/collected_at",
+    description = "The offset from the Unix epoch when blockio_latency sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_BLOCKIO_LATENCY_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/blockio_latency/runtime",
+    description = "The total runtime of the blockio_latency sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_BLOCKIO_LATENCY_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/blockio_latency/runtime",
+    description = "Distribution of sampling runtime of the blockio_latency sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_BLOCKIO_LATENCY_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/blockio_requests/collected_at",
+    description = "The offset from the Unix epoch when blockio_requests sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_BLOCKIO_REQUESTS_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/blockio_requests/runtime",
+    description = "The total runtime of the blockio_requests sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_BLOCKIO_REQUESTS_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/blockio_requests/runtime",
+    description = "Distribution of sampling runtime of the blockio_requests sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_BLOCKIO_REQUESTS_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
+
+#[metric(
     name = "blockio/latency",
     description = "Distribution of blockio operation latency in nanoseconds",
     metadata = { unit = "nanoseconds" }

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -1,6 +1,27 @@
 use super::super::stats::*;
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, AtomicHistogram, Counter, Gauge, LazyCounter, LazyGauge};
+use metriken::*;
+
+#[metric(
+    name = "metadata/cpu_perf/collected_at",
+    description = "The offset from the Unix epoch when cpu_perf sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_CPU_PERF_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/cpu_perf/runtime",
+    description = "The total runtime of the cpu_perf sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_CPU_PERF_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/cpu_perf/runtime",
+    description = "Distribution of sampling runtime of the cpu_usage_sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_CPU_PERF_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "cpu/cores",

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -9,6 +9,7 @@ use super::NAME;
 
 use std::io::{Read, Seek};
 
+use clocksource::precise::UnixInstant;
 use metriken::{DynBoxedMetric, MetricBuilder};
 
 use bpf::*;
@@ -244,6 +245,8 @@ impl CpuUsage {
     pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
+        METADATA_CPU_USAGE_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
         // refresh the counters from the kernel-space counters
         self.bpf.refresh_counters(elapsed);
 
@@ -313,8 +316,14 @@ fn busy() -> u64 {
 impl Sampler for CpuUsage {
     fn sample(&mut self) {
         let now = Instant::now();
-        let _ = self.update_online_cores(now);
-        let _ = self.refresh_counters(now);
-        let _ = self.refresh_distributions(now);
+
+        if self.update_online_cores(now).is_ok()
+            || self.refresh_counters(now).is_ok()
+            || self.refresh_distributions(now).is_ok()
+        {
+            let elapsed = now.elapsed().as_nanos() as u64;
+            METADATA_CPU_USAGE_RUNTIME.add(elapsed);
+            let _ = METADATA_CPU_USAGE_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
     }
 }

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -1,5 +1,26 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, AtomicHistogram, Counter, Format, LazyCounter, MetricEntry};
+use metriken::*;
+
+#[metric(
+    name = "metadata/cpu_usage/collected_at",
+    description = "The offset from the Unix epoch when cpu_usage sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_CPU_USAGE_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/cpu_usage/runtime",
+    description = "The total runtime of the cpu_usage sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_CPU_USAGE_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/cpu_usage/runtime",
+    description = "Distribution of sampling runtime of the cpu_usage_sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_CPU_USAGE_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "cpu/usage",

--- a/src/samplers/filesystem/linux/stats.rs
+++ b/src/samplers/filesystem/linux/stats.rs
@@ -1,4 +1,28 @@
-use metriken::{metric, Gauge, LazyGauge};
+use metriken::*;
+
+#[metric(
+    name = "metadata/filesystem_descriptors/collected_at",
+    description = "The offset from the Unix epoch when filesystem_descriptors sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_FILESYSTEM_DESCRIPTORS_COLLECTED_AT: LazyCounter =
+    LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/filesystem_descriptors/runtime",
+    description = "The total runtime of the filesystem_descriptors sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_FILESYSTEM_DESCRIPTORS_RUNTIME: LazyCounter =
+    LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/filesystem_descriptors/runtime",
+    description = "Distribution of sampling runtime of the filesystem_descriptors sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_FILESYSTEM_DESCRIPTORS_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "filesystem/descriptors/open",

--- a/src/samplers/gpu/nvidia/mod.rs
+++ b/src/samplers/gpu/nvidia/mod.rs
@@ -1,7 +1,6 @@
 use super::stats::*;
 use super::*;
-use crate::common::Interval;
-use crate::common::Nop;
+use crate::common::*;
 use metriken::{DynBoxedMetric, MetricBuilder};
 use nvml_wrapper::enum_wrappers::device::*;
 use nvml_wrapper::Nvml;
@@ -163,9 +162,15 @@ impl Sampler for Nvidia {
             return;
         }
 
+        METADATA_GPU_NVIDIA_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
         if let Err(e) = self.sample_nvml(now) {
             error!("error sampling: {e}");
         }
+
+        let elapsed = now.elapsed().as_nanos() as u64;
+        METADATA_GPU_NVIDIA_RUNTIME.add(elapsed);
+        let _ = METADATA_GPU_NVIDIA_RUNTIME_HISTOGRAM.increment(elapsed);
     }
 }
 

--- a/src/samplers/gpu/stats.rs
+++ b/src/samplers/gpu/stats.rs
@@ -1,4 +1,25 @@
-use metriken::{metric, Format, Gauge, LazyGauge, MetricEntry};
+use metriken::*;
+
+#[metric(
+    name = "metadata/gpu_nvidia/collected_at",
+    description = "The offset from the Unix epoch when gpu_nvidia sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_GPU_NVIDIA_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/gpu_nvidia/runtime",
+    description = "The total runtime of the gpu_nvidia sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_GPU_NVIDIA_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/gpu_nvidia/runtime",
+    description = "Distribution of sampling runtime of the gpu_nvidia sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_GPU_NVIDIA_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "gpu/memory",

--- a/src/samplers/memory/linux/proc_meminfo/mod.rs
+++ b/src/samplers/memory/linux/proc_meminfo/mod.rs
@@ -1,5 +1,5 @@
 use crate::common::units::KIBIBYTES;
-use crate::common::{Interval, Nop};
+use crate::common::*;
 use crate::samplers::memory::stats::*;
 use crate::samplers::memory::*;
 use metriken::Gauge;
@@ -56,7 +56,13 @@ impl Sampler for ProcMeminfo {
             return;
         }
 
+        METADATA_MEMORY_MEMINFO_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
         let _ = self.sample_proc_meminfo(now).is_err();
+
+        let elapsed = now.elapsed().as_nanos() as u64;
+        METADATA_MEMORY_MEMINFO_RUNTIME.add(elapsed);
+        let _ = METADATA_MEMORY_MEMINFO_RUNTIME_HISTOGRAM.increment(elapsed);
     }
 }
 

--- a/src/samplers/memory/stats.rs
+++ b/src/samplers/memory/stats.rs
@@ -1,4 +1,46 @@
-use metriken::{metric, Counter, Gauge, LazyCounter, LazyGauge};
+use metriken::*;
+
+#[metric(
+    name = "metadata/memory_meminfo/collected_at",
+    description = "The offset from the Unix epoch when memory_meminfo sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_MEMORY_MEMINFO_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/memory_meminfo/runtime",
+    description = "The total runtime of the memory_meminfo sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_MEMORY_MEMINFO_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/memory_meminfo/runtime",
+    description = "Distribution of sampling runtime of the memory_meminfo sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_MEMORY_MEMINFO_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/memory_vmstat/collected_at",
+    description = "The offset from the Unix epoch when memory_vmstat sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_MEMORY_VMSTAT_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/memory_vmstat/runtime",
+    description = "The total runtime of the memory_vmstat sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_MEMORY_VMSTAT_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/memory_vmstat/runtime",
+    description = "Distribution of sampling runtime of the memory_vmstat sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_MEMORY_VMSTAT_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "memory/total",

--- a/src/samplers/network/linux/interfaces/mod.rs
+++ b/src/samplers/network/linux/interfaces/mod.rs
@@ -1,16 +1,9 @@
+use crate::common::*;
 use crate::samplers::network::linux::*;
 
 #[distributed_slice(NETWORK_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    let metrics = vec![
-        (&NETWORK_CARRIER_CHANGES, "../carrier_changes"),
-        (&NETWORK_RX_CRC_ERRORS, "rx_crc_errors"),
-        (&NETWORK_RX_DROPPED, "rx_dropped"),
-        (&NETWORK_RX_MISSED_ERRORS, "rx_missed_errors"),
-        (&NETWORK_TX_DROPPED, "tx_dropped"),
-    ];
-
-    if let Ok(s) = SysfsNetSampler::new(config, NAME, metrics) {
+    if let Ok(s) = NetworkInterfaces::new(config) {
         Box::new(s)
     } else {
         Box::new(Nop::new(config))
@@ -18,3 +11,41 @@ fn init(config: &Config) -> Box<dyn Sampler> {
 }
 
 const NAME: &str = "network_interfaces";
+
+struct NetworkInterfaces {
+    inner: SysfsNetSampler,
+    interval: Interval,
+}
+
+impl NetworkInterfaces {
+    pub fn new(config: &Config) -> Result<Self, ()> {
+        let metrics = vec![
+            (&NETWORK_CARRIER_CHANGES, "../carrier_changes"),
+            (&NETWORK_RX_CRC_ERRORS, "rx_crc_errors"),
+            (&NETWORK_RX_DROPPED, "rx_dropped"),
+            (&NETWORK_RX_MISSED_ERRORS, "rx_missed_errors"),
+            (&NETWORK_TX_DROPPED, "tx_dropped"),
+        ];
+
+        Ok(Self {
+            inner: SysfsNetSampler::new(config, NAME, metrics)?,
+            interval: Interval::new(Instant::now(), config.interval(NAME)),
+        })
+    }
+}
+
+impl Sampler for NetworkInterfaces {
+    fn sample(&mut self) {
+        let now = Instant::now();
+
+        if let Ok(_) = self.interval.try_wait(now) {
+            METADATA_NETWORK_INTERFACES_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
+            let _ = self.inner.sample_now();
+
+            let elapsed = now.elapsed().as_nanos() as u64;
+            METADATA_NETWORK_INTERFACES_RUNTIME.add(elapsed);
+            let _ = METADATA_NETWORK_INTERFACES_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
+    }
+}

--- a/src/samplers/network/linux/mod.rs
+++ b/src/samplers/network/linux/mod.rs
@@ -1,17 +1,14 @@
-use crate::common::{Interval, Nop};
 use crate::samplers::hwinfo::hardware_info;
 use crate::samplers::network::stats::*;
 use crate::samplers::network::*;
 use metriken::Counter;
 use std::fs::File;
-use std::io::Read;
-use std::io::Seek;
+use std::io::{Read, Seek};
 
 mod interfaces;
 mod traffic;
 
 pub struct SysfsNetSampler {
-    interval: Interval,
     stats: Vec<(&'static Lazy<Counter>, &'static str, HashMap<String, File>)>,
 }
 
@@ -57,19 +54,10 @@ impl SysfsNetSampler {
             stats.push((counter, stat, if_stats));
         }
 
-        Ok(Self {
-            stats,
-            interval: Interval::new(Instant::now(), config.interval(name)),
-        })
+        Ok(Self { stats })
     }
-}
 
-impl Sampler for SysfsNetSampler {
-    fn sample(&mut self) {
-        if self.interval.try_wait(Instant::now()).is_err() {
-            return;
-        }
-
+    fn sample_now(&mut self) {
         let mut data = String::new();
 
         'outer: for (counter, _stat, ref mut if_stats) in &mut self.stats {

--- a/src/samplers/network/linux/traffic/bpf.rs
+++ b/src/samplers/network/linux/traffic/bpf.rs
@@ -80,6 +80,8 @@ impl NetworkTraffic {
     pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
+        METADATA_NETWORK_TRAFFIC_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
         self.bpf.refresh_counters(elapsed);
 
         Ok(())
@@ -97,7 +99,11 @@ impl NetworkTraffic {
 impl Sampler for NetworkTraffic {
     fn sample(&mut self) {
         let now = Instant::now();
-        let _ = self.refresh_counters(now);
-        let _ = self.refresh_distributions(now);
+
+        if self.refresh_counters(now).is_ok() || self.refresh_distributions(now).is_ok() {
+            let elapsed = now.elapsed().as_nanos() as u64;
+            METADATA_NETWORK_TRAFFIC_RUNTIME.add(elapsed);
+            let _ = METADATA_NETWORK_TRAFFIC_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
     }
 }

--- a/src/samplers/network/linux/traffic/mod.rs
+++ b/src/samplers/network/linux/traffic/mod.rs
@@ -1,3 +1,4 @@
+use crate::common::*;
 use crate::samplers::network::linux::*;
 
 const NAME: &str = "network_traffic";
@@ -6,23 +7,13 @@ const NAME: &str = "network_traffic";
 mod bpf;
 
 #[cfg(feature = "bpf")]
-use bpf::*;
-
-#[cfg(feature = "bpf")]
 #[distributed_slice(NETWORK_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
     // try to initialize the bpf based sampler
-    if let Ok(s) = NetworkTraffic::new(config) {
+    if let Ok(s) = bpf::NetworkTraffic::new(config) {
         Box::new(s)
     } else {
-        let metrics = vec![
-            (&NETWORK_RX_BYTES, "rx_bytes"),
-            (&NETWORK_RX_PACKETS, "rx_packets"),
-            (&NETWORK_TX_BYTES, "tx_bytes"),
-            (&NETWORK_TX_PACKETS, "tx_packets"),
-        ];
-
-        if let Ok(s) = SysfsNetSampler::new(config, NAME, metrics) {
+        if let Ok(s) = NetworkTraffic::new(config) {
             Box::new(s)
         } else {
             Box::new(Nop::new(config))
@@ -33,16 +24,46 @@ fn init(config: &Config) -> Box<dyn Sampler> {
 #[cfg(not(feature = "bpf"))]
 #[distributed_slice(NETWORK_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    let metrics = vec![
-        (&NETWORK_RX_BYTES, "rx_bytes"),
-        (&NETWORK_RX_PACKETS, "rx_packets"),
-        (&NETWORK_TX_BYTES, "tx_bytes"),
-        (&NETWORK_TX_PACKETS, "tx_packets"),
-    ];
-
-    if let Ok(s) = SysfsNetSampler::new(config, NAME, metrics) {
+    if let Ok(s) = NetworkTraffic::new(config) {
         Box::new(s)
     } else {
         Box::new(Nop::new(config))
+    }
+}
+
+struct NetworkTraffic {
+    inner: SysfsNetSampler,
+    interval: Interval,
+}
+
+impl NetworkTraffic {
+    pub fn new(config: &Config) -> Result<Self, ()> {
+        let metrics = vec![
+            (&NETWORK_RX_BYTES, "rx_bytes"),
+            (&NETWORK_RX_PACKETS, "rx_packets"),
+            (&NETWORK_TX_BYTES, "tx_bytes"),
+            (&NETWORK_TX_PACKETS, "tx_packets"),
+        ];
+
+        Ok(Self {
+            inner: SysfsNetSampler::new(config, NAME, metrics)?,
+            interval: Interval::new(Instant::now(), config.interval(NAME)),
+        })
+    }
+}
+
+impl Sampler for NetworkTraffic {
+    fn sample(&mut self) {
+        let now = Instant::now();
+
+        if let Ok(_) = self.interval.try_wait(now) {
+            METADATA_NETWORK_TRAFFIC_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
+            let _ = self.inner.sample_now();
+
+            let elapsed = now.elapsed().as_nanos() as u64;
+            METADATA_NETWORK_TRAFFIC_RUNTIME.add(elapsed);
+            let _ = METADATA_NETWORK_TRAFFIC_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
     }
 }

--- a/src/samplers/network/stats.rs
+++ b/src/samplers/network/stats.rs
@@ -1,5 +1,50 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, AtomicHistogram, Counter, LazyCounter};
+use metriken::*;
+
+#[metric(
+    name = "metadata/network_interfaces/collected_at",
+    description = "The offset from the Unix epoch when network_interfaces sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_NETWORK_INTERFACES_COLLECTED_AT: LazyCounter =
+    LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/network_interfaces/runtime",
+    description = "The total runtime of the network_interfaces sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_NETWORK_INTERFACES_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/network_interfaces/runtime",
+    description = "Distribution of sampling runtime of the network_interfaces sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_NETWORK_INTERFACES_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/network_traffic/collected_at",
+    description = "The offset from the Unix epoch when network_traffic sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_NETWORK_TRAFFIC_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/network_traffic/runtime",
+    description = "The total runtime of the network_traffic sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_NETWORK_TRAFFIC_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/network_traffic/runtime",
+    description = "Distribution of sampling runtime of the network_traffic sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_NETWORK_TRAFFIC_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "network/carrier_changes",

--- a/src/samplers/rezolus/stats.rs
+++ b/src/samplers/rezolus/stats.rs
@@ -1,5 +1,26 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, AtomicHistogram, Counter, Gauge, LazyCounter, LazyGauge};
+use metriken::*;
+
+#[metric(
+    name = "metadata/rezolus_rusage/collected_at",
+    description = "The offset from the Unix epoch when rezolus_rusage sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_REZOLUS_RUSAGE_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/rezolus_rusage/runtime",
+    description = "The total runtime of the rezolus_rusage sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_REZOLUS_RUSAGE_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/rezolus_rusage/runtime",
+    description = "Distribution of sampling runtime of the rezolus_rusage sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_REZOLUS_RUSAGE_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "rezolus/cpu/usage/user",

--- a/src/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/samplers/scheduler/linux/runqueue/mod.rs
@@ -93,6 +93,8 @@ impl Runqlat {
     pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
+        METADATA_SCHEDULER_RUNQUEUE_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
         self.bpf.refresh_counters(elapsed);
 
         Ok(())
@@ -110,7 +112,11 @@ impl Runqlat {
 impl Sampler for Runqlat {
     fn sample(&mut self) {
         let now = Instant::now();
-        let _ = self.refresh_counters(now);
-        let _ = self.refresh_distributions(now);
+
+        if self.refresh_counters(now).is_ok() || self.refresh_distributions(now).is_ok() {
+            let elapsed = now.elapsed().as_nanos() as u64;
+            METADATA_SCHEDULER_RUNQUEUE_RUNTIME.add(elapsed);
+            let _ = METADATA_SCHEDULER_RUNQUEUE_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
     }
 }

--- a/src/samplers/scheduler/stats.rs
+++ b/src/samplers/scheduler/stats.rs
@@ -1,5 +1,28 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, Counter, LazyCounter, RwLockHistogram};
+use metriken::*;
+
+#[metric(
+    name = "metadata/scheduler_runqueue/collected_at",
+    description = "The offset from the Unix epoch when scheduler_runqueue sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_SCHEDULER_RUNQUEUE_COLLECTED_AT: LazyCounter =
+    LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/scheduler_runqueue/runtime",
+    description = "The total runtime of the scheduler_runqueue sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_SCHEDULER_RUNQUEUE_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/scheduler_runqueue/runtime",
+    description = "Distribution of sampling runtime of the scheduler_runqueue sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_SCHEDULER_RUNQUEUE_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "scheduler/runqueue/latency",

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -1,6 +1,6 @@
 #[distributed_slice(SYSCALL_SAMPLERS)]
 fn init(config: &Config) -> Box<dyn Sampler> {
-    if let Ok(s) = Syscall::new(config) {
+    if let Ok(s) = SyscallCounts::new(config) {
         Box::new(s)
     } else {
         Box::new(Nop {})
@@ -40,12 +40,12 @@ impl GetMap for ModSkel<'_> {
 /// * `syscall/sleep`
 /// * `syscall/socket`
 /// * `syscall/yield`
-pub struct Syscall {
+pub struct SyscallCounts {
     bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Interval,
+    interval: Interval,
 }
 
-impl Syscall {
+impl SyscallCounts {
     pub fn new(config: &Config) -> Result<Self, ()> {
         // check if sampler should be enabled
         if !(config.enabled(NAME) && config.bpf(NAME)) {
@@ -90,22 +90,23 @@ impl Syscall {
 
         Ok(Self {
             bpf,
-            counter_interval: Interval::new(now, config.interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
-    }
-
-    pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
-        let elapsed = self.counter_interval.try_wait(now)?;
-
-        self.bpf.refresh_counters(elapsed);
-
-        Ok(())
     }
 }
 
-impl Sampler for Syscall {
+impl Sampler for SyscallCounts {
     fn sample(&mut self) {
         let now = Instant::now();
-        let _ = self.refresh_counters(now);
+
+        if let Ok(elapsed) = self.interval.try_wait(now) {
+            METADATA_SYSCALL_COUNTS_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
+            self.bpf.refresh_counters(elapsed);
+
+            let elapsed = now.elapsed().as_nanos() as u64;
+            METADATA_SYSCALL_COUNTS_RUNTIME.add(elapsed);
+            let _ = METADATA_SYSCALL_COUNTS_RUNTIME_HISTOGRAM.increment(elapsed);
+        }
     }
 }

--- a/src/samplers/syscall/stats.rs
+++ b/src/samplers/syscall/stats.rs
@@ -1,5 +1,48 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{metric, AtomicHistogram, Counter, LazyCounter, RwLockHistogram};
+use metriken::*;
+
+#[metric(
+    name = "metadata/syscall_counts/collected_at",
+    description = "The offset from the Unix epoch when syscall_counts sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_SYSCALL_COUNTS_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/syscall_counts/runtime",
+    description = "The total runtime of the syscall_counts sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_SYSCALL_COUNTS_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/syscall_counts/runtime",
+    description = "Distribution of sampling runtime of the syscall_counts sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_SYSCALL_COUNTS_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/syscall_latency/collected_at",
+    description = "The offset from the Unix epoch when syscall_latency sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_SYSCALL_LATENCY_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/syscall_latency/runtime",
+    description = "The total runtime of the syscall_latency sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_SYSCALL_LATENCY_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/syscall_latency/runtime",
+    description = "Distribution of sampling runtime of the syscall_latency sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_SYSCALL_LATENCY_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "syscall/total",

--- a/src/samplers/tcp/stats.rs
+++ b/src/samplers/tcp/stats.rs
@@ -1,8 +1,114 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
-use metriken::{
-    metric, AtomicHistogram, Counter, Format, Gauge, LazyCounter, LazyGauge, MetricEntry,
-    RwLockHistogram,
-};
+use metriken::*;
+
+#[metric(
+    name = "metadata/tcp_connection_state/collected_at",
+    description = "The offset from the Unix epoch when tcp_connection_state sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_CONNECTION_STATE_COLLECTED_AT: LazyCounter =
+    LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_connection_state/runtime",
+    description = "The total runtime of the tcp_connection_state sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_CONNECTION_STATE_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_connection_state/runtime",
+    description = "Distribution of sampling runtime of the tcp_connection_state sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_TCP_CONNECTION_STATE_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/tcp_packet_latency/collected_at",
+    description = "The offset from the Unix epoch when tcp_packet_latency sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_PACKET_LATENCY_COLLECTED_AT: LazyCounter =
+    LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_packet_latency/runtime",
+    description = "The total runtime of the tcp_packet_latency sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_PACKET_LATENCY_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_packet_latency/runtime",
+    description = "Distribution of sampling runtime of the tcp_packet_latency sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_TCP_PACKET_LATENCY_RUNTIME_HISTOGRAM: AtomicHistogram =
+    AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/tcp_receive/collected_at",
+    description = "The offset from the Unix epoch when tcp_receive sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_RECEIVE_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_receive/runtime",
+    description = "The total runtime of the tcp_receive sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_RECEIVE_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_receive/runtime",
+    description = "Distribution of sampling runtime of the tcp_receive sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_TCP_RECEIVE_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/tcp_retransmit/collected_at",
+    description = "The offset from the Unix epoch when tcp_retransmit sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_RETRANSMIT_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_retransmit/runtime",
+    description = "The total runtime of the tcp_retransmit sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_RETRANSMIT_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_retransmit/runtime",
+    description = "Distribution of sampling runtime of the tcp_retransmit sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_TCP_RETRANSMIT_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
+
+#[metric(
+    name = "metadata/tcp_traffic/collected_at",
+    description = "The offset from the Unix epoch when tcp_traffic sampler was last run",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_TRAFFIC_COLLECTED_AT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_traffic/runtime",
+    description = "The total runtime of the tcp_traffic sampler",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static METADATA_TCP_TRAFFIC_RUNTIME: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "metadata/tcp_traffic/runtime",
+    description = "Distribution of sampling runtime of the tcp_traffic sampler",
+    metadata = { unit = "nanoseconds/second" }
+)]
+pub static METADATA_TCP_TRAFFIC_RUNTIME_HISTOGRAM: AtomicHistogram = AtomicHistogram::new(4, 32);
 
 #[metric(
     name = "tcp/receive/bytes",


### PR DESCRIPTION
Adds metadata metrics that indicate when each sampler was last collected to provide a more precise interval for rate calculation.

Also adds runtime metrics so we can see how long various samplers take to run.
