### PR TITLE
prevent undercounting of throttled time

### DIFF
--- a/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
@@ -209,7 +209,6 @@ int throttle_cfs_rq(struct pt_regs *ctx)
 
     // record throttle start time
     u64 now = bpf_ktime_get_ns();
-    u32 cgroup_idx = (u32)cgroup_id;
     bpf_map_update_elem(&throttle_start, &cgroup_idx, &now, BPF_ANY);
 
     return 0;


### PR DESCRIPTION
Previously, we set the throttle start time for every cfs_throttle_rq() which can result in the throttling time being undercounted if it is updated again before unthrottling occurs. 

This checks if the throttle start and early returns if it is non-zero