### PR TITLE
add metrics for tlb_flush events

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ mod bpf {
         ("blockio", "requests"),
         ("cpu", "frequency"),
         ("cpu", "perf"),
+        ("cpu", "tlb_flush"),
         ("cpu", "usage"),
         ("network", "traffic"),
         ("scheduler", "runqueue"),

--- a/src/samplers/cpu/linux/mod.rs
+++ b/src/samplers/cpu/linux/mod.rs
@@ -1,4 +1,5 @@
 mod cores;
 mod frequency;
 mod perf;
+mod tlb_flush;
 mod usage;

--- a/src/samplers/cpu/linux/tlb_flush/mod.bpf.c
+++ b/src/samplers/cpu/linux/tlb_flush/mod.bpf.c
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2025 The Rezolus Authors
+
+// This BPF program tracks tlb_flush events
+
+#include <vmlinux.h>
+#include "../../../common/bpf/helpers.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define COUNTER_GROUP_WIDTH 8
+#define MAX_CPUS 1024
+
+// counters for tlb_flush events
+// 0 - task_switch
+// 1 - remote shootdown
+// 2 - local shootdown
+// 3 - local mm shootdown
+// 4 - remote send ipi
+//
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
+} events SEC(".maps");
+
+SEC("raw_tp/tlb_flush")
+int BPF_PROG(tlb_flush, int reason, u64 pages)
+{
+	u32 offset, idx;
+
+	offset = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id();
+
+	idx = reason + offset;
+
+	array_incr(&events, idx);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/samplers/cpu/linux/tlb_flush/mod.rs
+++ b/src/samplers/cpu/linux/tlb_flush/mod.rs
@@ -1,0 +1,63 @@
+//! Collects tlb flush event information using BPF and traces:
+//! * `tlb_flush`
+//!
+//! And produces these stats:
+//! * `cpu_tlb_flush`
+//!
+//! These stats can be used to understand the reason for TLB flushes.
+
+const NAME: &str = "cpu_tlb_flush";
+
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/cpu_tlb_flush.bpf.rs"));
+}
+
+use bpf::*;
+
+use crate::common::*;
+use crate::*;
+
+use std::sync::Arc;
+
+mod stats;
+
+use stats::*;
+
+#[distributed_slice(SAMPLERS)]
+fn init(config: Arc<Config>) -> SamplerResult {
+    if !config.enabled(NAME) {
+        return Ok(None);
+    }
+
+    let events = vec![
+        &TLB_FLUSH_TASK_SWITCH,
+        &TLB_FLUSH_REMOTE_SHOOTDOWN,
+        &TLB_FLUSH_LOCAL_SHOOTDOWN,
+        &TLB_FLUSH_LOCAL_MM_SHOOTDOWN,
+        &TLB_FLUSH_REMOTE_SEND_IPI,
+    ];
+
+    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+        .cpu_counters("events", events)
+        .build()?;
+
+    Ok(Some(Box::new(bpf)))
+}
+
+impl SkelExt for ModSkel<'_> {
+    fn map(&self, name: &str) -> &libbpf_rs::Map {
+        match name {
+            "events" => &self.maps.events,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl OpenSkelExt for ModSkel<'_> {
+    fn log_prog_instructions(&self) {
+        debug!(
+            "{NAME} tlb_flush() BPF instruction count: {}",
+            self.progs.tlb_flush.insn_cnt()
+        );
+    }
+}

--- a/src/samplers/cpu/linux/tlb_flush/stats.rs
+++ b/src/samplers/cpu/linux/tlb_flush/stats.rs
@@ -1,0 +1,40 @@
+use metriken::*;
+
+use crate::common::*;
+
+// per-CPU metrics
+
+#[metric(
+    name = "cpu_tlb_flush",
+    description = "The number of tlb_flush events",
+    metadata = { reason = "task_switch" }
+)]
+pub static TLB_FLUSH_TASK_SWITCH: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "cpu_tlb_flush",
+    description = "The number of tlb_flush events",
+    metadata = { reason = "remote_shootdown" }
+)]
+pub static TLB_FLUSH_REMOTE_SHOOTDOWN: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "cpu_tlb_flush",
+    description = "The number of tlb_flush events",
+    metadata = { reason = "local_shootdown" }
+)]
+pub static TLB_FLUSH_LOCAL_SHOOTDOWN: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "cpu_tlb_flush",
+    description = "The number of tlb_flush events",
+    metadata = { reason = "local_mm_shootdown" }
+)]
+pub static TLB_FLUSH_LOCAL_MM_SHOOTDOWN: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "cpu_tlb_flush",
+    description = "The number of tlb_flush events",
+    metadata = { reason = "remote_send_ipi" }
+)]
+pub static TLB_FLUSH_REMOTE_SEND_IPI: CounterGroup = CounterGroup::new(MAX_CPUS);


### PR DESCRIPTION
Adds metrics for tlb_flush events to provide insight into the rate and reason of TLB flush events.
