### PR TITLE
blockio latency and size for all operations and label histograms

### DIFF
--- a/src/samplers/blockio/linux/latency/mod.rs
+++ b/src/samplers/blockio/linux/latency/mod.rs
@@ -4,7 +4,7 @@
 /// * `block_rq_complete`
 ///
 /// And produces these stats:
-/// * `blockio/latency`
+/// * `blockio_latency`
 
 static NAME: &str = "blockio_latency";
 
@@ -29,9 +29,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
     }
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
-        .histogram("latency", &BLOCKIO_LATENCY)
         .histogram("read_latency", &BLOCKIO_READ_LATENCY)
         .histogram("write_latency", &BLOCKIO_WRITE_LATENCY)
+        .histogram("flush_latency", &BLOCKIO_FLUSH_LATENCY)
+        .histogram("discard_latency", &BLOCKIO_DISCARD_LATENCY)
         .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -40,9 +41,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
         match name {
-            "latency" => &self.maps.latency,
             "read_latency" => &self.maps.read_latency,
             "write_latency" => &self.maps.write_latency,
+            "flush_latency" => &self.maps.flush_latency,
+            "discard_latency" => &self.maps.discard_latency,
             _ => unimplemented!(),
         }
     }

--- a/src/samplers/blockio/linux/latency/stats.rs
+++ b/src/samplers/blockio/linux/latency/stats.rs
@@ -3,23 +3,32 @@ use metriken::*;
 
 #[metric(
     name = "blockio_latency",
-    description = "Distribution of blockio operation latency in nanoseconds",
-    metadata = { unit = "nanoseconds" }
-)]
-pub static BLOCKIO_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
-
-#[metric(
-    name = "blockio_read_latency",
     description = "Distribution of blockio read operation latency in nanoseconds",
-    metadata = { unit = "nanoseconds" }
+    metadata = { op = "read", unit = "nanoseconds" }
 )]
 pub static BLOCKIO_READ_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
-    name = "blockio_write_latency",
+    name = "blockio_latency",
     description = "Distribution of blockio write operation latency in nanoseconds",
-    metadata = { unit = "nanoseconds" }
+    metadata = { op = "write", unit = "nanoseconds" }
 )]
 pub static BLOCKIO_WRITE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_latency",
+    description = "Distribution of blockio flush operation latency in nanoseconds",
+    metadata = { op = "flush", unit = "nanoseconds" }
+)]
+pub static BLOCKIO_FLUSH_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_latency",
+    description = "Distribution of blockio discard operation latency in nanoseconds",
+    metadata = { op = "discard", unit = "nanoseconds" }
+)]
+pub static BLOCKIO_DISCARD_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);

--- a/src/samplers/blockio/linux/requests/mod.rs
+++ b/src/samplers/blockio/linux/requests/mod.rs
@@ -2,9 +2,9 @@
 /// * `block_rq_complete`
 ///
 /// And produces these stats:
-/// * `blockio/*/operations`
-/// * `blockio/*/bytes`
-/// * `blockio/size`
+/// * `blockio_bytes`
+/// * `blockio_operations`
+/// * `blockio_size`
 
 static NAME: &str = "blockio_requests";
 
@@ -41,9 +41,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .counters("counters", counters)
-        .histogram("size", &BLOCKIO_SIZE)
         .histogram("read_size", &BLOCKIO_READ_SIZE)
         .histogram("write_size", &BLOCKIO_WRITE_SIZE)
+        .histogram("flush_size", &BLOCKIO_FLUSH_SIZE)
+        .histogram("discard_size", &BLOCKIO_DISCARD_SIZE)
         .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -53,9 +54,10 @@ impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
         match name {
             "counters" => &self.maps.counters,
-            "size" => &self.maps.size,
             "read_size" => &self.maps.read_size,
             "write_size" => &self.maps.write_size,
+            "flush_size" => &self.maps.flush_size,
+            "discard_size" => &self.maps.discard_size,
             _ => unimplemented!(),
         }
     }

--- a/src/samplers/blockio/linux/requests/stats.rs
+++ b/src/samplers/blockio/linux/requests/stats.rs
@@ -27,7 +27,8 @@ pub static BLOCKIO_FLUSH_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_
     description = "Distribution of blockio discard operation sizes in bytes",
     metadata = { op = "discard", unit = "bytes" }
 )]
-pub static BLOCKIO_DISCARD_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+pub static BLOCKIO_DISCARD_SIZE: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio_operations",

--- a/src/samplers/blockio/linux/requests/stats.rs
+++ b/src/samplers/blockio/linux/requests/stats.rs
@@ -3,24 +3,31 @@ use metriken::*;
 
 #[metric(
     name = "blockio_size",
-    description = "Distribution of blockio operation sizes in bytes",
-    metadata = { unit = "bytes" }
-)]
-pub static BLOCKIO_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
-
-#[metric(
-    name = "blockio_read_size",
     description = "Distribution of blockio read operation sizes in bytes",
-    metadata = { unit = "bytes" }
+    metadata = { op = "read", unit = "bytes" }
 )]
 pub static BLOCKIO_READ_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
-    name = "blockio_write_size",
+    name = "blockio_size",
     description = "Distribution of blockio write operation sizes in bytes",
-    metadata = { unit = "bytes" }
+    metadata = { op = "write", unit = "bytes" }
 )]
 pub static BLOCKIO_WRITE_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_size",
+    description = "Distribution of blockio flush operation sizes in bytes",
+    metadata = { op = "flush", unit = "bytes" }
+)]
+pub static BLOCKIO_FLUSH_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_size",
+    description = "Distribution of blockio discard operation sizes in bytes",
+    metadata = { op = "discard", unit = "bytes" }
+)]
+pub static BLOCKIO_DISCARD_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio_operations",


### PR DESCRIPTION
Splits the blockio latency and size metrics into separate histograms for all four operation types. Removes the combined histograms and moves operation into a label.
