### PR TITLE
remove distribution interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rezolus"
-version = "3.18.2-alpha.2"
+version = "3.18.2-alpha.3"
 dependencies = [
  "backtrace",
  "chrono",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "systeminfo"
-version = "3.18.2-alpha.2"
+version = "3.18.2-alpha.3"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 description = "High resolution systems performance telemetry agent"
 
 [workspace.package]
-version = "3.18.2-alpha.2"
+version = "3.18.2-alpha.3"
 license = "MIT OR Apache-2.0"
 
 [dependencies]

--- a/config.toml
+++ b/config.toml
@@ -65,13 +65,10 @@ enabled = true
 # without BPF, that sampler will be used instead. Otherwise, the sampler will
 # effectively be disabled.
 bpf = true
-# The collection interval for counter and gauge based metrics. Shorter intervals
-# allow for more accurately capturing bursts in the related percentile metrics.
+# The collection interval for the sampler. Shorter intervals result in less
+# error when calculating rates and allow for more accurately capturing bursts in
+# the related percentile metrics.
 interval = "10ms"
-# The collection interval for metrics that sample a distribution. Shorter
-# intervals reduce the uncertainty of the exact period corresponding to the
-# related percentile metrics.
-distribution_interval = "50ms"
 
 # Each sampler can then be individually configured to override the defaults. All
 # of the configuration options in the `[defaults]` section are allowed.

--- a/src/common/bpf/mod.rs
+++ b/src/common/bpf/mod.rs
@@ -100,6 +100,11 @@ pub struct Bpf<T: 'static> {
 }
 
 impl<T: 'static + GetMap> Bpf<T> {
+    pub fn refresh(&mut self, elapsed: Duration) {
+        self.bpf.refresh_counters(elapsed.as_secs_f64());
+        self.bpf.refresh_distributions();
+    }
+    
     pub fn refresh_counters(&mut self, elapsed: Duration) {
         self.bpf.refresh_counters(elapsed.as_secs_f64())
     }

--- a/src/common/bpf/mod.rs
+++ b/src/common/bpf/mod.rs
@@ -101,16 +101,7 @@ pub struct Bpf<T: 'static> {
 
 impl<T: 'static + GetMap> Bpf<T> {
     pub fn refresh(&mut self, elapsed: Duration) {
-        self.bpf.refresh_counters(elapsed.as_secs_f64());
-        self.bpf.refresh_distributions();
-    }
-
-    pub fn refresh_counters(&mut self, elapsed: Duration) {
-        self.bpf.refresh_counters(elapsed.as_secs_f64())
-    }
-
-    pub fn refresh_distributions(&mut self) {
-        self.bpf.refresh_distributions()
+        self.bpf.refresh(elapsed.as_secs_f64())
     }
 }
 
@@ -178,16 +169,12 @@ impl<T: 'static + GetMap> _Bpf<T> {
         self
     }
 
