### PR TITLE
add ubuntu focal to deb packaging workflow

### DIFF
--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -56,7 +56,9 @@ jobs:
           - { distro: debian, release: bookworm, arch: x86_64 }
           - { distro: debian, release: bookworm, arch: arm64 }
 
-          # ubuntu kernels supported from 20.10 and up
+          # ubuntu kernels supported from 20.10 and up, but we can build for focal too
+          - { distro: ubuntu, release: focal, arch: x86_64 } # 20.04
+          - { distro: ubuntu, release: focal, arch: arm64 } # 20.04
           - { distro: ubuntu, release: jammy, arch: x86_64 } # 22.04
           - { distro: ubuntu, release: jammy, arch: arm64 } # 22.04
           - { distro: ubuntu, release: noble, arch: x86_64 } # 24.04

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -56,9 +56,9 @@ jobs:
           - { distro: debian, release: bookworm, arch: x86_64 }
           - { distro: debian, release: bookworm, arch: arm64 }
 
-          # ubuntu kernels supported from 20.10 and up, but we can build for focal too
+          # ubuntu kernels supported from 20.10 and up
+          # Rezolus will work on focal if a modern kernel is installed
           - { distro: ubuntu, release: focal, arch: x86_64 } # 20.04
-          - { distro: ubuntu, release: focal, arch: arm64 } # 20.04
           - { distro: ubuntu, release: jammy, arch: x86_64 } # 22.04
           - { distro: ubuntu, release: jammy, arch: arm64 } # 22.04
           - { distro: ubuntu, release: noble, arch: x86_64 } # 24.04

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: IOP Systems <team@iop.systems>
 Standards-Version: 4.6.2
+Kernel-Version: 5.5
 Build-Depends: 
     debhelper (>= 10),
     pkg-config,


### PR DESCRIPTION
Adds ubuntu focal to deb packaging workflow, this package will work as long as the kernel is new enough.
