### PR TITLE
use labels for syscall latency histograms

### DIFF
--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -136,6 +136,14 @@ async fn prometheus(State(state): State<Arc<AppState>>) -> String {
                                 &histogram
                             };
 
+                            let metadata: Vec<String> = metric
+                                .metadata()
+                                .iter()
+                                .map(|(key, value)| format!("{key}=\"{value}\""))
+                                .collect();
+
+                            let metadata = metadata.join(", ");
+
                             // we need to export a total count (free-running)
                             let mut count = 0;
                             // we also need to export a total sum of all observations
@@ -150,17 +158,32 @@ async fn prometheus(State(state): State<Arc<AppState>>) -> String {
                                 // add the count to the aggregate
                                 count += bucket.count();
 
-                                entry += &format!(
-                                    "{name}_distribution_bucket{{le=\"{}\"}} {count} {timestamp}\n",
-                                    bucket.end()
-                                );
+                                if metadata.is_empty() {
+                                    entry += &format!(
+                                        "{name}_distribution_bucket{{le=\"{}\"}} {count} {timestamp}\n",
+                                        bucket.end()
+                                    );
+                                } else {
+                                    entry += &format!(
+                                        "{name}_distribution_bucket{{{metadata}, le=\"{}\"}} {count} {timestamp}\n",
+                                        bucket.end()
+                                    );
+                                }
                             }
 
-                            entry += &format!(
-                                "{name}_distribution_bucket{{le=\"+Inf\"}} {count} {timestamp}\n"
-                            );
-                            entry += &format!("{name}_distribution_count {count} {timestamp}\n");
-                            entry += &format!("{name}_distribution_sum {sum} {timestamp}");
+                            if metadata.is_empty() {
+                                entry += &format!(
+                                    "{name}_distribution_bucket{{le=\"+Inf\"}} {count} {timestamp}\n"
+                                );
+                                entry += &format!("{name}_distribution_count {count} {timestamp}\n");
+                                entry += &format!("{name}_distribution_sum {sum} {timestamp}");
+                            } else {
+                                entry += &format!(
+                                    "{name}_distribution_bucket{{{metadata}, le=\"+Inf\"}} {count} {timestamp}\n"
+                                );
+                                entry += &format!("{name}_distribution_count{{{metadata}}} {count} {timestamp}\n");
+                                entry += &format!("{name}_distribution_sum{{{metadata}}} {sum} {timestamp}");
+                            }
 
                             data.push(entry);
                         }

--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -175,14 +175,19 @@ async fn prometheus(State(state): State<Arc<AppState>>) -> String {
                                 entry += &format!(
                                     "{name}_distribution_bucket{{le=\"+Inf\"}} {count} {timestamp}\n"
                                 );
-                                entry += &format!("{name}_distribution_count {count} {timestamp}\n");
+                                entry +=
+                                    &format!("{name}_distribution_count {count} {timestamp}\n");
                                 entry += &format!("{name}_distribution_sum {sum} {timestamp}");
                             } else {
                                 entry += &format!(
                                     "{name}_distribution_bucket{{{metadata}, le=\"+Inf\"}} {count} {timestamp}\n"
                                 );
-                                entry += &format!("{name}_distribution_count{{{metadata}}} {count} {timestamp}\n");
-                                entry += &format!("{name}_distribution_sum{{{metadata}}} {sum} {timestamp}");
+                                entry += &format!(
+                                    "{name}_distribution_count{{{metadata}}} {count} {timestamp}\n"
+                                );
+                                entry += &format!(
+                                    "{name}_distribution_sum{{{metadata}}} {sum} {timestamp}"
+                                );
                             }
 
                             data.push(entry);

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -36,7 +36,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
     }
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
-        .histogram("total_latency", &SYSCALL_TOTAL_LATENCY)
+        .histogram("other_latency", &SYSCALL_OTHER_LATENCY)
         .histogram("read_latency", &SYSCALL_READ_LATENCY)
         .histogram("write_latency", &SYSCALL_WRITE_LATENCY)
         .histogram("poll_latency", &SYSCALL_POLL_LATENCY)
@@ -54,7 +54,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
         match name {
-            "total_latency" => &self.maps.total_latency,
+            "other_latency" => &self.maps.other_latency,
             "read_latency" => &self.maps.read_latency,
             "write_latency" => &self.maps.write_latency,
             "poll_latency" => &self.maps.poll_latency,

--- a/src/samplers/syscall/linux/latency/stats.rs
+++ b/src/samplers/syscall/linux/latency/stats.rs
@@ -6,73 +6,73 @@ use metriken::*;
 static LATENCY_HISTOGRAM_MAX: u8 = 64;
 
 #[metric(
-    name = "syscall_total_latency",
-    description = "Distribution of the latency for all syscalls",
-    metadata = { unit = "nanoseconds" }
+    name = "syscall_latency",
+    description = "Distribution of the latency for all other syscalls",
+    metadata = { unit = "nanoseconds", op = "other" }
 )]
-pub static SYSCALL_TOTAL_LATENCY: RwLockHistogram =
+pub static SYSCALL_OTHER_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_read_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for read related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "read" }
 )]
 pub static SYSCALL_READ_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_write_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for write related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "write" }
 )]
 pub static SYSCALL_WRITE_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_poll_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for poll related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "poll" }
 )]
 pub static SYSCALL_POLL_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_lock_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for lock related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "lock" }
 )]
 pub static SYSCALL_LOCK_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_time_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for time related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "time" }
 )]
 pub static SYSCALL_TIME_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_sleep_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for sleep related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "sleep" }
 )]
 pub static SYSCALL_SLEEP_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_socket_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for socket related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "socket" }
 )]
 pub static SYSCALL_SOCKET_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
 
 #[metric(
-    name = "syscall_yield_latency",
+    name = "syscall_latency",
     description = "Distribution of the latency for yield related syscalls",
-    metadata = { unit = "nanoseconds" }
+    metadata = { unit = "nanoseconds", op = "yield" }
 )]
 pub static SYSCALL_YIELD_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);


### PR DESCRIPTION
Use labels for each syscall type for the syscall latency histograms.
