### PR TITLE
use BPF to collect cpu perf

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ mod bpf {
     const SOURCES: &[(&str, &str)] = &[
         ("blockio", "latency"),
         ("blockio", "requests"),
+        ("cpu", "perf"),
         ("cpu", "usage"),
         ("network", "traffic"),
         ("scheduler", "runqueue"),

--- a/src/common/bpf/builder.rs
+++ b/src/common/bpf/builder.rs
@@ -89,8 +89,6 @@ where
                 .perf_events
                 .into_iter()
                 .map(|(name, event)| {
-                    println!("initializing perf events: {name}");
-
                     let map = skel.map(name);
 
                     let mut counters = Vec::new();
@@ -114,29 +112,19 @@ where
 
                             let fd = c.as_raw_fd();
 
-                            println!("cpu: {cpu} with fd: {}", fd as i32);
-                            if map
-                                .update(
-                                    &((cpu as u32).to_ne_bytes()),
-                                    &((fd as i32).to_ne_bytes()),
-                                    MapFlags::ANY,
-                                )
-                                .is_err()
-                            {
-                                println!("error updating perf_event_array for cpu {cpu}");
-                            }
+                            let _ = map.update(
+                                &((cpu as u32).to_ne_bytes()),
+                                &((fd as i32).to_ne_bytes()),
+                                MapFlags::ANY,
+                            );
                         }
 
                         counters.push(counter);
                     }
 
-                    println!("initialized: {} counters for {name}", counters.len());
-
                     counters
                 })
                 .collect();
-
-            println!("{} total perf events initialized", perf_events.len());
 
             // load any data from userspace into BPF maps
             for (name, values) in self.maps.into_iter() {

--- a/src/common/bpf/builder.rs
+++ b/src/common/bpf/builder.rs
@@ -2,8 +2,9 @@ use crate::common::bpf::*;
 use crate::common::*;
 
 use libbpf_rs::skel::{OpenSkel, Skel, SkelBuilder};
-use libbpf_rs::OpenObject;
+use libbpf_rs::{MapCore, MapFlags, OpenObject};
 use metriken::{LazyCounter, RwLockHistogram};
+use perf_event::ReadFormat;
 
 use std::mem::MaybeUninit;
 use std::os::fd::{AsFd, AsRawFd, FromRawFd};
@@ -16,6 +17,7 @@ pub struct Builder<T: 'static + SkelBuilder<'static>> {
     histograms: Vec<(&'static str, &'static RwLockHistogram)>,
     maps: Vec<(&'static str, Vec<u64>)>,
     cpu_counters: Vec<(&'static str, Vec<&'static LazyCounter>, ScopedCounters)>,
+    perf_events: Vec<(&'static str, perf_event::events::Hardware)>,
 }
 
 impl<T: 'static> Builder<T>
@@ -31,6 +33,7 @@ where
             histograms: Vec::new(),
             maps: Vec::new(),
             cpu_counters: Vec::new(),
+            perf_events: Vec::new(),
         }
     }
 
@@ -76,6 +79,64 @@ where
                     CpuCounters::new(skel.map(name), totals, individual)
                 })
                 .collect();
