### PR TITLE
add syscall latency tracking for all categories

### DIFF
--- a/src/agent/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/agent/samplers/syscall/linux/latency/mod.bpf.c
@@ -104,6 +104,62 @@ struct {
 	__uint(max_entries, HISTOGRAM_BUCKETS);
 } yield_latency SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
+} filesystem_latency SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
+} memory_latency SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
+} process_latency SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
+} query_latency SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
+} ipc_latency SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
+} timer_latency SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, HISTOGRAM_BUCKETS);
+} event_latency SEC(".maps");
+
 // provides a lookup table from syscall id to a counter index offset
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
@@ -190,6 +246,27 @@ int sys_exit(struct trace_event_raw_sys_exit *args)
 			break;
 		case 8:
 			array_incr(&yield_latency, idx);
+			break;
+		case 9:
+			array_incr(&filesystem_latency, idx);
+			break;
+		case 10:
+			array_incr(&memory_latency, idx);
+			break;
+		case 11:
+			array_incr(&process_latency, idx);
+			break;
+		case 12:
+			array_incr(&query_latency, idx);
+			break;
+		case 13:
+			array_incr(&ipc_latency, idx);
+			break;
+		case 14:
+			array_incr(&timer_latency, idx);
+			break;
+		case 15:
+			array_incr(&event_latency, idx);
 			break;
 		default:
 			array_incr(&other_latency, idx);

--- a/src/agent/samplers/syscall/linux/latency/mod.rs
+++ b/src/agent/samplers/syscall/linux/latency/mod.rs
@@ -44,7 +44,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .histogram("ipc_latency", &SYSCALL_IPC_LATENCY)
         .histogram("timer_latency", &SYSCALL_TIMER_LATENCY)
         .histogram("event_latency", &SYSCALL_EVENT_LATENCY)
-
         .map("syscall_lut", syscall_lut())
         .build()?;
 
@@ -71,7 +70,6 @@ impl SkelExt for ModSkel<'_> {
             "timer_latency" => &self.maps.timer_latency,
             "event_latency" => &self.maps.event_latency,
             "syscall_lut" => &self.maps.syscall_lut,
-
             _ => unimplemented!(),
         }
     }

--- a/src/agent/samplers/syscall/linux/latency/mod.rs
+++ b/src/agent/samplers/syscall/linux/latency/mod.rs
@@ -37,6 +37,14 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .histogram("sleep_latency", &SYSCALL_SLEEP_LATENCY)
         .histogram("socket_latency", &SYSCALL_SOCKET_LATENCY)
         .histogram("yield_latency", &SYSCALL_YIELD_LATENCY)
+        .histogram("filesystem_latency", &SYSCALL_FILESYSTEM_LATENCY)
+        .histogram("memory_latency", &SYSCALL_MEMORY_LATENCY)
+        .histogram("process_latency", &SYSCALL_PROCESS_LATENCY)
+        .histogram("query_latency", &SYSCALL_QUERY_LATENCY)
+        .histogram("ipc_latency", &SYSCALL_IPC_LATENCY)
+        .histogram("timer_latency", &SYSCALL_TIMER_LATENCY)
+        .histogram("event_latency", &SYSCALL_EVENT_LATENCY)
+
         .map("syscall_lut", syscall_lut())
         .build()?;
 
@@ -55,7 +63,15 @@ impl SkelExt for ModSkel<'_> {
             "sleep_latency" => &self.maps.sleep_latency,
             "socket_latency" => &self.maps.socket_latency,
             "yield_latency" => &self.maps.yield_latency,
+            "filesystem_latency" => &self.maps.filesystem_latency,
+            "memory_latency" => &self.maps.memory_latency,
+            "process_latency" => &self.maps.process_latency,
+            "query_latency" => &self.maps.query_latency,
+            "ipc_latency" => &self.maps.ipc_latency,
+            "timer_latency" => &self.maps.timer_latency,
+            "event_latency" => &self.maps.event_latency,
             "syscall_lut" => &self.maps.syscall_lut,
