### PR TITLE
separate histogram for blockio read and write sizes

### DIFF
--- a/src/samplers/blockio/linux/requests/mod.rs
+++ b/src/samplers/blockio/linux/requests/mod.rs
@@ -40,6 +40,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .counters("counters", counters)
         .histogram("size", &BLOCKIO_SIZE)
+        .histogram("read_size", &BLOCKIO_READ_SIZE)
+        .histogram("write_size", &BLOCKIO_WRITE_SIZE)
         .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -50,6 +52,8 @@ impl SkelExt for ModSkel<'_> {
         match name {
             "counters" => &self.maps.counters,
             "size" => &self.maps.size,
+            "read_size" => &self.maps.read_size,
+            "write_size" => &self.maps.write_size,
             _ => unimplemented!(),
         }
     }


### PR DESCRIPTION
Add separate histogram tracking for read and write blockio sizes.