+
+            let cpus = match common::linux::cpus() {
+                Ok(cpus) => cpus.last().map(|v| *v).unwrap_or(1023),
+                Err(_) => 1023,
+            };
+
+            let perf_events: Vec<Vec<std::io::Result<perf_event::Counter>>> = self
+                .perf_events
+                .into_iter()
+                .map(|(name, event)| {
+                    println!("initializing perf events: {name}");
+
+                    let map = skel.map(name);
+
+                    let mut counters = Vec::new();
+
+                    for cpu in 0..=cpus {
+                        let mut counter = perf_event::Builder::new(event)
+                            .one_cpu(cpu)
+                            .any_pid()
+                            .exclude_hv(false)
+                            .exclude_kernel(false)
+                            .pinned(true)
+                            .read_format(
+                                ReadFormat::TOTAL_TIME_ENABLED
+                                    | ReadFormat::TOTAL_TIME_RUNNING
+                                    | ReadFormat::GROUP,
+                            )
+                            .build();
+
+                        if let Ok(c) = counter.as_mut() {
+                            let _ = c.enable();
+
+                            let fd = c.as_raw_fd();
+
+                            println!("cpu: {cpu} with fd: {}", fd as i32);
+                            if map
+                                .update(
+                                    &((cpu as u32).to_ne_bytes()),
+                                    &((fd as i32).to_ne_bytes()),
+                                    MapFlags::ANY,
+                                )
+                                .is_err()
+                            {
+                                println!("error updating perf_event_array for cpu {cpu}");
+                            }
+                        }
+
+                        counters.push(counter);
+                    }
+
+                    println!("initialized: {} counters for {name}", counters.len());
+
+                    counters
+                })
+                .collect();
+
+            println!("{} total perf events initialized", perf_events.len());
 
             // load any data from userspace into BPF maps
             for (name, values) in self.maps.into_iter() {
@@ -187,6 +248,12 @@ where
         individual: ScopedCounters,
     ) -> Self {
         self.cpu_counters.push((name, totals, individual));
+        self
+    }
+
+    /// Specify a perf event array name and an associated perf event.
+    pub fn perf_event(mut self, name: &'static str, event: perf_event::events::Hardware) -> Self {
+        self.perf_events.push((name, event));
         self
     }
 }

--- a/src/common/bpf/builder.rs
+++ b/src/common/bpf/builder.rs
@@ -126,7 +126,10 @@ where
                 })
                 .collect();
 
-            debug!("initialized perf events for: {} hardware counters", perf_events.len());
+            debug!(
+                "initialized perf events for: {} hardware counters",
+                perf_events.len()
+            );
 
             // load any data from userspace into BPF maps
             for (name, values) in self.maps.into_iter() {

--- a/src/common/bpf/builder.rs
+++ b/src/common/bpf/builder.rs
@@ -81,7 +81,7 @@ where
                 .collect();
 
             let cpus = match common::linux::cpus() {
-                Ok(cpus) => cpus.last().map(|v| *v).unwrap_or(1023),
+                Ok(cpus) => cpus.last().copied().unwrap_or(1023),
                 Err(_) => 1023,
             };
 
@@ -114,7 +114,7 @@ where
 
                             let _ = map.update(
                                 &((cpu as u32).to_ne_bytes()),
-                                &((fd as i32).to_ne_bytes()),
+                                &(fd.to_ne_bytes()),
                                 MapFlags::ANY,
                             );
                         }
@@ -125,6 +125,8 @@ where
                     counters
                 })
                 .collect();
