### PR TITLE
use attribute for direction for network traffic stats

### DIFF
--- a/src/samplers/network/linux/traffic/stats.rs
+++ b/src/samplers/network/linux/traffic/stats.rs
@@ -1,29 +1,29 @@
 use metriken::*;
 
 #[metric(
-    name = "network_receive_bytes",
+    name = "network_bytes",
     description = "The number of bytes received over the network",
-    metadata = { unit = "bytes" }
+    metadata = { direction = "receive", unit = "bytes" }
 )]
 pub static NETWORK_RX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "network_receive_packets",
+    name = "network_packets",
     description = "The number of packets received over the network",
-    metadata = { unit = "packets" }
+    metadata = { direction = "receive", unit = "packets" }
 )]
 pub static NETWORK_RX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "network_transmit_bytes",
+    name = "network_bytes",
     description = "The number of bytes transmitted over the network",
-    metadata = { unit = "bytes" }
+    metadata = { direction = "transmit", unit = "bytes" }
 )]
 pub static NETWORK_TX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "network_transmit_packets",
+    name = "network_packets",
     description = "The number of packets transmitted over the network",
-    metadata = { unit = "packets" }
+    metadata = { direction = "transmit", unit = "packets" }
 )]
 pub static NETWORK_TX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);


### PR DESCRIPTION
Moves "transmit" or "receive" to a "direction" attribute for network traffic stats.
