### PR TITLE
improvements for deb packaging workflow

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-22.04, macos-latest ]
+        os: [ ubuntu-24.04, ubuntu-22.04, macos-latest ]
         profile: [ release, debug ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,6 +72,8 @@ jobs:
       - name: modify /etc/apt/sources.list
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
+          cat /etc/apt/sources.list
+          
           cat /etc/apt/sources.list             | \
             sed 's/^deb /deb [arch=amd64] /g'   | \
             grep '^deb '                          \

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,6 +72,8 @@ jobs:
       - name: enable arm64 dpkg architecture - ubuntu
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
+          cat /etc/apt/sources.list
+          
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
       

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: enable arm64 dpkg architecture - ubuntu
+      - name: enable ubuntu ports
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
@@ -78,8 +78,7 @@ jobs:
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
       
-      - name: enable arm64 dpkg architecture - debian
-        if: ${{ matrix.distro == 'debian' }}
+      - name: enable arm64 dpkg architecture
         run: |
           dpkg --add-architecture arm64
 

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -70,7 +70,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: enable arm64 dpkg architecture
-        run: dpkg --add-architecture arm64
+        if: ${{ matrix.distro == 'ubuntu' }}
+        run: |
+          sudo add-apt-repository 'deb [arch=arm64] http://ports.ubuntu.com/dists/ ${{matrix.release}} main'
+        if: ${{ matrix.distro == 'debian' }}
+        run: |
+          dpkg --add-architecture arm64
 
       - name: install buildsystem apt dependencies
         run: |

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -69,26 +69,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: modify /etc/apt/sources.list
-        if: ${{ matrix.distro == 'ubuntu' }}
-        run: |
-          cat /etc/apt/sources.list
-          cat /etc/apt/sources.list.d/ubuntu.sources
+      # - name: modify /etc/apt/sources.list
+      #   if: ${{ matrix.distro == 'ubuntu' }}
+      #   run: |
+      #     cat /etc/apt/sources.list
+      #     cat /etc/apt/sources.list.d/ubuntu.sources
           
-          cat /etc/apt/sources.list             | \
-            sed 's/^deb /deb [arch=amd64] /g'   | \
-            grep '^deb '                          \
-            > amd64.list
+      #     cat /etc/apt/sources.list             | \
+      #       sed 's/^deb /deb [arch=amd64] /g'   | \
+      #       grep '^deb '                          \
+      #       > amd64.list
           
-          cat /etc/apt/sources.list             | \
-            sed 's/^deb /deb [arch=arm64] /g'   | \
-            grep archive.ubuntu.com             | \
-            grep '^deb '                        | \
-            sed 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com|g' \
-            > arm64.list
+      #     cat /etc/apt/sources.list             | \
+      #       sed 's/^deb /deb [arch=arm64] /g'   | \
+      #       grep archive.ubuntu.com             | \
+      #       grep '^deb '                        | \
+      #       sed 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com|g' \
+      #       > arm64.list
 
-          cat amd64.list arm64.list | tee /etc/apt/sources.list
-          rm amd64.list arm64.list
+      #     cat amd64.list arm64.list | tee /etc/apt/sources.list
+      #     rm amd64.list arm64.list
 
       - name: enable arm64 dpkg architecture
         run: dpkg --add-architecture arm64

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -1,13 +1,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: package
+name: package-deb
 
 "on":
   push:
-    paths:
-      - .github/actions/**
-      - .github/workflows/package.yml
-      - debian/**
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:
@@ -39,7 +36,7 @@ env:
 jobs:
   build-deb:
     name: "${{ matrix.distro }}:${{ matrix.release }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: "${{ matrix.distro }}:${{ matrix.release }}"
     strategy:
       matrix:
@@ -100,22 +97,6 @@ jobs:
 
       - name: enable additional rustup targets
         run: rustup target add aarch64-unknown-linux-gnu
-
-      # Newer clang versions need a newer version of libstdc++ then bionic provides.
-      - name: install a newer libstc++ version needed for clang
-        if: ${{ matrix.release == 'bionic' }}
-        run: |
-          apt-get -q install -y software-properties-common
-          add-apt-repository -y ppa:ubuntu-toolchain-r/test
-
-      # bpf-rs needs a newer version of clang than is available in older distro releases
-      - name: install a newer clang version
-        run: |
-          curl -sSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-          cat > /etc/apt/sources.list.d/llvm.list <<EOM
-            deb http://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc) main
-          EOM
-          apt-get -q update
 
       - name: check cargo
         shell: bash

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -57,7 +57,7 @@ jobs:
 
           # ubuntu kernels supported from 20.10 and up
           - { distro: ubuntu, release: jammy   } # 22.04
-          - { distro: ubuntu, release: noble   } # 24.04
+          # - { distro: ubuntu, release: noble   } # 24.04
       fail-fast: false
     env:
       # dpkg-buildpackage issues a warning if we attempt to cross compile and
@@ -69,23 +69,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: enable ubuntu ports
+      - name: modify /etc/apt/sources.list
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
-          cat /etc/apt/sources.list
+          cat /etc/apt/sources.list             | \
+            sed 's/^deb /deb [arch=amd64] /g'   | \
+            grep '^deb '                          \
+            > amd64.list
+          
+          cat /etc/apt/sources.list             | \
+            sed 's/^deb /deb [arch=arm64] /g'   | \
+            grep archive.ubuntu.com             | \
+            grep '^deb '                        | \
+            sed 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com|g' \
+            > arm64.list
 
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-security main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-backports main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
-          apt-get update
+          cat amd64.list arm64.list > /etc/apt/sources.list
+          rm amd64.list arm64.list
 
-          apt install libelf-dev libelf-dev:arm64 
-      
-      - name: enable arm64 dpkg architecture - debian
-        if: ${{ matrix.distro == 'debian' }}
-        run: |
-          dpkg --add-architecture arm64
+      - name: enable arm64 dpkg architecture
+        run: dpkg --add-architecture arm64
 
       - name: install buildsystem apt dependencies
         run: |

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -69,27 +69,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # - name: modify /etc/apt/sources.list
-      #   if: ${{ matrix.distro == 'ubuntu' }}
-      #   run: |
-      #     cat /etc/apt/sources.list
-      #     cat /etc/apt/sources.list.d/ubuntu.sources
-          
-      #     cat /etc/apt/sources.list             | \
-      #       sed 's/^deb /deb [arch=amd64] /g'   | \
-      #       grep '^deb '                          \
-      #       > amd64.list
-          
-      #     cat /etc/apt/sources.list             | \
-      #       sed 's/^deb /deb [arch=arm64] /g'   | \
-      #       grep archive.ubuntu.com             | \
-      #       grep '^deb '                        | \
-      #       sed 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com|g' \
-      #       > arm64.list
-
-      #     cat amd64.list arm64.list | tee /etc/apt/sources.list
-      #     rm amd64.list arm64.list
-
       - name: enable arm64 dpkg architecture
         run: dpkg --add-architecture arm64
 

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,6 +72,7 @@ jobs:
       - name: enable arm64 dpkg architecture - ubuntu
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
+          apt-get install software-properties-common
           add-apt-repository 'deb [arch=arm64] http://ports.ubuntu.com/dists/ ${{matrix.release}} main'
       
       - name: enable arm64 dpkg architecture - debian

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,6 +72,8 @@ jobs:
       - name: enable ubuntu ports
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
+          cat /etc/apt/sources.list
+          
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-security main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-backports main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,7 +72,7 @@ jobs:
       - name: enable arm64 dpkg architecture - ubuntu
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
-          echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu ${{ matrix.release }} main' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
       
       - name: enable arm64 dpkg architecture - debian

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -78,7 +78,8 @@ jobs:
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
       
-      - name: enable arm64 dpkg architecture
+      - name: enable arm64 dpkg architecture - debian
+        if: ${{ matrix.distro == 'debian' }}
         run: |
           dpkg --add-architecture arm64
 

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,9 +72,10 @@ jobs:
       - name: enable arm64 dpkg architecture - ubuntu
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
-          cat /etc/apt/sources.list
-          
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-security main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-backports main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
       
       - name: enable arm64 dpkg architecture - debian

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -79,7 +79,8 @@ jobs:
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-backports main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
-          dpkg --add-architecture arm64
+
+          apt install libelf-dev libelf-dev:arm64 
       
       - name: enable arm64 dpkg architecture - debian
         if: ${{ matrix.distro == 'debian' }}

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -84,7 +84,7 @@ jobs:
             sed 's|archive.ubuntu.com/ubuntu|ports.ubuntu.com|g' \
             > arm64.list
 
-          cat amd64.list arm64.list > /etc/apt/sources.list
+          cat amd64.list arm64.list | tee /etc/apt/sources.list
           rm amd64.list arm64.list
 
       - name: enable arm64 dpkg architecture

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -79,6 +79,7 @@ jobs:
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-backports main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
+          dpkg --add-architecture arm64
       
       - name: enable arm64 dpkg architecture - debian
         if: ${{ matrix.distro == 'debian' }}

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,8 +72,8 @@ jobs:
       - name: enable arm64 dpkg architecture - ubuntu
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
-          apt-get install software-properties-common
-          add-apt-repository 'deb [arch=arm64] http://ports.ubuntu.com/dists/ ${{matrix.release}} main'
+          echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu ${{ matrix.release }} main' | tee /etc/apt/sources.list.d/arm64.list
+          apt-get update
       
       - name: enable arm64 dpkg architecture - debian
         if: ${{ matrix.distro == 'debian' }}

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -4,7 +4,15 @@ name: package-deb
 
 "on":
   push:
+    paths:
+      - .github/actions/**
+      - .github/workflows/package-deb.yml
+      - debian/**
   pull_request:
+    paths:
+      - .github/actions/**
+      - .github/workflows/package-deb.yml
+      - debian/**
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -73,11 +73,11 @@ jobs:
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
           cat /etc/apt/sources.list
-          
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-security main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-backports main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
-          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
+
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }} main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-security main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-backports main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
+          echo 'deb [arch=arm64] http://ports.ubuntu.com ${{ matrix.release }}-updates main restricted multiverse universe' | tee /etc/apt/sources.list.d/arm64.list
           apt-get update
       
       - name: enable arm64 dpkg architecture - debian

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -72,7 +72,7 @@ jobs:
       - name: enable arm64 dpkg architecture - ubuntu
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
-          sudo add-apt-repository 'deb [arch=arm64] http://ports.ubuntu.com/dists/ ${{matrix.release}} main'
+          add-apt-repository 'deb [arch=arm64] http://ports.ubuntu.com/dists/ ${{matrix.release}} main'
       
       - name: enable arm64 dpkg architecture - debian
         if: ${{ matrix.distro == 'debian' }}

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -73,6 +73,7 @@ jobs:
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
           cat /etc/apt/sources.list
+          cat /etc/apt/sources.list.d/ubuntu.sources
           
           cat /etc/apt/sources.list             | \
             sed 's/^deb /deb [arch=amd64] /g'   | \

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -69,10 +69,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: enable arm64 dpkg architecture
+      - name: enable arm64 dpkg architecture - ubuntu
         if: ${{ matrix.distro == 'ubuntu' }}
         run: |
           sudo add-apt-repository 'deb [arch=arm64] http://ports.ubuntu.com/dists/ ${{matrix.release}} main'
+      
+      - name: enable arm64 dpkg architecture - debian
         if: ${{ matrix.distro == 'debian' }}
         run: |
           dpkg --add-architecture arm64


### PR DESCRIPTION
Run the deb packaging workflow on any push or pull request. This ensures that we don't break the workflow and only find out at release time.

Bumps the ubuntu runner version
