### PR TITLE
nicer cgroup names

### DIFF
--- a/src/common/bpf/cgroup_info.h
+++ b/src/common/bpf/cgroup_info.h
@@ -5,6 +5,7 @@
 
 struct cgroup_info {
 	int id;
+	int level;
 	u8 name[CGROUP_NAME_LEN];
 	u8 pname[CGROUP_NAME_LEN];
 	u8 gpname[CGROUP_NAME_LEN];

--- a/src/samplers/cpu/linux/frequency/mod.bpf.c
+++ b/src/samplers/cpu/linux/frequency/mod.bpf.c
@@ -177,7 +177,7 @@ int handle__sched_switch(u64 *ctx)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
-					.level = prev->sched_task_group->css.cgroup.level,
+					.level = prev->sched_task_group->css.cgroup->level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/cpu/linux/frequency/mod.bpf.c
+++ b/src/samplers/cpu/linux/frequency/mod.bpf.c
@@ -177,6 +177,7 @@ int handle__sched_switch(u64 *ctx)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
+					.level = prev->sched_task_group->css.cgroup.level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -51,23 +51,33 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}/{pname}/{name}")
+            if cgroup_info.level > 3 {
+                format!(".../{gpname}/{pname}/{name}")
+            } else {
+                format!("/{gpname}/{pname}/{name}")
+            }
         } else if !pname.is_empty() {
-            format!("{pname}/{name}")
+            format!("/{pname}/{name}")
+        } else if !name.is_empty() {
+            format!("/{name}")
         } else {
-            name.to_string()
+            "".to_string()
         };
 
         let id = cgroup_info.id;
 
-        if !name.is_empty() {
-            CGROUP_CPU_APERF.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_MPERF.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_TSC.insert_metadata(id as usize, "name".to_string(), name);
-        }
+        set_name(id, name)
     }
 
     0
+}
+
+fn set_name(id: usize, name: String) {
+    if !name.is_empty() {
+        CGROUP_CPU_APERF.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_MPERF.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_TSC.insert_metadata(id as usize, "name".to_string(), name);
+    }
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -75,6 +85,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
     }
+
+    set_name(1, "/".to_string());
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .perf_event("aperf", PerfEvent::msr(MsrId::APERF)?, &CPU_APERF)

--- a/src/samplers/cpu/linux/frequency/mod.rs
+++ b/src/samplers/cpu/linux/frequency/mod.rs
@@ -66,7 +66,7 @@ fn handle_event(data: &[u8]) -> i32 {
 
         let id = cgroup_info.id;
 
-        set_name(id, name)
+        set_name(id as usize, name)
     }
 
     0
@@ -74,9 +74,9 @@ fn handle_event(data: &[u8]) -> i32 {
 
 fn set_name(id: usize, name: String) {
     if !name.is_empty() {
-        CGROUP_CPU_APERF.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_MPERF.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_TSC.insert_metadata(id as usize, "name".to_string(), name);
+        CGROUP_CPU_APERF.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_MPERF.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_TSC.insert_metadata(id, "name".to_string(), name);
     }
 }
 

--- a/src/samplers/cpu/linux/perf/mod.bpf.c
+++ b/src/samplers/cpu/linux/perf/mod.bpf.c
@@ -153,7 +153,7 @@ int handle__sched_switch(u64 *ctx)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
-					.level = prev->sched_task_group->css.cgroup.level,
+					.level = prev->sched_task_group->css.cgroup->level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/cpu/linux/perf/mod.bpf.c
+++ b/src/samplers/cpu/linux/perf/mod.bpf.c
@@ -153,6 +153,7 @@ int handle__sched_switch(u64 *ctx)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
+					.level = prev->sched_task_group->css.cgroup.level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -64,7 +64,7 @@ fn handle_event(data: &[u8]) -> i32 {
 
         let id = cgroup_info.id;
 
-        set_name(id, name)
+        set_name(id as usize, name)
     }
 
     0
@@ -72,8 +72,8 @@ fn handle_event(data: &[u8]) -> i32 {
 
 fn set_name(id: usize, name: String) {
     if !name.is_empty() {
-        CGROUP_CPU_CYCLES.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_INSTRUCTIONS.insert_metadata(id as usize, "name".to_string(), name);
+        CGROUP_CPU_CYCLES.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_INSTRUCTIONS.insert_metadata(id, "name".to_string(), name);
     }
 }
 

--- a/src/samplers/cpu/linux/perf/mod.rs
+++ b/src/samplers/cpu/linux/perf/mod.rs
@@ -49,22 +49,32 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}/{pname}/{name}")
+            if cgroup_info.level > 3 {
+                format!(".../{gpname}/{pname}/{name}")
+            } else {
+                format!("/{gpname}/{pname}/{name}")
+            }
         } else if !pname.is_empty() {
-            format!("{pname}/{name}")
+            format!("/{pname}/{name}")
+        } else if !name.is_empty() {
+            format!("/{name}")
         } else {
-            name.to_string()
+            "".to_string()
         };
 
         let id = cgroup_info.id;
 