-    pub fn refresh_counters(&mut self, elapsed: f64) {
+    pub fn refresh(&mut self, elapsed: f64) {
         self.with_mut(|this| {
             for counters in this.counters.iter_mut() {
                 counters.refresh(elapsed);
             }
-        })
-    }
 
-    pub fn refresh_distributions(&mut self) {
-        self.with_mut(|this| {
             for distribution in this.distributions.iter_mut() {
                 distribution.refresh();
             }

--- a/src/common/bpf/mod.rs
+++ b/src/common/bpf/mod.rs
@@ -104,7 +104,7 @@ impl<T: 'static + GetMap> Bpf<T> {
         self.bpf.refresh_counters(elapsed.as_secs_f64());
         self.bpf.refresh_distributions();
     }
-    
+
     pub fn refresh_counters(&mut self, elapsed: Duration) {
         self.bpf.refresh_counters(elapsed.as_secs_f64())
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -93,23 +93,6 @@ impl Config {
 
         Duration::from_nanos(interval.as_nanos() as u64)
     }
-
-    pub fn distribution_interval(&self, name: &str) -> Duration {
-        let interval = self
-            .samplers
-            .get(name)
-            .and_then(|v| v.distribution_interval.as_ref())
-            .unwrap_or(
-                self.defaults
-                    .distribution_interval
-                    .as_ref()
-                    .unwrap_or(&distribution_interval()),
-            )
-            .parse::<humantime::Duration>()
-            .unwrap();
-
-        Duration::from_nanos(interval.as_nanos() as u64)
-    }
 }
 
 #[derive(Deserialize)]
@@ -256,10 +239,6 @@ pub fn interval() -> String {
     "10ms".into()
 }
 
-pub fn distribution_interval() -> String {
-    "50ms".into()
-}
-
 pub fn snapshot_interval() -> String {
     "1s".into()
 }
@@ -272,8 +251,6 @@ pub struct SamplerConfig {
     bpf: Option<bool>,
     #[serde(default)]
     interval: Option<String>,
-    #[serde(default)]
-    distribution_interval: Option<String>,
 }
 
 impl SamplerConfig {
@@ -290,24 +267,6 @@ impl SamplerConfig {
             Some(Ok(interval)) => {
                 if Duration::from_nanos(interval.as_nanos() as u64) < Duration::from_millis(1) {
                     eprintln!("{name} sampler interval is too short. Minimum interval is: 1ms");
-                    std::process::exit(1);
-                }
-            }
-            _ => {}
-        }
-
-        match self
-            .distribution_interval
-            .as_ref()
-            .map(|v| v.parse::<humantime::Duration>())
-        {
-            Some(Err(e)) => {
-                eprintln!("{name} sampler distribution_interval is not valid: {e}");
-                std::process::exit(1);
-            }
-            Some(Ok(interval)) => {
-                if Duration::from_nanos(interval.as_nanos() as u64) < Duration::from_millis(1) {
-                    eprintln!("{name} sampler distribution_interval is too short. Minimum interval is: 1ms");
                     std::process::exit(1);
                 }
             }

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -39,7 +39,7 @@ impl GetMap for ModSkel<'_> {
 /// * `blockio/size`
 pub struct BlockIOLatency {
     bpf: Bpf<ModSkel<'static>>,
-    distribution_interval: Interval,
+    interval: Interval,
 }
 
 impl BlockIOLatency {
@@ -83,14 +83,16 @@ impl BlockIOLatency {
 
         Ok(Self {
             bpf,
-            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 
-    pub fn refresh_distributions(&mut self, now: Instant) -> Result<(), ()> {
-        self.distribution_interval.try_wait(now)?;
+    pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
+        let elapsed = self.interval.try_wait(now)?;
 
-        self.bpf.refresh_distributions();
+        METADATA_BLOCKIO_LATENCY_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
+
+        self.bpf.refresh(elapsed);
 
         Ok(())
     }
@@ -100,11 +102,10 @@ impl Sampler for BlockIOLatency {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.refresh_distributions(now).is_ok() {
+        if self.refresh(now).is_ok() {
             let elapsed = now.elapsed().as_nanos() as u64;
 
-            METADATA_BLOCKIO_LATENCY_COLLECTED_AT
-                .set(UnixInstant::EPOCH.elapsed().as_nanos() - elapsed);
+            
             METADATA_BLOCKIO_LATENCY_RUNTIME.add(elapsed);
             let _ = METADATA_BLOCKIO_LATENCY_RUNTIME_HISTOGRAM.increment(elapsed);
         }

--- a/src/samplers/block_io/linux/latency/mod.rs
+++ b/src/samplers/block_io/linux/latency/mod.rs
@@ -105,7 +105,6 @@ impl Sampler for BlockIOLatency {
         if self.refresh(now).is_ok() {
             let elapsed = now.elapsed().as_nanos() as u64;
 
-            
             METADATA_BLOCKIO_LATENCY_RUNTIME.add(elapsed);
             let _ = METADATA_BLOCKIO_LATENCY_RUNTIME_HISTOGRAM.increment(elapsed);
         }

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -39,8 +39,7 @@ impl GetMap for ModSkel<'_> {
 /// * `blockio/size`
 pub struct BlockIORequests {
     bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Interval,
-    distribution_interval: Interval,
+    interval: Interval,
 }
 
 impl BlockIORequests {
@@ -92,24 +91,15 @@ impl BlockIORequests {
         Ok(Self {
             bpf,
             counter_interval: Interval::new(now, config.interval(NAME)),
-            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
         })
     }
 
-    pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
+    pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
         METADATA_BLOCKIO_REQUESTS_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-        self.bpf.refresh_counters(elapsed);
-
-        Ok(())
-    }
-
-    pub fn refresh_distributions(&mut self, now: Instant) -> Result<(), ()> {
-        self.distribution_interval.try_wait(now)?;
-
-        self.bpf.refresh_distributions();
+        self.bpf.refresh(elapsed);
 
         Ok(())
     }
@@ -119,7 +109,7 @@ impl Sampler for BlockIORequests {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.refresh_counters(now).is_ok() || self.refresh_distributions(now).is_ok() {
+        if self.refresh(now).is_ok() {
             let elapsed = now.elapsed().as_nanos() as u64;
 
             METADATA_BLOCKIO_REQUESTS_RUNTIME.add(elapsed);

--- a/src/samplers/block_io/linux/requests/mod.rs
+++ b/src/samplers/block_io/linux/requests/mod.rs
@@ -90,12 +90,12 @@ impl BlockIORequests {
 
         Ok(Self {
             bpf,
-            counter_interval: Interval::new(now, config.interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 
     pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
-        let elapsed = self.counter_interval.try_wait(now)?;
+        let elapsed = self.interval.try_wait(now)?;
 
         METADATA_BLOCKIO_REQUESTS_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -247,7 +247,7 @@ impl CpuUsage {
     }
 
     pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
-        let elapsed = self.counter_interval.try_wait(now)?;
+        let elapsed = self.interval.try_wait(now)?;
 
         METADATA_CPU_USAGE_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 

--- a/src/samplers/cpu/linux/usage/bpf.rs
+++ b/src/samplers/cpu/linux/usage/bpf.rs
@@ -314,9 +314,7 @@ impl Sampler for CpuUsage {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.update_online_cores(now).is_ok()
-            || self.refresh(now).is_ok()
-        {
+        if self.update_online_cores(now).is_ok() || self.refresh(now).is_ok() {
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_CPU_USAGE_RUNTIME.add(elapsed);
             let _ = METADATA_CPU_USAGE_RUNTIME_HISTOGRAM.increment(elapsed);

--- a/src/samplers/network/linux/traffic/bpf.rs
+++ b/src/samplers/network/linux/traffic/bpf.rs
@@ -32,8 +32,7 @@ impl GetMap for ModSkel<'_> {
 /// * `network/transmit/frames`
 pub struct NetworkTraffic {
     bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Interval,
-    distribution_interval: Interval,
+    interval: Interval,
 }
 
 impl NetworkTraffic {
@@ -78,25 +77,16 @@ impl NetworkTraffic {
 
         Ok(Self {
             bpf,
-            counter_interval: Interval::new(now, config.interval(NAME)),
-            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 
-    pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
+    pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
         METADATA_NETWORK_TRAFFIC_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-        self.bpf.refresh_counters(elapsed);
-
-        Ok(())
-    }
-
-    pub fn refresh_distributions(&mut self, now: Instant) -> Result<(), ()> {
-        self.distribution_interval.try_wait(now)?;
-
-        self.bpf.refresh_distributions();
+        self.bpf.refresh(elapsed);
 
         Ok(())
     }
@@ -106,7 +96,7 @@ impl Sampler for NetworkTraffic {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.refresh_counters(now).is_ok() || self.refresh_distributions(now).is_ok() {
+        if self.refresh(now).is_ok() {
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_NETWORK_TRAFFIC_RUNTIME.add(elapsed);
             let _ = METADATA_NETWORK_TRAFFIC_RUNTIME_HISTOGRAM.increment(elapsed);

--- a/src/samplers/network/linux/traffic/bpf.rs
+++ b/src/samplers/network/linux/traffic/bpf.rs
@@ -82,7 +82,7 @@ impl NetworkTraffic {
     }
 
     pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
-        let elapsed = self.counter_interval.try_wait(now)?;
+        let elapsed = self.interval.try_wait(now)?;
 
         METADATA_NETWORK_TRAFFIC_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 

--- a/src/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/samplers/scheduler/linux/runqueue/mod.rs
@@ -97,7 +97,7 @@ impl Runqlat {
         })
     }
 
-    pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
+    pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.interval.try_wait(now)?;
 
         METADATA_SCHEDULER_RUNQUEUE_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());

--- a/src/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/samplers/scheduler/linux/runqueue/mod.rs
@@ -44,8 +44,7 @@ impl GetMap for ModSkel<'_> {
 /// * `scheduler/context_switch/voluntary`
 pub struct Runqlat {
     bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Interval,
-    distribution_interval: Interval,
+    interval: Interval,
 }
 
 impl Runqlat {
@@ -94,25 +93,16 @@ impl Runqlat {
 
         Ok(Self {
             bpf,
-            counter_interval: Interval::new(now, config.interval(NAME)),
-            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 
     pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
-        let elapsed = self.counter_interval.try_wait(now)?;
+        let elapsed = self.interval.try_wait(now)?;
 
         METADATA_SCHEDULER_RUNQUEUE_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-        self.bpf.refresh_counters(elapsed);
-
-        Ok(())
-    }
-
-    pub fn refresh_distributions(&mut self, now: Instant) -> Result<(), ()> {
-        self.distribution_interval.try_wait(now)?;
-
-        self.bpf.refresh_distributions();
+        self.bpf.refresh(elapsed);
 
         Ok(())
     }
@@ -122,7 +112,7 @@ impl Sampler for Runqlat {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.refresh_counters(now).is_ok() || self.refresh_distributions(now).is_ok() {
+        if self.refresh(now).is_ok() {
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_SCHEDULER_RUNQUEUE_RUNTIME.add(elapsed);
             let _ = METADATA_SCHEDULER_RUNQUEUE_RUNTIME_HISTOGRAM.increment(elapsed);

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -107,7 +107,7 @@ impl Sampler for SyscallCounts {
         if let Ok(elapsed) = self.interval.try_wait(now) {
             METADATA_SYSCALL_COUNTS_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-            self.bpf.refresh_counters(elapsed);
+            self.bpf.refresh(elapsed);
 
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_SYSCALL_COUNTS_RUNTIME.add(elapsed);

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -106,7 +106,7 @@ impl SyscallLatency {
 
         Ok(Self {
             bpf,
-            interval: Interval::new(now, config.distribution_interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 }
@@ -115,10 +115,10 @@ impl Sampler for SyscallLatency {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if let Ok(_) = self.interval.try_wait(now) {
+        if let Ok(elapsed) = self.interval.try_wait(now) {
             METADATA_SYSCALL_LATENCY_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-            self.bpf.refresh_distributions();
+            self.bpf.refresh(elapsed);
 
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_SYSCALL_LATENCY_RUNTIME.add(elapsed);

--- a/src/samplers/tcp/linux/packet_latency/mod.rs
+++ b/src/samplers/tcp/linux/packet_latency/mod.rs
@@ -82,7 +82,7 @@ impl PacketLatency {
 
         Ok(Self {
             bpf,
-            interval: Interval::new(now, config.distribution_interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 }
@@ -91,10 +91,10 @@ impl Sampler for PacketLatency {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.interval.try_wait(now).is_ok() {
+        if let Ok(elapsed) = self.interval.try_wait(now) {
             METADATA_TCP_PACKET_LATENCY_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-            self.bpf.refresh_distributions();
+            self.bpf.refresh(elapsed);
 
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_TCP_PACKET_LATENCY_RUNTIME.add(elapsed);

--- a/src/samplers/tcp/linux/receive/mod.rs
+++ b/src/samplers/tcp/linux/receive/mod.rs
@@ -75,7 +75,7 @@ impl Receive {
 
         Ok(Self {
             bpf,
-            interval: Interval::new(now, config.distribution_interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 }
@@ -84,10 +84,10 @@ impl Sampler for Receive {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.interval.try_wait(now).is_ok() {
+        if let Ok(elapsed) = self.interval.try_wait(now) {
             METADATA_TCP_RECEIVE_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-            self.bpf.refresh_distributions();
+            self.bpf.refresh(elapsed);
 
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_TCP_RECEIVE_RUNTIME.add(elapsed);

--- a/src/samplers/tcp/linux/retransmit/mod.rs
+++ b/src/samplers/tcp/linux/retransmit/mod.rs
@@ -87,7 +87,7 @@ impl Sampler for Retransmit {
         if let Ok(elapsed) = self.interval.try_wait(now) {
             METADATA_TCP_RETRANSMIT_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-            self.bpf.refresh_counters(elapsed);
+            self.bpf.refresh(elapsed);
 
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_TCP_RETRANSMIT_RUNTIME.add(elapsed);

--- a/src/samplers/tcp/linux/traffic/bpf.rs
+++ b/src/samplers/tcp/linux/traffic/bpf.rs
@@ -36,8 +36,7 @@ impl GetMap for ModSkel<'_> {
 /// * `tcp/transmit/size`
 pub struct TcpTraffic {
     bpf: Bpf<ModSkel<'static>>,
-    counter_interval: Interval,
-    distribution_interval: Interval,
+    interval: Interval,
 }
 
 impl TcpTraffic {
@@ -86,25 +85,16 @@ impl TcpTraffic {
 
         Ok(Self {
             bpf,
-            counter_interval: Interval::new(now, config.interval(NAME)),
-            distribution_interval: Interval::new(now, config.distribution_interval(NAME)),
+            interval: Interval::new(now, config.interval(NAME)),
         })
     }
 
-    pub fn refresh_counters(&mut self, now: Instant) -> Result<(), ()> {
+    pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
         let elapsed = self.counter_interval.try_wait(now)?;
 
         METADATA_TCP_TRAFFIC_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 
-        self.bpf.refresh_counters(elapsed);
-
-        Ok(())
-    }
-
-    pub fn refresh_distributions(&mut self, now: Instant) -> Result<(), ()> {
-        self.distribution_interval.try_wait(now)?;
-
-        self.bpf.refresh_distributions();
+        self.bpf.refresh(elapsed);
 
         Ok(())
     }
@@ -114,7 +104,7 @@ impl Sampler for TcpTraffic {
     fn sample(&mut self) {
         let now = Instant::now();
 
-        if self.refresh_counters(now).is_ok() || self.refresh_distributions(now).is_ok() {
+        if self.refresh(now).is_ok() {
             let elapsed = now.elapsed().as_nanos() as u64;
             METADATA_TCP_TRAFFIC_RUNTIME.add(elapsed);
             let _ = METADATA_TCP_TRAFFIC_RUNTIME_HISTOGRAM.increment(elapsed);

--- a/src/samplers/tcp/linux/traffic/bpf.rs
+++ b/src/samplers/tcp/linux/traffic/bpf.rs
@@ -90,7 +90,7 @@ impl TcpTraffic {
     }
 
     pub fn refresh(&mut self, now: Instant) -> Result<(), ()> {
-        let elapsed = self.counter_interval.try_wait(now)?;
+        let elapsed = self.interval.try_wait(now)?;
 
         METADATA_TCP_TRAFFIC_COLLECTED_AT.set(UnixInstant::EPOCH.elapsed().as_nanos());
 


### PR DESCRIPTION
Remove the separate distribution interval. BPF histogram refreshes are very quick and this makes the configuration simpler and easier to reason about.
