### PR TITLE
track softirq cpu usage with its own tracepoints

### DIFF
--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -92,7 +92,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
+	__uint(max_entries, MAX_CPUS * SOFTIRQ_GROUP_WIDTH);
 } softirq SEC(".maps");
 
 // per-cpu softirq time in nanoseconds by category
@@ -111,7 +111,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
+	__uint(max_entries, MAX_CPUS * SOFTIRQ_GROUP_WIDTH);
 } softirq_time SEC(".maps");
 
 // per-cpu cpu usage tracking in nanoseconds by category
@@ -120,7 +120,7 @@ struct {
 	__uint(map_flags, BPF_F_MMAPABLE);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(max_entries, MAX_CPUS * COUNTER_GROUP_WIDTH);
+	__uint(max_entries, MAX_CPUS * CPU_USAGE_GROUP_WIDTH);
 } cpu_usage SEC(".maps");
 
 // per-cgroup user

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -338,7 +338,7 @@ int softirq_exit(struct trace_event_raw_softirq *args)
 {
 	u32 cpu = bpf_get_smp_processor_id();
 	u64 *elem, *start_ts, dur = 0;
-	u32 offset, idx, group = 0;
+	u32 idx, group = 0;
 
 	u32 irq_id = 0;
 
@@ -354,11 +354,11 @@ int softirq_exit(struct trace_event_raw_softirq *args)
 	dur = bpf_ktime_get_ns() - *start_ts;
 
 	// update the cpu usage
-	offset = CPU_USAGE_GROUP_WIDTH * cpu + SOFTIRQ_OFFSET;
+	idx = CPU_USAGE_GROUP_WIDTH * cpu + SOFTIRQ_OFFSET;
 	array_add(&cpu_usage, idx, dur);
 
 	// update the softirq time
-	offset = SOFTIRQ_GROUP_WIDTH * cpu + args->vec;
+	idx = SOFTIRQ_GROUP_WIDTH * cpu + args->vec;
 	array_add(&softirq_time, idx, dur);
 
 	// clear the start timestamp

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -319,7 +319,7 @@ int softirq_enter(struct trace_event_raw_softirq *args)
 
 	u32 idx = cpu * SOFTIRQ_GROUP_WIDTH + args->vec;
 
-	bpf_map_update_elem(&start, &cpu, &ts, 0);
+	bpf_map_update_elem(&softirq_start, &cpu, &ts, 0);
 	array_incr(&softirq, idx);
 
 	return 0;
@@ -335,7 +335,7 @@ int softirq_exit(struct trace_event_raw_softirq *args)
 	u32 irq_id = 0;
 
 	// lookup the start time
-	start_ts = bpf_map_lookup_elem(&start, &cpu);
+	start_ts = bpf_map_lookup_elem(&softirq_start, &cpu);
 
 	// possible we missed the start
 	if (!start_ts || *start_ts == 0) {

--- a/src/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/samplers/cpu/linux/usage/mod.bpf.c
@@ -115,6 +115,14 @@ struct {
 } softirq_time SEC(".maps");
 
 // per-cpu cpu usage tracking in nanoseconds by category
+// 0 - USER
+// 1 - NICE
+// 2 - SYSTEM
+// 3 - SOFTIRQ
+// 4 - IRQ
+// 5 - STEAL
+// 6 - GUEST
+// 7 - GUEST_NICE
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(map_flags, BPF_F_MMAPABLE);

--- a/src/samplers/cpu/linux/usage/mod.rs
+++ b/src/samplers/cpu/linux/usage/mod.rs
@@ -1,17 +1,17 @@
-/// Collects CPU usage stats using BPF and traces:
-/// * `cpuacct_account_field`
-/// * `softirq_entry`
-/// * `softirq_exit`
-///
-/// And produces these stats:
-/// * `cpu_usage`
-/// * `cgroup_cpu_usage`
-/// * `softirq`
-/// * `softirq_time`
-///
-/// Note: softirq is included because we need to trace softirq entry/exit in
-/// order to provide accurate accounting of cpu_usage for softirq. That makes
-/// these additional metrics free.
+//! Collects CPU usage stats using BPF and traces:
+//! * `cpuacct_account_field`
+//! * `softirq_entry`
+//! * `softirq_exit`
+//!
+//! And produces these stats:
+//! * `cpu_usage`
+//! * `cgroup_cpu_usage`
+//! * `softirq`
+//! * `softirq_time`
+//!
+//! Note: softirq is included because we need to trace softirq entry/exit in
+//! order to provide accurate accounting of cpu_usage for softirq. That makes
+//! these additional metrics free.
 
 const NAME: &str = "cpu_usage";
 

--- a/src/samplers/cpu/linux/usage/stats.rs
+++ b/src/samplers/cpu/linux/usage/stats.rs
@@ -121,3 +121,151 @@ pub static CGROUP_CPU_USAGE_GUEST: CounterGroup = CounterGroup::new(MAX_CGROUPS)
     metadata = { state = "guest_nice", unit = "nanoseconds" }
 )]
 pub static CGROUP_CPU_USAGE_GUEST_NICE: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+/*
+ * softirq metrics
+ */
+
+// softirq count by kind
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "hi" }
+)]
+pub static SOFTIRQ_HI: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "timer" }
+)]
+pub static SOFTIRQ_TIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "net_tx" }
+)]
+pub static SOFTIRQ_NET_TX: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "net_rx" }
+)]
+pub static SOFTIRQ_NET_RX: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "block" }
+)]
+pub static SOFTIRQ_BLOCK: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "irq_poll" }
+)]
+pub static SOFTIRQ_IRQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "tasklet" }
+)]
+pub static SOFTIRQ_TASKLET: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "sched" }
+)]
+pub static SOFTIRQ_SCHED: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "hrtimer" }
+)]
+pub static SOFTIRQ_HRTIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq",
+    description = "The count of softirqs",
+    metadata = { unit = "interrupts", kind = "rcu" }
+)]
+pub static SOFTIRQ_RCU: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+// softirq time by kind
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "hi" }
+)]
+pub static SOFTIRQ_HI: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "timer" }
+)]
+pub static SOFTIRQ_TIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "net_tx" }
+)]
+pub static SOFTIRQ_NET_TX: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "net_rx" }
+)]
+pub static SOFTIRQ_NET_RX: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "block" }
+)]
+pub static SOFTIRQ_BLOCK: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "irq_poll" }
+)]
+pub static SOFTIRQ_IRQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "tasklet" }
+)]
+pub static SOFTIRQ_TASKLET: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "sched" }
+)]
+pub static SOFTIRQ_SCHED: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "hrtimer" }
+)]
+pub static SOFTIRQ_HRTIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "softirq_time",
+    description = "The time spent in softirq handlers",
+    metadata = { unit = "nanoseconds", kind = "rcu" }
+)]
+pub static SOFTIRQ_RCU: CounterGroup = CounterGroup::new(MAX_CPUS);

