### PR TITLE
prepare for alpha release 5.0.0-alpha.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.0.0-alpha.12"
+version = "5.0.0-alpha.13"
 dependencies = [
  "anyhow",
  "archspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "5.0.0-alpha.12"
+version = "5.0.0-alpha.13"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "High resolution systems performance telemetry agent"

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -74,14 +74,12 @@ impl PerfCounters {
 
 enum Event {
     Hardware(perf_event::events::Hardware),
-    Msr(perf_event::events::x86::Msr),
 }
 
 impl Event {
     fn builder(&self) -> perf_event::Builder {
         match self {
             Self::Hardware(e) => perf_event::Builder::new(*e),
-            Self::Msr(m) => perf_event::Builder::new(*m),
         }
     }
 }
@@ -97,14 +95,6 @@ impl PerfEvent {
         Self {
             inner: Event::Hardware(perf_event::events::Hardware::INSTRUCTIONS),
         }
-    }
-
-    pub fn msr(msr_id: perf_event::events::x86::MsrId) -> Result<Self, std::io::Error> {
-        let msr = perf_event::events::x86::Msr::new(msr_id)?;
-
-        Ok(Self {
-            inner: Event::Msr(msr),
-        })
     }
 }
 

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -60,8 +60,6 @@ impl FrequencyInner {
     pub fn new() -> Result<Self, std::io::Error> {
         let cores = get_cores()?;
 
-        println!("initialized frequency counters for: {} cores", cores.len());
-
         Ok(Self { cores })
     }
 

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -246,8 +246,6 @@ fn parse_cpu_list(list: &str) -> Vec<usize> {
 
 fn get_events() -> Option<(LowLevelEvent, LowLevelEvent)> {
     if let Ok(uarch) = archspec::cpu::host().map(|u| u.name().to_owned()) {
-        println!("detected uarch: {uarch}");
-
         let events = match uarch.as_str() {
             "zen" | "zen2" | "zen3" | "zen4" | "zen5" => (
                 LowLevelEvent::new(0xb, 0xFF04),


### PR DESCRIPTION
Fix warnings for unused enum variants and functions. Cleanup stray print statements.
