### PR TITLE
cleanup metric exposition to reduce use of as_any()

### DIFF
--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -139,12 +139,12 @@ async fn prometheus(State(state): State<Arc<AppState>>) -> String {
                 continue;
             }
             Some(Value::Gauge(value)) => {
-                 data.push(format!(
+                data.push(format!(
                     "# TYPE {name} gauge\n{name_with_metadata} {value} {timestamp}"
                 ));
                 continue;
             }
-            Some(_) => { }
+            Some(_) => {}
             None => {
                 continue;
             }
@@ -253,7 +253,7 @@ fn simple_stats(quoted: bool) -> Vec<String> {
             Some(Value::Gauge(value)) => {
                 data.push(format!("{q}{simple_name}{q}: {value}"));
             }
-            Some(_) | None => { }
+            Some(_) | None => {}
         }
     }
 


### PR DESCRIPTION
Cleanup the metric exposition logic to first match on the metric value and resort to as_any() only when necessary.
