### PR TITLE
add cfs bandwidth gauges

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,9 +13,9 @@ mod bpf {
     const SOURCES: &[(&str, &str)] = &[
         ("blockio", "latency"),
         ("blockio", "requests"),
+        ("cpu", "bandwidth"),
         ("cpu", "migrations"),
         ("cpu", "perf"),
-        ("cpu", "throttled"),
         ("cpu", "tlb_flush"),
         ("cpu", "usage"),
         ("network", "softnet"),

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -26,15 +26,14 @@ enabled = true
 # the number of bytes by request type, and the size distribution.
 [samplers.block_io_requests]
 
+# BPF sampler that collects CPU CFS bandwidth control and throttling stats
+[samplers.cpu_bandwidth]
+
 # Instruments CPU migrations.
 [samplers.cpu_migrations]
 
 # Instruments CPU frequency, instructions, and cycles using perf counters.
 [samplers.cpu_perf]
-
-# BPF sampler that instruments cgroup CPU throttling to measure throttled time
-# and throttling events
-[samplers.cpu_throttled]
 
 # Instruments CPU usage by state with BPF on linux. On macos
 # host_processor_info() is used

--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -29,7 +29,6 @@ pub const MAX_CPUS: usize = 1024;
 pub const MAX_CGROUPS: usize = 4096;
 
 const COUNTER_SIZE: usize = std::mem::size_of::<u64>();
-
 const COUNTERS_PER_CACHELINE: usize = CACHELINE_SIZE / COUNTER_SIZE;
 
 fn whole_cachelines<T>(count: usize) -> usize {

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2025 The Rezolus Authors
 
-// This BPF program probes CFS throttling events to track the time cgroups are throttled
+// This BPF program probes CFS throttling events and changes to CFS bandwidth
+// settings to capture metrics about throttling and cpu quota
 
 #include <vmlinux.h>
 #include "../../../agent/bpf/cgroup_info.h"
@@ -13,8 +14,16 @@
 #define MAX_CGROUPS 4096
 #define RINGBUF_CAPACITY 262144
 
+// struct to pass bandwidth info to userspace
+struct bandwidth_info {
+    u32 id;             // cgroup id
+    u64 quota;          // quota in nanoseconds
+    u64 period;         // period in nanoseconds
+};
+
 // dummy instance for skeleton to generate definition
 struct cgroup_info _cgroup_info = {};
+struct bandwidth_info _bandwidth_info = {};
 
 // ringbuf to pass cgroup info
 struct {
@@ -23,6 +32,14 @@ struct {
     __uint(value_size, 0);
     __uint(max_entries, RINGBUF_CAPACITY);
 } cgroup_info SEC(".maps");
+
+// ringbuf to pass bandwidth info
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(key_size, 0);
+    __uint(value_size, 0);
+    __uint(max_entries, RINGBUF_CAPACITY);
+} bandwidth_info SEC(".maps");
 
 // holds known cgroup serial numbers to help determine new or changed groups
 struct {
@@ -59,6 +76,68 @@ struct {
     __type(value, u64);
     __uint(max_entries, MAX_CGROUPS);
 } throttled_count SEC(".maps");
+
+SEC("kprobe/tg_set_cfs_bandwidth")
+int tg_set_cfs_bandwidth(struct pt_regs *ctx)
+{
+    struct task_group *tg = (struct task_group *)PT_REGS_PARM1(ctx);
+    struct cfs_bandwidth *cfs_b = (struct cfs_bandwidth *)PT_REGS_PARM2(ctx);
+
+    if (!tg || !cfs_b)
+        return 0;
+
+    // get the cgroup id and serial number
+
+    struct cgroup_subsys_state *css = &tg->css;
+    if (!css)
+        return 0;
+
+    u32 cgroup_id = BPF_CORE_READ(css, id);
+    if (!cgroup_id || cgroup_id >= MAX_CGROUPS)
+        return 0;
+
+    u64 serial_nr = BPF_CORE_READ(css, serial_nr);
+
+    // check if this is a new cgroup by checking the serial number and id
+
+    u64 *elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
+
+    if (elem && *elem != serial_nr) {
+        // zero the counters, they will not be exported until they are non-zero
+        u64 zero = 0;
+        bpf_map_update_elem(&throttled_time, &cgroup_id, &zero, BPF_ANY);
+        bpf_map_update_elem(&throttled_count, &cgroup_id, &zero, BPF_ANY);
+
+        // initialize the cgroup info
+        struct cgroup_info cginfo = {
+            .id = cgroup_id,
+            .level = BPF_CORE_READ(css, cgroup, level),
+        };
+
+        // assemble cgroup name
+        bpf_probe_read_kernel_str(&cginfo.name, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, name));
+        bpf_probe_read_kernel_str(&cginfo.pname, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, parent, name));
+        bpf_probe_read_kernel_str(&cginfo.gpname, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, parent, parent, name));
+
+        // push the cgroup info into the ringbuf
+        bpf_ringbuf_output(&cgroup_info, &cginfo, sizeof(cginfo), 0);
+
+        // update the serial number in the local map
+        bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
+    }
+
+    // get the bandwidth info and send to userspace
+    u64 quota = BPF_CORE_READ(cfs_b, quota);
+    u64 period = BPF_CORE_READ(cfs_b, period);
+    struct bandwidth_info bw_info = {
+        .id = cgroup_id,
+        .quota = quota,
+        .period = period
+    };
+    bpf_ringbuf_output(&bandwidth_info, &bw_info, sizeof(bw_info), 0);
+
+    return 0;
+}
 
 SEC("kprobe/throttle_cfs_rq")
 int throttle_cfs_rq(struct pt_regs *ctx)
@@ -101,10 +180,20 @@ int throttle_cfs_rq(struct pt_regs *ctx)
         bpf_probe_read_kernel_str(&cginfo.name, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, name));
         bpf_probe_read_kernel_str(&cginfo.pname, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, parent, name));
         bpf_probe_read_kernel_str(&cginfo.gpname, CGROUP_NAME_LEN, BPF_CORE_READ(css, cgroup, kn, parent, parent, name));
