### PR TITLE
add threads to collect perf event counter readings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622892f5635ce1fc38c8f16dfc938553ed64af482edb5e150bf4caedbfcb2304"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1079,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "histogram"
@@ -1866,6 +1883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "nvml-wrapper"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,6 +2330,7 @@ dependencies = [
  "backtrace",
  "clap",
  "clocksource",
+ "core_affinity",
  "ctrlc",
  "futures",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tower-http = { version = "0.5.2", features = ["compression-full", "decompression
 thiserror = "1.0.63"
 walkdir = "2.5.0"
 plain = "0.2.3"
+core_affinity = "0.8.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.24.2" }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
+use crate::debug;
 
 use ringlog::Level;
 use serde::Deserialize;
@@ -93,9 +94,18 @@ impl Config {
     }
 
     pub fn enabled(&self, name: &str) -> bool {
-        self.samplers
+        let enabled = self
+            .samplers
             .get(name)
             .and_then(|v| v.enabled())
-            .unwrap_or(self.defaults.enabled().unwrap_or(enabled()))
+            .unwrap_or(self.defaults.enabled().unwrap_or(enabled()));
+
+        if enabled {
+            debug!("'{name}' sampler is enabled");
+        } else {
+            debug!("'{name}' sampler is not enabled");
+        }
+
+        enabled
     }
 }

--- a/src/samplers/cpu/linux/frequency/mod.bpf.c
+++ b/src/samplers/cpu/linux/frequency/mod.bpf.c
@@ -40,14 +40,7 @@ struct {
 	__uint(max_entries, MAX_CGROUPS);
 } cgroup_serial_numbers SEC(".maps");
 
-// counters (see constants defined at top)
-struct {
-	__uint(type, BPF_MAP_TYPE_ARRAY);
-	__uint(map_flags, BPF_F_MMAPABLE);
-	__type(key, u32);
-	__type(value, u64);
-	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
-} counters SEC(".maps");
+// counters for various events
 
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
@@ -72,6 +65,8 @@ struct {
 	__type(value, u64);
 	__uint(max_entries, MAX_CGROUPS);
 } cgroup_tsc SEC(".maps");
+
+// previous readings for various events
 
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
@@ -142,28 +137,6 @@ static __always_inline __s64 get_task_state(void *task)
 	return BPF_CORE_READ((struct task_struct___o *)task, state);
 }
 
-// attach a kprobe cpuacct to update per-cpu counters
-
-SEC("kprobe/cpuacct_account_field")
-int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
-{
-	u32 idx;
-	u32 processor_id = bpf_get_smp_processor_id();
-
-	u64 a = bpf_perf_event_read(&aperf, BPF_F_CURRENT_CPU);
-	u64 m = bpf_perf_event_read(&mperf, BPF_F_CURRENT_CPU);
-	u64 t = bpf_perf_event_read(&tsc, BPF_F_CURRENT_CPU);
-
-	idx = processor_id * COUNTER_GROUP_WIDTH + APERF;
-	bpf_map_update_elem(&counters, &idx, &a, BPF_ANY);
-
-	idx = processor_id * COUNTER_GROUP_WIDTH + MPERF;
-	bpf_map_update_elem(&counters, &idx, &m, BPF_ANY);
-
-	idx = processor_id * COUNTER_GROUP_WIDTH + TSC;
-	bpf_map_update_elem(&counters, &idx, &t, BPF_ANY);
-}
-
 // attach a tracepoint on sched_switch for per-cgroup accounting
 
 SEC("tp_btf/sched_switch")
@@ -183,15 +156,6 @@ int handle__sched_switch(u64 *ctx)
 	u64 a = bpf_perf_event_read(&aperf, BPF_F_CURRENT_CPU);
 	u64 m = bpf_perf_event_read(&mperf, BPF_F_CURRENT_CPU);
 	u64 t = bpf_perf_event_read(&tsc, BPF_F_CURRENT_CPU);
-
-	idx = processor_id * COUNTER_GROUP_WIDTH + APERF;
-	bpf_map_update_elem(&counters, &idx, &a, BPF_ANY);
-
-	idx = processor_id * COUNTER_GROUP_WIDTH + MPERF;
-	bpf_map_update_elem(&counters, &idx, &m, BPF_ANY);
-
-	idx = processor_id * COUNTER_GROUP_WIDTH + TSC;
-	bpf_map_update_elem(&counters, &idx, &t, BPF_ANY);
 
 	if (bpf_core_field_exists(prev->sched_task_group)) {
 		int cgroup_id = prev->sched_task_group->css.id;


### PR DESCRIPTION
For per-core perf event counter readings, we need to collect those readings on-demand as there is no reliable way of getting regular updates via BPF.

This changes adds pinned threads using one thread per core to read the perf counters and update the values in userspace.
