### PR TITLE
report time as start of snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4705165958c21932a7ff376d889203312c8587531321067d2659ce1eb11400"
+checksum = "59367fe19bb1623684f4faa1ab7e5c9e8ec11b2693a8bfc903d8ac6739c2189f"
 dependencies = [
  "arrow",
  "chrono",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.0.0-alpha.2"
+version = "5.0.0-alpha.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "5.0.0-alpha.2"
+version = "5.0.0-alpha.3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "High resolution systems performance telemetry agent"
@@ -27,7 +27,7 @@ libc = "0.2.158"
 linkme = "0.3.28"
 memmap2 = "0.9.4"
 metriken = "0.7.0"
-metriken-exposition = "0.11.1"
+metriken-exposition = "0.12.0"
 ouroboros = "0.18.4"
 parking_lot = "0.12.3"
 reqwest = { version = "0.12.9", default-features = false, features = ["blocking"] }

--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -1,4 +1,3 @@
-use std::time::SystemTime;
 use crate::common::*;
 use crate::debug;
 use crate::{Arc, Config, Sampler};
@@ -7,6 +6,7 @@ use axum::routing::get;
 use axum::Router;
 use metriken::{RwLockHistogram, Value};
 use std::time::Instant;
+use std::time::SystemTime;
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_http::{compression::CompressionLayer, decompression::RequestDecompressionLayer};

--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -1,15 +1,15 @@
 use crate::common::*;
-use crate::debug;
-use crate::{Arc, Config, Sampler};
+use crate::{debug, Arc, Config, Sampler};
+
 use axum::extract::State;
 use axum::routing::get;
 use axum::Router;
 use metriken::{RwLockHistogram, Value};
-use std::time::Instant;
-use std::time::SystemTime;
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_http::{compression::CompressionLayer, decompression::RequestDecompressionLayer};
+
+use std::time::{Instant, SystemTime};
 
 mod snapshot;
 

--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -60,14 +60,12 @@ fn app(state: Arc<AppState>) -> Router {
 }
 
 async fn msgpack(State(state): State<Arc<AppState>>) -> Vec<u8> {
-    let ts = SystemTime::now();
+    let timestamp = SystemTime::now();
     let start = Instant::now();
 
     state.refresh().await;
 
-    let duration = start.elapsed();
-
-    let snapshot = snapshot::create(ts, duration);
+    let snapshot = snapshot::create(timestamp, start.elapsed());
 
     rmp_serde::encode::to_vec(&snapshot).expect("failed to serialize snapshot")
 }

--- a/src/exposition/http/snapshot.rs
+++ b/src/exposition/http/snapshot.rs
@@ -1,14 +1,16 @@
+use std::time::Duration;
 use crate::exposition::http::CounterGroup;
 use crate::exposition::http::GaugeGroup;
 use metriken::RwLockHistogram;
 use metriken::Value;
-use metriken_exposition::{Counter, Gauge, Histogram, Snapshot};
+use metriken_exposition::{Counter, Gauge, Histogram, Snapshot, SnapshotV2};
 use std::collections::HashMap;
 use std::time::SystemTime;
 
-pub fn create() -> Snapshot {
-    let mut s = Snapshot {
-        systemtime: SystemTime::now(),
+pub fn create(timestamp: SystemTime, duration: Duration) -> Snapshot {
+    let mut s = SnapshotV2 {
+        systemtime: timestamp,
+        duration,
         metadata: [
             ("source".to_string(), env!("CARGO_BIN_NAME").to_string()),
             ("version".to_string(), env!("CARGO_PKG_VERSION").to_string()),
@@ -123,5 +125,5 @@ pub fn create() -> Snapshot {
         }
     }
 
-    s
+    Snapshot::V2(s)
 }

--- a/src/exposition/http/snapshot.rs
+++ b/src/exposition/http/snapshot.rs
@@ -1,10 +1,10 @@
-use std::time::Duration;
 use crate::exposition::http::CounterGroup;
 use crate::exposition::http::GaugeGroup;
 use metriken::RwLockHistogram;
 use metriken::Value;
 use metriken_exposition::{Counter, Gauge, Histogram, Snapshot, SnapshotV2};
 use std::collections::HashMap;
+use std::time::Duration;
 use std::time::SystemTime;
 
 pub fn create(timestamp: SystemTime, duration: Duration) -> Snapshot {

--- a/src/exposition/http/snapshot.rs
+++ b/src/exposition/http/snapshot.rs
@@ -1,11 +1,10 @@
-use crate::exposition::http::CounterGroup;
-use crate::exposition::http::GaugeGroup;
-use metriken::RwLockHistogram;
-use metriken::Value;
+use crate::exposition::http::{CounterGroup, GaugeGroup};
+
+use metriken::{RwLockHistogram, Value};
 use metriken_exposition::{Counter, Gauge, Histogram, Snapshot, SnapshotV2};
+
 use std::collections::HashMap;
-use std::time::Duration;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 pub fn create(timestamp: SystemTime, duration: Duration) -> Snapshot {
     let mut s = SnapshotV2 {


### PR DESCRIPTION
Previously, we used the end of the refresh of all samplers as the timestamp for our metrics snapshots. With the changes in metriken to support reporting both a timestamp and duration in the snapshot, we update to using the start edge and the new snapshot v2 format.

Prometheus exposition is updated to also use the start edge as this time is likely to better reflect when metrics are read out.
