### PR TITLE
add per-cgroup cpu frequency related metrics

### DIFF
--- a/src/samplers/cpu/linux/frequency/mod.bpf.c
+++ b/src/samplers/cpu/linux/frequency/mod.bpf.c
@@ -5,9 +5,11 @@
 #include "../../../common/bpf/helpers.h"
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 
 #define COUNTER_GROUP_WIDTH 8
 #define MAX_CPUS 1024
+#define MAX_CGROUPS 4096
 
 #define TASK_RUNNING 0
 
@@ -24,6 +26,54 @@ struct {
 	__type(value, u64);
 	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
 } counters SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_aperf SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_mperf SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_tsc SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} aperf_prev SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} mperf_prev SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} tsc_prev SEC(".maps");
 
 /**
  * perf event arrays
@@ -70,6 +120,30 @@ static __always_inline __s64 get_task_state(void *task)
 	return BPF_CORE_READ((struct task_struct___o *)task, state);
 }
 
+// attach a kprobe cpuacct to update per-cpu counters
+
+SEC("kprobe/cpuacct_account_field")
+int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
+{
+	u32 idx;
+	u32 processor_id = bpf_get_smp_processor_id();
+
+	u64 a = bpf_perf_event_read(&aperf, BPF_F_CURRENT_CPU);
+	u64 m = bpf_perf_event_read(&mperf, BPF_F_CURRENT_CPU);
+	u64 t = bpf_perf_event_read(&tsc, BPF_F_CURRENT_CPU);
+
+	idx = processor_id * COUNTER_GROUP_WIDTH + APERF;
+	bpf_map_update_elem(&counters, &idx, &a, BPF_ANY);
+
+	idx = processor_id * COUNTER_GROUP_WIDTH + MPERF;
+	bpf_map_update_elem(&counters, &idx, &m, BPF_ANY);
+
+	idx = processor_id * COUNTER_GROUP_WIDTH + TSC;
+	bpf_map_update_elem(&counters, &idx, &t, BPF_ANY);
+}
+
+// attach a tracepoint on sched_switch for per-cgroup accounting
+
 SEC("tp_btf/sched_switch")
 int handle__sched_switch(u64 *ctx)
 {
@@ -80,16 +154,13 @@ int handle__sched_switch(u64 *ctx)
 	struct task_struct *next = (struct task_struct *)ctx[2];
 
 	u32 idx;
-	u64 *elem;
+	u64 *elem, delta_a, delta_m, delta_t;
 
 	u32 processor_id = bpf_get_smp_processor_id();
-	u64 ts = bpf_ktime_get_ns();
 
-	u64 flags = processor_id & BPF_F_INDEX_MASK;
-
-	u64 a = bpf_perf_event_read(&aperf, flags);
-	u64 m = bpf_perf_event_read(&mperf, flags);
-	u64 t = bpf_perf_event_read(&tsc, flags);
+	u64 a = bpf_perf_event_read(&aperf, BPF_F_CURRENT_CPU);
+	u64 m = bpf_perf_event_read(&mperf, BPF_F_CURRENT_CPU);
+	u64 t = bpf_perf_event_read(&tsc, BPF_F_CURRENT_CPU);
 
 	idx = processor_id * COUNTER_GROUP_WIDTH + APERF;
 	bpf_map_update_elem(&counters, &idx, &a, BPF_ANY);
@@ -99,6 +170,46 @@ int handle__sched_switch(u64 *ctx)
 
 	idx = processor_id * COUNTER_GROUP_WIDTH + TSC;
 	bpf_map_update_elem(&counters, &idx, &t, BPF_ANY);
+
+	if (bpf_core_field_exists(prev->sched_task_group)) {
+		int cgroup_id = prev->sched_task_group->css.id;
+
+		if (cgroup_id && cgroup_id < MAX_CGROUPS) {
+			// update cgroup aperf
+
+			elem = bpf_map_lookup_elem(&aperf_prev, &processor_id);
+
+			if (elem) {
+				delta_a = a - *elem;
+
+				array_add(&cgroup_aperf, cgroup_id, delta_a);
+			}
+
+			// update cgroup mperf
+
+			elem = bpf_map_lookup_elem(&mperf_prev, &processor_id);
+
+			if (elem) {
+				delta_m = m - *elem;
+
+				array_add(&cgroup_mperf, cgroup_id, delta_m);
+			}
+
+			// update cgroup tsc
+
+			elem = bpf_map_lookup_elem(&tsc_prev, &processor_id);
+
+			if (elem) {
+				delta_t = t - *elem;
+
+				array_add(&cgroup_tsc, cgroup_id, delta_t);
+			}
+		}
+	}
+
+	bpf_map_update_elem(&aperf_prev, &processor_id, &a, BPF_ANY);
+	bpf_map_update_elem(&mperf_prev, &processor_id, &m, BPF_ANY);
+	bpf_map_update_elem(&tsc_prev, &processor_id, &t, BPF_ANY);
 
 	return 0;
 }

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -129,13 +129,22 @@ pub static CPU_CYCLES: LazyCounter = LazyCounter::new(Counter::default);
 )]
 pub static CPU_INSTRUCTIONS: LazyCounter = LazyCounter::new(Counter::default);
 
-#[metric(name = "cpu/aperf/total")]
+#[metric(
+    name = "cpu/aperf/total",
+    metadata = { unit = "cycles" }
+)]
 pub static CPU_APERF: LazyCounter = LazyCounter::new(Counter::default);
 
-#[metric(name = "cpu/mperf/total")]
+#[metric(
+    name = "cpu/mperf/total",
+    metadata = { unit = "cycles" }
+)]
 pub static CPU_MPERF: LazyCounter = LazyCounter::new(Counter::default);
 
-#[metric(name = "cpu/tsc/total")]
+#[metric(
+    name = "cpu/tsc/total",
+    metadata = { unit = "cycles" }
+)]
 pub static CPU_TSC: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
@@ -156,19 +165,22 @@ pub static CPU_INSTRUCTIONS_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu/aperf",
-    formatter = cpu_metric_percore_formatter
+    formatter = cpu_metric_percore_formatter,
+    metadata = { unit = "cycles" }
 )]
 pub static CPU_APERF_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu/mperf",
-    formatter = cpu_metric_percore_formatter
+    formatter = cpu_metric_percore_formatter,
+    metadata = { unit = "cycles" }
 )]
 pub static CPU_MPERF_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu/tsc",
-    formatter = cpu_metric_percore_formatter
+    formatter = cpu_metric_percore_formatter,
+    metadata = { unit = "cycles" }
 )]
 pub static CPU_TSC_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
 
@@ -184,9 +196,30 @@ pub static CGROUP_CPU_CYCLES: CounterGroup = CounterGroup::new(MAX_CGROUPS);
     name = "cgroup/cpu/instructions",
     description = "The number of elapsed CPU cycles on a per-cgroup basis",
     formatter = cpu_metric_cgroup_formatter,
-    metadata = { unit = "cycles" }
+    metadata = { unit = "instructions" }
 )]
 pub static CGROUP_CPU_INSTRUCTIONS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup/cpu/aperf",
+    formatter = cpu_metric_cgroup_formatter,
+    metadata = { unit = "cycles" }
+)]
+pub static CGROUP_CPU_APERF: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup/cpu/mperf",
+    formatter = cpu_metric_cgroup_formatter,
+    metadata = { unit = "cycles" }
+)]
+pub static CGROUP_CPU_MPERF: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup/cpu/tsc",
+    formatter = cpu_metric_cgroup_formatter,
+    metadata = { unit = "cycles" }
+)]
+pub static CGROUP_CPU_TSC: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 pub fn cpu_metric_percore_formatter(metric: &MetricEntry, format: Format) -> String {
     match format {


### PR DESCRIPTION
Adds per-cgroup cpu frequency related metrics. Adds and corrects metadata for some existing metrics.
