### PR TITLE
Rewrite packaging to use a single script in a docker container

### DIFF
--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -45,7 +45,6 @@ jobs:
   build-deb:
     name: "${{ matrix.distro }}:${{ matrix.release }}"
     runs-on: buildjet-16vcpu-ubuntu-2204${{ matrix.arch == 'arm64' && '-arm' || '' }}
-    container: "${{ matrix.distro }}:${{ matrix.release }}"
     strategy:
       matrix:
         include:
@@ -73,59 +72,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install buildsystem apt dependencies
-        run: |
-          apt-get update
-          apt-get install -y            \
-            build-essential             \
-            curl jq lsb-release unzip gpg
-
-      - name: install rust
-        run: |
-          curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
-          echo "PATH=$HOME/.cargo/bin:$PATH" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: build-deb-${{ matrix.distro }}-${{ matrix.release }}-${{ matrix.arch }}
-
-      - name: check cargo
-        shell: bash
-        run: |
-          echo "::group::rustc -vV"
-          rustc -vV
-          echo "::endgroup::"
-          echo "::group::cargo -vV"
-          cargo -vV
-          echo "::endgroup::"
-
       - name: set release env var
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
           echo 'RELEASE=${{ github.event.inputs.release }}' >> $GITHUB_ENV
-
-      # Changelogs with revisions cause dpkg-source to emit an error when
-      # building. We only use the source package to install the build deps
-      # so building it with an invalid version is ok.
-      - name: build source package
-        run: dpkg-source --build .
-
-      - name: generate changelog
-        shell: bash
-        run: ./debian/gen-changelog.sh > debian/changelog
-
-      - name: install build dependencies
-        run: apt-get build-dep -y ../rezolus*.dsc
-      - name: build package
-        run: dpkg-buildpackage -b -us -uc
-
-      - name: copy debs
+      
+      - name: set release env var
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         shell: bash
         run: |
-          shopt -s nullglob
+          echo 'RELEASE=0' >> $GITHUB_ENV
+
+      - name: run packaging script
+        run: |
           mkdir -p target/debian
