### PR TITLE
Add cgroup_cpu_bandwidth metrics

### DIFF
--- a/src/agent/bpf/helpers.h
+++ b/src/agent/bpf/helpers.h
@@ -19,3 +19,13 @@ static __always_inline void histogram_incr(void *array, u8 grouping_power, u64 v
     u32 idx = value_to_index(value, grouping_power);
     array_add(array, idx, 1);
 }
+
+static __always_inline void array_set_if_larger(void *array, u32 idx, u64 value) {
+  u64 *elem;
+
+  elem = bpf_map_lookup_elem(array, &idx);
+
+  if (elem && value > *elem) {
+    *elem = value;
+  }
+}

--- a/src/agent/samplers/cpu/linux/bandwidth/stats.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/stats.rs
@@ -18,35 +18,35 @@ pub static CGROUP_CPU_BANDWIDTH_PERIOD_DURATION: GaugeGroup = GaugeGroup::new(MA
 
 #[metric(
     name = "cgroup_cpu_throttled_time",
-    description = "The total time a cgroup has been throttled by the CPU controller in nanoseconds",
+    description = "The total time all runqueues in a cgroup throttled by the CPU controller in nanoseconds",
     metadata = { unit = "nanoseconds" }
 )]
 pub static CGROUP_CPU_THROTTLED_TIME: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 #[metric(
     name = "cgroup_cpu_throttled",
-    description = "The number of times a cgroup has been throttled by the CPU controller",
+    description = "The number of times all runqueues in a cgroup throttled by the CPU controller",
     metadata = { unit = "events" }
 )]
 pub static CGROUP_CPU_THROTTLED: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 #[metric(
-    name = "cgroup_cpu_bandwidth",
-    description = "Cgroup CPU bandwidth periods",
-    metadata = { state = "periods", unit = "events" }
+    name = "cgroup_cpu_bandwidth_periods",
+    description = "The total number of periods in a cgroup with the CPU bandwidth set",
+    metadata = { unit = "events" }
 )]
 pub static CGROUP_CPU_BANDWIDTH_PERIODS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 #[metric(
-    name = "cgroup_cpu_bandwidth",
-    description = "Cgroup CPU bandwidth throttled periods",
-    metadata = { state = "throttled_periods", unit = "events" }
+    name = "cgroup_cpu_bandwidth_throttled_periods",
+    description = "The total number of throttled periods in a cgroup with the CPU bandwidth set",
+    metadata = { unit = "events" }
 )]
 pub static CGROUP_CPU_BANDWIDTH_THROTTLED_PERIODS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 #[metric(
-    name = "cgroup_cpu_bandwidth",
-    description = "Cgroup CPU bandwidth throttled time",
-    metadata = { state = "throttled_time", unit = "nanoseconds" }
+    name = "cgroup_cpu_bandwidth_throttled_time",
+    description = "The total throttled time of all runqueues in a cgroup read from the cgroup cfs_bandwidth statistics",
+    metadata = { unit = "nanoseconds" }
 )]
 pub static CGROUP_CPU_BANDWIDTH_THROTTLED_TIME: CounterGroup = CounterGroup::new(MAX_CGROUPS);

--- a/src/agent/samplers/cpu/linux/bandwidth/stats.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/stats.rs
@@ -10,11 +10,11 @@ use crate::agent::*;
 pub static CGROUP_CPU_BANDWIDTH_QUOTA: GaugeGroup = GaugeGroup::new(MAX_CGROUPS);
 
 #[metric(
-    name = "cgroup_cpu_bandwidth_period",
+    name = "cgroup_cpu_bandwidth_period_duration",
     description = "The duration of the CFS bandwidth period in nanoseconds",
     metadata = { unit = "nanoseconds" }
 )]
-pub static CGROUP_CPU_BANDWIDTH_PERIOD: GaugeGroup = GaugeGroup::new(MAX_CGROUPS);
+pub static CGROUP_CPU_BANDWIDTH_PERIOD_DURATION: GaugeGroup = GaugeGroup::new(MAX_CGROUPS);
 
 #[metric(
     name = "cgroup_cpu_throttled_time",
@@ -29,3 +29,24 @@ pub static CGROUP_CPU_THROTTLED_TIME: CounterGroup = CounterGroup::new(MAX_CGROU
     metadata = { unit = "events" }
 )]
 pub static CGROUP_CPU_THROTTLED: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_bandwidth",
+    description = "Cgroup CPU bandwidth periods",
+    metadata = { state = "periods", unit = "events" }
+)]
+pub static CGROUP_CPU_BANDWIDTH_PERIODS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_bandwidth",
+    description = "Cgroup CPU bandwidth throttled periods",
+    metadata = { state = "throttled_periods", unit = "events" }
+)]
+pub static CGROUP_CPU_BANDWIDTH_THROTTLED_PERIODS: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_bandwidth",
+    description = "Cgroup CPU bandwidth throttled time",
+    metadata = { state = "throttled_time", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_BANDWIDTH_THROTTLED_TIME: CounterGroup = CounterGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
Add three cgroup_cpu_bandwidth metrics for tracking the cgroup periods, throttled periods, and throttled time.