### PR TITLE
add cpu throttled metrics for cgroups

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ mod bpf {
         ("blockio", "latency"),
         ("blockio", "requests"),
         ("cpu", "perf"),
+        ("cpu", "throttled"),
         ("cpu", "tlb_flush"),
         ("cpu", "usage"),
         ("network", "softnet"),

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -29,6 +29,10 @@ enabled = true
 # Instruments CPU frequency, instructions, and cycles using perf counters.
 [samplers.cpu_perf]
 
+# BPF sampler that instruments cgroup CPU throttling to measure throttled time
+# and throttling events
+[samplers.cpu_throttled]
+
 # Instruments CPU usage by state with BPF on linux. On macos
 # host_processor_info() is used
 [samplers.cpu_usage]

--- a/src/agent/samplers/cpu/linux/mod.rs
+++ b/src/agent/samplers/cpu/linux/mod.rs
@@ -1,5 +1,6 @@
 mod cores;
 mod frequency;
 mod perf;
+mod throttled;
 mod tlb_flush;
 mod usage;

--- a/src/agent/samplers/cpu/linux/throttled/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/throttled/mod.bpf.c
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2025 The Rezolus Authors
+
+// This BPF program probes CFS throttling events to track the time cgroups are throttled
+
+#include <vmlinux.h>
+#include "../../../agent/bpf/cgroup_info.h"
+#include "../../../agent/bpf/helpers.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#define MAX_CGROUPS 4096
+#define RINGBUF_CAPACITY 262144
+
+// dummy instance for skeleton to generate definition
+struct cgroup_info _cgroup_info = {};
+
+// ringbuf to pass cgroup info
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(key_size, 0);
+    __uint(value_size, 0);
+    __uint(max_entries, RINGBUF_CAPACITY);
+} cgroup_info SEC(".maps");
+
+// holds known cgroup serial numbers to help determine new or changed groups
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, MAX_CGROUPS);
+} cgroup_serial_numbers SEC(".maps");
+
+// track throttle start times
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, MAX_CGROUPS);
+} throttle_start SEC(".maps");
+
+// counters
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, MAX_CGROUPS);
+} throttled_time SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, MAX_CGROUPS);
+} throttled_count SEC(".maps");
+
+SEC("kprobe/throttle_cfs_rq")
+int throttle_cfs_rq(struct pt_regs *ctx)
+{
+    struct cfs_rq *cfs_rq = (struct cfs_rq *)PT_REGS_PARM1(ctx);
+
+    // get the cgroup id and serial number
+
+    struct task_group *tg = BPF_CORE_READ(cfs_rq, tg);
+    if (!tg)
+        return 0;
+
+    struct cgroup_subsys_state *css = &tg->css;
+    if (!css)
+        return 0;
+
+    u64 cgroup_id = BPF_CORE_READ(css, id);
+    if (!cgroup_id || cgroup_id >= MAX_CGROUPS)
+        return 0;
+
+    u64 serial_nr = BPF_CORE_READ(css, serial_nr);
+
+    // check if this is a new cgroup by checking the serial number and id
+
+    u64 *elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
+
+    if (elem && *elem != serial_nr) {
+        // zero the counters, they will not be exported until they are non-zero
+        u64 zero = 0;
+        bpf_map_update_elem(&throttled_time, &cgroup_id, &zero, BPF_ANY);
+        bpf_map_update_elem(&throttled_count, &cgroup_id, &zero, BPF_ANY);
+
+        // initialize the cgroup info
+        struct cgroup_info cginfo = {
+            .id = cgroup_id,
+            .level = BPF_CORE_READ(css, cgroup, level),
+        };
+
+        // assemble cgroup name
+        bpf_probe_read_kernel_str(&cginfo.name, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, name));
+        bpf_probe_read_kernel_str(&cginfo.pname, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, parent, name));
+        bpf_probe_read_kernel_str(&cginfo.gpname, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, parent, parent, name));
+        
+        // push the cgroup info into the ringbuf
+        bpf_ringbuf_output(&cgroup_info, &cginfo, sizeof(cginfo), 0);
+        
+        // update the serial number in the local map
+        bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
+    }
+
+    // record throttle start time
+    u64 now = bpf_ktime_get_ns();
+    u32 cgroup_idx = (u32)cgroup_id;
+    bpf_map_update_elem(&throttle_start, &cgroup_idx, &now, BPF_ANY);
+
+    // increment the throttle count
+    array_incr(&throttled_count, cgroup_id);
+
+    return 0;
+}
+
+SEC("kprobe/unthrottle_cfs_rq")
+int unthrottle_cfs_rq(struct pt_regs *ctx)
+{
+    struct cfs_rq *cfs_rq = (struct cfs_rq *)PT_REGS_PARM1(ctx);
+
+    // get the cgroup id
+
+    struct task_group *tg = BPF_CORE_READ(cfs_rq, tg);
+    if (!tg)
+        return 0;
+
+    struct cgroup_subsys_state *css = &tg->css;
+    if (!css)
+        return 0;
+
+    u64 cgroup_id = BPF_CORE_READ(css, id);
+    if (!cgroup_id || cgroup_id >= MAX_CGROUPS)
+        return 0;
+
+    // lookup start time
+    u32 cgroup_idx = (u32)cgroup_id;
+    u64 *start_ts = bpf_map_lookup_elem(&throttle_start, &cgroup_idx);
+    if (!start_ts || *start_ts == 0)
+        return 0;
+
+    // increment the throttled time counter
+    u64 now = bpf_ktime_get_ns();
+    u64 duration = now - *start_ts;
+    array_add(&throttled_time, cgroup_id, duration);
+
+    // clear the throttle start time
+    u64 zero = 0;
+    bpf_map_update_elem(&throttle_start, &cgroup_idx, &zero, BPF_ANY);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/cpu/linux/throttled/mod.rs
+++ b/src/agent/samplers/cpu/linux/throttled/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! And produces these stats:
 //! * `cgroup_cpu_throttled_time`
-//! * `cgroup_cpu_throttled_count`
+//! * `cgroup_cpu_throttled`
 //!
 //! These stats can be used to understand when and for how long cgroups are being
 //! throttled by the CPU controller.
@@ -71,7 +71,7 @@ fn handle_event(data: &[u8]) -> i32 {
 fn set_name(id: usize, name: String) {
     if !name.is_empty() {
         CGROUP_CPU_THROTTLED_TIME.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_THROTTLED_COUNT.insert_metadata(id, "name".to_string(), name);
+        CGROUP_CPU_THROTTLED.insert_metadata(id, "name".to_string(), name);
     }
 }
 
@@ -85,7 +85,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .packed_counters("throttled_time", &CGROUP_CPU_THROTTLED_TIME)
-        .packed_counters("throttled_count", &CGROUP_CPU_THROTTLED_COUNT)
+        .packed_counters("throttled_count", &CGROUP_CPU_THROTTLED)
         .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 

--- a/src/agent/samplers/cpu/linux/throttled/mod.rs
+++ b/src/agent/samplers/cpu/linux/throttled/mod.rs
@@ -1,0 +1,117 @@
+//! Collects CPU throttle stats using BPF and traces:
+//! * `throttle_cfs_rq`
+//! * `unthrottle_cfs_rq`
+//!
+//! And produces these stats:
+//! * `cgroup_cpu_throttled_time`
+//! * `cgroup_cpu_throttled_count`
+//!
+//! These stats can be used to understand when and for how long cgroups are being
+//! throttled by the CPU controller.
+
+const NAME: &str = "cpu_throttled";
+
+mod bpf {
+    include!(concat!(env!("OUT_DIR"), "/cpu_throttled.bpf.rs"));
+}
+
+use bpf::*;
+
+use crate::agent::*;
+
+use std::sync::Arc;
+
+mod stats;
+
+use stats::*;
+
+unsafe impl plain::Plain for bpf::types::cgroup_info {}
+
+fn handle_event(data: &[u8]) -> i32 {
+    let mut cgroup_info = bpf::types::cgroup_info::default();
+
+    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
+        let name = std::str::from_utf8(&cgroup_info.name)
+            .unwrap()
+            .trim_end_matches(char::from(0))
+            .replace("\\x2d", "-");
+
+        let pname = std::str::from_utf8(&cgroup_info.pname)
+            .unwrap()
+            .trim_end_matches(char::from(0))
+            .replace("\\x2d", "-");
+
+        let gpname = std::str::from_utf8(&cgroup_info.gpname)
+            .unwrap()
+            .trim_end_matches(char::from(0))
+            .replace("\\x2d", "-");
+
+        let name = if !gpname.is_empty() {
+            if cgroup_info.level > 3 {
+                format!(".../{gpname}/{pname}/{name}")
+            } else {
+                format!("/{gpname}/{pname}/{name}")
+            }
+        } else if !pname.is_empty() {
+            format!("/{pname}/{name}")
+        } else if !name.is_empty() {
+            format!("/{name}")
+        } else {
+            "".to_string()
+        };
+
+        let id = cgroup_info.id;
+
+        set_name(id as usize, name)
+    }
+
+    0
+}
+
+fn set_name(id: usize, name: String) {
+    if !name.is_empty() {
+        CGROUP_CPU_THROTTLED_TIME.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_CPU_THROTTLED_COUNT.insert_metadata(id, "name".to_string(), name);
+    }
+}
+
+#[distributed_slice(SAMPLERS)]
+fn init(config: Arc<Config>) -> SamplerResult {
+    if !config.enabled(NAME) {
+        return Ok(None);
+    }
+
+    set_name(1, "/".to_string());
+
+    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+        .packed_counters("throttled_time", &CGROUP_CPU_THROTTLED_TIME)
+        .packed_counters("throttled_count", &CGROUP_CPU_THROTTLED_COUNT)
+        .ringbuf_handler("cgroup_info", handle_event)
+        .build()?;
+
+    Ok(Some(Box::new(bpf)))
+}
+
+impl SkelExt for ModSkel<'_> {
+    fn map(&self, name: &str) -> &libbpf_rs::Map {
+        match name {
+            "cgroup_info" => &self.maps.cgroup_info,
+            "throttled_time" => &self.maps.throttled_time,
+            "throttled_count" => &self.maps.throttled_count,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl OpenSkelExt for ModSkel<'_> {
+    fn log_prog_instructions(&self) {
+        debug!(
+            "{NAME} throttle_cfs_rq() BPF instruction count: {}",
+            self.progs.throttle_cfs_rq.insn_cnt()
+        );
+        debug!(
+            "{NAME} unthrottle_cfs_rq() BPF instruction count: {}",
+            self.progs.unthrottle_cfs_rq.insn_cnt()
+        );
+    }
+}

--- a/src/agent/samplers/cpu/linux/throttled/stats.rs
+++ b/src/agent/samplers/cpu/linux/throttled/stats.rs
@@ -10,8 +10,8 @@ use crate::agent::*;
 pub static CGROUP_CPU_THROTTLED_TIME: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 #[metric(
-    name = "cgroup_cpu_throttled_count",
+    name = "cgroup_cpu_throttled",
     description = "The number of times a cgroup has been throttled by the CPU controller",
     metadata = { unit = "events" }
 )]
-pub static CGROUP_CPU_THROTTLED_COUNT: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+pub static CGROUP_CPU_THROTTLED: CounterGroup = CounterGroup::new(MAX_CGROUPS);

--- a/src/agent/samplers/cpu/linux/throttled/stats.rs
+++ b/src/agent/samplers/cpu/linux/throttled/stats.rs
@@ -1,0 +1,17 @@
+use metriken::*;
+
+use crate::agent::*;
+
+#[metric(
+    name = "cgroup_cpu_throttled_time",
+    description = "The total time a cgroup has been throttled by the CPU controller in nanoseconds",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_THROTTLED_TIME: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_throttled_count",
+    description = "The number of times a cgroup has been throttled by the CPU controller",
+    metadata = { unit = "events" }
+)]
+pub static CGROUP_CPU_THROTTLED_COUNT: CounterGroup = CounterGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
Adds a cpu_throttled sampler which tracks throttling events for cgroups.
