### PR TITLE
fix: flight-recorder off-by-one error while writing artifact

### DIFF
--- a/src/flight_recorder.rs
+++ b/src/flight_recorder.rs
@@ -314,13 +314,14 @@ pub fn run(config: Config) {
             let _ = destination.set_len(0);
 
             // handle any output format specific transforms
+            //
+            // note: as the idx is the position we will write to next, it is
+            //       also the position to start reading from
             match config.format {
                 Format::Raw => {
                     debug!("capturing ringbuffer and writing to raw");
 
-                    for offset in 1..=snapshot_count {
-                        // we start at the last recorded index + 1 to get the oldest
-                        // record first
+                    for offset in 0..snapshot_count {
                         let mut i = idx + offset;
 
                         // handle wrap-around in the ring-buffer
@@ -380,9 +381,7 @@ pub fn run(config: Config) {
                         }
                     };
 
-                    for offset in 1..=snapshot_count {
-                        // we start at the last recorded index + 1 to get the oldest
-                        // record first
+                    for offset in 0..snapshot_count {
                         let mut i = idx + offset;
 
                         // handle wrap-around in the ring-buffer


### PR DESCRIPTION
Fixes a simple off-by-one error when writing out the packed msgpack artifact.

Previously, the oldest sample mistakenly is placed at the end of the artifact. This may cause issues if the consumer expects the timestamps to be monotonically nondecreasing.

Corrects the error and fixes up the comments so it's clearer going forward.
