### PR TITLE
fix: metric type annotations have incorrect metric name

### DIFF
--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -139,7 +139,7 @@ async fn prometheus(State(state): State<Arc<AppState>>) -> String {
 
         if let Some(counter) = any.downcast_ref::<Counter>() {
             data.push(format!(
-                 "# TYPE {name} counter\n{name_with_metadata} {} {timestamp}",
+                "# TYPE {name} counter\n{name_with_metadata} {} {timestamp}",
                 counter.value()
             ));
         } else if let Some(gauge) = any.downcast_ref::<Gauge>() {

--- a/src/samplers/blockio/linux/stats.rs
+++ b/src/samplers/blockio/linux/stats.rs
@@ -114,23 +114,25 @@ pub static BLOCKIO_FLUSH_BYTES: LazyCounter = LazyCounter::new(Counter::default)
 pub fn blockio_bytes_metric_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            let op = metric.metadata().get("op").expect("no `op` for metric formatter");
+            let op = metric
+                .metadata()
+                .get("op")
+                .expect("no `op` for metric formatter");
             format!("blockio/{op}/bytes/total")
         }
-        _ => {
-            metric.name().to_string()
-        }
+        _ => metric.name().to_string(),
     }
 }
 
 pub fn blockio_ops_metric_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            let op = metric.metadata().get("op").expect("no `op` for metric formatter");
+            let op = metric
+                .metadata()
+                .get("op")
+                .expect("no `op` for metric formatter");
             format!("blockio/{op}/operations/total")
         }
-        _ => {
-            metric.name().to_string()
-        }
+        _ => metric.name().to_string(),
     }
 }

--- a/src/samplers/blockio/linux/stats.rs
+++ b/src/samplers/blockio/linux/stats.rs
@@ -46,118 +46,91 @@ pub static BLOCKIO_READ_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_G
 pub static BLOCKIO_WRITE_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
-    name = "blockio/operations",
+    name = "blockio/operations/total",
     description = "The number of completed read operations for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_ops_metric_formatter,
     metadata = { op = "read", unit = "operations" }
 )]
 pub static BLOCKIO_READ_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "blockio/operations",
+    name = "blockio/operations/total",
     description = "The number of completed write operations for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_ops_metric_formatter,
     metadata = { op = "write", unit = "operations" }
 )]
 pub static BLOCKIO_WRITE_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "blockio/operations",
+    name = "blockio/operations/total",
     description = "The number of completed discard operations for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_ops_metric_formatter,
     metadata = { op = "discard", unit = "operations" }
 )]
 pub static BLOCKIO_DISCARD_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "blockio/operations",
+    name = "blockio/operations/total",
     description = "The number of completed flush operations for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_ops_metric_formatter,
     metadata = { op = "flush", unit = "operations" }
 )]
 pub static BLOCKIO_FLUSH_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "blockio/bytes",
+    name = "blockio/bytes/total",
     description = "The number of bytes read for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_bytes_metric_formatter,
     metadata = { op = "read", unit = "bytes" }
 )]
 pub static BLOCKIO_READ_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "blockio/bytes",
+    name = "blockio/bytes/total",
     description = "The number of bytes written for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_bytes_metric_formatter,
     metadata = { op = "write", unit = "bytes" }
 )]
 pub static BLOCKIO_WRITE_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "blockio/bytes",
+    name = "blockio/bytes/total",
     description = "The number of bytes discarded for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_bytes_metric_formatter,
     metadata = { op = "discard", unit = "bytes" }
 )]
 pub static BLOCKIO_DISCARD_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "blockio/bytes",
+    name = "blockio/bytes/total",
     description = "The number of bytes flushed for block devices",
-    formatter = blockio_metric_formatter,
+    formatter = blockio_bytes_metric_formatter,
     metadata = { op = "flush", unit = "bytes" }
 )]
 pub static BLOCKIO_FLUSH_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
-/// A function to format the blockio metrics that allows for export of ops and
-/// byte counters by operation type.
-///
-/// Note: we do not currently support per-device metrics.
-///
-/// For the `Simple` format, the metrics will be formatted according to the
-/// a pattern which depends on the metric metadata:
-/// `blockio/{op}/{operations, bytes}/total` eg: `blockio/read/operations/total`
-///
-/// For the `Prometheus` format, we supply the operation type as metadata. Note:
-/// we rely on the exposition logic to convert the `/`s to `_`s in the metric
-/// name.
-pub fn blockio_metric_formatter(metric: &MetricEntry, format: Format) -> String {
+// metric formatters
+
+pub fn blockio_bytes_metric_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            let name = if let Some(op) = metric.metadata().get("op") {
-                match metric.name() {
-                    "blockio/bytes" => {
-                        format!("blockio/{op}/bytes")
-                    }
-                    "blockio/operations" => {
-                        format!("blockio/{op}/operations")
-                    }
-                    _ => {
-                        format!("{}/{op}", metric.name())
-                    }
-                }
-            } else {
-                metric.name().to_string()
-            };
-
-            format!("{name}/total")
+            let op = metric.metadata().get("op").expect("no `op` for metric formatter");
+            format!("blockio/{op}/bytes/total")
         }
