### PR TITLE
add counter group metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,6 +2145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2321,7 @@ dependencies = [
  "ouroboros",
  "parking_lot",
  "perf-event2",
+ "plain",
  "reqwest",
  "ringlog",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tower = { version = "0.5.0", features = ["tokio"] }
 tower-http = { version = "0.5.2", features = ["compression-full", "decompression-full"] }
 thiserror = "1.0.63"
 walkdir = "2.5.0"
+plain = "0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.24.2" }

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Rust >= 1.70.0
 
 #### Linux
 
-A minimum kernel version of 5.5 is required. The following distributions should
+A minimum kernel version of 5.8 is required. The following distributions should
 work:
 
-* Debian: Bullseye and newer
-* Ubuntu: 20.10 and newer
-* Red Hat: RHEL 9 and newer
-* Amazon Linux: AL2 w/ 5.10 or newer, AL2023
+* Debian: Bullseye and newer (5.10+)
+* Ubuntu: 20.10 and newer (5.8+)
+* Red Hat: RHEL 9 and newer (5.14+)
+* Amazon Linux: AL2 w/ 5.10 or newer, AL2023 (6.1+)
 * Any rolling-release distro: Arch, Gentoo, ...
 
 In addition to the base dependencies, the following are needed:

--- a/src/common/bpf/cgroup_info.h
+++ b/src/common/bpf/cgroup_info.h
@@ -1,0 +1,11 @@
+#ifndef CGROUP_INFO_H
+#define CGROUP_INFO_H
+
+#define CGROUP_NAME_LEN 256
+
+struct cgroup_info {
+	int id;
+	u8 name[CGROUP_NAME_LEN];
+};
+
+#endif //CGROUP_INFO_H

--- a/src/samplers/cpu/linux/frequency/mod.bpf.c
+++ b/src/samplers/cpu/linux/frequency/mod.bpf.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 The Rezolus Authors
 
 #include <vmlinux.h>
+#include "../../../common/bpf/cgroup_info.h"
 #include "../../../common/bpf/helpers.h"
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
@@ -10,6 +11,7 @@
 #define COUNTER_GROUP_WIDTH 8
 #define MAX_CPUS 1024
 #define MAX_CGROUPS 4096
+#define RINGBUF_CAPACITY 32768
 
 #define TASK_RUNNING 0
 
@@ -17,6 +19,26 @@
 #define APERF 0
 #define MPERF 1
 #define TSC 2
