### PR TITLE
fix: frequency counters per logical core

### DIFF
--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -205,7 +205,7 @@ fn logical_cores() -> Result<Vec<usize>, std::io::Error> {
         }
     }
 
-    Ok(cores.iter().map(|v| *v).collect())
+    Ok(cores.iter().copied().collect())
 }
 
 fn get_cores() -> Result<Vec<Core>, std::io::Error> {


### PR DESCRIPTION
Previously we had a set of pref events on the MSRs that we need for CPU frequency on a physical core basis instead of per logical core.

This change fixes this to initialize each of the counters per logical core.