-        Format::Prometheus => {
-            let metadata: Vec<String> = metric
-                .metadata()
-                .iter()
-                .map(|(key, value)| format!("{key}=\"{value}\""))
-                .collect();
-            let metadata = metadata.join(", ");
-
-            let name = format!("{}/total", metric.name());
-
-            if metadata.is_empty() {
-                name
-            } else {
-                format!("{}{{{metadata}}}", name)
-            }
+        _ => {
+            metric.name().to_string()
         }
-        _ => metriken::default_formatter(metric, format),
+    }
+}
+
+pub fn blockio_ops_metric_formatter(metric: &MetricEntry, format: Format) -> String {
+    match format {
+        Format::Simple => {
+            let op = metric.metadata().get("op").expect("no `op` for metric formatter");
+            format!("blockio/{op}/operations/total")
+        }
+        _ => {
+            metric.name().to_string()
+        }
     }
 }

--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -14,7 +14,6 @@ use group::*;
 
 use crate::common::*;
 use crate::samplers::cpu::linux::stats::*;
-use crate::samplers::cpu::stats::*;
 use crate::samplers::Sampler;
 use crate::*;
 
@@ -56,7 +55,7 @@ impl PerfInner {
                 cpu,
                 DynamicGaugeBuilder::new("cpu/frequency")
                     .metadata("id", format!("{}", cpu))
-                    .formatter(cpu_metric_formatter)
+                    .formatter(cpu_metric_percore_formatter)
                     .build(),
             );
 

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -17,7 +17,6 @@ use bpf::*;
 
 use crate::common::*;
 use crate::samplers::cpu::linux::stats::*;
-use crate::samplers::cpu::stats::*;
 use crate::*;
 
 use std::sync::Arc;
@@ -42,7 +41,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
                 cpu,
                 DynamicCounterBuilder::new(metric)
                     .metadata("id", format!("{}", cpu))
-                    .formatter(cpu_metric_formatter)
+                    .formatter(cpu_metric_percore_formatter)
                     .build(),
             );
         }

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -3,65 +3,65 @@ use crate::samplers::cpu::stats::*;
 use metriken::*;
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent waiting for IO to complete",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "io_wait", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_IO_WAIT: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent servicing interrupts",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "irq", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_IRQ: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent servicing softirqs",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "softirq", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_SOFTIRQ: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time stolen by the hypervisor",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "steal", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_STEAL: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent running a virtual CPU for a guest",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "guest", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_GUEST: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent running a virtual CPU for a guest in low priority mode",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "guest_nice", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_GUEST_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/cycles",
+    name = "cpu/cycles/total",
     description = "The number of elapsed CPU cycles",
-    formatter = cpu_metric_formatter,
+    formatter = simple_formatter,
     metadata = { unit = "cycles" }
 )]
 pub static CPU_CYCLES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/instructions",
+    name = "cpu/instructions/total",
     description = "The number of instructions retired",
-    formatter = cpu_metric_formatter,
+    formatter = simple_formatter,
     metadata = { unit = "instructions" }
 )]
 pub static CPU_INSTRUCTIONS: LazyCounter = LazyCounter::new(Counter::default);
@@ -79,3 +79,32 @@ pub static CPU_BASE_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default
     metadata = { unit = "megahertz" }
 )]
 pub static CPU_FREQUENCY_AVERAGE: LazyGauge = LazyGauge::new(Gauge::default);
+
+pub fn simple_formatter(metric: &MetricEntry, _format: Format) -> String {
+    metric.name().to_string()
+}
+
+pub fn cpu_metric_percore_formatter(metric: &MetricEntry, format: Format) -> String {
+    match format {
+        Format::Simple => {
+            let id = metric.metadata().get("id").expect("no `id` for metric formatter");
+            format!("{}/cpu{id}", metric.name())
+        }
+        _ => {
+            metric.name().to_string()
+        }
+    }
+}
+
+pub fn cpu_usage_percore_formatter(metric: &MetricEntry, format: Format) -> String {
+    match format {
+        Format::Simple => {
+            let id = metric.metadata().get("id").expect("no `id` for metric formatter");
+            let state = metric.metadata().get("state").expect("no `state` for metric formatter");
+            format!("{}/{state}/cpu{id}", metric.name())
+        }
+        _ => {
+            metric.name().to_string()
+        }
+    }
+}

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -87,24 +87,29 @@ pub fn simple_formatter(metric: &MetricEntry, _format: Format) -> String {
 pub fn cpu_metric_percore_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            let id = metric.metadata().get("id").expect("no `id` for metric formatter");
+            let id = metric
+                .metadata()
+                .get("id")
+                .expect("no `id` for metric formatter");
             format!("{}/cpu{id}", metric.name())
         }