-          cp ../*.deb ../*.ddeb target/debian/
+          docker run -it --rm                   \
+            -v $(pwd):/mnt/rezolus              \
+            -v $(pwd)/target/debian:/mnt/output \
+            ${{ matrix.distro }}:${{ matrix.release }} \
+            /mnt/rezolus/debian/package.sh      \
+            --release "$RELEASE"                \
+            --chown "$(id -u)"                  \
+            --verbose
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -87,7 +87,7 @@ jobs:
       - name: run packaging script
         run: |
           mkdir -p target/debian
-          docker run -it --rm                   \
+          docker run --rm                   \
             -v $(pwd):/mnt/rezolus              \
             -v $(pwd)/target/debian:/mnt/output \
             ${{ matrix.distro }}:${{ matrix.release }} \

--- a/.github/workflows/package-rpm.yml
+++ b/.github/workflows/package-rpm.yml
@@ -59,7 +59,7 @@ jobs:
       - name: install build dependencies
         shell: bash
         run: |
-          yum install -y gcc elfutils-devel clang
+          yum install -y gcc elfutils-devel clang openssl-devel
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/debian/control
+++ b/debian/control
@@ -6,6 +6,7 @@ Standards-Version: 4.6.2
 Build-Depends: 
     debhelper (>= 10),
     pkg-config,
+    libssl-dev,
     libelf-dev,
     libelf-dev:native,
     clang:native

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -34,7 +34,7 @@ USE WITH DOCKER:
     docker run -it --rm \\
         -v \$(pwd):/mnt/rezolus \\
         -v \$(pwd)/target/debian:/mnt/output \\
-        ubuntu:focal /mnt/rezolus/debian/package.sh --release 0 --chown \$(id -u) --verbose
+        ubuntu:noble /mnt/rezolus/debian/package.sh --release 0 --chown \$(id -u) --verbose
 
     You should be able to swap out the docker container in order to build for different
     distros, provided that rezolus can be built on each distro. Note that you may have to

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -73,7 +73,7 @@ done
 pushgroup() {
     (
         set +x
-        if [ -n "$CI" ]; then
+        if [ -n "${CI:-}" ]; then
             echo "::group::$*"
         fi
     )
@@ -82,7 +82,7 @@ pushgroup() {
 nextgroup() {
     (
         set +x
-        if [ -n "$CI" ]; then
+        if [ -n "${CI:-}" ]; then
             echo "::endgroup::"
             echo "::group::$*"
         fi
@@ -92,7 +92,7 @@ nextgroup() {
 popgroup() {
     (
         set +x
-        if [ -n "$CI" ]; then
+        if [ -n "${CI:-}" ]; then
             echo "::endgroup::"
         fi
     )

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -10,11 +10,10 @@ REZOLUS=/mnt/rezolus
 OUTPUT=/mnt/output
 RELEASE=0
 CHOWN=
-ARCH=
 
 help() {
     cat <<EOF
-$PROGRAM - Built rezolus debian packages.
+$PROGRAM - Build rezolus debian packages.
 
 USAGE:
     $PROGRAM <FLAGS>
@@ -93,7 +92,7 @@ apt-get -q install -y build-essential curl jq lsb-release unzip gpg
 
 # Install rust
 curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
-. "$HOME/.cargo/env"
+export PATH="$HOME/.cargo/env:$PATH"
 
 # Build source package
 dpkg-source --build .

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROGRAM="$(basename "$0")"
+
+VERBOSE=false
+
+REZOLUS=/mnt/rezolus
+OUTPUT=/mnt/output
+RELEASE=0
+CHOWN=
+ARCH=
+
+help() {
+    cat <<EOF
+$PROGRAM - Built rezolus debian packages.
+
+USAGE:
+    $PROGRAM <FLAGS>
+
+OPTIONS:
+    -h|--help       Show this help text.
+    -v|--verbose    Display the commands run by this script.
+
+    --release       The release number to use for the package. [default: $RELEASE]
+    --rezolus-dir   The directory that the rezolus source is stored in. [default: $REZOLUS]
+    --output-dir    The directory to place the output artifacts in. [default: $OUTPUT]
+    --chown         Change the ownership of the resulting package files.
+
+USE WITH DOCKER:
+    This script is intended to be run within a debian-based docker container.
+    As an example, consider building for ubuntu focal:
+
+    docker run -it --rm \\
+        -v \$(pwd):/mnt/rezolus \\
+        -v \$(pwd)/target/debian:/mnt/output \\
+        ubuntu:focal /mnt/rezolus/debian/package.sh --release 0 --chown \$(id -u) --verbose
+
+    You should be able to swap out the docker container in order to build for different
+    distros, provided that rezolus can be built on each distro. Note that you may have to
+    clean out the debian/cargo_home and debian/cargo_target directories when switching distros.
+EOF
+}
+
+error() {
+    1>&2 echo "error: $1"
+    1>&2 echo "Try '$PROGRAM --help' for more information."
+}
+
+while [ $# -gt 0 ]; do
+    opt="$1"
+    shift
+
+    case "$opt" in
+        -h|--help)
+            help
+            exit 0
+            ;;
+        -v|--verbose)   VERBOSE=true            ;;
+
+        --release)      RELEASE="$1";   shift   ;;
+        --rezolus-dir)  REZOLUS="$1";   shift   ;;
+        --output-dir)   OUTPUT="$1";    shift   ;;
+        --chown)        CHOWN="$1";     shift   ;;
+
+        *)
+            error "unexpected option '$opt'"
+            exit 1
+            ;;
+    esac
+done
+
+if $VERBOSE; then
+    set -x
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    error "package script must be run as root"
+fi
+
+shopt -s nullglob globstar
+
+cd "$REZOLUS"
+
+# Install required dependencies
+
+# Disable tzdata requests or other things that may require user interaction
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get -q update
+apt-get -q install -y build-essential curl jq lsb-release unzip gpg
+
+# Install rust
+curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
+. "$HOME/.cargo/env"
+
+# Build source package
+dpkg-source --build .
+
+# Generate the changelog file
+cp -p debian/changelog /tmp/changelog
+trap 'cp -fp /tmp/changelog debian/changelog' EXIT
+./debian/gen-changelog.sh > debian/changelog
+
+# Install build dependencies
+apt-get -q build-dep -y ../rezolus*.dsc
+
+# Build the package
+dpkg-buildpackage -b -us -uc
+
+# Change ownership of the deb files, if requested
+if [ -n "$CHOWN" ]; then
+    chown "$CHOWN" ../*.deb ../*.ddeb
+fi
+
+# Copy the debs to the output directory
+cp ../*.deb ../*.ddeb "$OUTPUT"

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -99,6 +99,7 @@ curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
 dpkg-source --build .
 
 # Generate the changelog file
+export RELEASE="$RELEASE"
 cp -p debian/changelog /tmp/changelog
 trap 'cp -fp /tmp/changelog debian/changelog' EXIT
 ./debian/gen-changelog.sh > debian/changelog

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -71,22 +71,31 @@ while [ $# -gt 0 ]; do
 done
 
 pushgroup() {
-    if [ -n "$CI" ]; then
-        echo "::group::$*"
-    fi
+    (
+        set +x
+        if [ -n "$CI" ]; then
+            echo "::group::$*"
+        fi
+    )
 }
 
 nextgroup() {
-    if [ -n "$CI" ]; then
-        echo "::endgroup::"
-        echo "::group::$*"
-    fi
+    (
+        set +x
+        if [ -n "$CI" ]; then
+            echo "::endgroup::"
+            echo "::group::$*"
+        fi
+    )
 }
 
 popgroup() {
-    if [ -n "$CI" ]; then
-        echo "::endgroup::"
-    fi
+    (
+        set +x
+        if [ -n "$CI" ]; then
+            echo "::endgroup::"
+        fi
+    )
 }
 
 


### PR DESCRIPTION
This should avoid the problems with running github actions within an older docker container. It should also make building packages by hand somewhat easier.