### PR TITLE
Fix exporter restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ options and their defaults.
 sudo editor /etc/rezolus/exporter.toml
 
 # restart the exporter to apply changes
-sudo systemsctl restart rezolus-exporter
+sudo systemctl restart rezolus-exporter
 ```
 
 #### Hindsight


### PR DESCRIPTION
## Summary
- fix typo in README instructions for restarting the exporter

## Testing
- `cargo test` *(fails: could not connect to crates.io)*