### PR TITLE
use join_all to await on all samplers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,12 +844,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -857,6 +873,34 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -876,10 +920,16 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1907,6 +1957,7 @@ dependencies = [
  "backtrace",
  "clap",
  "clocksource",
+ "futures",
  "histogram",
  "humantime",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rezolus"
-version = "4.0.0-alpha.1"
+version = "4.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "4.0.0-alpha.1"
+version = "4.0.0-alpha.2"
 license = "MIT OR Apache-2.0"
 publish = false
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ axum = { version = "0.7.5", features = ["http2"] }
 backtrace = "0.3.73"
 clap = "4.5.17"
 clocksource = "0.8.1"
+futures = "0.3.30"
 histogram = "0.11.0"
 humantime = "2.1.0"
 lazy_static = "1.5.0"

--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -206,9 +206,9 @@ async fn root() -> String {
 }
 
 async fn refresh(samplers: &[Box<dyn Sampler>]) {
-    for sampler in samplers.iter() {
-        sampler.refresh().await;
-    }
+    let s: Vec<_> = samplers.iter().map(|s| s.refresh()).collect();
+
+    futures::future::join_all(s).await;
 }
 
 fn simple_stats(quoted: bool) -> Vec<String> {


### PR DESCRIPTION
Instead of looping through each sampler and sequentially await'ing we can use join_all on the set of all sampler futures.

Result

Reduces sampling (and therefore HTTP metrics endpoint) latency by executing the sampler futures concurrently.
