### PR TITLE
change rezolus cpu usage attributes to match system cpu usage

### DIFF
--- a/src/samplers/rezolus/rusage/stats.rs
+++ b/src/samplers/rezolus/rusage/stats.rs
@@ -3,14 +3,14 @@ use metriken::*;
 #[metric(
     name = "rezolus_cpu_usage",
     description = "The amount of CPU time Rezolus was executing in user mode",
-    metadata = { mode = "user", unit = "nanoseconds" }
+    metadata = { state = "user", unit = "nanoseconds" }
 )]
 pub static RU_UTIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_cpu_usage",
     description = "The amount of CPU time Rezolus was executing in system mode",
-    metadata = { mode = "system", unit = "nanoseconds" }
+    metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static RU_STIME: LazyCounter = LazyCounter::new(Counter::default);
 


### PR DESCRIPTION
We used "mode" as the attribute to indicate user vs system time within the rezolus process itself. For better consistency with the cpu usage metrics, we rename the attribute to "state"
