### PR TITLE
fix: syscall_latency sampler fixes

### DIFF
--- a/src/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/samplers/syscall/linux/counts/mod.bpf.c
@@ -216,33 +216,33 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 			}
 
 			switch (group) {
-			    case 1:
-			        array_incr(&cgroup_syscall_read, cgroup_id);
-			        break;
-			    case 2:
-			        array_incr(&cgroup_syscall_write, cgroup_id);
-			        break;
-			    case 3:
-			        array_incr(&cgroup_syscall_poll, cgroup_id);
-			        break;
-			    case 4:
-			        array_incr(&cgroup_syscall_lock, cgroup_id);
-			        break;
-			    case 5:
-			        array_incr(&cgroup_syscall_time, cgroup_id);
-			        break;
-			    case 6:
-			        array_incr(&cgroup_syscall_sleep, cgroup_id);
-			        break;
-			    case 7:
-			        array_incr(&cgroup_syscall_socket, cgroup_id);
-			        break;
-			    case 8:
-			        array_incr(&cgroup_syscall_yield, cgroup_id);
-			        break;
-			    default:
-			        array_incr(&cgroup_syscall_other, cgroup_id);
-			        break;
+				case 1:
+					array_incr(&cgroup_syscall_read, cgroup_id);
+					break;
+				case 2:
+					array_incr(&cgroup_syscall_write, cgroup_id);
+					break;
+				case 3:
+					array_incr(&cgroup_syscall_poll, cgroup_id);
+					break;
+				case 4:
+					array_incr(&cgroup_syscall_lock, cgroup_id);
+					break;
+				case 5:
+					array_incr(&cgroup_syscall_time, cgroup_id);
+					break;
+				case 6:
+					array_incr(&cgroup_syscall_sleep, cgroup_id);
+					break;
+				case 7:
+					array_incr(&cgroup_syscall_socket, cgroup_id);
+					break;
+				case 8:
+					array_incr(&cgroup_syscall_yield, cgroup_id);
+					break;
+				default:
+					array_incr(&cgroup_syscall_other, cgroup_id);
+					break;
 			}
 		}
 	}

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -1,9 +1,9 @@
-/// Collects Syscall stats using BPF and traces:
-/// * `raw_syscalls/sys_enter`
-///
-/// And produces these stats:
-/// * `syscall`
-/// * `cgroup_syscall`
+//! Collects Syscall stats using BPF and traces:
+//! * `raw_syscalls/sys_enter`
+//!
+//! And produces these stats:
+//! * `syscall`
+//! * `cgroup_syscall`
 
 const NAME: &str = "syscall_counts";
 

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -12,7 +12,7 @@
 /// * `syscall/socket`
 /// * `syscall/yield`
 
-const NAME: &str = "syscall_counts";
+const NAME: &str = "syscall_latency";
 
 mod bpf {
     include!(concat!(env!("OUT_DIR"), "/syscall_latency.bpf.rs"));

--- a/src/samplers/syscall/linux/latency/mod.rs
+++ b/src/samplers/syscall/linux/latency/mod.rs
@@ -1,16 +1,9 @@
-/// Collects Syscall stats using BPF and traces:
-/// * `raw_syscalls/sys_enter`
-///
-/// And produces these stats:
-/// * `syscall/total`
-/// * `syscall/read`
-/// * `syscall/write`
-/// * `syscall/poll`
-/// * `syscall/lock`
-/// * `syscall/time`
-/// * `syscall/sleep`
-/// * `syscall/socket`
-/// * `syscall/yield`
+//! Collects Syscall stats using BPF and traces:
+//! * `raw_syscalls/sys_enter`
+//! * `raw_syscalls/sys_exit`
+//!
+//! And produces these stats:
+//! * `syscall_latency`
 
 const NAME: &str = "syscall_latency";
 


### PR DESCRIPTION
Fixes missing syscall latency metrics on some systems through some small changes to the BPF program which bring it in-line with the handling we use in the syscall counts prog.

Move BPF perf-thread initialization into conditional block to avoid excessive logging lines for BPF samplers that do not use any perf events.

Fixes the `syscall_latency` sampler's name constant so it can be enabled/disabled properly.
