### PR TITLE
use forward slash as cgroup path joiner

### DIFF
--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -51,9 +51,9 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}_{pname}_{name}")
+            format!("{gpname}/{pname}/{name}")
         } else if !pname.is_empty() {
-            format!("{pname}_{name}")
+            format!("{pname}/{name}")
         } else {
             name.to_string()
         };

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -49,9 +49,9 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}_{pname}_{name}")
+            format!("{gpname}/{pname}/{name}")
         } else if !pname.is_empty() {
-            format!("{pname}_{name}")
+            format!("{pname}/{name}")
         } else {
             name.to_string()
         };

--- a/src/samplers/cpu/linux/usage/mod.rs
+++ b/src/samplers/cpu/linux/usage/mod.rs
@@ -44,9 +44,9 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}_{pname}_{name}")
+            format!("{gpname}/{pname}/{name}")
         } else if !pname.is_empty() {
-            format!("{pname}_{name}")
+            format!("{pname}/{name}")
         } else {
             name.to_string()
         };

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -44,9 +44,9 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}_{pname}_{name}")
+            format!("{gpname}/{pname}/{name}")
         } else if !pname.is_empty() {
-            format!("{pname}_{name}")
+            format!("{pname}/{name}")
         } else {
             name.to_string()
         };


### PR DESCRIPTION
Change the cgroup name label to use a forward slash as the path joiner to make hierarchy more obvious.