--- a/src/samplers/cpu/linux/usage/stats.rs
+++ b/src/samplers/cpu/linux/usage/stats.rs
@@ -205,67 +205,67 @@ pub static SOFTIRQ_RCU: CounterGroup = CounterGroup::new(MAX_CPUS);
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "hi" }
 )]
-pub static SOFTIRQ_HI: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_HI: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "timer" }
 )]
-pub static SOFTIRQ_TIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_TIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "net_tx" }
 )]
-pub static SOFTIRQ_NET_TX: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_NET_TX: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "net_rx" }
 )]
-pub static SOFTIRQ_NET_RX: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_NET_RX: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "block" }
 )]
-pub static SOFTIRQ_BLOCK: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_BLOCK: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "irq_poll" }
 )]
-pub static SOFTIRQ_IRQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_ITIME_RQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "tasklet" }
 )]
-pub static SOFTIRQ_TASKLET: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_TASKLET: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "sched" }
 )]
-pub static SOFTIRQ_SCHED: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_SCHED: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "hrtimer" }
 )]
-pub static SOFTIRQ_HRTIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_HRTIMER: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "rcu" }
 )]
-pub static SOFTIRQ_RCU: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_RCU: CounterGroup = CounterGroup::new(MAX_CPUS);

--- a/src/samplers/cpu/linux/usage/stats.rs
+++ b/src/samplers/cpu/linux/usage/stats.rs
@@ -240,7 +240,7 @@ pub static SOFTIRQ_TIME_BLOCK: CounterGroup = CounterGroup::new(MAX_CPUS);
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "irq_poll" }
 )]
-pub static SOFTIRQ_ITIME_RQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_RQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",

--- a/src/samplers/cpu/linux/usage/stats.rs
+++ b/src/samplers/cpu/linux/usage/stats.rs
@@ -240,7 +240,7 @@ pub static SOFTIRQ_TIME_BLOCK: CounterGroup = CounterGroup::new(MAX_CPUS);
     description = "The time spent in softirq handlers",
     metadata = { unit = "nanoseconds", kind = "irq_poll" }
 )]
-pub static SOFTIRQ_TIME_RQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
+pub static SOFTIRQ_TIME_IRQ_POLL: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "softirq_time",


### PR DESCRIPTION
The cpu_usage accounting for softirq time is a bit inaccurate due to the tick based nature of the kernel function we probe.

To address the undercounting of softirq time, we add tracepoints for the softirq entry and exit and calculate time spent in the softirq handlers.

This makes it very low-cost to add additional metrics for tracking both softirq counts and softirq time by category. This will provide additional insight into the cause of high softirq time.
