### PR TITLE
remove unusued total metrics for perf counters

### DIFF
--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -74,9 +74,9 @@ fn init(config: Arc<Config>) -> SamplerResult {
     }
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
-        .perf_event("aperf", PerfEvent::msr(MsrId::APERF)?, &CPU_APERF_PERCORE)
-        .perf_event("mperf", PerfEvent::msr(MsrId::MPERF)?, &CPU_MPERF_PERCORE)
-        .perf_event("tsc", PerfEvent::msr(MsrId::TSC)?, &CPU_TSC_PERCORE)
+        .perf_event("aperf", PerfEvent::msr(MsrId::APERF)?, &CPU_APERF)
+        .perf_event("mperf", PerfEvent::msr(MsrId::MPERF)?, &CPU_MPERF)
+        .perf_event("tsc", PerfEvent::msr(MsrId::TSC)?, &CPU_TSC)
         .packed_counters("cgroup_aperf", &CGROUP_CPU_APERF)
         .packed_counters("cgroup_mperf", &CGROUP_CPU_MPERF)
         .packed_counters("cgroup_tsc", &CGROUP_CPU_TSC)

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -71,12 +71,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
     }
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
-        .perf_event("cycles", PerfEvent::cpu_cycles(), &CPU_CYCLES_PERCORE)
-        .perf_event(
-            "instructions",
-            PerfEvent::instructions(),
-            &CPU_INSTRUCTIONS_PERCORE,
-        )
+        .perf_event("cycles", PerfEvent::cpu_cycles(), &CPU_CYCLES)
+        .perf_event("instructions", PerfEvent::instructions(), &CPU_INSTRUCTIONS)
         .packed_counters("cgroup_cycles", &CGROUP_CPU_CYCLES)
         .packed_counters("cgroup_instructions", &CGROUP_CPU_INSTRUCTIONS)
         .ringbuf_handler("cgroup_info", handle_event)

--- a/src/samplers/cpu/linux/stats.rs
+++ b/src/samplers/cpu/linux/stats.rs
@@ -116,44 +116,12 @@ pub static CPU_USAGE_PERCORE_GUEST: CounterGroup = CounterGroup::new(MAX_CPUS);
 pub static CPU_USAGE_PERCORE_GUEST_NICE: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
-    name = "cpu/cycles/total",
-    description = "The number of elapsed CPU cycles",
-    metadata = { unit = "cycles" }
-)]
-pub static CPU_CYCLES: LazyCounter = LazyCounter::new(Counter::default);
-
-#[metric(
-    name = "cpu/instructions/total",
-    description = "The number of instructions retired",
-    metadata = { unit = "instructions" }
-)]
-pub static CPU_INSTRUCTIONS: LazyCounter = LazyCounter::new(Counter::default);
-
-#[metric(
-    name = "cpu/aperf/total",
-    metadata = { unit = "cycles" }
-)]
-pub static CPU_APERF: LazyCounter = LazyCounter::new(Counter::default);
-
-#[metric(
-    name = "cpu/mperf/total",
-    metadata = { unit = "cycles" }
-)]
-pub static CPU_MPERF: LazyCounter = LazyCounter::new(Counter::default);
-
-#[metric(
-    name = "cpu/tsc/total",
-    metadata = { unit = "cycles" }
-)]
-pub static CPU_TSC: LazyCounter = LazyCounter::new(Counter::default);
-
-#[metric(
     name = "cpu/cycles",
     description = "The number of elapsed CPU cycles",
     formatter = cpu_metric_percore_formatter,
     metadata = { unit = "cycles" }
 )]
-pub static CPU_CYCLES_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static CPU_CYCLES: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu/instructions",
@@ -161,28 +129,28 @@ pub static CPU_CYCLES_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
     formatter = cpu_metric_percore_formatter,
     metadata = { unit = "instructions" }
 )]
-pub static CPU_INSTRUCTIONS_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static CPU_INSTRUCTIONS: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu/aperf",
     formatter = cpu_metric_percore_formatter,
     metadata = { unit = "cycles" }
 )]
-pub static CPU_APERF_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static CPU_APERF: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu/mperf",
     formatter = cpu_metric_percore_formatter,
     metadata = { unit = "cycles" }
 )]
-pub static CPU_MPERF_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static CPU_MPERF: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu/tsc",
     formatter = cpu_metric_percore_formatter,
     metadata = { unit = "cycles" }
 )]
-pub static CPU_TSC_PERCORE: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static CPU_TSC: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cgroup/cpu/cycles",


### PR DESCRIPTION
We don't track system-wide totals for the various perf counters as this aggregation is possible outside of Rezolus.

This change removes the unused metrics.
