### PR TITLE
blockio: add read and write latency histograms

### DIFF
--- a/src/samplers/blockio/linux/latency/mod.rs
+++ b/src/samplers/blockio/linux/latency/mod.rs
@@ -28,6 +28,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .histogram("latency", &BLOCKIO_LATENCY)
+        .histogram("read_latency", &BLOCKIO_READ_LATENCY)
+        .histogram("write_latency", &BLOCKIO_WRITE_LATENCY)
         .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -37,6 +39,8 @@ impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
         match name {
             "latency" => &self.maps.latency,
+            "read_latency" => &self.maps.read_latency,
+            "write_latency" => &self.maps.write_latency,
             _ => unimplemented!(),
         }
     }

--- a/src/samplers/blockio/linux/stats.rs
+++ b/src/samplers/blockio/linux/stats.rs
@@ -13,14 +13,16 @@ pub static BLOCKIO_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GRO
     description = "Distribution of blockio read operation latency in nanoseconds",
     metadata = { unit = "nanoseconds" }
 )]
-pub static BLOCKIO_READ_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_READ_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/write/latency",
     description = "Distribution of blockio write operation latency in nanoseconds",
     metadata = { unit = "nanoseconds" }
 )]
-pub static BLOCKIO_WRITE_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_WRITE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/size",

--- a/src/samplers/blockio/linux/stats.rs
+++ b/src/samplers/blockio/linux/stats.rs
@@ -9,11 +9,39 @@ use metriken::*;
 pub static BLOCKIO_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
+    name = "blockio/read/latency",
+    description = "Distribution of blockio read operation latency in nanoseconds",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static BLOCKIO_READ_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio/write/latency",
+    description = "Distribution of blockio write operation latency in nanoseconds",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static BLOCKIO_WRITE_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
     name = "blockio/size",
     description = "Distribution of blockio operation sizes in bytes",
     metadata = { unit = "bytes" }
 )]
 pub static BLOCKIO_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio/read/size",
+    description = "Distribution of blockio read operation sizes in bytes",
+    metadata = { unit = "bytes" }
+)]
+pub static BLOCKIO_READ_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio/write/size",
+    description = "Distribution of blockio write operation sizes in bytes",
+    metadata = { unit = "bytes" }
+)]
+pub static BLOCKIO_WRITE_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio/operations",


### PR DESCRIPTION
Adds separate latency histograms for read and write operations.
