### PR TITLE
fix: increase service open file limit

### DIFF
--- a/debian/rezolus.rezolus.service
+++ b/debian/rezolus.rezolus.service
@@ -9,6 +9,7 @@ Group=root
 ExecStart=/usr/bin/rezolus /etc/rezolus/agent.toml
 KillMode=control-group
 Restart=on-failure
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On systems with a large number of cores, and depending on the system configuration, we may exceed the open file descriptor limit.

This change makes the limit explicit in the service definition.
