### PR TITLE
add more syscall groups

### DIFF
--- a/src/agent/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/agent/samplers/syscall/linux/counts/mod.bpf.c
@@ -142,6 +142,62 @@ struct {
 	__uint(max_entries, MAX_CGROUPS);
 } cgroup_syscall_yield SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_syscall_filesystem SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_syscall_memory SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_syscall_process SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_syscall_query SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_syscall_ipc SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_syscall_timer SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_syscall_event SEC(".maps");
+
 SEC("tracepoint/raw_syscalls/sys_enter")
 int sys_enter(struct trace_event_raw_sys_enter *args)
 {
@@ -193,6 +249,13 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 				bpf_map_update_elem(&cgroup_syscall_sleep, &cgroup_id, &zero, BPF_ANY);
 				bpf_map_update_elem(&cgroup_syscall_socket, &cgroup_id, &zero, BPF_ANY);
 				bpf_map_update_elem(&cgroup_syscall_yield, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_syscall_filesystem, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_syscall_memory, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_syscall_process, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_syscall_query, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_syscall_ipc, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_syscall_timer, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_syscall_event, &cgroup_id, &zero, BPF_ANY);
 
 				// initialize the cgroup info
 				struct cgroup_info cginfo = {
@@ -240,6 +303,27 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 					break;
 				case 8:
 					array_incr(&cgroup_syscall_yield, cgroup_id);
+					break;
+				case 9:
+					array_incr(&cgroup_syscall_filesystem, cgroup_id);
+					break;
+				case 10:
+					array_incr(&cgroup_syscall_memory, cgroup_id);
+					break;
+				case 11:
+					array_incr(&cgroup_syscall_process, cgroup_id);
+					break;
+				case 12:
+					array_incr(&cgroup_syscall_query, cgroup_id);
+					break;
+				case 13:
+					array_incr(&cgroup_syscall_ipc, cgroup_id);
+					break;
+				case 14:
+					array_incr(&cgroup_syscall_timer, cgroup_id);
+					break;
+				case 15:
+					array_incr(&cgroup_syscall_event, cgroup_id);
 					break;
 				default:
 					array_incr(&cgroup_syscall_other, cgroup_id);

--- a/src/agent/samplers/syscall/linux/counts/mod.rs
+++ b/src/agent/samplers/syscall/linux/counts/mod.rs
@@ -66,15 +66,26 @@ fn handle_event(data: &[u8]) -> i32 {
 
 fn set_name(id: usize, name: String) {
     if !name.is_empty() {
-        CGROUP_SYSCALL_OTHER.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_READ.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_WRITE.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_POLL.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_LOCK.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_TIME.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_SLEEP.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_SOCKET.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SYSCALL_YIELD.insert_metadata(id, "name".to_string(), name);
+        for group in &[
+            &CGROUP_SYSCALL_OTHER,
+            &CGROUP_SYSCALL_READ,
+            &CGROUP_SYSCALL_WRITE,
+            &CGROUP_SYSCALL_POLL,
+            &CGROUP_SYSCALL_LOCK,
+            &CGROUP_SYSCALL_TIME,
+            &CGROUP_SYSCALL_SLEEP,
+            &CGROUP_SYSCALL_SOCKET,
+            &CGROUP_SYSCALL_YIELD,
+            &CGROUP_SYSCALL_FILESYSTEM,
+            &CGROUP_SYSCALL_MEMORY,
+            &CGROUP_SYSCALL_PROCESS,
+            &CGROUP_SYSCALL_QUERY,
+            &CGROUP_SYSCALL_IPC,
+            &CGROUP_SYSCALL_TIMER,
+            &CGROUP_SYSCALL_EVENT,
+        ] {
+            group.insert_metadata(id, "name".to_string(), name.clone());
+        }
     }
 }
 
@@ -96,6 +107,13 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &SYSCALL_SLEEP,
         &SYSCALL_SOCKET,
         &SYSCALL_YIELD,
+        &SYSCALL_FILESYSTEM,
+        &SYSCALL_MEMORY,
+        &SYSCALL_PROCESS,
+        &SYSCALL_QUERY,
+        &SYSCALL_IPC,
+        &SYSCALL_TIMER,
+        &SYSCALL_EVENT,
     ];
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
@@ -110,6 +128,13 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .packed_counters("cgroup_syscall_sleep", &CGROUP_SYSCALL_SLEEP)
         .packed_counters("cgroup_syscall_socket", &CGROUP_SYSCALL_SOCKET)
         .packed_counters("cgroup_syscall_yield", &CGROUP_SYSCALL_YIELD)
+        .packed_counters("cgroup_syscall_filesystem", &CGROUP_SYSCALL_FILESYSTEM)
+        .packed_counters("cgroup_syscall_memory", &CGROUP_SYSCALL_MEMORY)
+        .packed_counters("cgroup_syscall_process", &CGROUP_SYSCALL_PROCESS)
+        .packed_counters("cgroup_syscall_query", &CGROUP_SYSCALL_QUERY)
+        .packed_counters("cgroup_syscall_ipc", &CGROUP_SYSCALL_IPC)
+        .packed_counters("cgroup_syscall_timer", &CGROUP_SYSCALL_TIMER)
+        .packed_counters("cgroup_syscall_event", &CGROUP_SYSCALL_EVENT)
         .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 
@@ -129,6 +154,13 @@ impl SkelExt for ModSkel<'_> {
             "cgroup_syscall_sleep" => &self.maps.cgroup_syscall_sleep,
             "cgroup_syscall_socket" => &self.maps.cgroup_syscall_socket,
             "cgroup_syscall_yield" => &self.maps.cgroup_syscall_yield,
+            "cgroup_syscall_filesystem" => &self.maps.cgroup_syscall_filesystem,
+            "cgroup_syscall_memory" => &self.maps.cgroup_syscall_memory,
+            "cgroup_syscall_process" => &self.maps.cgroup_syscall_process,
+            "cgroup_syscall_query" => &self.maps.cgroup_syscall_query,
+            "cgroup_syscall_ipc" => &self.maps.cgroup_syscall_ipc,
+            "cgroup_syscall_timer" => &self.maps.cgroup_syscall_timer,
+            "cgroup_syscall_event" => &self.maps.cgroup_syscall_event,
             "counters" => &self.maps.counters,
             "syscall_lut" => &self.maps.syscall_lut,
             _ => unimplemented!(),

--- a/src/agent/samplers/syscall/linux/counts/stats.rs
+++ b/src/agent/samplers/syscall/linux/counts/stats.rs
@@ -69,6 +69,55 @@ pub static SYSCALL_SOCKET: LazyCounter = LazyCounter::new(Counter::default);
 )]
 pub static SYSCALL_YIELD: LazyCounter = LazyCounter::new(Counter::default);
 
