### PR TITLE
Release rezolus to $distro-public repos

### DIFF
--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -162,6 +162,7 @@ jobs:
 
             echo "::group::upload $release $name"
             gcloud artifacts apt upload "$release" --source "$artifact"
+            gcloud artifacts apt upload "$release-public" --source "$artifact"
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
We already release to the private systemslab repo. However, we don't actually need to do that and releasing rezolus to the public repo makes it easier for people to make use of it.

There are no RPM packages so this only applies to the debian ones.