### PR TITLE
add l3 cache sampler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "archspec"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7"
+dependencies = [
+ "cfg-if",
+ "itertools",
+ "libc",
+ "serde",
+ "serde_json",
+ "sysctl",
+]
+
+[[package]]
 name = "arrow"
 version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +799,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1365,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2165,6 +2206,7 @@ name = "rezolus"
 version = "5.0.0-alpha.10"
 dependencies = [
  "anyhow",
+ "archspec",
  "async-trait",
  "axum",
  "backtrace",
@@ -2190,6 +2232,7 @@ dependencies = [
  "nvml-wrapper",
  "ouroboros",
  "parking_lot",
+ "perf-event-open-sys2",
  "perf-event2",
  "plain",
  "reqwest",
@@ -2497,6 +2540,20 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
+dependencies = [
+ "bitflags 2.8.0",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,13 @@ walkdir = "2.5.0"
 plain = "0.2.3"
 core_affinity = "0.8.1"
 chrono = "0.4.39"
+archspec = "0.1.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.24.8" }
 libbpf-sys = { version = "1.5.0" }
 perf-event2 = "0.7.4"
+perf-event-open-sys2 = "5.0.6"
 nvml-wrapper = "0.10.0"
 
 [target.'cfg(target_os = "linux")'.build-dependencies]

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -8,8 +8,8 @@ const NAME: &str = "cpu_l3";
 
 use crate::agent::*;
 
-use perf_event::ReadFormat;
 use perf_event::events::Event;
+use perf_event::ReadFormat;
 use tokio::sync::Mutex;
 use walkdir::WalkDir;
 
@@ -84,10 +84,7 @@ pub struct LowLevelEvent {
 
 impl LowLevelEvent {
     pub fn new(event_type: u32, config: u64) -> Self {
-        Self {
-            event_type,
-            config,
-        }
+        Self { event_type, config }
     }
 }
 
@@ -252,7 +249,10 @@ fn get_events() -> Option<(LowLevelEvent, LowLevelEvent)> {
         println!("detected uarch: {uarch}");
 
         let events = match uarch.as_str() {
-            "zen" | "zen2" | "zen3" | "zen4" | "zen5" => (LowLevelEvent::new(0xb, 0xFF04), LowLevelEvent::new(0xb, 0x0104)),
+            "zen" | "zen2" | "zen3" | "zen4" | "zen5" => (
+                LowLevelEvent::new(0xb, 0xFF04),
+                LowLevelEvent::new(0xb, 0x0104),
+            ),
             _ => {
                 return None;
             }

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -1,0 +1,265 @@
+/// This sampler is used to measure CPU L3 cache access and misses. It does this
+/// by using two uncore PMUs for each L3 cache domain.
+///
+/// This requires that we identify each L3 cache domain but also identify the
+/// correct raw perf events to use which are processor dependent.
+
+const NAME: &str = "cpu_l3";
+
+use crate::agent::*;
+
+use perf_event::ReadFormat;
+use perf_event::events::Event;
+use tokio::sync::Mutex;
+use walkdir::WalkDir;
+
+use std::collections::HashSet;
+
+mod stats;
+
+use stats::*;
+
+#[distributed_slice(SAMPLERS)]
+fn init(config: Arc<Config>) -> SamplerResult {
+    if !config.enabled(NAME) {
+        return Ok(None);
+    }
+
+    let inner = CpuL3Inner::new()?;
+
+    Ok(Some(Box::new(CpuL3 {
+        inner: inner.into(),
+    })))
+}
+
+struct CpuL3 {
+    inner: Mutex<CpuL3Inner>,
+}
+
+#[async_trait]
+impl Sampler for CpuL3 {
+    async fn refresh(&self) {
+        let mut inner = self.inner.lock().await;
+
+        let _ = inner.refresh().await;
+    }
+}
+
+struct CpuL3Inner {
+    caches: Vec<L3Cache>,
+}
+
+impl CpuL3Inner {
+    pub fn new() -> Result<Self, std::io::Error> {
+        let caches = get_l3_caches()?;
+
+        Ok(Self { caches })
+    }
+
+    pub async fn refresh(&mut self) -> Result<(), std::io::Error> {
+        for cache in &mut self.caches {
+            if let Ok(group) = cache.access.read_group() {
+                if let (Some(access), Some(miss)) =
+                    (group.get(&cache.access), group.get(&cache.miss))
+                {
+                    let access = access.value();
+                    let miss = miss.value();
+
+                    for cpu in &cache.shared_cores {
+                        let _ = CPU_L3_ACCESS.set(*cpu, access);
+                        let _ = CPU_L3_MISS.set(*cpu, miss);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct LowLevelEvent {
+    event_type: u32,
+    config: u64,
+}
+
+impl LowLevelEvent {
+    pub fn new(event_type: u32, config: u64) -> Self {
+        Self {
+            event_type,
+            config,
+        }
+    }
+}
+
+impl Event for LowLevelEvent {
+    fn update_attrs(self, attr: &mut perf_event_open_sys::bindings::perf_event_attr) {
+        attr.type_ = self.event_type;
+        attr.config = self.config;
+    }
+}
+
+/// A struct that contains the perf counters for each L3 cache as well as the
+/// list of all CPUs in that L3 domain.
+struct L3Cache {
+    /// perf events for this cache
+    access: perf_event::Counter,
+    miss: perf_event::Counter,
+    /// all cores which share this cache
+    shared_cores: Vec<usize>,
+}
+
+impl L3Cache {
+    pub fn new(shared_cores: Vec<usize>) -> Result<Self, ()> {
+        let cpu = *shared_cores.first().expect("empty l3 domain");
+
+        let (access_event, miss_event) = if let Some(events) = get_events() {
+            events
+        } else {
+            return Err(());
+        };
+
+        if let Ok(mut access) = perf_event::Builder::new(access_event)
+            .one_cpu(cpu)
+            .any_pid()
+            .exclude_hv(false)
+            .exclude_kernel(false)
+            .pinned(true)
+            .read_format(
+                ReadFormat::TOTAL_TIME_ENABLED | ReadFormat::TOTAL_TIME_RUNNING | ReadFormat::GROUP,
+            )
+            .build()
+        {
+            if let Ok(miss) = perf_event::Builder::new(miss_event)
+                .one_cpu(cpu)
+                .any_pid()
+                .exclude_hv(false)
+                .exclude_kernel(false)
+                .build_with_group(&mut access)
+            {
+                match access.enable_group() {
+                    Ok(_) => {
+                        return Ok(L3Cache {
+                            access,
+                            miss,
+                            shared_cores,
+                        });
+                    }
+                    Err(e) => {
+                        error!("failed to enable the perf group on CPU{cpu}: {e}");
+                    }
+                }
+            }
+        }
+
+        Err(())
+    }
+}
+
+fn l3_domains() -> Result<Vec<Vec<usize>>, std::io::Error> {
+    let mut l3_domains = Vec::new();
+    let mut processed = HashSet::new();
+
+    // walk the cpu devices directory
+    for entry in WalkDir::new("/sys/devices/system/cpu")
+        .min_depth(1)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        let filename = path.file_name().and_then(|v| v.to_str()).unwrap_or("");
+
+        // check if this is a cpu directory
+        if filename.starts_with("cpu") && filename[3..].chars().all(char::is_numeric) {
+            let cache_dir = path.join("cache");
+
+            // look for the cache where level = 3
+            if let Some(l3_index) = WalkDir::new(&cache_dir)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .find(|entry| {
+                    let index_path = entry.path();
+                    index_path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map_or(false, |name| {
+                            name.starts_with("index")
+                                && index_path.join("level").exists()
+                                && std::fs::read_to_string(index_path.join("level"))
+                                    .unwrap_or_default()
+                                    .trim()
+                                    == "3"
+                        })
+                })
+            {
+                let shared_cpu_list = l3_index.path().join("shared_cpu_list");
+
+                // parse the shared cpu list
+                if let Ok(shared_cpu_list) = std::fs::read_to_string(&shared_cpu_list) {
+                    let shared_cores = parse_cpu_list(&shared_cpu_list);
+
+                    // avoid duplicates
+                    if !processed.contains(&shared_cores) {
+                        processed.insert(shared_cores.clone());
+                        l3_domains.push(shared_cores);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(l3_domains)
+}
+
+fn get_l3_caches() -> Result<Vec<L3Cache>, std::io::Error> {
+    let mut l3_domains = l3_domains()?;
+
+    let mut l3_caches = Vec::new();
+
+    for l3_domain in l3_domains.drain(..) {
+        if let Ok(l3_cache) = L3Cache::new(l3_domain) {
+            l3_caches.push(l3_cache);
+        }
+    }
+
+    Ok(l3_caches)
+}
+
+fn parse_cpu_list(list: &str) -> Vec<usize> {
+    let mut cores = Vec::new();
+
+    for range in list.trim().split(',') {
+        if let Some((start, end)) = range.split_once('-') {
+            // Range of cores
+            if let (Ok(start_num), Ok(end_num)) = (start.parse::<usize>(), end.parse::<usize>()) {
+                cores.extend(start_num..=end_num);
+            }
+        } else {
+            // Single core
+            if let Ok(core) = range.parse::<usize>() {
+                cores.push(core);
+            }
+        }
+    }
+
+    cores.sort_unstable();
+    cores.dedup();
+    cores
+}
+
+fn get_events() -> Option<(LowLevelEvent, LowLevelEvent)> {
+    if let Ok(uarch) = archspec::cpu::host().map(|u| u.name().to_owned()) {
+        println!("detected uarch: {uarch}");
+
+        let events = match uarch.as_str() {
+            "zen" | "zen2" | "zen3" | "zen4" | "zen5" => (LowLevelEvent::new(0xb, 0xFF04), LowLevelEvent::new(0xb, 0x0104)),
+            _ => {
+                return None;
+            }
+        };
+
+        Some(events)
+    } else {
+        None
+    }
+}

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -1,8 +1,8 @@
-/// This sampler is used to measure CPU L3 cache access and misses. It does this
-/// by using two uncore PMUs for each L3 cache domain.
-///
-/// This requires that we identify each L3 cache domain but also identify the
-/// correct raw perf events to use which are processor dependent.
+//! This sampler is used to measure CPU L3 cache access and misses. It does this
+//! by using two uncore PMUs for each L3 cache domain.
+//!
+//! This requires that we identify each L3 cache domain but also identify the
+//! correct raw perf events to use which are processor dependent.
 
 const NAME: &str = "cpu_l3";
 
@@ -178,8 +178,7 @@ fn l3_domains() -> Result<Vec<Vec<usize>>, std::io::Error> {
                     let index_path = entry.path();
                     index_path
                         .file_name()
-                        .and_then(|n| n.to_str())
-                        .map_or(false, |name| {
+                        .and_then(|n| n.to_str()).is_some_and(|name| {
                             name.starts_with("index")
                                 && index_path.join("level").exists()
                                 && std::fs::read_to_string(index_path.join("level"))

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -178,7 +178,8 @@ fn l3_domains() -> Result<Vec<Vec<usize>>, std::io::Error> {
                     let index_path = entry.path();
                     index_path
                         .file_name()
-                        .and_then(|n| n.to_str()).is_some_and(|name| {
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|name| {
                             name.starts_with("index")
                                 && index_path.join("level").exists()
                                 && std::fs::read_to_string(index_path.join("level"))

--- a/src/agent/samplers/cpu/linux/l3/stats.rs
+++ b/src/agent/samplers/cpu/linux/l3/stats.rs
@@ -1,0 +1,11 @@
+use metriken::*;
+
+use crate::agent::*;
+
+// per-CPU metrics
+
+#[metric(name = "cpu_l3_access", description = "The number of L3 cache access")]
+pub static CPU_L3_ACCESS: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(name = "cpu_l3_miss", description = "The number of L3 cache miss")]
+pub static CPU_L3_MISS: CounterGroup = CounterGroup::new(MAX_CPUS);

--- a/src/agent/samplers/cpu/linux/mod.rs
+++ b/src/agent/samplers/cpu/linux/mod.rs
@@ -1,5 +1,6 @@
 mod cores;
 mod frequency;
+mod l3;
 mod perf;
 mod tlb_flush;
 mod usage;


### PR DESCRIPTION
Adds a sampler that tracks l3 cache accesses and misses. Currently supports AMD Zen processors.
