### PR TITLE
use attributes to group syscalls

### DIFF
--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -61,7 +61,9 @@ fn handle_event(data: &[u8]) -> i32 {
         let id = cgroup_info.id;
 
         if !name.is_empty() {
-            CGROUP_SYSCALL_TOTAL.insert_metadata(id as usize, "name".to_string(), name);
+            CGROUP_SYSCALL_OTHER.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_SYSCALL_READ.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_SYSCALL_WRITE.insert_metadata(id as usize, "name".to_string(), name);
         }
     }
 
@@ -75,7 +77,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
     }
 
     let counters = vec![
-        &SYSCALL_TOTAL,
+        &SYSCALL_OTHER,
         &SYSCALL_READ,
         &SYSCALL_WRITE,
         &SYSCALL_POLL,
@@ -89,7 +91,9 @@ fn init(config: Arc<Config>) -> SamplerResult {
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .counters("counters", counters)
         .map("syscall_lut", syscall_lut())
-        .packed_counters("cgroup_syscall_total", &CGROUP_SYSCALL_TOTAL)
+        .packed_counters("cgroup_syscall_other", &CGROUP_SYSCALL_OTHER)
+        .packed_counters("cgroup_syscall_read", &CGROUP_SYSCALL_READ)
+        .packed_counters("cgroup_syscall_write", &CGROUP_SYSCALL_WRITE)
         .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 
@@ -100,7 +104,9 @@ impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
         match name {
             "cgroup_info" => &self.maps.cgroup_info,
-            "cgroup_syscall_total" => &self.maps.cgroup_syscall_total,
+            "cgroup_syscall_other" => &self.maps.cgroup_syscall_other,
+            "cgroup_syscall_read" => &self.maps.cgroup_syscall_read,
+            "cgroup_syscall_write" => &self.maps.cgroup_syscall_write,
             "counters" => &self.maps.counters,
             "syscall_lut" => &self.maps.syscall_lut,
             _ => unimplemented!(),

--- a/src/samplers/syscall/linux/counts/stats.rs
+++ b/src/samplers/syscall/linux/counts/stats.rs
@@ -3,71 +3,85 @@ use metriken::*;
 use crate::common::*;
 
 #[metric(
-    name = "syscall_total",
-    description = "The total number of syscalls",
-    metadata = { unit = "syscalls" }
-)]
-pub static SYSCALL_TOTAL: LazyCounter = LazyCounter::new(Counter::default);
-
-#[metric(
-    name = "syscall_read",
+    name = "syscall",
     description = "The number of read related syscalls (read, recvfrom, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "read" }
 )]
 pub static SYSCALL_READ: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "syscall_write",
+    name = "syscall",
     description = "The number of write related syscalls (write, sendto, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "write" }
 )]
 pub static SYSCALL_WRITE: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "syscall_poll",
+    name = "syscall",
     description = "The number of poll related syscalls (poll, select, epoll, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "poll" }
 )]
 pub static SYSCALL_POLL: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "syscall_lock",
+    name = "syscall",
     description = "The number of lock related syscalls (futex, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "lock" }
 )]
 pub static SYSCALL_LOCK: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "syscall_time",
+    name = "syscall",
     description = "The number of time related syscalls (clock_gettime, clock_settime, clock_getres, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "time" }
 )]
 pub static SYSCALL_TIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "syscall_sleep",
+    name = "syscall",
     description = "The number of sleep related syscalls (nanosleep, clock_nanosleep, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "sleep" }
 )]
 pub static SYSCALL_SLEEP: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "syscall_socket",
+    name = "syscall",
     description = "The number of socket related syscalls (accept, connect, bind, setsockopt, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "socket" }
 )]
 pub static SYSCALL_SOCKET: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "syscall_yield",
+    name = "syscall",
     description = "The number of socket related syscalls (sched_yield, ...)",
-    metadata = { unit = "syscalls" }
+    metadata = { unit = "syscalls", op = "yield" }
 )]
 pub static SYSCALL_YIELD: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "cgroup_syscall_total",
-    description = "The total number of syscalls on a per-cgroup basis",
-    metadata = { unit = "syscalls" }
+    name = "syscall",
+    description = "The total number of syscalls",
+    metadata = { unit = "syscalls", op = "other" }
 )]
-pub static CGROUP_SYSCALL_TOTAL: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+pub static SYSCALL_OTHER: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of read related syscalls (read, recvfrom, ...)",
+    metadata = { unit = "syscalls", op = "read" }
+)]
+pub static CGROUP_SYSCALL_READ: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of write related syscalls (write, sendto, ...)",
+    metadata = { unit = "syscalls", op = "write" }
+)]
+pub static CGROUP_SYSCALL_WRITE: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The total number of syscalls on a per-cgroup basis",
+    metadata = { unit = "syscalls", op = "other" }
+)]
+pub static CGROUP_SYSCALL_OTHER: CounterGroup = CounterGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
Refactors the syscall metrics to use attributes to group by syscall type instead of encoding this in the metric name.

This makes the metric naming conventions more consistent with the Prometheus and OTel recommendations.

Adds per-cgroup read and write syscall counts.
