### PR TITLE
Update help string for duration argument

### DIFF
--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -70,7 +70,7 @@ pub fn command() -> Command {
             clap::Arg::new("DURATION")
                 .long("duration")
                 .short('d')
-                .help("Sets the collection interval")
+                .help("Sets the collection duration")
                 .action(clap::ArgAction::Set)
                 .value_parser(value_parser!(humantime::Duration)),
         )


### PR DESCRIPTION
## Summary
- update `DURATION` option help text in `recorder` module

## Testing
- `cargo test --locked` *(fails: could not download crates)*