### PR TITLE
Add cgroup_bandwidth metrics to track periods throttled periods and throttled time

### DIFF
--- a/src/agent/bpf/helpers.h
+++ b/src/agent/bpf/helpers.h
@@ -19,3 +19,13 @@ static __always_inline void histogram_incr(void *array, u8 grouping_power, u64 v
     u32 idx = value_to_index(value, grouping_power);
     array_add(array, idx, 1);
 }
+
+static __always_inline void array_set_if_larger(void *array, u32 idx, u64 value) {
+    u64 *elem;
+
+    elem = bpf_map_lookup_elem(array, &idx);
+
+    if (elem && value > *elem) {
+      bpf_map_update_elem(array, &idx, &value, BPF_ANY);
+    }
+}

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -81,7 +81,10 @@ fn set_name(id: usize, name: String) {
         CGROUP_CPU_USAGE_IRQ.insert_metadata(id, "name".to_string(), name.clone());
         CGROUP_CPU_USAGE_STEAL.insert_metadata(id, "name".to_string(), name.clone());
         CGROUP_CPU_USAGE_GUEST.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id, "name".to_string(), name);
+        CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_BANDWIDTH_PERIODS.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_BANDWIDTH_THROTTLED_PERIODS.insert_metadata(id, "name".to_string(), name.clone());
+        CGROUP_BANDWIDTH_THROTTLED_TIME.insert_metadata(id, "name".to_string(), name);
     }
 }
 
@@ -142,6 +145,9 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .packed_counters("cgroup_steal", &CGROUP_CPU_USAGE_STEAL)
         .packed_counters("cgroup_guest", &CGROUP_CPU_USAGE_GUEST)
         .packed_counters("cgroup_guest_nice", &CGROUP_CPU_USAGE_GUEST_NICE)
+        .packed_counters("cgroup_bandwidth_periods", &CGROUP_BANDWIDTH_PERIODS)
+        .packed_counters("cgroup_bandwidth_throttled_periods", &CGROUP_BANDWIDTH_THROTTLED_PERIODS)
+        .packed_counters("cgroup_bandwidth_throttled_time", &CGROUP_BANDWIDTH_THROTTLED_TIME)
         .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 
@@ -160,6 +166,9 @@ impl SkelExt for ModSkel<'_> {
             "cgroup_steal" => &self.maps.cgroup_steal,
             "cgroup_guest" => &self.maps.cgroup_guest,
             "cgroup_guest_nice" => &self.maps.cgroup_guest_nice,
+            "cgroup_bandwidth_periods" => &self.maps.cgroup_periods,
+            "cgroup_bandwidth_throttled_periods" => &self.maps.cgroup_throttled_periods,
+            "cgroup_bandwidth_throttled_time" => &self.maps.cgroup_throttled_time,
             "cpu_usage" => &self.maps.cpu_usage,
             "softirq" => &self.maps.softirq,
             "softirq_time" => &self.maps.softirq_time,

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -146,8 +146,14 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .packed_counters("cgroup_guest", &CGROUP_CPU_USAGE_GUEST)
         .packed_counters("cgroup_guest_nice", &CGROUP_CPU_USAGE_GUEST_NICE)
         .packed_counters("cgroup_bandwidth_periods", &CGROUP_BANDWIDTH_PERIODS)
-        .packed_counters("cgroup_bandwidth_throttled_periods", &CGROUP_BANDWIDTH_THROTTLED_PERIODS)
-        .packed_counters("cgroup_bandwidth_throttled_time", &CGROUP_BANDWIDTH_THROTTLED_TIME)
+        .packed_counters(
+            "cgroup_bandwidth_throttled_periods",
+            &CGROUP_BANDWIDTH_THROTTLED_PERIODS,
+        )
+        .packed_counters(
+            "cgroup_bandwidth_throttled_time",
+            &CGROUP_BANDWIDTH_THROTTLED_TIME,
+        )
         .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 

--- a/src/agent/samplers/cpu/linux/usage/stats.rs
+++ b/src/agent/samplers/cpu/linux/usage/stats.rs
@@ -122,6 +122,27 @@ pub static CGROUP_CPU_USAGE_GUEST: CounterGroup = CounterGroup::new(MAX_CGROUPS)
 )]
 pub static CGROUP_CPU_USAGE_GUEST_NICE: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
+#[metric(
+    name = "cgroup_cpu_bandwidth",
+    description = "The amount of cgroup cpu bandwidth periods",
+    metadata = { state = "periods", unit = "events" }
+)]
+pub static CGROUP_BANDWIDTH_PERIODS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_bandwidth",
+    description = "The amount of cgroup cpu bandwidth throttled periods",
+    metadata = { state = "throttled_periods", unit = "events" }
+)]
+pub static CGROUP_BANDWIDTH_THROTTLED_PERIODS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_bandwidth",
+    description = "The amount of cgroup cpu bandwidth throttled time",
+    metadata = { state = "throttled_time", unit = "nanoseconds" }
+)]
+pub static CGROUP_BANDWIDTH_THROTTLED_TIME: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
 /*
  * softirq metrics
  */


### PR DESCRIPTION
Add three cgroup_cpu_bandwidth metrics for tracking the cgroup periods, throttled periods, and throttled time.
