### PR TITLE
fix rpm packaging

### DIFF
--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   build-deb:
     name: "${{ matrix.distro }}:${{ matrix.release }}"
-    runs-on: ${{ matrix.arch == 'arm64' && 'buildjet-16vcpu-ubuntu-2204-arm' || 'buildjet-8vcpu-ubuntu-2204' }}
+    runs-on: buildjet-16vcpu-ubuntu-2204${{ matrix.arch == 'arm64' && '-arm' || '' }}
     container: "${{ matrix.distro }}:${{ matrix.release }}"
     strategy:
       matrix:

--- a/.github/workflows/package-rpm.yml
+++ b/.github/workflows/package-rpm.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   build-rpm:
     name: "${{ matrix.distro }}:${{ matrix.version }} (${{ matrix.arch }})"
-    runs-on: buildjet-8vcpu-ubuntu-2204${{ matrix.arch == 'arm64' && '-arm' || '' }}
+    runs-on: buildjet-16vcpu-ubuntu-2204${{ matrix.arch == 'arm64' && '-arm' || '' }}
     container: "${{ matrix.distro }}:${{ matrix.version }}"
     strategy:
       matrix:


### PR DESCRIPTION
Increase the size of the buildjet worker for RPM packaging to prevent failure due to OOM.