-        if !name.is_empty() {
-            CGROUP_CPU_CYCLES.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_INSTRUCTIONS.insert_metadata(id as usize, "name".to_string(), name);
-        }
+        set_name(id, name)
     }
 
     0
+}
+
+fn set_name(id: usize, name: String) {
+    if !name.is_empty() {
+        CGROUP_CPU_CYCLES.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_INSTRUCTIONS.insert_metadata(id as usize, "name".to_string(), name);
+    }
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -72,6 +82,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
     }
+
+    set_name(1, "/".to_string());
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .perf_event("cycles", PerfEvent::cpu_cycles(), &CPU_CYCLES)

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -177,7 +177,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
-					.level = prev->sched_task_group->css.cgroup->level,
+					.level = current->sched_task_group->css.cgroup->level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -177,7 +177,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
-					.level = prev->sched_task_group->css.cgroup.level,
+					.level = prev->sched_task_group->css.cgroup->level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -177,6 +177,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, void *task, u32 index, u64 delta)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
+					.level = prev->sched_task_group->css.cgroup.level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/cpu/linux/usage/mod.rs
+++ b/src/samplers/cpu/linux/usage/mod.rs
@@ -59,7 +59,7 @@ fn handle_event(data: &[u8]) -> i32 {
 
         let id = cgroup_info.id;
 
-        set_name(id, name)
+        set_name(id as usize, name)
     }
 
     0
@@ -67,14 +67,14 @@ fn handle_event(data: &[u8]) -> i32 {
 
 fn set_name(id: usize, name: String) {
     if !name.is_empty() {
-        CGROUP_CPU_USAGE_USER.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_NICE.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_SYSTEM.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_SOFTIRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_IRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_STEAL.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_GUEST.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id as usize, "name".to_string(), name);
+        CGROUP_CPU_USAGE_USER.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_NICE.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_SYSTEM.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_SOFTIRQ.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_IRQ.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_STEAL.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_GUEST.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id, "name".to_string(), name);
     }
 }
 

--- a/src/samplers/cpu/linux/usage/mod.rs
+++ b/src/samplers/cpu/linux/usage/mod.rs
@@ -44,28 +44,38 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}/{pname}/{name}")
+            if cgroup_info.level > 3 {
+                format!(".../{gpname}/{pname}/{name}")
+            } else {
+                format!("/{gpname}/{pname}/{name}")
+            }
         } else if !pname.is_empty() {
-            format!("{pname}/{name}")
+            format!("/{pname}/{name}")
+        } else if !name.is_empty() {
+            format!("/{name}")
         } else {
-            name.to_string()
+            "".to_string()
         };
 
         let id = cgroup_info.id;
 
-        if !name.is_empty() {
-            CGROUP_CPU_USAGE_USER.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_USAGE_NICE.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_USAGE_SYSTEM.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_USAGE_SOFTIRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_USAGE_IRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_USAGE_STEAL.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_USAGE_GUEST.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id as usize, "name".to_string(), name);
-        }
+        set_name(id, name)
     }
 
     0