+
+            debug!("initialized perf events for: {} hardware counters", perf_events.len());
 
             // load any data from userspace into BPF maps
             for (name, values) in self.maps.into_iter() {

--- a/src/common/linux/mod.rs
+++ b/src/common/linux/mod.rs
@@ -3,8 +3,8 @@ use walkdir::{DirEntry, WalkDir};
 use std::io::Error;
 
 pub fn cpus() -> Result<Vec<usize>, Error> {
-    let raw = std::fs::read_to_string("/sys/devices/system/cpu/possible")
-        .map(|v| v.trim().to_string())?;
+    let raw =
+        std::fs::read_to_string("/sys/devices/system/cpu/present").map(|v| v.trim().to_string())?;
 
     let mut ids = Vec::new();
 

--- a/src/samplers/cpu/linux/frequency/group.rs
+++ b/src/samplers/cpu/linux/frequency/group.rs
@@ -224,11 +224,9 @@ impl PerfGroup {
 
         let mut running_frequency_mhz = None;
 
-        if aperf.is_some() && mperf.is_some() {
-            if base_frequency_mhz.is_some() {
-                running_frequency_mhz =
-                    Some(base_frequency_mhz.unwrap() * aperf.unwrap() / mperf.unwrap());
-            }
+        if aperf.is_some() && mperf.is_some() && base_frequency_mhz.is_some() {
+            running_frequency_mhz =
+                Some(base_frequency_mhz.unwrap() * aperf.unwrap() / mperf.unwrap());
         }
 
         self.prev = Some(current);

--- a/src/samplers/cpu/linux/frequency/group.rs
+++ b/src/samplers/cpu/linux/frequency/group.rs
@@ -1,13 +1,10 @@
 use crate::*;
 
 use perf_event::events::x86::{Msr, MsrId};
-use perf_event::events::Hardware;
 use perf_event::{Builder, ReadFormat};
 
 #[derive(Copy, Clone, Debug)]
 enum Counter {
-    Cycles,
-    Instructions,
     Tsc,
     Aperf,
     Mperf,
@@ -16,8 +13,6 @@ enum Counter {
 impl Counter {
     fn builder(&self) -> Result<perf_event::Builder, std::io::Error> {
         match self {
-            Self::Cycles => Ok(Builder::new(Hardware::CPU_CYCLES)),
-            Self::Instructions => Ok(Builder::new(Hardware::INSTRUCTIONS)),
             Self::Tsc => {
                 let msr = Msr::new(MsrId::TSC)?;
                 Ok(Builder::new(msr))
@@ -101,10 +96,6 @@ impl GroupData {
 pub struct Reading {
     /// The CPU this reading is from
     pub cpu: usize,
-    pub cycles: Option<u64>,
-    pub instructions: Option<u64>,
-    pub ipkc: Option<u64>,
-    pub ipus: Option<u64>,
     pub base_frequency_mhz: Option<u64>,
     pub running_frequency_mhz: Option<u64>,
 }
@@ -128,12 +119,7 @@ impl PerfGroup {
 
         let leader_id;
 
-        if let Ok(c) = Counter::Cycles.as_leader(cpu) {
-            leader_id = Counter::Cycles as usize;
-
-            group.resize_with(Counter::Cycles as usize + 1, || None);
-            group[Counter::Cycles as usize] = Some(c);
-        } else if let Ok(c) = Counter::Tsc.as_leader(cpu) {
+        if let Ok(c) = Counter::Tsc.as_leader(cpu) {
             leader_id = Counter::Tsc as usize;
 
             group.resize_with(Counter::Tsc as usize + 1, || None);
@@ -143,12 +129,7 @@ impl PerfGroup {
             return Err(());
         }
 
-        for counter in &[
-            Counter::Instructions,
-            Counter::Tsc,
-            Counter::Aperf,
-            Counter::Mperf,
-        ] {
+        for counter in &[Counter::Aperf, Counter::Mperf] {
             if leader_id == *counter as usize {
                 continue;
             }
@@ -223,19 +204,9 @@ impl PerfGroup {
             return Err(());
         }
 
-        let mut cycles = None;
-        let mut instructions = None;
         let mut tsc = None;
         let mut aperf = None;
         let mut mperf = None;
-
-        if let Some(Some(c)) = &self.group.get(Counter::Cycles as usize) {
-            cycles = current.delta(prev, c);
-        }
-
-        if let Some(Some(c)) = &self.group.get(Counter::Instructions as usize) {
-            instructions = current.delta(prev, c);
-        }
 
         if let Some(Some(c)) = &self.group.get(Counter::Tsc as usize) {
             tsc = current.delta(prev, c);
@@ -249,29 +220,14 @@ impl PerfGroup {
             mperf = current.delta(prev, c);
         }
 
-        let ipkc = if let (Some(instructions), Some(cycles)) = (instructions, cycles) {
-            if cycles == 0 {
-                None
-            } else {
-                Some(instructions * 1000 / cycles)
-            }
-        } else {
-            None
-        };
-
         let base_frequency_mhz = tsc.map(|v| v / running_us);
 
         let mut running_frequency_mhz = None;
-        let mut ipus = None;
 
         if aperf.is_some() && mperf.is_some() {
             if base_frequency_mhz.is_some() {
                 running_frequency_mhz =
                     Some(base_frequency_mhz.unwrap() * aperf.unwrap() / mperf.unwrap());
-            }
-
-            if ipkc.is_some() {
-                ipus = Some(ipkc.unwrap() * aperf.unwrap() / mperf.unwrap());
             }
         }
 
@@ -279,10 +235,6 @@ impl PerfGroup {
 
         Ok(Reading {
             cpu: self.cpu,
-            cycles,
-            instructions,
-            ipkc,
-            ipus,
             base_frequency_mhz,
             running_frequency_mhz,
         })

--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -1,3 +1,11 @@
+//! Collects CPU frequency using a combination of MSRs.
+//!
+//! Initializes perf events to collect TSC, APERF, MPERF.
+//!
+//! Produces:
+//! * `cpu/base_frequency`
+//! * `cpu/running_frequency`
+
 const NAME: &str = "cpu_frequency";
 
 mod group;

--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -44,15 +44,13 @@ impl PerfInner {
         let mut gauges = ScopedGauges::new();
 
         for cpu in cpus {
-            for gauge in &["cpu/frequency"] {
-                gauges.push(
-                    cpu,
-                    DynamicGaugeBuilder::new(*gauge)
-                        .metadata("id", format!("{}", cpu))
-                        .formatter(cpu_metric_formatter)
-                        .build(),
-                );
-            }
+            gauges.push(
+                cpu,
+                DynamicGaugeBuilder::new("cpu/frequency")
+                    .metadata("id", format!("{}", cpu))
+                    .formatter(cpu_metric_formatter)
+                    .build(),
+            );
 
             match PerfGroup::new(cpu) {
                 Ok(g) => groups.push(g),

--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -1,0 +1,122 @@
+const NAME: &str = "cpu_frequency";
+
+mod group;
+
+use group::*;
+
+use crate::common::*;
+use crate::samplers::cpu::linux::stats::*;
+use crate::samplers::cpu::stats::*;
+use crate::samplers::Sampler;
+use crate::*;
+
+use parking_lot::Mutex;
+
+use tokio::task::spawn_blocking;
+
+#[distributed_slice(SAMPLERS)]
+fn init(config: Arc<Config>) -> SamplerResult {
+    if !config.enabled(NAME) {
+        return Ok(None);
+    }
+
+    let inner = PerfInner::new()?;
+
+    Ok(Some(Box::new(Perf {
+        inner: Arc::new(Mutex::new(inner)),
+    })))
+}
+
+pub struct Perf {
+    inner: Arc<Mutex<PerfInner>>,
+}
+
+struct PerfInner {
+    groups: Vec<PerfGroup>,
+    gauges: ScopedGauges,
+}
+
+impl PerfInner {
+    pub fn new() -> Result<Self, std::io::Error> {
+        let cpus = common::linux::cpus()?;
+
+        let mut groups = Vec::with_capacity(cpus.len());
+        let mut gauges = ScopedGauges::new();
+
+        for cpu in cpus {
+            for gauge in &["cpu/frequency"] {
+                gauges.push(
+                    cpu,
+                    DynamicGaugeBuilder::new(*gauge)
+                        .metadata("id", format!("{}", cpu))
+                        .formatter(cpu_metric_formatter)
+                        .build(),
+                );
+            }
+
+            match PerfGroup::new(cpu) {
+                Ok(g) => groups.push(g),
+                Err(_) => {
+                    warn!("Failed to create the perf group on CPU {}", cpu);
+                    // we want to continue because it's possible that this CPU is offline
+                    continue;
+                }
+            };
+        }
+
+        if groups.is_empty() {
+            return Err(std::io::Error::other(
+                "Failed to create perf group on any CPU",
+            ));
+        }
+
+        Ok(Self { groups, gauges })
+    }
+
+    /// Refreshes the metrics from the underlying perf counter groups.
+    ///
+    /// *Note:* the reading returned by `get_metrics()` returns delta'd counters
+    /// so instead of setting our counters, we will add the delta to them.
+    pub fn refresh(&mut self) {
+        let mut nr_active_groups: u64 = 0;
+
+        let mut avg_base_frequency = 0;
+        let mut avg_running_frequency = 0;
+
+        for group in &mut self.groups {
+            if let Ok(reading) = group.get_metrics() {
+                nr_active_groups += 1;
+
+                avg_base_frequency += reading.base_frequency_mhz.unwrap_or(0);
+                avg_running_frequency += reading.running_frequency_mhz.unwrap_or(0);
+
+                if let Some(g) = reading.running_frequency_mhz {
+                    let _ = self.gauges.set(reading.cpu, 0, g as _);
+                }
+            }
+
+            // we can only update averages if at least one group of perf
+            // counters was active in the period
+            if nr_active_groups > 0 {
+                CPU_BASE_FREQUENCY_AVERAGE.set((avg_base_frequency / nr_active_groups) as i64);
+                CPU_FREQUENCY_AVERAGE.set((avg_running_frequency / nr_active_groups) as i64);
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Sampler for Perf {
+    async fn refresh(&self) {
+        let inner = self.inner.clone();
+
+        // we spawn onto a blocking thread because this can take on the order of
+        // tens of milliseconds on large systems
+
+        let _ = spawn_blocking(move || {
+            let mut inner = inner.lock();
+            inner.refresh();
+        })
+        .await;
+    }
+}

--- a/src/samplers/cpu/linux/mod.rs
+++ b/src/samplers/cpu/linux/mod.rs
@@ -1,5 +1,6 @@
 mod stats;
 
 mod cores;
+mod frequency;
 mod perf;
 mod usage;

--- a/src/samplers/cpu/linux/perf/mod.bpf.c
+++ b/src/samplers/cpu/linux/perf/mod.bpf.c
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2023 The Rezolus Authors
+
+#include <vmlinux.h>
+#include "../../../common/bpf/helpers.h"
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+
+#define COUNTER_GROUP_WIDTH 8
+#define MAX_CPUS 1024
+
+#define TASK_RUNNING 0
+
+// counter positions
+#define CYCLES 0
+#define INSTRUCTIONS 1
+#define TSC 2
+#define APERF 3
+#define MPERF 4
+
+// counters (see constants defined at top)
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
+} counters SEC(".maps");
+
+/**
+ * perf event arrays
+ */
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	// __uint(max_entries, MAX_CPUS);
+} cycles SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	// __uint(max_entries, MAX_CPUS);
+} instructions SEC(".maps");
+
+/**
+ * commit 2f064a59a1 ("sched: Change task_struct::state") changes
+ * the name of task_struct::state to task_struct::__state
+ * see:
+ *     https://github.com/torvalds/linux/commit/2f064a59a1
+ */
+struct task_struct___o {
+	volatile long int state;
+} __attribute__((preserve_access_index));
+
+struct task_struct___x {
+	unsigned int __state;
+} __attribute__((preserve_access_index));
+
+static __always_inline __s64 get_task_state(void *task)
+{
+	struct task_struct___x *t = task;
+
+	if (bpf_core_field_exists(t->__state))
+		return BPF_CORE_READ(t, __state);
+	return BPF_CORE_READ((struct task_struct___o *)task, state);
+}
+
+SEC("tp_btf/sched_switch")
+int handle__sched_switch(u64 *ctx)
+{
+	/* TP_PROTO(bool preempt, struct task_struct *prev,
+	 *      struct task_struct *next)
+	 */
+	struct task_struct *prev = (struct task_struct *)ctx[1];
+	struct task_struct *next = (struct task_struct *)ctx[2];
+
+	u32 idx;
+	u64 *elem;
+
+	u32 processor_id = bpf_get_smp_processor_id();
+	u64 ts = bpf_ktime_get_ns();
+
+	u64 flags = processor_id & BPF_F_INDEX_MASK;
+
+	u64 c = bpf_perf_event_read(&cycles, flags);
+	u64 i = bpf_perf_event_read(&instructions, flags);
+
+	idx = processor_id * COUNTER_GROUP_WIDTH + CYCLES;
+	bpf_map_update_elem(&counters, &idx, &c, BPF_ANY);
+
+	idx = processor_id * COUNTER_GROUP_WIDTH + INSTRUCTIONS;
+	bpf_map_update_elem(&counters, &idx, &i, BPF_ANY);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -1,18 +1,31 @@
+/// Collects CPU usage stats using BPF and traces:
+/// * `cpuacct_account_field`
+///
+/// And produces these stats:
+/// * `cpu_usage/busy`
+/// * `cpu_usage/user`
+/// * `cpu_usage/nice`
+/// * `cpu_usage/system`
+/// * `cpu_usage/softirq`
+/// * `cpu_usage/irq`
+/// * `cpu_usage/steal`
+/// * `cpu_usage/guest`
+/// * `cpu_usage/guest_nice`
+
 const NAME: &str = "cpu_perf";
 
-mod group;
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/cpu_perf.bpf.rs"));
+}
 
-use group::*;
+use bpf::*;
 
 use crate::common::*;
 use crate::samplers::cpu::linux::stats::*;
 use crate::samplers::cpu::stats::*;
-use crate::samplers::Sampler;
 use crate::*;
 
-use parking_lot::Mutex;
-
-use tokio::task::spawn_blocking;
+use std::sync::Arc;
 
 #[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
@@ -20,142 +33,53 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let inner = PerfInner::new()?;
+    let cpus = crate::common::linux::cpus()?;
 
-    Ok(Some(Box::new(Perf {
-        inner: Arc::new(Mutex::new(inner)),
-    })))
-}
+    let totals = vec![&CPU_CYCLES, &CPU_INSTRUCTIONS];
 
-pub struct Perf {
-    inner: Arc<Mutex<PerfInner>>,
-}
+    let metrics = ["cpu/cycles", "cpu/instructions"];
 
-struct PerfInner {
-    groups: Vec<PerfGroup>,
-    counters: ScopedCounters,
-    gauges: ScopedGauges,
-}
+    let mut individual = ScopedCounters::new();
 
-impl PerfInner {
-    pub fn new() -> Result<Self, std::io::Error> {
-        let cpus = common::linux::cpus()?;
-
-        let mut groups = Vec::with_capacity(cpus.len());
-        let mut counters = ScopedCounters::new();
-        let mut gauges = ScopedGauges::new();
-
-        for cpu in cpus {
-            for counter in &["cpu/cycles", "cpu/instructions"] {
-                counters.push(
-                    cpu,
-                    DynamicCounterBuilder::new(*counter)
-                        .metadata("id", format!("{}", cpu))
-                        .formatter(cpu_metric_formatter)
-                        .build(),
-                );
-            }
-
-            for gauge in &["cpu/ipkc", "cpu/ipus", "cpu/frequency"] {
-                gauges.push(
-                    cpu,
-                    DynamicGaugeBuilder::new(*gauge)
-                        .metadata("id", format!("{}", cpu))
-                        .formatter(cpu_metric_formatter)
-                        .build(),
-                );
-            }
-
-            match PerfGroup::new(cpu) {
-                Ok(g) => groups.push(g),
-                Err(_) => {
-                    warn!("Failed to create the perf group on CPU {}", cpu);
-                    // we want to continue because it's possible that this CPU is offline
-                    continue;
-                }
-            };
+    for cpu in cpus {
+        for metric in metrics {
+            individual.push(
+                cpu,
+                DynamicCounterBuilder::new(metric)
+                    .metadata("id", format!("{}", cpu))
+                    .formatter(cpu_metric_formatter)
+                    .build(),
+            );
         }
-
-        if groups.is_empty() {
-            return Err(std::io::Error::other(
-                "Failed to create perf group on any CPU",
-            ));
-        }
-
-        Ok(Self {
-            groups,
-            counters,
-            gauges,
-        })
     }
 
-    /// Refreshes the metrics from the underlying perf counter groups.
-    ///
-    /// *Note:* the reading returned by `get_metrics()` returns delta'd counters
-    /// so instead of setting our counters, we will add the delta to them.
-    pub fn refresh(&mut self) {
-        let mut nr_active_groups: u64 = 0;
+    println!("initializing bpf for: {NAME}");
 
-        let mut avg_ipkc = 0;
-        let mut avg_ipus = 0;
-        let mut avg_base_frequency = 0;
-        let mut avg_running_frequency = 0;
+    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+        .perf_event("cycles", perf_event::events::Hardware::CPU_CYCLES)
+        .perf_event("instructions", perf_event::events::Hardware::INSTRUCTIONS)
+        .cpu_counters("counters", totals, individual)
+        .build()?;
 
-        for group in &mut self.groups {
-            if let Ok(reading) = group.get_metrics() {
-                nr_active_groups += 1;
+    Ok(Some(Box::new(bpf)))
+}
 
-                avg_ipkc += reading.ipkc.unwrap_or(0);
-                avg_ipus += reading.ipus.unwrap_or(0);
-                avg_base_frequency += reading.base_frequency_mhz.unwrap_or(0);
-                avg_running_frequency += reading.running_frequency_mhz.unwrap_or(0);
-
-                // note: add counters, these are deltas
-                if let Some(c) = reading.cycles {
-                    let _ = self.counters.add(reading.cpu, 0, c);
-                    CPU_CYCLES.add(c);
-                }
-                if let Some(c) = reading.instructions {
-                    let _ = self.counters.add(reading.cpu, 1, c);
-                    CPU_INSTRUCTIONS.add(c);
-                }
-
-                if let Some(g) = reading.ipkc {
-                    let _ = self.gauges.set(reading.cpu, 0, g as _);
-                }
-                if let Some(g) = reading.ipus {
-                    let _ = self.gauges.set(reading.cpu, 1, g as _);
-                }
-                if let Some(g) = reading.running_frequency_mhz {
-                    let _ = self.gauges.set(reading.cpu, 2, g as _);
-                }
-            }
-
-            // we can only update averages if at least one group of perf
-            // counters was active in the period
-            if nr_active_groups > 0 {
-                CPU_PERF_GROUPS_ACTIVE.set(nr_active_groups as i64);
-                CPU_IPKC_AVERAGE.set((avg_ipkc / nr_active_groups) as i64);
-                CPU_IPUS_AVERAGE.set((avg_ipus / nr_active_groups) as i64);
-                CPU_BASE_FREQUENCY_AVERAGE.set((avg_base_frequency / nr_active_groups) as i64);
-                CPU_FREQUENCY_AVERAGE.set((avg_running_frequency / nr_active_groups) as i64);
-            }
+impl SkelExt for ModSkel<'_> {
+    fn map(&self, name: &str) -> &libbpf_rs::Map {
+        match name {
+            "counters" => &self.maps.counters,
+            "cycles" => &self.maps.cycles,
+            "instructions" => &self.maps.instructions,
+            _ => unimplemented!(),
         }
     }
 }
 
-#[async_trait]
-impl Sampler for Perf {
-    async fn refresh(&self) {
-        let inner = self.inner.clone();
-
-        // we spawn onto a blocking thread because this can take on the order of
-        // tens of milliseconds on large systems
-
-        let _ = spawn_blocking(move || {
-            let mut inner = inner.lock();
-            inner.refresh();
-        })
-        .await;
+impl OpenSkelExt for ModSkel<'_> {
+    fn log_prog_instructions(&self) {
+        debug!(
+            "{NAME} handle__sched_switch() BPF instruction count: {}",
+            self.progs.handle__sched_switch.insn_cnt()
+        );
     }
 }

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -1,16 +1,11 @@
-/// Collects CPU usage stats using BPF and traces:
-/// * `cpuacct_account_field`
-///
-/// And produces these stats:
-/// * `cpu_usage/busy`
-/// * `cpu_usage/user`
-/// * `cpu_usage/nice`
-/// * `cpu_usage/system`
-/// * `cpu_usage/softirq`
-/// * `cpu_usage/irq`
-/// * `cpu_usage/steal`
-/// * `cpu_usage/guest`
-/// * `cpu_usage/guest_nice`
+//! Collects CPU perf counters using BPF and traces:
+//! * `sched_switch`
+//!
+//! Initializes perf events to collect cycles and instructions.
+//!
+//! And produces these stats:
+//! * `cpu/cycles`
+//! * `cpu/instructions`
 
 const NAME: &str = "cpu_perf";
 

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -67,26 +67,6 @@ pub static CPU_CYCLES: LazyCounter = LazyCounter::new(Counter::default);
 pub static CPU_INSTRUCTIONS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/perf_groups/active",
-    description = "The number of currently active perf event groups"
-)]
-pub static CPU_PERF_GROUPS_ACTIVE: LazyGauge = LazyGauge::new(Gauge::default);
-
-#[metric(
-    name = "cpu/ipkc/average",
-    description = "Average IPKC (instructions per thousand cycles): SUM(IPKC_CPU0...N)/N)",
-    metadata = { unit = "instructions/kilocycle" }
-)]
-pub static CPU_IPKC_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
-
-#[metric(
-    name = "cpu/ipus/average",
-    description = "Average IPUS (instructions per microsecond): SUM(IPUS_CPU0...N)/N)",
-    metadata = { unit = "instructions/microsecond" }
-)]
-pub static CPU_IPUS_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
-
-#[metric(
     name = "cpu/base_frequency/average",
     description = "Average base CPU frequency (MHz)",
     metadata = { unit = "megahertz" }


### PR DESCRIPTION
Converts the cpu perf sampler to use BPF on task_switch to sample cycles and instructions.

Splits the cpu frequency perf sampler out into its own sampler and leaves it as on-demand collection of the various MSRs.
