### PR TITLE
bump alpha version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,7 +2308,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "4.1.3-alpha.0"
+version = "5.0.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "4.1.3-alpha.0"
+version = "5.0.0-alpha.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "High resolution systems performance telemetry agent"


### PR DESCRIPTION
Next release will be 5.0.0. This sets the alpha version so we have the proper major version reflected during development.