+}
+
+fn set_name(id: usize, name: String) {
+    if !name.is_empty() {
+        CGROUP_CPU_USAGE_USER.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_NICE.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_SYSTEM.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_SOFTIRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_IRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_STEAL.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_GUEST.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id as usize, "name".to_string(), name);
+    }
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -73,6 +83,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
     }
+
+    set_name(1, "/".to_string());
 
     let counters = vec![
         &CPU_USAGE_USER,

--- a/src/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/samplers/syscall/linux/counts/mod.bpf.c
@@ -197,7 +197,7 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
-					.level = prev->sched_task_group->css.cgroup->level,
+					.level = current->sched_task_group->css.cgroup->level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/samplers/syscall/linux/counts/mod.bpf.c
@@ -197,6 +197,7 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
+					.level = prev->sched_task_group->css.cgroup.level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/samplers/syscall/linux/counts/mod.bpf.c
@@ -197,7 +197,7 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
 					.id = cgroup_id,
-					.level = prev->sched_task_group->css.cgroup.level,
+					.level = prev->sched_task_group->css.cgroup->level,
 				};
 
 				// read the cgroup name

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -44,29 +44,39 @@ fn handle_event(data: &[u8]) -> i32 {
             .replace("\\x2d", "-");
 
         let name = if !gpname.is_empty() {
-            format!("{gpname}/{pname}/{name}")
+            if cgroup_info.level > 3 {
+                format!(".../{gpname}/{pname}/{name}")
+            } else {
+                format!("/{gpname}/{pname}/{name}")
+            }
         } else if !pname.is_empty() {
-            format!("{pname}/{name}")
+            format!("/{pname}/{name}")
+        } else if !name.is_empty() {
+            format!("/{name}")
         } else {
-            name.to_string()
+            "".to_string()
         };
 
         let id = cgroup_info.id;
 
-        if !name.is_empty() {
-            CGROUP_SYSCALL_OTHER.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_READ.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_WRITE.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_POLL.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_LOCK.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_TIME.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_SLEEP.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_SOCKET.insert_metadata(id as usize, "name".to_string(), name.clone());
-            CGROUP_SYSCALL_YIELD.insert_metadata(id as usize, "name".to_string(), name);
-        }
+        set_name(id, name)
     }
 
     0
+}
+
+fn set_name(id: usize, name: String) {
+    if !name.is_empty() {
+        CGROUP_SYSCALL_OTHER.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_READ.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_WRITE.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_POLL.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_LOCK.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_TIME.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_SLEEP.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_SOCKET.insert_metadata(id as usize, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_YIELD.insert_metadata(id as usize, "name".to_string(), name);
+    }
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -74,6 +84,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
     }
+
+    set_name(1, "/".to_string());
 
     let counters = vec![
         &SYSCALL_OTHER,

--- a/src/samplers/syscall/linux/counts/mod.rs
+++ b/src/samplers/syscall/linux/counts/mod.rs
@@ -59,7 +59,7 @@ fn handle_event(data: &[u8]) -> i32 {
 
         let id = cgroup_info.id;
 
-        set_name(id, name)
+        set_name(id as usize, name)
     }
 
     0
@@ -67,15 +67,15 @@ fn handle_event(data: &[u8]) -> i32 {
 
 fn set_name(id: usize, name: String) {
     if !name.is_empty() {
-        CGROUP_SYSCALL_OTHER.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_READ.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_WRITE.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_POLL.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_LOCK.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_TIME.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_SLEEP.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_SOCKET.insert_metadata(id as usize, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_YIELD.insert_metadata(id as usize, "name".to_string(), name);
+        CGROUP_SYSCALL_OTHER.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_READ.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_WRITE.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_POLL.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_LOCK.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_TIME.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_SLEEP.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_SOCKET.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_SYSCALL_YIELD.insert_metadata(id, "name".to_string(), name);
     }
 }
 


### PR DESCRIPTION
cgroup names will now be prefixed with a `/` when it is known to be an absolute path. `.../` indicates that the name is a partial name, this will happen if the cgroup level is deeper than 3.

Root cgroup (id 1) will now have `/` for its name instead of being unlabeled.
