### PR TITLE
fix memory samplers

### DIFF
--- a/src/samplers/memory/linux/meminfo/mod.rs
+++ b/src/samplers/memory/linux/meminfo/mod.rs
@@ -65,6 +65,8 @@ impl MeminfoInner {
     pub async fn refresh(&mut self) -> Result<(), std::io::Error> {
         self.file.rewind().await?;
 
+        self.data.clear();
+
         self.file.read_to_string(&mut self.data).await?;
 
         let lines = self.data.lines();

--- a/src/samplers/memory/linux/vmstat/mod.rs
+++ b/src/samplers/memory/linux/vmstat/mod.rs
@@ -65,6 +65,8 @@ impl MeminfoInner {
     pub async fn refresh(&mut self) -> Result<(), std::io::Error> {
         self.file.rewind().await?;
 
+        self.data.clear();
+
         self.file.read_to_string(&mut self.data).await?;
 
         let lines = self.data.lines();


### PR DESCRIPTION
Fixes the memory samplers by ensuring that the string is cleared.

This bug only exists in the current 4.0.0-alpha
