### PR TITLE
decrease histogram grouping power

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,24 +33,19 @@ histograms = false
 # buckets, and therefore reduce the number of timeseries needed to store the
 # distribution.
 #
-# The grouping power must be in the range 2..=7. The native histograms are
-# recorded with a grouping power of 7. Any reduction in the grouping power will
+# The grouping power must be in the range 0..=3. The native histograms are
+# recorded with a grouping power of 3. Any reduction in the grouping power will
 # increase the relative error, as the buckets are wider with lower grouping
 # powers.
-#
-# By default, we reduce the grouping power to 4 to greatly reduce the number of
-# timeseries but maintain an acceptable relative error for most uses.
 #
 # See https://docs.rs/histogram/ for more information about the grouping power.
 #
 # Power:   	    Error:		Buckets:
-# 7             0.781%      7424
-# 6             1.56%       3776
-# 5             3.13%       1920
-# 4             6.25%       976
-# 3             12.5%       496
-# 2             25.0%       252
-histogram_grouping_power = 4
+# 3              12.5%      496
+# 2              25.0%      252
+# 1              50.0%      128
+# 0             100.0%       65
+histogram_grouping_power = 3
 
 # The defaults are used for each sampler unless there's a sampler level
 # configuration present.

--- a/src/common/bpf/histogram.h
+++ b/src/common/bpf/histogram.h
@@ -1,5 +1,7 @@
 // Helpers for converting values to histogram indices. 
 
+#define HISTOGRAM_BUCKETS_POW_2 252
+#define HISTOGRAM_BUCKETS_POW_3 496
 #define HISTOGRAM_BUCKETS_POW_4 976
 #define HISTOGRAM_BUCKETS_POW_5 1920
 #define HISTOGRAM_BUCKETS_POW_6 3776

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -13,4 +13,6 @@ pub use counter::Counter;
 pub use interval::{AsyncInterval, Interval};
 pub use nop::Nop;
 
-pub const HISTOGRAM_GROUPING_POWER: u8 = 7;
+// the grouping power must match what we use in the BPF samplers and limits the
+// value grouping to a 12.5% relative error. This uses only 4KiB per histogram.
+pub const HISTOGRAM_GROUPING_POWER: u8 = 3;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -217,10 +217,10 @@ impl Default for Prometheus {
 
 impl Prometheus {
     pub fn check(&self) {
-        if !(2..=(crate::common::HISTOGRAM_GROUPING_POWER)).contains(&self.histogram_grouping_power)
+        if !(0..=(crate::common::HISTOGRAM_GROUPING_POWER)).contains(&self.histogram_grouping_power)
         {
             eprintln!(
-                "prometheus histogram downsample factor must be in the range 2..={}",
+                "prometheus histogram grouping power must be in the range 0..={}",
                 crate::common::HISTOGRAM_GROUPING_POWER
             );
             std::process::exit(1);

--- a/src/samplers/block_io/linux/latency/mod.bpf.c
+++ b/src/samplers/block_io/linux/latency/mod.bpf.c
@@ -11,7 +11,8 @@
 extern int LINUX_KERNEL_VERSION __kconfig;
 
 #define COUNTER_GROUP_WIDTH 8
-#define HISTOGRAM_POWER 7
+#define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
+#define HISTOGRAM_POWER 3
 #define MAX_CPUS 1024
 
 #define REQ_OP_BITS	8
@@ -35,7 +36,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, 7424);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } latency SEC(".maps");
 
 static int __always_inline trace_rq_start(struct request *rq, int issue)

--- a/src/samplers/block_io/linux/requests/mod.bpf.c
+++ b/src/samplers/block_io/linux/requests/mod.bpf.c
@@ -11,7 +11,8 @@
 extern int LINUX_KERNEL_VERSION __kconfig;
 
 #define COUNTER_GROUP_WIDTH 8
-#define HISTOGRAM_POWER 7
+#define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
+#define HISTOGRAM_POWER 3
 #define MAX_CPUS 1024
 
 #define REQ_OP_BITS	8
@@ -45,7 +46,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, 7424);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } size SEC(".maps");
 
 static int handle_block_rq_complete(struct request *rq, int error, unsigned int nr_bytes)