-        _ => {
-            metric.name().to_string()
-        }
+        _ => metric.name().to_string(),
     }
 }
 
 pub fn cpu_usage_percore_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            let id = metric.metadata().get("id").expect("no `id` for metric formatter");
-            let state = metric.metadata().get("state").expect("no `state` for metric formatter");
+            let id = metric
+                .metadata()
+                .get("id")
+                .expect("no `id` for metric formatter");
+            let state = metric
+                .metadata()
+                .get("state")
+                .expect("no `state` for metric formatter");
             format!("{}/{state}/cpu{id}", metric.name())
         }
-        _ => {
-            metric.name().to_string()
-        }
+        _ => metric.name().to_string(),
     }
 }

--- a/src/samplers/cpu/linux/usage/mod.rs
+++ b/src/samplers/cpu/linux/usage/mod.rs
@@ -68,7 +68,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
                 DynamicCounterBuilder::new("cpu/usage")
                     .metadata("id", format!("{}", cpu))
                     .metadata("state", state)
-                    .formatter(cpu_metric_formatter)
+                    .formatter(cpu_usage_percore_formatter)
                     .build(),
             );
         }

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -41,11 +41,12 @@ pub static CPU_USAGE_SYSTEM: LazyCounter = LazyCounter::new(Counter::default);
 pub fn cpu_usage_total_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            let state = metric.metadata().get("state").expect("no `state` for metric formatter");
+            let state = metric
+                .metadata()
+                .get("state")
+                .expect("no `state` for metric formatter");
             format!("cpu/usage/{state}/total")
         }
-        _ => {
-            metric.name().to_string()
-        }
+        _ => metric.name().to_string(),
     }
 }

--- a/src/samplers/cpu/stats.rs
+++ b/src/samplers/cpu/stats.rs
@@ -7,88 +7,45 @@ use metriken::*;
 pub static CPU_CORES: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent busy",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "busy", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_BUSY: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent executing normal tasks is user mode",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "user", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_USER: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent executing low priority tasks in user mode",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "nice", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cpu/usage",
+    name = "cpu/usage/total",
     description = "The amount of CPU time spent executing tasks in kernel mode",
-    formatter = cpu_metric_formatter,
+    formatter = cpu_usage_total_formatter,
     metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_SYSTEM: LazyCounter = LazyCounter::new(Counter::default);
 
-/// A function to format the cpu metrics that allows for export of both total
-/// and per-CPU metrics.
-///
-/// For the `Simple` format, the metrics will be formatted according to the
-/// a pattern which depends on the metric metadata:
-/// `{name}/cpu{id}` eg: `cpu/frequency/cpu0`
-/// `{name}/total` eg: `cpu/cycles/total`
-/// `{name}/{state}/cpu{id}` eg: `cpu/usage/user/cpu0`
-/// `{name}/{state}/total` eg: `cpu/usage/user/total`
-///
-/// For the `Prometheus` format, if the metric has an `id` set in the metadata,
-/// the metric name is left as-is. Otherwise, `/total` is appended. Note: we
-/// rely on the exposition logic to convert the `/`s to `_`s in the metric name.
-pub fn cpu_metric_formatter(metric: &MetricEntry, format: Format) -> String {
+pub fn cpu_usage_total_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {
         Format::Simple => {
-            let name = if let Some(state) = metric.metadata().get("state") {
-                format!("{}/{state}", metric.name())
-            } else {
-                metric.name().to_string()
-            };
-
-            if metric.metadata().contains_key("id") {
-                format!(
-                    "{name}/cpu{}",
-                    metric.metadata().get("id").unwrap_or("unknown"),
-                )
-            } else {
-                format!("{name}/total",)
-            }
+            let state = metric.metadata().get("state").expect("no `state` for metric formatter");
+            format!("cpu/usage/{state}/total")
         }
-        Format::Prometheus => {
-            let metadata: Vec<String> = metric
-                .metadata()
-                .iter()
-                .map(|(key, value)| format!("{key}=\"{value}\""))
-                .collect();
-            let metadata = metadata.join(", ");
-
-            let name = if metric.metadata().contains_key("id") {
-                metric.name().to_string()
-            } else {
-                format!("{}/total", metric.name())
-            };
-
-            if metadata.is_empty() {
-                name
-            } else {
-                format!("{}{{{metadata}}}", name)
-            }
+        _ => {
+            metric.name().to_string()
         }
-        _ => metriken::default_formatter(metric, format),
     }
 }


### PR DESCRIPTION
Problem

Prometheus type annotations don't always match the metric name. This results in missing type annotations which may cause issues for systems that rely on having those annotations.

Solution

Fixes the name / name + metadata handling.

Result

Type annotations carry though properly
