### PR TITLE
change flight-recorder to use a config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ auto_req = "builtin"
 assets = [
     { source = "target/release/rezolus", dest = "/usr/bin/", mode = "755" },
     { source = "config/agent.toml", dest = "/etc/rezolus/", mode = "644" },
+    { source = "config/exporter.toml", dest = "/etc/rezolus/", mode = "644" },
+    { source = "config/flight-recorder.toml", dest = "/etc/rezolus/", mode = "644" },
     { source = "debian/rezolus.service", dest = "/usr/lib/systemd/system/", mode = "644" },
     { source = "debian/rezolus-exporter.service", dest = "/usr/lib/systemd/system/", mode = "644" },
     { source = "debian/rezolus-flight-recorder.service", dest = "/usr/lib/systemd/system/", mode = "644" },

--- a/config/exporter.toml
+++ b/config/exporter.toml
@@ -3,7 +3,7 @@
 listen = "0.0.0.0:4242"
 
 # Specify the address of the Rezolus Agent
-target = "127.0.0.1:4241"
+source = "127.0.0.1:4241"
 
 [log]
 # Controls the log level: "error", "warn", "info", "debug", "trace"

--- a/config/flight-recorder.toml
+++ b/config/flight-recorder.toml
@@ -1,0 +1,17 @@
+[general]
+# Specify the sampling interval
+interval = "1s"
+
+# Specify the address of the Rezolus Agent
+source = "127.0.0.1:4241"
+
+# Specify the path for output file. The directory for the output file is also
+# the location that is used for the ring buffer.
+output = "/tmp/rezolus.parquet"
+
+# Specify the output format
+format = "parquet"
+
+[log]
+# Controls the log level: "error", "warn", "info", "debug", "trace"
+level = "info"

--- a/debian/rezolus-flight-recorder.service
+++ b/debian/rezolus-flight-recorder.service
@@ -5,7 +5,7 @@ After=rezolus.service
 
 [Service]
 User=rezolus
-ExecStart=/usr/bin/rezolus flight-recorder http://localhost:4241 /tmp/flight-recorder.parquet
+ExecStart=/usr/bin/rezolus flight-recorder /etc/rezolus/flight-recorder.toml
 KillMode=control-group
 Restart=on-failure
 KillSignal=SIGKILL

--- a/src/exporter/config/general.rs
+++ b/src/exporter/config/general.rs
@@ -11,9 +11,9 @@ pub struct General {
     #[serde(default = "listen")]
     listen: String,
 
-    // the address of the Rezolus agent to target
-    #[serde(default = "target")]
-    target: String,
+    // the address of the Rezolus agent
+    #[serde(default = "source")]
+    source: String,
 }
 
 impl Default for General {
@@ -21,7 +21,7 @@ impl Default for General {
         Self {
             interval: interval(),
             listen: listen(),
-            target: target(),
+            source: source(),
         }
     }
 }
@@ -55,7 +55,7 @@ impl General {
     }
 
     pub fn target(&self) -> SocketAddr {
-        self.target
+        self.source
             .to_socket_addrs()
             .map_err(|e| {
                 eprintln!("bad target address: {e}");

--- a/src/flight_recorder/config/general.rs
+++ b/src/flight_recorder/config/general.rs
@@ -1,0 +1,73 @@
+use super::*;
+use crate::{Format, Url};
+
+#[derive(Deserialize)]
+pub struct General {
+    // how often to sample from the agent
+    #[serde(default = "interval")]
+    interval: String,
+
+    // the address of the Rezolus agent
+    #[serde(default = "source")]
+    source: String,
+
+    // the path for output file
+    #[serde(default = "output")]
+    output: String,
+
+    #[serde(default = "parquet")]
+    format: Format,
+}
+
+impl Default for General {
+    fn default() -> Self {
+        Self {
+            interval: interval(),
+            source: source(),
+            output: output(),
+            format: parquet(),
+        }
+    }
+}
+
+impl General {
+    pub fn check(&self) {
+        if let Err(e) = self.interval.parse::<humantime::Duration>() {
+            eprintln!("prometheus sample interval couldn't be parsed: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    pub fn output(&self) -> PathBuf {
+        self.output.clone().into()
+    }
+
+    pub fn format(&self) -> Format {
+        self.format
+    }
+
+    pub fn interval(&self) -> humantime::Duration {
+        self.interval.parse().unwrap()
+    }
+
+    pub fn source(&self) -> SocketAddr {
+        self.source
+            .to_socket_addrs()
+            .map_err(|e| {
+                eprintln!("bad source address: {e}");
+                std::process::exit(1);
+            })
+            .unwrap()
+            .next()
+            .ok_or_else(|| {
+                eprintln!("could not resolve source socket addr");
+                std::process::exit(1);
+            })
+            .unwrap()
+    }
+
+    pub fn url(&self) -> Url {
+        let source = self.source();
+        Url::try_from(format!("http://{source}/metrics/binary").as_str()).unwrap()
+    }
+}

--- a/src/flight_recorder/config/log.rs
+++ b/src/flight_recorder/config/log.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+#[derive(Deserialize)]
+pub struct Log {
+    #[serde(with = "LevelDef")]
+    #[serde(default = "log_level")]
+    level: Level,
+}
+
+impl Default for Log {
+    fn default() -> Self {
+        Self { level: log_level() }
+    }
+}
+
+impl Log {
+    pub fn level(&self) -> Level {
+        self.level
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[serde(remote = "Level")]
+#[serde(deny_unknown_fields)]
+enum LevelDef {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+fn log_level() -> Level {
+    Level::Info
+}

--- a/src/flight_recorder/config/mod.rs
+++ b/src/flight_recorder/config/mod.rs
@@ -1,20 +1,17 @@
-use crate::common::HISTOGRAM_GROUPING_POWER;
-use clap::ArgMatches;
-use std::path::PathBuf;
+use crate::Format;
 
+use clap::ArgMatches;
 use ringlog::Level;
 use serde::Deserialize;
 
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 mod general;
 mod log;
-mod prometheus;
 
 use general::General;
 use log::Log;
-use prometheus::Prometheus;
 
 fn disabled() -> bool {
     false
@@ -22,14 +19,6 @@ fn disabled() -> bool {
 
 fn enabled() -> bool {
     true
-}
-
-fn histogram_grouping_power() -> u8 {
-    HISTOGRAM_GROUPING_POWER
-}
-
-fn listen() -> String {
-    "0.0.0.0:4242".into()
 }
 
 fn source() -> String {
@@ -40,14 +29,20 @@ fn interval() -> String {
     "1s".into()
 }
 
+fn output() -> String {
+    "/tmp/rezolus.parquet".into()
+}
+
+fn parquet() -> Format {
+    Format::Parquet
+}
+
 #[derive(Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
     general: General,
     #[serde(default)]
     log: Log,
-    #[serde(default)]
-    prometheus: Prometheus,
 }
 
 impl TryFrom<ArgMatches> for Config {
@@ -85,8 +80,6 @@ impl Config {
 
         config.general.check();
 
-        config.prometheus().check();
-
         Ok(config)
     }
 
@@ -96,9 +89,5 @@ impl Config {
 
     pub fn general(&self) -> &General {
         &self.general
-    }
-
-    pub fn prometheus(&self) -> &Prometheus {
-        &self.prometheus
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use serde::Deserialize;
 use async_trait::async_trait;
 use backtrace::Backtrace;
 use clap::{value_parser, Command, ValueEnum};
@@ -31,7 +32,7 @@ static RUNNING: usize = 0;
 static CAPTURING: usize = 1;
 static TERMINATING: usize = 2;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Deserialize)]
 enum Format {
     Parquet,
     Raw,


### PR DESCRIPTION
Changes the flight-recorder to use a TOML config file. This gives it a more natural pattern of splitting the configuration from the service definition.