+#[metric(
+    name = "syscall",
+    description = "The number of filesystem operations (open, close, stat, chmod, mkdir, ...)",
+    metadata = { unit = "syscalls", op = "filesystem" }
+)]
+pub static SYSCALL_FILESYSTEM: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall",
+    description = "The number of memory management syscalls (mmap, munmap, mprotect, brk, ...)",
+    metadata = { unit = "syscalls", op = "memory" }
+)]
+pub static SYSCALL_MEMORY: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall",
+    description = "The number of process control syscalls (fork, clone, exec, wait, kill, ...)",
+    metadata = { unit = "syscalls", op = "process" }
+)]
+pub static SYSCALL_PROCESS: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall",
+    description = "The number of resource query syscalls (getrusage, getrlimit, getpid, ...)",
+    metadata = { unit = "syscalls", op = "query" }
+)]
+pub static SYSCALL_QUERY: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall",
+    description = "The number of IPC syscalls (pipe, msgget, semop, shmat, mq_open, ...)",
+    metadata = { unit = "syscalls", op = "ipc" }
+)]
+pub static SYSCALL_IPC: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall",
+    description = "The number of timer syscalls (alarm, setitimer, timer_create, ...)",
+    metadata = { unit = "syscalls", op = "timer" }
+)]
+pub static SYSCALL_TIMER: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "syscall",
+    description = "The number of event notification syscalls (eventfd, inotify, io_uring, ...)",
+    metadata = { unit = "syscalls", op = "event" }
+)]
+pub static SYSCALL_EVENT: LazyCounter = LazyCounter::new(Counter::default);
+
 /*
  * per-cgroup
  */