+
+// dummy instance for skeleton to generate definition
+struct cgroup_info _cgroup_info = {};
+
+// ringbuf to pass cgroup info
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(key_size, 0);
+	__uint(value_size, 0);
+	__uint(max_entries, RINGBUF_CAPACITY);
+} cgroup_info SEC(".maps");
+
+// holds known cgroup serial numbers to help determine new or changed groups
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_serial_numbers SEC(".maps");
 
 // counters (see constants defined at top)
 struct {
@@ -173,8 +195,36 @@ int handle__sched_switch(u64 *ctx)
 
 	if (bpf_core_field_exists(prev->sched_task_group)) {
 		int cgroup_id = prev->sched_task_group->css.id;
+		u64	serial_nr = prev->sched_task_group->css.serial_nr;
 
 		if (cgroup_id && cgroup_id < MAX_CGROUPS) {
+
+			// we check to see if this is a new cgroup by checking the serial number
+
+			elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
+
+			if (elem && *elem != serial_nr) {
+				// zero the counters, they will not be exported until they are non-zero
+				u64 zero = 0;
+				bpf_map_update_elem(&cgroup_aperf, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_mperf, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_tsc, &cgroup_id, &zero, BPF_ANY);
+
+				// initialize the cgroup info
+				struct cgroup_info cginfo = {
+					.id = cgroup_id,
+				};
+
+				// read the cgroup name
+				bpf_probe_read_kernel_str(&cginfo.name, CGROUP_NAME_LEN, prev->sched_task_group->css.cgroup->kn->name);
+				
+				// push the cgroup info into the ringbuf
+				bpf_ringbuf_output(&cgroup_info, &cginfo, sizeof(cginfo), 0);
+
+				// update the serial number in the local map
+				bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
+			}
+
 			// update cgroup aperf
 
 			elem = bpf_map_lookup_elem(&aperf_prev, &processor_id);

--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -26,6 +26,28 @@ use crate::*;
 
 use std::sync::Arc;
 
+unsafe impl plain::Plain for bpf::types::cgroup_info {}
+
+fn handle_event(data: &[u8]) -> i32 {
+    let mut cgroup_info = bpf::types::cgroup_info::default();
+
+    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
+        let name = std::str::from_utf8(&cgroup_info.name)
+            .unwrap()
+            .trim_end_matches(char::from(0));
+
+        let id = cgroup_info.id;
+
+        if !name.is_empty() {
+            CGROUP_CPU_APERF.insert_metadata(id as usize, "name".to_string(), name.to_string());
+            CGROUP_CPU_MPERF.insert_metadata(id as usize, "name".to_string(), name.to_string());
+            CGROUP_CPU_TSC.insert_metadata(id as usize, "name".to_string(), name.to_string());
+        }
+    }
+
+    0
+}
+
 #[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
@@ -43,6 +65,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .packed_counters("cgroup_aperf", &CGROUP_CPU_APERF)
         .packed_counters("cgroup_mperf", &CGROUP_CPU_MPERF)
         .packed_counters("cgroup_tsc", &CGROUP_CPU_TSC)
+        .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -52,6 +75,7 @@ impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
         match name {
             "cgroup_aperf" => &self.maps.cgroup_aperf,
+            "cgroup_info" => &self.maps.cgroup_info,
             "cgroup_mperf" => &self.maps.cgroup_mperf,
             "cgroup_tsc" => &self.maps.cgroup_tsc,
             "counters" => &self.maps.counters,

--- a/src/samplers/cpu/linux/perf/mod.bpf.c
+++ b/src/samplers/cpu/linux/perf/mod.bpf.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 The Rezolus Authors
 
 #include <vmlinux.h>
+#include "../../../common/bpf/cgroup_info.h"
 #include "../../../common/bpf/helpers.h"
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
@@ -11,12 +12,33 @@
 #define COUNTER_GROUP_WIDTH 8
 #define MAX_CPUS 1024
 #define MAX_CGROUPS 4096
+#define RINGBUF_CAPACITY 32768
 
 #define TASK_RUNNING 0
 
 // counter positions
 #define CYCLES 0
 #define INSTRUCTIONS 1
+
+// dummy instance for skeleton to generate definition
+struct cgroup_info _cgroup_info = {};
+
+// ringbuf to pass cgroup info
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(key_size, 0);
+	__uint(value_size, 0);
+	__uint(max_entries, RINGBUF_CAPACITY);
+} cgroup_info SEC(".maps");
+
+// holds known cgroup serial numbers to help determine new or changed groups
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_serial_numbers SEC(".maps");
 
 // counters (see constants defined at top)
 struct {
@@ -143,8 +165,35 @@ int handle__sched_switch(u64 *ctx)
 
 	if (bpf_core_field_exists(prev->sched_task_group)) {
 		int cgroup_id = prev->sched_task_group->css.id;
+		u64	serial_nr = prev->sched_task_group->css.serial_nr;
 
 		if (cgroup_id && cgroup_id < MAX_CGROUPS) {
+
+			// we check to see if this is a new cgroup by checking the serial number
+
+			elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
+
+			if (elem && *elem != serial_nr) {
+				// zero the counters, they will not be exported until they are non-zero
+				u64 zero = 0;
+				bpf_map_update_elem(&cgroup_cycles, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_instructions, &cgroup_id, &zero, BPF_ANY);
+
+				// initialize the cgroup info
+				struct cgroup_info cginfo = {
+					.id = cgroup_id,
+				};
+
+				// read the cgroup name
+				bpf_probe_read_kernel_str(&cginfo.name, CGROUP_NAME_LEN, prev->sched_task_group->css.cgroup->kn->name);
+				
+				// push the cgroup info into the ringbuf
+				bpf_ringbuf_output(&cgroup_info, &cginfo, sizeof(cginfo), 0);
+
+				// update the serial number in the local map
+				bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
+			}
+		
 			// update cgroup cycles
 
 			elem = bpf_map_lookup_elem(&cycles_prev, &processor_id);
@@ -166,6 +215,8 @@ int handle__sched_switch(u64 *ctx)
 			}
 		}
 	}
+
+	// update the per-core counters
 
 	bpf_map_update_elem(&cycles_prev, &processor_id, &c, BPF_ANY);
 	bpf_map_update_elem(&instructions_prev, &processor_id, &i, BPF_ANY);


### PR DESCRIPTION
Adds per-counter metadata to `CounterGroup` so that we are able to provide things like the cgroup name during exposition.

Adds ringbuffer to cpu frequency and perf samplers to pass cgroup info to userspace.
