### PR TITLE
fix blockio and syscall latency charts to use log scale

### DIFF
--- a/src/viewer/dashboard/blockio.rs
+++ b/src/viewer/dashboard/blockio.rs
@@ -56,7 +56,8 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     for op in &["Read", "Write"] {
         latency.scatter(
-            PlotOpts::scatter(*op, format!("latency-{}", op.to_lowercase()), Unit::Time),
+            PlotOpts::scatter(*op, format!("latency-{}", op.to_lowercase()), Unit::Time)
+                .with_log_scale(true),
             data.percentiles("blockio_latency", [("op", op.to_lowercase())], PERCENTILES),
         );
     }
@@ -71,7 +72,8 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     for op in &["Read", "Write"] {
         size.scatter(
-            PlotOpts::scatter(*op, format!("size-{}", op.to_lowercase()), Unit::Bytes),
+            PlotOpts::scatter(*op, format!("size-{}", op.to_lowercase()), Unit::Bytes)
+                .with_log_scale(true),
             data.percentiles("blockio_size", [("op", op.to_lowercase())], PERCENTILES),
         );
     }

--- a/src/viewer/dashboard/syscall.rs
+++ b/src/viewer/dashboard/syscall.rs
@@ -44,7 +44,8 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         );
 
         syscall.scatter(
-            PlotOpts::scatter(*op, format!("syscall-{op}-latency"), Unit::Time),
+            PlotOpts::scatter(*op, format!("syscall-{op}-latency"), Unit::Time)
+                .with_log_scale(true),
             data.percentiles("syscall_latency", [("op", op.to_lowercase())], PERCENTILES),
         );
     }


### PR DESCRIPTION
Changes the viewer charts for blockio and syscall latency to use log scale for y-axis.