--- a/src/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -15,7 +15,8 @@
 #include <bpf/bpf_helpers.h>
 
 #define COUNTER_GROUP_WIDTH 8
-#define HISTOGRAM_POWER 7
+#define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
+#define HISTOGRAM_POWER 3
 #define MAX_CPUS 1024
 #define MAX_PID 4194304
 
@@ -90,7 +91,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } runqlat SEC(".maps");
 
 struct {
@@ -98,7 +99,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } running SEC(".maps");
 
 struct {
@@ -106,7 +107,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } offcpu SEC(".maps");
 
 /* record enqueue timestamp */

--- a/src/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/samplers/syscall/linux/latency/mod.bpf.c
@@ -18,7 +18,8 @@
 #include <bpf/bpf_core_read.h>
 
 #define COUNTER_GROUP_WIDTH 16
-#define HISTOGRAM_POWER 7
+#define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
+#define HISTOGRAM_POWER 3
 #define MAX_CPUS 1024
 #define MAX_SYSCALL_ID 1024
 #define MAX_PID 4194304
@@ -46,7 +47,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } total_latency SEC(".maps");
 
 struct {
@@ -54,7 +55,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } read_latency SEC(".maps");
 
 struct {
@@ -62,7 +63,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } write_latency SEC(".maps");
 
 struct {
@@ -70,7 +71,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } poll_latency SEC(".maps");
 
 struct {
@@ -78,7 +79,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } lock_latency SEC(".maps");
 
 struct {
@@ -86,7 +87,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } time_latency SEC(".maps");
 
 struct {
@@ -94,7 +95,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } sleep_latency SEC(".maps");
 
 struct {
@@ -102,7 +103,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } socket_latency SEC(".maps");
 
 struct {
@@ -110,7 +111,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } yield_latency SEC(".maps");
 
 // provides a lookup table from syscall id to a counter index offset

--- a/src/samplers/tcp/linux/packet_latency/mod.bpf.c
+++ b/src/samplers/tcp/linux/packet_latency/mod.bpf.c
@@ -16,7 +16,8 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 
-#define HISTOGRAM_POWER 7
+#define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
+#define HISTOGRAM_POWER 3
 
 #define MAX_ENTRIES	10240
 #define AF_INET		2
@@ -34,7 +35,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } latency SEC(".maps");
 
 static __always_inline __u64 get_sock_ident(struct sock *sk)

--- a/src/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/samplers/tcp/linux/receive/mod.bpf.c
@@ -16,14 +16,15 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
 
-#define HISTOGRAM_POWER 7
+#define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
+#define HISTOGRAM_POWER 3
 
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } jitter SEC(".maps");
 
 struct {
@@ -31,7 +32,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } srtt SEC(".maps");
 
 SEC("kprobe/tcp_rcv_established")

--- a/src/samplers/tcp/linux/traffic/mod.bpf.c
+++ b/src/samplers/tcp/linux/traffic/mod.bpf.c
@@ -16,7 +16,8 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
 
-#define HISTOGRAM_POWER 7
+#define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
+#define HISTOGRAM_POWER 3
 
 /* Taken from kernel include/linux/socket.h. */
 #define AF_INET		2	/* Internet IP Protocol 	*/
@@ -41,7 +42,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } rx_size SEC(".maps");
 
 struct {
@@ -49,7 +50,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, HISTOGRAM_BUCKETS_POW_7);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
 } tx_size SEC(".maps");
 
 static int probe_ip(bool receiving, struct sock *sk, size_t size)


### PR DESCRIPTION
We have been using a histogram grouping power of 7 internally, but we can often tolerate higher relative error for metrics reported out of these histograms.

This PR reduces the histogram grouping power to 3. This gives a 12.5% relative error and reduces the per-histogram size from 58KiB to 4KiB. Our previous relative error was bounded at 0.781%.
