### PR TITLE
fix: remove slash rewriting in prometheus exposition

### DIFF
--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -291,10 +291,7 @@ async fn prometheus(State(state): State<Arc<AppState>>) -> String {
 
     data.sort();
     data.dedup();
-    let mut content = data.join("\n");
-    content += "\n";
-    let parts: Vec<&str> = content.split('/').collect();
-    parts.join("_")
+    data.join("\n") + "\n"
 }
 
 async fn root() -> String {


### PR DESCRIPTION
The rewriting of `/` to `_` in prometheus exposition is no longer needed and complicates the exposition of the cgroup names in a legible manner.

This removes the string replacement that was being done. All metric names have already had the slashes replaced, so this change does not break the exposition format or metric names.

After this change, cgroup names as collected on the prometheus endpoint will have forward slashes used to indicate the cgroup hierarchy.
