### PR TITLE
remove softirq from cpu_usage

### DIFF
--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -112,7 +112,6 @@ struct {
 // per-cpu cpu usage tracking in nanoseconds by category
 // 0 - USER
 // 1 - SYSTEM
-// 3 - IRQ
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(map_flags, BPF_F_MMAPABLE);

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -87,10 +87,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     set_name(1, "/".to_string());
 
-    let cpu_usage = vec![
-        &CPU_USAGE_USER,
-        &CPU_USAGE_SYSTEM,
-    ];
+    let cpu_usage = vec![&CPU_USAGE_USER, &CPU_USAGE_SYSTEM];
 
     let softirq = vec![
         &SOFTIRQ_HI,

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -75,13 +75,7 @@ fn handle_event(data: &[u8]) -> i32 {
 fn set_name(id: usize, name: String) {
     if !name.is_empty() {
         CGROUP_CPU_USAGE_USER.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_NICE.insert_metadata(id, "name".to_string(), name.clone());
         CGROUP_CPU_USAGE_SYSTEM.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_SOFTIRQ.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_IRQ.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_STEAL.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_GUEST.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id, "name".to_string(), name);
     }
 }
 
@@ -95,13 +89,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let cpu_usage = vec![
         &CPU_USAGE_USER,
-        &CPU_USAGE_NICE,
         &CPU_USAGE_SYSTEM,
-        &CPU_USAGE_SOFTIRQ,
-        &CPU_USAGE_IRQ,
-        &CPU_USAGE_STEAL,
-        &CPU_USAGE_GUEST,
-        &CPU_USAGE_GUEST_NICE,
     ];
 
     let softirq = vec![
@@ -135,13 +123,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .cpu_counters("softirq", softirq)
         .cpu_counters("softirq_time", softirq_time)
         .packed_counters("cgroup_user", &CGROUP_CPU_USAGE_USER)
-        .packed_counters("cgroup_nice", &CGROUP_CPU_USAGE_NICE)
         .packed_counters("cgroup_system", &CGROUP_CPU_USAGE_SYSTEM)
-        .packed_counters("cgroup_softirq", &CGROUP_CPU_USAGE_SOFTIRQ)
-        .packed_counters("cgroup_irq", &CGROUP_CPU_USAGE_IRQ)
-        .packed_counters("cgroup_steal", &CGROUP_CPU_USAGE_STEAL)
-        .packed_counters("cgroup_guest", &CGROUP_CPU_USAGE_GUEST)
-        .packed_counters("cgroup_guest_nice", &CGROUP_CPU_USAGE_GUEST_NICE)
         .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 
@@ -153,13 +135,7 @@ impl SkelExt for ModSkel<'_> {
         match name {
             "cgroup_info" => &self.maps.cgroup_info,
             "cgroup_user" => &self.maps.cgroup_user,
-            "cgroup_nice" => &self.maps.cgroup_nice,
             "cgroup_system" => &self.maps.cgroup_system,
-            "cgroup_softirq" => &self.maps.cgroup_softirq,
-            "cgroup_irq" => &self.maps.cgroup_irq,
-            "cgroup_steal" => &self.maps.cgroup_steal,
-            "cgroup_guest" => &self.maps.cgroup_guest,
-            "cgroup_guest_nice" => &self.maps.cgroup_guest_nice,
             "cpu_usage" => &self.maps.cpu_usage,
             "softirq" => &self.maps.softirq,
             "softirq_time" => &self.maps.softirq_time,

--- a/src/agent/samplers/cpu/linux/usage/stats.rs
+++ b/src/agent/samplers/cpu/linux/usage/stats.rs
@@ -15,52 +15,10 @@ pub static CPU_USAGE_USER: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 #[metric(
     name = "cpu_usage",
-    description = "The amount of CPU time spent executing low priority tasks in user mode",
-    metadata = { state = "nice", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_NICE: CounterGroup = CounterGroup::new(MAX_CPUS);
-
-#[metric(
-    name = "cpu_usage",
     description = "The amount of CPU time spent executing tasks in kernel mode",
     metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_SYSTEM: CounterGroup = CounterGroup::new(MAX_CPUS);
-
-#[metric(
-    name = "cpu_usage",
-    description = "The amount of CPU time spent servicing softirqs",
-    metadata = { state = "softirq", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_SOFTIRQ: CounterGroup = CounterGroup::new(MAX_CPUS);
-
-#[metric(
-    name = "cpu_usage",
-    description = "The amount of CPU time spent servicing interrupts",
-    metadata = { state = "irq", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_IRQ: CounterGroup = CounterGroup::new(MAX_CPUS);
-
-#[metric(
-    name = "cpu_usage",
-    description = "The amount of CPU time stolen by the hypervisor",
-    metadata = { state = "steal", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_STEAL: CounterGroup = CounterGroup::new(MAX_CPUS);
-
-#[metric(
-    name = "cpu_usage",
-    description = "The amount of CPU time spent running a virtual CPU for a guest",
-    metadata = { state = "guest", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_GUEST: CounterGroup = CounterGroup::new(MAX_CPUS);
-
-#[metric(
-    name = "cpu_usage",
-    description = "The amount of CPU time spent running a virtual CPU for a guest in low priority mode",
-    metadata = { state = "guest_nice", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_GUEST_NICE: CounterGroup = CounterGroup::new(MAX_CPUS);
 
 /*
  * per-cgroup metrics
@@ -75,52 +33,10 @@ pub static CGROUP_CPU_USAGE_USER: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 #[metric(
     name = "cgroup_cpu_usage",
-    description = "The amount of CPU time spent executing low priority tasks in user mode on a per-cgroup basis",
-    metadata = { state = "nice", unit = "nanoseconds" }
-)]
-pub static CGROUP_CPU_USAGE_NICE: CounterGroup = CounterGroup::new(MAX_CGROUPS);
-
-#[metric(
-    name = "cgroup_cpu_usage",
     description = "The amount of CPU time spent executing tasks in kernel mode on a per-cgroup basis",
     metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static CGROUP_CPU_USAGE_SYSTEM: CounterGroup = CounterGroup::new(MAX_CGROUPS);
-
-#[metric(
-    name = "cgroup_cpu_usage",
-    description = "The amount of CPU time spent servicing softirqs on a per-cgroup basis",
-    metadata = { state = "softirq", unit = "nanoseconds" }
-)]
-pub static CGROUP_CPU_USAGE_SOFTIRQ: CounterGroup = CounterGroup::new(MAX_CGROUPS);
-
-#[metric(
-    name = "cgroup_cpu_usage",
-    description = "The amount of CPU time spent servicing interrupts on a per-cgroup basis",
-    metadata = { state = "irq", unit = "nanoseconds" }
-)]
-pub static CGROUP_CPU_USAGE_IRQ: CounterGroup = CounterGroup::new(MAX_CGROUPS);
-
-#[metric(
-    name = "cgroup_cpu_usage",
-    description = "The amount of CPU time stolen by the hypervisor on a per-cgroup basis",
-    metadata = { state = "steal", unit = "nanoseconds" }
-)]
-pub static CGROUP_CPU_USAGE_STEAL: CounterGroup = CounterGroup::new(MAX_CGROUPS);
-
-#[metric(
-    name = "cgroup_cpu_usage",
-    description = "The amount of CPU time spent running a virtual CPU for a guest on a per-cgroup basis",
-    metadata = { state = "guest", unit = "nanoseconds" }
-)]
-pub static CGROUP_CPU_USAGE_GUEST: CounterGroup = CounterGroup::new(MAX_CGROUPS);
-
-#[metric(
-    name = "cgroup_cpu_usage",
-    description = "The amount of CPU time spent running a virtual CPU for a guest in low priority mode on a per-cgroup basis",
-    metadata = { state = "guest_nice", unit = "nanoseconds" }
-)]
-pub static CGROUP_CPU_USAGE_GUEST_NICE: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 /*
  * softirq metrics


### PR DESCRIPTION
Removes the softirq accounting from the cpu_usage metric which now simply tracks user and system time.

Removes the unused irq, nice, guest, ... metrics as well from both per-cpu and per-cgroup levels.

As a result, we now can look at the cpu_usage as total usage again, and softirq time is still available via the softirq_time metrics.