@@ -135,3 +184,52 @@ pub static CGROUP_SYSCALL_SOCKET: CounterGroup = CounterGroup::new(MAX_CGROUPS);
     metadata = { unit = "syscalls", op = "yield" }
 )]
 pub static CGROUP_SYSCALL_YIELD: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of filesystem operations on a per-cgroup basis (open, stat, mkdir, ...)",
+    metadata = { unit = "syscalls", op = "filesystem" }
+)]
+pub static CGROUP_SYSCALL_FILESYSTEM: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of memory management syscalls on a per-cgroup basis (mmap, brk, ...)",
+    metadata = { unit = "syscalls", op = "memory" }
+)]
+pub static CGROUP_SYSCALL_MEMORY: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of process control syscalls on a per-cgroup basis (fork, exec, ...)",
+    metadata = { unit = "syscalls", op = "process" }
+)]
+pub static CGROUP_SYSCALL_PROCESS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of resource query syscalls on a per-cgroup basis (getrusage, ...)",
+    metadata = { unit = "syscalls", op = "query" }
+)]
+pub static CGROUP_SYSCALL_QUERY: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of IPC syscalls on a per-cgroup basis (pipe, semop, shmat, ...)",
+    metadata = { unit = "syscalls", op = "ipc" }
+)]
+pub static CGROUP_SYSCALL_IPC: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of timer syscalls on a per-cgroup basis (setitimer, timer_create, ...)",
+    metadata = { unit = "syscalls", op = "timer" }
+)]
+pub static CGROUP_SYSCALL_TIMER: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_syscall",
+    description = "The number of event notification syscalls on a per-cgroup basis (inotify, io_uring, ...)",
+    metadata = { unit = "syscalls", op = "event" }
+)]
+pub static CGROUP_SYSCALL_EVENT: CounterGroup = CounterGroup::new(MAX_CGROUPS);

