### PR TITLE
[RFC] Add a rezolus metrics subscription endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,9 +2192,11 @@ name = "rezolus"
 version = "5.0.0-alpha.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "axum",
  "backtrace",
+ "bytes",
  "chrono",
  "clap",
  "clocksource",
@@ -2182,6 +2206,7 @@ dependencies = [
  "h2",
  "histogram",
  "http",
+ "http-body",
  "humantime",
  "lazy_static",
  "libbpf-cargo",
@@ -2198,6 +2223,7 @@ dependencies = [
  "perf-event2",
  "plain",
  "reqwest",
+ "rezolus-exposition",
  "ringlog",
  "rmp-serde",
  "serde",
@@ -2210,6 +2236,14 @@ dependencies = [
  "tower",
  "tower-http",
  "walkdir",
+]
+
+[[package]]
+name = "rezolus-exposition"
+version = "0.1.0"
+dependencies = [
+ "histogram",
+ "serde",
 ]
 
 [[package]]
@@ -2496,6 +2530,16 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "systeminfo"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ metriken-exposition = "0.10.0"
 ouroboros = "0.18.4"
 parking_lot = "0.12.3"
 reqwest = { version = "0.12.9", default-features = false, features = ["blocking"] }
+rezolus-exposition = { path = "./crates/rezolus-exposition" }
 ringlog = "0.8.0"
 rmp-serde = "1.1.2"
 serde = { version = "1.0.209", features = ["derive"] }
@@ -46,6 +47,9 @@ walkdir = "2.5.0"
 plain = "0.2.3"
 core_affinity = "0.8.1"
 chrono = "0.4.39"
+async-stream = "0.3.6"
+http-body = "1.0.1"
+bytes = "1.10.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.24.8" }
@@ -75,3 +79,9 @@ assets = [
 ]
 post_install_script = "rpm/systemd-start.sh"
 pre_uninstall_script = "rpm/systemd-stop.sh"
+
+[workspace]
+members = [
+    ".",
+    "./crates/*"
+, "crates/rezolus-exposition"]

--- a/crates/rezolus-exposition/Cargo.toml
+++ b/crates/rezolus-exposition/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rezolus-exposition"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+histogram = { version = "0.11.2", features = ["serde"] }
+serde = { version = "1.0.217", features = ["derive"] }

--- a/crates/rezolus-exposition/src/lib.rs
+++ b/crates/rezolus-exposition/src/lib.rs
@@ -1,0 +1,126 @@
+//! Type definitions for the wire protocol making up the metrics subscription
+//! endpoint for rezolus.
+//!
+//! # Wire Protocol
+//! The wire protocol is a series a message frames made up as follows:
+//! - An 8-byte little-endian header describing the length of the frame.
+//!   This length does not include the 8 bytes for the length.
+//! - A msgpack-serialized [`Message`] instance with the relevant message data.
+//!
+//! Rezolus will push messages down the connection. If the client does not
+//! manage to keep up with the connection then rezolus will drop snapshot
+//! messages until the client catches back up. No other message type will be
+//! dropped.
+//!
+//! # Message Protocol
+//! The message protocol always starts with a [`Message::Metadata`] message
+//! that provides protocol-level metadata.
+//!
+//! After that the connection will periodically send the following messages:
+//! - [`Message::Info`] is sent in order to provide information on new metrics
+//!   being emitted via the subscription. An info frame for a metric will
+//!   always be emitted before that metric is emitted as part of a snapshot.
+//! - [`Message::Snapshot`] is sent periodically with a snapshot of all metrics
+//!   that are emitted by rezolus.
+//! - [`Message::Lost`] is sent after snapshots are lost due to the client not
+//!   consuming them quickly enough or due to rezolus not being able to emit
+//!   them fast enough.
+
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Message {
+    /// Connection-level metadata information.
+    ///
+    /// This will always be the first message emitted on a new connection.
+    Metadata(Metadata),
+
+    /// Metadata information about future metrics that will be emitted.
+    ///
+    /// Rezolus will always emit a [`MetricInfo`] entry for a given metric ID
+    /// _before_ that metric is emitted in a snapshot.
+    Info(Vec<MetricInfo>),
+
+    /// A snapshot of metrics exported by rezolus at a given point in time.
+    Snapshot(Snapshot),
+
+    /// An indication that some number of snapshots have been lost because the
+    /// reader was not consuming messages quickly enough.
+    Lost(u64),
+
+    #[doc(hidden)]
+    #[serde(other)]
+    __Other,
+}
+
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum MetricType {
+    Counter = 0,
+    Gauge = 1,
+    Histogram = 2,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MetricInfo {
+    /// The name of this metric.
+    ///
+    /// This will be used to identify the metric in future messages.
+    pub name: String,
+
+    /// The type of this metric.
+    #[serde(rename = "type")]
+    pub ty: MetricType,
+
+    /// Metadata for this metric.
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Metadata {
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Snapshot {
+    /// The timestamp that this snapshot was recorded at.
+    pub timestamp: SystemTime,
+
+    pub counters: Vec<Counter>,
+    pub gauges: Vec<Gauge>,
+    pub histograms: Vec<Histogram>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Counter {
+    /// A unique name for this counter.
+    ///
+    /// This will correspond to a previously emitted [`MetricInfo`] in an
+    /// `Info` message.
+    pub name: String,
+    pub value: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Gauge {
+    /// A unique name for this counter.
+    ///
+    /// This will correspond to a previously emitted [`MetricInfo`] in an
+    /// `Info` message.
+    pub name: String,
+    pub value: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Histogram {
+    /// A unique name for this counter.
+    ///
+    /// This will correspond to a previously emitted [`MetricInfo`] in an
+    /// `Info` message.
+    pub name: String,
+    pub value: histogram::Histogram,
+}

--- a/crates/systeminfo/Cargo.toml
+++ b/crates/systeminfo/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "systeminfo"
 edition = "2021"
-version = { workspace = true }
-license = { workspace = true }
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [features]

--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -11,6 +11,7 @@ use tower::ServiceBuilder;
 use tower_http::{compression::CompressionLayer, decompression::RequestDecompressionLayer};
 
 mod snapshot;
+mod subscribe;
 
 use snapshot::Snapshot;
 
@@ -52,6 +53,7 @@ fn app(state: Arc<AppState>) -> Router {
         .route("/", get(root))
         .route("/metrics", get(prometheus))
         .route("/metrics/binary", get(msgpack))
+        .route("/metrics/subscribe", get(subscribe::subscribe))
         .with_state(state)
         .layer(
             ServiceBuilder::new()

--- a/src/exposition/http/subscribe.rs
+++ b/src/exposition/http/subscribe.rs
@@ -1,0 +1,325 @@
+use std::collections::{HashMap, HashSet};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, SystemTime};
+
+use axum::body::{Body, Bytes};
+use futures::Stream;
+use http_body::Frame;
+use metriken::{RwLockHistogram, Value};
+use rezolus_exposition::*;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::Mutex;
+use tokio::time::{Instant, MissedTickBehavior};
+
+use crate::common::{CounterGroup, GaugeGroup};
+
+#[derive(Default)]
+struct Shared {
+    lost: u64,
+    info: Vec<MetricInfo>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct SubscribeQueryParams {
+    /// The sampling interval, in milliseconds.
+    #[serde(default = "default_u64::<1000>")]
+    pub interval: u64,
+}
+
+const fn default_u64<const C: u64>() -> u64 {
+    C
+}
+
+pub(super) async fn subscribe(
+    query: axum::extract::Query<SubscribeQueryParams>,
+) -> axum::body::Body {
+    let duration = Duration::from_millis(query.interval).max(Duration::from_millis(100));
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    let shared = Arc::new(Mutex::new(Shared::default()));
+
+    let recorder = AbortJoinHandle(tokio::task::spawn(record(shared.clone(), tx, duration)));
+    let stream = async_stream::try_stream! {
+        let _task = recorder;
+
+        yield Message::Metadata(Metadata {
+            metadata: HashMap::from([
+                ("source".to_string(), env!("CARGO_BIN_NAME").to_string()),
+                ("version".to_string(), env!("CARGO_PKG_VERSION").to_string())
+            ])
+        });
+
+        loop {
+            let snapshot = match rx.recv().await {
+                Some(snapshot) => snapshot,
+                None => break,
+            };
+
+            let (info, lost) = {
+                let mut shared = shared.lock().await;
+                (
+                    std::mem::take(&mut shared.info),
+                    std::mem::take(&mut shared.lost)
+                )
+            };
+
+            if !info.is_empty() {
+                yield Message::Info(info);
+            }
+
+            if lost != 0 {
+                yield Message::Lost(lost);
+            }
+
+            yield Message::Snapshot(snapshot);
+        }
+    };
+
+    Body::new(ExpositionMessageStreamBody::new(stream))
+}
+
+/// Return a start time that is aligned to the last multiple of duration.
+///
+/// Multiple 0 is considered to be aligned to the unix epoch.
+fn align_start_to_duration_edge(duration: Duration) -> Instant {
+    let now_sys = SystemTime::now();
+    let now_ins = Instant::now();
+
+    let unix = now_sys.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+    let offset = unix.as_nanos() % duration.as_nanos();
+    let offset = Duration::new((offset / 1_000_000_000) as _, (offset % 1_000_000_000) as _);
+
+    now_ins - offset
+}
+
+async fn record(shared: Arc<Mutex<Shared>>, tx: Sender<Snapshot>, duration: Duration) {
+    let start = align_start_to_duration_edge(duration);
+    let mut interval = tokio::time::interval_at(start, duration);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    let mut known = HashSet::<String>::new();
+    let mut prev = start;
+    let mut infos = Vec::new();
+
+    loop {
+        // First figure out how many samples have been lost, if any.
+        let current = interval.tick().await;
+        let step = current - prev;
+        let lost = step.div_duration_f32(duration) as u64;
+        prev = current;
+
+        let mut snapshot = Snapshot {
+            timestamp: SystemTime::now(),
+            counters: Vec::new(),
+            gauges: Vec::new(),
+            histograms: Vec::new(),
+        };
+
+        'metric: for (metric_id, metric) in metriken::metrics().iter().enumerate() {
+            let value = metric.value();
+            if value.is_none() {
+                continue;
+            }
+
+            let name = metric.name();
+            if name.starts_with("log_") {
+                continue;
+            }
+
+            match value {
+                Some(Value::Counter(value)) => {
+                    let name = metric_id.to_string();
+
+                    if known.insert(name.clone()) {
+                        infos.push(MetricInfo {
+                            name: name.clone(),
+                            ty: MetricType::Counter,
+                            metadata: HashMap::from_iter([("metric".to_owned(), name.to_string())]),
+                        });
+                    }
+
+                    snapshot.counters.push(Counter { name, value })
+                }
+                Some(Value::Gauge(value)) => {
+                    let name = metric_id.to_string();
+
+                    if known.insert(name.clone()) {
+                        infos.push(MetricInfo {
+                            name: name.clone(),
+                            ty: MetricType::Gauge,
+                            metadata: HashMap::from_iter([("metric".to_owned(), name.to_string())]),
+                        });
+                    }
+
+                    snapshot.gauges.push(Gauge { name, value })
+                }
+                Some(Value::Other(any)) => {
+                    if let Some(histogram) = any.downcast_ref::<RwLockHistogram>() {
+                        let value = match histogram.load() {
+                            Some(value) => value,
+                            None => continue 'metric,
+                        };
+                        let name = metric_id.to_string();
+
+                        if known.insert(name.clone()) {
+                            infos.push(MetricInfo {
+                                name: name.clone(),
+                                ty: MetricType::Histogram,
+                                metadata: HashMap::from_iter([
+                                    ("metric".to_owned(), name.to_owned()),
+                                    (
+                                        "grouping_power".to_owned(),
+                                        histogram.config().grouping_power().to_string(),
+                                    ),
+                                    (
+                                        "max_value_power".to_owned(),
+                                        histogram.config().max_value_power().to_string(),
+                                    ),
+                                ]),
+                            });
+                        }
+
+                        snapshot.histograms.push(Histogram { name, value });
+                    } else if let Some(counters) = any.downcast_ref::<CounterGroup>() {
+                        let c = match counters.load() {
+                            Some(counters) => counters,
+                            None => continue 'metric,
+                        };
+
+                        for (counter_id, counter) in c.iter().enumerate() {
+                            if *counter == 0 {
+                                continue;
+                            }
+
+                            let name = format!("{metric_id}x{counter_id}");
+                            if known.insert(name.clone()) {
+                                let mut metadata = HashMap::from_iter([
+                                    ("metric".to_owned(), name.to_owned()),
+                                    ("id".to_owned(), counter_id.to_string()),
+                                ]);
+                                metadata.extend(
+                                    counters.load_metadata(counter_id).into_iter().flatten(),
+                                );
+
+                                infos.push(MetricInfo {
+                                    name: name.clone(),
+                                    ty: MetricType::Counter,
+                                    metadata,
+                                })
+                            }
+
+                            snapshot.counters.push(Counter {
+                                name,
+                                value: *counter,
+                            });
+                        }
+                    } else if let Some(gauges) = any.downcast_ref::<GaugeGroup>() {
+                        let g = match gauges.load() {
+                            Some(g) => g,
+                            None => continue 'metric,
+                        };
+
+                        for (gauge_id, gauge) in g.iter().enumerate() {
+                            if *gauge == i64::MIN {
+                                continue;
+                            }
+
+                            let name = format!("{metric_id}x{gauge_id}");
+                            if known.insert(name.clone()) {
+                                let mut metadata = HashMap::from_iter([
+                                    ("metric".to_owned(), name.to_owned()),
+                                    ("id".to_owned(), gauge_id.to_string()),
+                                ]);
+                                metadata
+                                    .extend(gauges.load_metadata(gauge_id).into_iter().flatten());
+
+                                infos.push(MetricInfo {
+                                    name: name.clone(),
+                                    ty: MetricType::Counter,
+                                    metadata,
+                                });
+                            }
+
+                            snapshot.gauges.push(Gauge {
+                                name,
+                                value: *gauge,
+                            });
+                        }
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        let mut shared = shared.lock().await;
+        shared.lost += lost;
+        shared.info.append(&mut infos);
+
+        match tx.try_send(snapshot) {
+            Ok(()) => (),
+            Err(TrySendError::Full(_)) => shared.lost += 1,
+            Err(TrySendError::Closed(_)) => break,
+        }
+    }
+}
+
+struct ExpositionMessageStreamBody<S> {
+    stream: S,
+}
+
+impl<S> ExpositionMessageStreamBody<S>
+where
+    S: Stream<Item = Result<Message, axum::BoxError>>,
+{
+    pub fn new(stream: S) -> Self {
+        Self { stream }
+    }
+}
+
+impl<S> ExpositionMessageStreamBody<S> {
+    fn project(self: Pin<&mut Self>) -> Pin<&mut S> {
+        // SAFETY: We do not move the inner field.
+        unsafe { self.map_unchecked_mut(|this| &mut this.stream) }
+    }
+}
+
+impl<S> axum::body::HttpBody for ExpositionMessageStreamBody<S>
+where
+    S: Stream<Item = Result<Message, axum::BoxError>>,
+{
+    type Data = Bytes;
+    type Error = axum::BoxError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let stream = self.project();
+
+        let message = match std::task::ready!(stream.poll_next(cx)) {
+            Some(Ok(message)) => message,
+            Some(Err(e)) => return Poll::Ready(Some(Err(e))),
+            None => return Poll::Ready(None),
+        };
+
+        let mut bytes = vec![0u8; 8];
+        if let Err(e) = rmp_serde::encode::write(&mut bytes, &message) {
+            return Poll::Ready(Some(Err(e.into())));
+        };
+
+        let len = bytes.len();
+        bytes[..8].copy_from_slice(&u64::to_le_bytes((len - 8) as u64));
+
+        Poll::Ready(Some(Ok(Frame::data(bytes.into()))))
+    }
+}
+
+struct AbortJoinHandle<T>(tokio::task::JoinHandle<T>);
+
+impl<T> Drop for AbortJoinHandle<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}


### PR DESCRIPTION
We've had a few concerns with jitter and overhead with rezolus. I originally started writing this as an experiment to see how it would look to add a subscription endpoint.

Here were my goals/constraints when designing this:
- Metadata for metrics is only sent once per metric.
- There is no unbounded memory usage on the rezolus end, there will be at most 3 snapshots being stored concurrently (1 being sent, 1 buffered, and 1 being recorded). Extra snapshots will be dropped if they are not sent in time.
- Snapshots only contain the metric id and value and nothing else.
- The protocol allows for recovering from parsing errors. Individual frames are prefixed with their length, so if a frame fails to parse then it can be skipped without having to drop the stream.
- Snapshot frequency is driven by rezolus itself, although it is configured by a query parameter.

Here's how it works. There are (currently) 4 different frame types:
- An initial metadata frame with connection-level metadata.
- A metric info frame with metadata info about metrics. A metadata entry is sent once per metric (before it shows up in a snapshot) but an info frame can contain info on multiple metrics.
- A snapshot frame which contains metric ids and values.
- A frame that indicates some number of snapshots have been lost.

I have ultimately settled on using the metric names as the metric id as I found that to be more convenient. The code could be optimized a bit to reduce allocations by using a small-string library, but I have ignored that for this PR.