### PR TITLE
use labels for tcp stats

### DIFF
--- a/src/samplers/tcp/linux/retransmit/mod.rs
+++ b/src/samplers/tcp/linux/retransmit/mod.rs
@@ -26,7 +26,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let counters = vec![&TCP_TX_RETRANSMIT];
+    let counters = vec![&TCP_RETRANSMIT];
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .counters("counters", counters)

--- a/src/samplers/tcp/linux/retransmit/stats.rs
+++ b/src/samplers/tcp/linux/retransmit/stats.rs
@@ -1,8 +1,8 @@
 use metriken::*;
 
 #[metric(
-    name = "tcp_transmit_retransmit",
+    name = "tcp_retransmit",
     description = "The number of TCP packets that were re-transmitted",
     metadata = { unit = "packets" }
 )]
-pub static TCP_TX_RETRANSMIT: LazyCounter = LazyCounter::new(Counter::default);
+pub static TCP_RETRANSMIT: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/samplers/tcp/linux/traffic/stats.rs
+++ b/src/samplers/tcp/linux/traffic/stats.rs
@@ -2,43 +2,43 @@ use crate::common::HISTOGRAM_GROUPING_POWER;
 use metriken::*;
 
 #[metric(
-    name = "tcp_receive_bytes",
+    name = "tcp_bytes",
     description = "The number of bytes received over TCP",
-    metadata = { unit = "bytes" }
+    metadata = { direction = "receive", unit = "bytes" }
 )]
 pub static TCP_RX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "tcp_receive_packets",
+    name = "tcp_packets",
     description = "The number of packets received over TCP",
-    metadata = { unit = "packets" }
+    metadata = { direction = "receive", unit = "packets" }
 )]
 pub static TCP_RX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "tcp_receive_size",
+    name = "tcp_size",
     description = "Distribution of the size of TCP packets received after reassembly",
-    metadata = { unit = "bytes" }
+    metadata = { direction = "receive", unit = "bytes" }
 )]
 pub static TCP_RX_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
-    name = "tcp_transmit_bytes",
+    name = "tcp_bytes",
     description = "The number of bytes transmitted over TCP",
-    metadata = { unit = "bytes" }
+    metadata = { direction = "transmit", unit = "bytes" }
 )]
 pub static TCP_TX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "tcp_transmit_packets",
+    name = "tcp_packets",
     description = "The number of packets transmitted over TCP",
-    metadata = { unit = "packets" }
+    metadata = { direction = "transmit", unit = "packets" }
 )]
 pub static TCP_TX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
-    name = "tcp_transmit_size",
+    name = "tcp_size",
     description = "Distribution of the size of TCP packets transmitted before fragmentation",
-    metadata = { unit = "bytes" }
+    metadata = { direction = "transmit", unit = "bytes" }
 )]
 pub static TCP_TX_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);


### PR DESCRIPTION
Updates the tcp traffic stats to use labels for direction.

Renames the retransmit metric to simplify the metric name.