--- a/src/agent/samplers/syscall/linux/mod.rs
+++ b/src/agent/samplers/syscall/linux/mod.rs
@@ -8,29 +8,80 @@ pub fn syscall_lut() -> Vec<u64> {
         .map(|id| {
             if let Some(syscall_name) = syscall_numbers::native::sys_call_name(id as i64) {
                 match syscall_name {
-                    // read related
+                    // 1: Read related
                     "pread64" | "preadv" | "preadv2" | "read" | "readv" | "recvfrom"
                     | "recvmmsg" | "recvmsg" => 1,
-                    // write related
+
+                    // 2: Write related
                     "pwrite64" | "pwritev" | "pwritev2" | "sendmmsg" | "sendmsg" | "sendto"
                     | "write" | "writev" => 2,
-                    // poll/select/epoll
+
+                    // 3: Poll/select/epoll
                     "epoll_create" | "epoll_create1" | "epoll_ctl" | "epoll_ctl_old"
                     | "epoll_pwait" | "epoll_pwait2" | "epoll_wait" | "epoll_wait_old" | "poll"
                     | "ppoll" | "ppoll_time64" | "pselect6" | "pselect6_time64" | "select" => 3,
-                    // locking
+
+                    // 4: Locking
                     "futex" => 4,
-                    // time
+
+                    // 5: Time
                     "adjtimex" | "clock_adjtime" | "clock_getres" | "clock_gettime"
                     | "clock_settime" | "gettimeofday" | "settimeofday" | "time" => 5,
-                    // sleep
+
+                    // 6: Sleep
                     "clock_nanosleep" | "nanosleep" => 6,
-                    // socket creation and management
+
+                    // 7: Socket
                     "accept" | "accept4" | "bind" | "connect" | "getpeername" | "getsockname"
                     | "getsockopt" | "listen" | "setsockopt" | "shutdown" | "socket"
                     | "socketpair" => 7,
-                    // yield
+
+                    // 8: Yield
                     "sched_yield" => 8,
+
+                    // 9: Filesystem operations
+                    "open" | "openat" | "close" | "creat" | "lseek" | "fsync" | "fdatasync"
+                    | "sync" | "syncfs" | "truncate" | "ftruncate" | "rename" | "renameat"
+                    | "link" | "symlink" | "unlink" | "readlink" | "stat" | "fstat" | "lstat"
+                    | "statx" | "access" | "faccessat" | "chmod" | "fchmod" | "chown"
+                    | "fchown" | "lchown" | "utime" | "utimes" | "utimensat" | "mkdir"
+                    | "rmdir" | "chdir" | "fchdir" | "getcwd" | "getdents" | "getdents64"
+                    | "readdir" => 9,
+
+                    // 10: Memory management
+                    "mmap" | "munmap" | "mprotect" | "mremap" | "madvise" | "msync" | "mincore"
+                    | "mlock" | "munlock" | "mlockall" | "munlockall" | "brk" | "sbrk" => 10,
+
+                    // 11: Process control
+                    "clone" | "fork" | "vfork" | "execve" | "execveat" | "exit" | "exit_group"
+                    | "wait4" | "waitid" | "waitpid" | "kill" | "tkill" | "tgkill" | "ptrace"
+                    | "prctl" | "setpgid" | "getpgid" | "setpriority" | "getpriority"
+                    | "sched_setaffinity" | "sched_getaffinity" | "sched_setscheduler"
+                    | "sched_getscheduler" | "sched_setparam" | "sched_getparam" => 11,
+
+                    // 12: Resource query
+                    "getrusage" | "getrlimit" | "setrlimit" | "prlimit64" | "times" | "getpid"
+                    | "getppid" | "getuid" | "geteuid" | "getgid" | "getegid" | "gettid"
+                    | "uname" | "sysinfo" | "getcpu" => 12,
+
+                    // 13: IPC (Inter-Process Communication)
+                    "pipe" | "pipe2" | "msgget" | "msgsnd" | "msgrcv" | "msgctl" | "semget"
+                    | "semop" | "semctl" | "shmget" | "shmat" | "shmdt" | "shmctl" | "mq_open"
+                    | "mq_close" | "mq_unlink" | "mq_send" | "mq_receive" | "mq_getsetattr"
+                    | "mq_notify" | "mq_timedreceive" | "mq_timedsend" => 13,
+
+                    // 14: Timers and alarms
+                    "alarm" | "getitimer" | "setitimer" | "timer_create" | "timer_delete"
+                    | "timer_getoverrun" | "timer_gettime" | "timer_settime" | "timerfd_create"
+                    | "timerfd_gettime" | "timerfd_settime" => 14,
+
+                    // 15: Event notification
+                    "eventfd" | "eventfd2" | "signalfd" | "signalfd4" | "inotify_init"
+                    | "inotify_init1" | "inotify_add_watch" | "inotify_rm_watch"
+                    | "fanotify_init" | "fanotify_mark" | "io_setup" | "io_destroy"
+                    | "io_submit" | "io_cancel" | "io_getevents" | "io_uring_setup"
+                    | "io_uring_enter" | "io_uring_register" => 15,
+
                     _ => {
                         // no group defined for these syscalls
                         0


### PR DESCRIPTION
Adds additional syscall groups with corresponding metrics. With this change we now have groups for syscalls related to:
- filesystem operations
- memory management
- process/thread control
- resource queries
- inter-process communication (IPC)
- timers
- events (eventfd, inotify, io_uring)
