### PR TITLE
Fix metadata clearing in metric groups

### DIFF
--- a/src/agent/metrics/counters/mod.rs
+++ b/src/agent/metrics/counters/mod.rs
@@ -78,7 +78,9 @@ impl CounterGroup {
 
     pub fn clear_metadata(&self, idx: usize) {
         if let Some(metadata) = self.metadata.get() {
-            let _ = metadata.write().get(idx).cloned();
+            if let Some(m) = metadata.write().get_mut(idx) {
+                m.clear();
+            }
         }
     }
 

--- a/src/agent/metrics/gauges/mod.rs
+++ b/src/agent/metrics/gauges/mod.rs
@@ -79,7 +79,9 @@ impl GaugeGroup {
 
     pub fn clear_metadata(&self, idx: usize) {
         if let Some(metadata) = self.metadata.get() {
-            let _ = metadata.write().get(idx).cloned();
+            if let Some(m) = metadata.write().get_mut(idx) {
+                m.clear();
+            }
         }
     }
 


### PR DESCRIPTION
Fix the implementation of `clear_metadata` in `CounterGroup` and `GaugeGroup`