-        
+
         // push the cgroup info into the ringbuf
         bpf_ringbuf_output(&cgroup_info, &cginfo, sizeof(cginfo), 0);
-        
+
+        // get the bandwidth info and send to userspace
+        u64 quota = BPF_CORE_READ(tg, cfs_bandwidth.quota);
+        u64 period = BPF_CORE_READ(tg, cfs_bandwidth.period);
+        struct bandwidth_info bw_info = {
+            .id = cgroup_id,
+            .quota = quota,
+            .period = period
+        };
+        bpf_ringbuf_output(&bandwidth_info, &bw_info, sizeof(bw_info), 0);
+
         // update the serial number in the local map
         bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
     }
@@ -137,6 +226,12 @@ int unthrottle_cfs_rq(struct pt_regs *ctx)
 
     u64 cgroup_id = BPF_CORE_READ(css, id);
     if (!cgroup_id || cgroup_id >= MAX_CGROUPS)
+        return 0;
+
+    // skip accounting if the serial number doesn't match
+    u64 serial_nr = BPF_CORE_READ(css, serial_nr);
+    u64 *elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
+    if (!elem || *elem != serial_nr)
         return 0;
 
     // lookup start time

--- a/src/agent/samplers/cpu/linux/bandwidth/stats.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/stats.rs
@@ -3,6 +3,20 @@ use metriken::*;
 use crate::agent::*;
 
 #[metric(
+    name = "cgroup_cpu_bandwidth_quota",
+    description = "The CPU bandwidth quota assigned to the cgroup in nanoseconds",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_BANDWIDTH_QUOTA: GaugeGroup = GaugeGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_bandwidth_period",
+    description = "The duration of the CFS bandwidth period in nanoseconds",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_BANDWIDTH_PERIOD: GaugeGroup = GaugeGroup::new(MAX_CGROUPS);
+
+#[metric(
     name = "cgroup_cpu_throttled_time",
     description = "The total time a cgroup has been throttled by the CPU controller in nanoseconds",
     metadata = { unit = "nanoseconds" }

--- a/src/agent/samplers/cpu/linux/mod.rs
+++ b/src/agent/samplers/cpu/linux/mod.rs
@@ -1,8 +1,8 @@
+mod bandwidth;
 mod cores;
 mod frequency;
 mod l3;
 mod migrations;
 mod perf;
-mod throttled;
 mod tlb_flush;
 mod usage;


### PR DESCRIPTION
Renames the cpu_throttled sampler to cpu_bandwidth and adds quota and period metrics. These are useful when evaluating the throttled metrics.

Throttled metrics retain original naming.
