### PR TITLE
fix: set aligned interval missed tick behavior

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -60,7 +60,10 @@ pub fn aligned_interval(interval: Duration) -> tokio::time::Interval {
     // get an aligned start time
     let start = now - Duration::from_nanos(utc.nanosecond() as u64) + interval;
 
-    tokio::time::interval_at(start.into(), interval)
+    let mut interval = tokio::time::interval_at(start.into(), interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    interval
 }
 
 pub fn utc_instant() -> (DateTime<Utc>, Instant) {


### PR DESCRIPTION
Previously, we allowed our aligned intervals to use the default missed tick behavior which is to burst to catch-up.

This change sets the behavior to 'skip' which gets us back to our aligned snapshot time and avoids putting additional pressure on the agent.