+
             _ => unimplemented!(),
         }
     }

--- a/src/agent/samplers/syscall/linux/latency/stats.rs
+++ b/src/agent/samplers/syscall/linux/latency/stats.rs
@@ -7,7 +7,7 @@ static LATENCY_HISTOGRAM_MAX: u8 = 64;
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for all other syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "other" }
 )]
 pub static SYSCALL_OTHER_LATENCY: RwLockHistogram =
@@ -15,7 +15,7 @@ pub static SYSCALL_OTHER_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for read related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "read" }
 )]
 pub static SYSCALL_READ_LATENCY: RwLockHistogram =
@@ -23,7 +23,7 @@ pub static SYSCALL_READ_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for write related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "write" }
 )]
 pub static SYSCALL_WRITE_LATENCY: RwLockHistogram =
@@ -31,7 +31,7 @@ pub static SYSCALL_WRITE_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for poll related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "poll" }
 )]
 pub static SYSCALL_POLL_LATENCY: RwLockHistogram =
@@ -39,7 +39,7 @@ pub static SYSCALL_POLL_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for lock related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "lock" }
 )]
 pub static SYSCALL_LOCK_LATENCY: RwLockHistogram =
@@ -47,7 +47,7 @@ pub static SYSCALL_LOCK_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for time related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "time" }
 )]
 pub static SYSCALL_TIME_LATENCY: RwLockHistogram =
@@ -55,7 +55,7 @@ pub static SYSCALL_TIME_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for sleep related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "sleep" }
 )]
 pub static SYSCALL_SLEEP_LATENCY: RwLockHistogram =
@@ -63,7 +63,7 @@ pub static SYSCALL_SLEEP_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for socket related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "socket" }
 )]
 pub static SYSCALL_SOCKET_LATENCY: RwLockHistogram =
@@ -71,8 +71,64 @@ pub static SYSCALL_SOCKET_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "syscall_latency",
-    description = "Distribution of the latency for yield related syscalls",
+    description = "Distribution of syscall latencies",
     metadata = { unit = "nanoseconds", op = "yield" }
 )]
 pub static SYSCALL_YIELD_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
+
+#[metric(
+    name = "syscall_latency",
+    description = "Distribution of syscall latencies",
+    metadata = { unit = "nanoseconds", op = "filesystem" }
+)]
+pub static SYSCALL_FILESYSTEM_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
+
+#[metric(
+    name = "syscall_latency",
+    description = "Distribution of syscall latencies",
+    metadata = { unit = "nanoseconds", op = "memory" }
+)]
+pub static SYSCALL_MEMORY_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
+
+#[metric(
+    name = "syscall_latency",
+    description = "Distribution of syscall latencies",
+    metadata = { unit = "nanoseconds", op = "process" }
+)]
+pub static SYSCALL_PROCESS_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
+
+#[metric(
+    name = "syscall_latency",
+    description = "Distribution of syscall latencies",
+    metadata = { unit = "nanoseconds", op = "query" }
+)]
+pub static SYSCALL_QUERY_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
+
+#[metric(
+    name = "syscall_latency",
+    description = "Distribution of syscall latencies",
+    metadata = { unit = "nanoseconds", op = "ipc" }
+)]
+pub static SYSCALL_IPC_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
+
+#[metric(
+    name = "syscall_latency",
+    description = "Distribution of syscall latencies",
+    metadata = { unit = "nanoseconds", op = "timer" }
+)]
+pub static SYSCALL_TIMER_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);
+
+#[metric(
+    name = "syscall_latency",
+    description = "Distribution of syscall latencies",
+    metadata = { unit = "nanoseconds", op = "event" }
+)]
+pub static SYSCALL_EVENT_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, LATENCY_HISTOGRAM_MAX);


### PR DESCRIPTION
The newer syscall categories did not have latency tracking added yet, this change adds the latency tracking so it is present for all syscall categories.
