### PR TITLE
add bpf execution count and run time metrics

### DIFF
--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -14,6 +14,11 @@ use std::sync::mpsc::sync_channel;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub struct BpfProgStats {
+    pub run_time: &'static LazyCounter,
+    pub run_count: &'static LazyCounter,
+}
+
 pub struct PerfEvent {
     inner: Event,
 }
@@ -100,6 +105,7 @@ impl PerfEvent {
 
 pub struct Builder<T: 'static + SkelBuilder<'static>> {
     skel: fn() -> T,
+    prog_stats: BpfProgStats,
     counters: Vec<(&'static str, Vec<&'static LazyCounter>)>,
     histograms: Vec<(&'static str, &'static RwLockHistogram)>,
     maps: Vec<(&'static str, Vec<u64>)>,
@@ -115,9 +121,10 @@ where
     <<T as SkelBuilder<'static>>::Output as OpenSkel<'static>>::Output: OpenSkelExt,
     <<T as SkelBuilder<'static>>::Output as OpenSkel<'static>>::Output: SkelExt,
 {
-    pub fn new(skel: fn() -> T) -> Self {
+    pub fn new(prog_stats: BpfProgStats, skel: fn() -> T) -> Self {
         Self {
             skel,
+            prog_stats,
             counters: Vec::new(),
             histograms: Vec::new(),
             maps: Vec::new(),
@@ -382,6 +389,33 @@ where
 
                 for v in &mut packed_counters {
                     v.refresh();
+                }
+
+                let mut run_time: u64 = 0;
+                let mut run_count: u64 = 0;
+
+                for prog in skel.object().progs() {
+                    let mut info = libbpf_sys::bpf_prog_info::default();
+                    let mut len = std::mem::size_of::<libbpf_sys::bpf_prog_info>() as u32;
+
+                    let fd = prog.as_fd().as_raw_fd();
+
+                    let result = unsafe {
+                        libbpf_sys::bpf_prog_get_info_by_fd(fd, &mut info, &mut len)
+                    };
+
+                    if result == 0 {
+                        run_time = run_time.wrapping_add(info.run_time_ns);
+                        run_count = run_count.wrapping_add(info.run_cnt);
+                    }
+                }
+
+                if run_time > 0 {
+                    self.prog_stats.run_time.set(run_time);
+                }
+
+                if run_count > 0 {
+                    self.prog_stats.run_count.set(run_count);
                 }
 
                 // notify that we have finished running

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -400,9 +400,8 @@ where
 
                     let fd = prog.as_fd().as_raw_fd();
 
-                    let result = unsafe {
-                        libbpf_sys::bpf_prog_get_info_by_fd(fd, &mut info, &mut len)
-                    };
+                    let result =
+                        unsafe { libbpf_sys::bpf_prog_get_info_by_fd(fd, &mut info, &mut len) };
 
                     if result == 0 {
                         run_time = run_time.wrapping_add(info.run_time_ns);

--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -4,7 +4,7 @@ mod histogram;
 mod sync_primitive;
 
 pub use builder::Builder as BpfBuilder;
-pub use builder::PerfEvent;
+pub use builder::{BpfProgStats, PerfEvent};
 
 use crate::agent::samplers::Sampler;
 use crate::*;

--- a/src/agent/samplers/blockio/linux/latency/mod.rs
+++ b/src/agent/samplers/blockio/linux/latency/mod.rs
@@ -27,12 +27,18 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .histogram("read_latency", &BLOCKIO_READ_LATENCY)
-        .histogram("write_latency", &BLOCKIO_WRITE_LATENCY)
-        .histogram("flush_latency", &BLOCKIO_FLUSH_LATENCY)
-        .histogram("discard_latency", &BLOCKIO_DISCARD_LATENCY)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .histogram("read_latency", &BLOCKIO_READ_LATENCY)
+    .histogram("write_latency", &BLOCKIO_WRITE_LATENCY)
+    .histogram("flush_latency", &BLOCKIO_FLUSH_LATENCY)
+    .histogram("discard_latency", &BLOCKIO_DISCARD_LATENCY)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/blockio/linux/latency/mod.rs
+++ b/src/agent/samplers/blockio/linux/latency/mod.rs
@@ -27,7 +27,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .histogram("read_latency", &BLOCKIO_READ_LATENCY)
         .histogram("write_latency", &BLOCKIO_WRITE_LATENCY)
         .histogram("flush_latency", &BLOCKIO_FLUSH_LATENCY)

--- a/src/agent/samplers/blockio/linux/latency/stats.rs
+++ b/src/agent/samplers/blockio/linux/latency/stats.rs
@@ -1,6 +1,28 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
 use metriken::*;
 
+/*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "blockio_latency"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "blockio_latency"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * system-wide
+ */
+
 #[metric(
     name = "blockio_latency",
     description = "Distribution of blockio read operation latency in nanoseconds",

--- a/src/agent/samplers/blockio/linux/requests/mod.rs
+++ b/src/agent/samplers/blockio/linux/requests/mod.rs
@@ -38,7 +38,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &BLOCKIO_DISCARD_BYTES,
     ];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .counters("counters", counters)
         .histogram("read_size", &BLOCKIO_READ_SIZE)
         .histogram("write_size", &BLOCKIO_WRITE_SIZE)

--- a/src/agent/samplers/blockio/linux/requests/mod.rs
+++ b/src/agent/samplers/blockio/linux/requests/mod.rs
@@ -38,13 +38,19 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &BLOCKIO_DISCARD_BYTES,
     ];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .counters("counters", counters)
-        .histogram("read_size", &BLOCKIO_READ_SIZE)
-        .histogram("write_size", &BLOCKIO_WRITE_SIZE)
-        .histogram("flush_size", &BLOCKIO_FLUSH_SIZE)
-        .histogram("discard_size", &BLOCKIO_DISCARD_SIZE)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .counters("counters", counters)
+    .histogram("read_size", &BLOCKIO_READ_SIZE)
+    .histogram("write_size", &BLOCKIO_WRITE_SIZE)
+    .histogram("flush_size", &BLOCKIO_FLUSH_SIZE)
+    .histogram("discard_size", &BLOCKIO_DISCARD_SIZE)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/blockio/linux/requests/stats.rs
+++ b/src/agent/samplers/blockio/linux/requests/stats.rs
@@ -5,7 +5,7 @@ use metriken::*;
  * bpf prog stats
  */
 
- #[metric(
+#[metric(
     name = "rezolus_bpf_run_count",
     description = "The number of times Rezolus BPF programs have been run",
     metadata = { sampler = "blockio_requests"}

--- a/src/agent/samplers/blockio/linux/requests/stats.rs
+++ b/src/agent/samplers/blockio/linux/requests/stats.rs
@@ -1,6 +1,28 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
 use metriken::*;
 
+/*
+ * bpf prog stats
+ */
+
+ #[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "blockio_requests"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "blockio_requests"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * system-wide
+ */
+
 #[metric(
     name = "blockio_size",
     description = "Distribution of blockio read operation sizes in bytes",

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.rs
@@ -114,7 +114,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     set_cgroup_name(1, "/".to_string());
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .packed_counters("throttled_time", &CGROUP_CPU_THROTTLED_TIME)
         .packed_counters("throttled_count", &CGROUP_CPU_THROTTLED)
         .packed_counters("bandwidth_periods", &CGROUP_CPU_BANDWIDTH_PERIODS)

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.rs
@@ -114,21 +114,27 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     set_cgroup_name(1, "/".to_string());
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .packed_counters("throttled_time", &CGROUP_CPU_THROTTLED_TIME)
-        .packed_counters("throttled_count", &CGROUP_CPU_THROTTLED)
-        .packed_counters("bandwidth_periods", &CGROUP_CPU_BANDWIDTH_PERIODS)
-        .packed_counters(
-            "bandwidth_throttled_periods",
-            &CGROUP_CPU_BANDWIDTH_THROTTLED_PERIODS,
-        )
-        .packed_counters(
-            "bandwidth_throttled_time",
-            &CGROUP_CPU_BANDWIDTH_THROTTLED_TIME,
-        )
-        .ringbuf_handler("cgroup_info", handle_cgroup_info)
-        .ringbuf_handler("bandwidth_info", handle_bandwidth_info)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .packed_counters("throttled_time", &CGROUP_CPU_THROTTLED_TIME)
+    .packed_counters("throttled_count", &CGROUP_CPU_THROTTLED)
+    .packed_counters("bandwidth_periods", &CGROUP_CPU_BANDWIDTH_PERIODS)
+    .packed_counters(
+        "bandwidth_throttled_periods",
+        &CGROUP_CPU_BANDWIDTH_THROTTLED_PERIODS,
+    )
+    .packed_counters(
+        "bandwidth_throttled_time",
+        &CGROUP_CPU_BANDWIDTH_THROTTLED_TIME,
+    )
+    .ringbuf_handler("cgroup_info", handle_cgroup_info)
+    .ringbuf_handler("bandwidth_info", handle_bandwidth_info)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/bandwidth/stats.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/stats.rs
@@ -6,7 +6,7 @@ use crate::agent::*;
  * bpf prog stats
  */
 
- #[metric(
+#[metric(
     name = "rezolus_bpf_run_count",
     description = "The number of times Rezolus BPF programs have been run",
     metadata = { sampler = "cpu_bandwidth"}

--- a/src/agent/samplers/cpu/linux/bandwidth/stats.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/stats.rs
@@ -2,6 +2,28 @@ use metriken::*;
 
 use crate::agent::*;
 
+/*
+ * bpf prog stats
+ */
+
+ #[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "cpu_bandwidth"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "cpu_bandwidth"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * per-cgroup
+ */
+
 #[metric(
     name = "cgroup_cpu_bandwidth_quota",
     description = "The CPU bandwidth quota assigned to the cgroup in nanoseconds",

--- a/src/agent/samplers/cpu/linux/migrations/mod.rs
+++ b/src/agent/samplers/cpu/linux/migrations/mod.rs
@@ -81,12 +81,18 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     set_name(1, "/".to_string());
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .packed_counters("cpu_migrations_from", &CPU_MIGRATIONS_FROM)
-        .packed_counters("cpu_migrations_to", &CPU_MIGRATIONS_TO)
-        .packed_counters("cgroup_cpu_migrations", &CGROUP_CPU_MIGRATIONS)
-        .ringbuf_handler("cgroup_info", handle_event)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .packed_counters("cpu_migrations_from", &CPU_MIGRATIONS_FROM)
+    .packed_counters("cpu_migrations_to", &CPU_MIGRATIONS_TO)
+    .packed_counters("cgroup_cpu_migrations", &CGROUP_CPU_MIGRATIONS)
+    .ringbuf_handler("cgroup_info", handle_event)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/migrations/mod.rs
+++ b/src/agent/samplers/cpu/linux/migrations/mod.rs
@@ -81,7 +81,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     set_name(1, "/".to_string());
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .packed_counters("cpu_migrations_from", &CPU_MIGRATIONS_FROM)
         .packed_counters("cpu_migrations_to", &CPU_MIGRATIONS_TO)
         .packed_counters("cgroup_cpu_migrations", &CGROUP_CPU_MIGRATIONS)

--- a/src/agent/samplers/cpu/linux/migrations/stats.rs
+++ b/src/agent/samplers/cpu/linux/migrations/stats.rs
@@ -6,7 +6,7 @@ use crate::agent::*;
  * bpf prog stats
  */
 
- #[metric(
+#[metric(
     name = "rezolus_bpf_run_count",
     description = "The number of times Rezolus BPF programs have been run",
     metadata = { sampler = "cpu_migrations"}

--- a/src/agent/samplers/cpu/linux/migrations/stats.rs
+++ b/src/agent/samplers/cpu/linux/migrations/stats.rs
@@ -2,6 +2,28 @@ use metriken::*;
 
 use crate::agent::*;
 
+/*
+ * bpf prog stats
+ */
+
+ #[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "cpu_migrations"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "cpu_migrations"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * system-wide
+ */
+
 #[metric(
     name = "cpu_migrations",
     description = "The number of process CPU migrations",

--- a/src/agent/samplers/cpu/linux/perf/mod.rs
+++ b/src/agent/samplers/cpu/linux/perf/mod.rs
@@ -86,7 +86,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     set_name(1, "/".to_string());
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .perf_event("cycles", PerfEvent::cpu_cycles(), &CPU_CYCLES)
         .perf_event("instructions", PerfEvent::instructions(), &CPU_INSTRUCTIONS)
         .packed_counters("cgroup_cycles", &CGROUP_CPU_CYCLES)

--- a/src/agent/samplers/cpu/linux/perf/mod.rs
+++ b/src/agent/samplers/cpu/linux/perf/mod.rs
@@ -86,13 +86,19 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     set_name(1, "/".to_string());
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .perf_event("cycles", PerfEvent::cpu_cycles(), &CPU_CYCLES)
-        .perf_event("instructions", PerfEvent::instructions(), &CPU_INSTRUCTIONS)
-        .packed_counters("cgroup_cycles", &CGROUP_CPU_CYCLES)
-        .packed_counters("cgroup_instructions", &CGROUP_CPU_INSTRUCTIONS)
-        .ringbuf_handler("cgroup_info", handle_event)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .perf_event("cycles", PerfEvent::cpu_cycles(), &CPU_CYCLES)
+    .perf_event("instructions", PerfEvent::instructions(), &CPU_INSTRUCTIONS)
+    .packed_counters("cgroup_cycles", &CGROUP_CPU_CYCLES)
+    .packed_counters("cgroup_instructions", &CGROUP_CPU_INSTRUCTIONS)
+    .ringbuf_handler("cgroup_info", handle_event)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/perf/stats.rs
+++ b/src/agent/samplers/cpu/linux/perf/stats.rs
@@ -2,7 +2,27 @@ use metriken::*;
 
 use crate::agent::*;
 
-// per-CPU metrics
+/*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "cpu_perf"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "cpu_perf"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * system-wide
+ */
 
 #[metric(
     name = "cpu_cycles",
@@ -18,7 +38,9 @@ pub static CPU_CYCLES: CounterGroup = CounterGroup::new(MAX_CPUS);
 )]
 pub static CPU_INSTRUCTIONS: CounterGroup = CounterGroup::new(MAX_CPUS);
 
-// per-cgroup metrics
+/*
+ * per-cgroup
+ */
 
 #[metric(
     name = "cgroup_cpu_cycles",

--- a/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
+++ b/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
@@ -90,7 +90,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &TLB_FLUSH_REMOTE_SEND_IPI,
     ];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .cpu_counters("events", events)
         .packed_counters("cgroup_task_switch", &CGROUP_TLB_FLUSH_TASK_SWITCH)
         .packed_counters(

--- a/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
+++ b/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
@@ -90,21 +90,27 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &TLB_FLUSH_REMOTE_SEND_IPI,
     ];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .cpu_counters("events", events)
-        .packed_counters("cgroup_task_switch", &CGROUP_TLB_FLUSH_TASK_SWITCH)
-        .packed_counters(
-            "cgroup_remote_shootdown",
-            &CGROUP_TLB_FLUSH_REMOTE_SHOOTDOWN,
-        )
-        .packed_counters("cgroup_local_shootdown", &CGROUP_TLB_FLUSH_LOCAL_SHOOTDOWN)
-        .packed_counters(
-            "cgroup_local_mm_shootdown",
-            &CGROUP_TLB_FLUSH_LOCAL_MM_SHOOTDOWN,
-        )
-        .packed_counters("cgroup_remote_send_ipi", &CGROUP_TLB_FLUSH_REMOTE_SEND_IPI)
-        .ringbuf_handler("cgroup_info", handle_event)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .cpu_counters("events", events)
+    .packed_counters("cgroup_task_switch", &CGROUP_TLB_FLUSH_TASK_SWITCH)
+    .packed_counters(
+        "cgroup_remote_shootdown",
+        &CGROUP_TLB_FLUSH_REMOTE_SHOOTDOWN,
+    )
+    .packed_counters("cgroup_local_shootdown", &CGROUP_TLB_FLUSH_LOCAL_SHOOTDOWN)
+    .packed_counters(
+        "cgroup_local_mm_shootdown",
+        &CGROUP_TLB_FLUSH_LOCAL_MM_SHOOTDOWN,
+    )
+    .packed_counters("cgroup_remote_send_ipi", &CGROUP_TLB_FLUSH_REMOTE_SEND_IPI)
+    .ringbuf_handler("cgroup_info", handle_event)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/tlb_flush/stats.rs
+++ b/src/agent/samplers/cpu/linux/tlb_flush/stats.rs
@@ -2,7 +2,27 @@ use metriken::*;
 
 use crate::agent::*;
 
-// per-CPU metrics
+/*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "cpu_tlb_flush"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "cpu_tlb_flush"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * per-cpu
+ */
 
 #[metric(
     name = "cpu_tlb_flush",
@@ -39,7 +59,9 @@ pub static TLB_FLUSH_LOCAL_MM_SHOOTDOWN: CounterGroup = CounterGroup::new(MAX_CP
 )]
 pub static TLB_FLUSH_REMOTE_SEND_IPI: CounterGroup = CounterGroup::new(MAX_CPUS);
 
-// per-cgroup metrics
+/*
+ * per-cgroup
+ */
 
 #[metric(
     name = "cgroup_cpu_tlb_flush",

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -115,14 +115,20 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &SOFTIRQ_TIME_RCU,
     ];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .cpu_counters("cpu_usage", cpu_usage)
-        .cpu_counters("softirq", softirq)
-        .cpu_counters("softirq_time", softirq_time)
-        .packed_counters("cgroup_user", &CGROUP_CPU_USAGE_USER)
-        .packed_counters("cgroup_system", &CGROUP_CPU_USAGE_SYSTEM)
-        .ringbuf_handler("cgroup_info", handle_event)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .cpu_counters("cpu_usage", cpu_usage)
+    .cpu_counters("softirq", softirq)
+    .cpu_counters("softirq_time", softirq_time)
+    .packed_counters("cgroup_user", &CGROUP_CPU_USAGE_USER)
+    .packed_counters("cgroup_system", &CGROUP_CPU_USAGE_SYSTEM)
+    .ringbuf_handler("cgroup_info", handle_event)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -115,7 +115,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &SOFTIRQ_TIME_RCU,
     ];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .cpu_counters("cpu_usage", cpu_usage)
         .cpu_counters("softirq", softirq)
         .cpu_counters("softirq_time", softirq_time)

--- a/src/agent/samplers/cpu/linux/usage/stats.rs
+++ b/src/agent/samplers/cpu/linux/usage/stats.rs
@@ -3,6 +3,24 @@ use metriken::*;
 use crate::agent::*;
 
 /*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "cpu_usage"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "cpu_usage"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
  * per-cpu metrics
  */
 

--- a/src/agent/samplers/network/linux/traffic/mod.rs
+++ b/src/agent/samplers/network/linux/traffic/mod.rs
@@ -37,9 +37,15 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &NETWORK_TX_PACKETS,
     ];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .counters("counters", counters)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .counters("counters", counters)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/network/linux/traffic/mod.rs
+++ b/src/agent/samplers/network/linux/traffic/mod.rs
@@ -37,7 +37,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &NETWORK_TX_PACKETS,
     ];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .counters("counters", counters)
         .build()?;
 

--- a/src/agent/samplers/network/linux/traffic/stats.rs
+++ b/src/agent/samplers/network/linux/traffic/stats.rs
@@ -1,5 +1,27 @@
 use metriken::*;
 
+/*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "network_traffic"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "network_traffic"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * system-wide
+ */
+
 #[metric(
     name = "network_bytes",
     description = "The number of bytes received over the network",

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -32,12 +32,18 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let counters = vec![&SCHEDULER_IVCSW];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .counters("counters", counters)
-        .histogram("runqlat", &SCHEDULER_RUNQUEUE_LATENCY)
-        .histogram("running", &SCHEDULER_RUNNING)
-        .histogram("offcpu", &SCHEDULER_OFFCPU)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .counters("counters", counters)
+    .histogram("runqlat", &SCHEDULER_RUNQUEUE_LATENCY)
+    .histogram("running", &SCHEDULER_RUNNING)
+    .histogram("offcpu", &SCHEDULER_OFFCPU)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -32,7 +32,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let counters = vec![&SCHEDULER_IVCSW];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .counters("counters", counters)
         .histogram("runqlat", &SCHEDULER_RUNQUEUE_LATENCY)
         .histogram("running", &SCHEDULER_RUNNING)

--- a/src/agent/samplers/scheduler/linux/runqueue/stats.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/stats.rs
@@ -1,6 +1,28 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
 use metriken::*;
 
+/*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "scheduler_runqueue"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "scheduler_runqueue"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * system-wide
+ */
+
 #[metric(
     name = "scheduler_runqueue_latency",
     description = "Distribution of the amount of time tasks were waiting in the runqueue",

--- a/src/agent/samplers/syscall/linux/counts/mod.rs
+++ b/src/agent/samplers/syscall/linux/counts/mod.rs
@@ -116,27 +116,33 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &SYSCALL_EVENT,
     ];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .counters("counters", counters)
-        .map("syscall_lut", syscall_lut())
-        .packed_counters("cgroup_syscall_other", &CGROUP_SYSCALL_OTHER)
-        .packed_counters("cgroup_syscall_read", &CGROUP_SYSCALL_READ)
-        .packed_counters("cgroup_syscall_write", &CGROUP_SYSCALL_WRITE)
-        .packed_counters("cgroup_syscall_poll", &CGROUP_SYSCALL_POLL)
-        .packed_counters("cgroup_syscall_lock", &CGROUP_SYSCALL_LOCK)
-        .packed_counters("cgroup_syscall_time", &CGROUP_SYSCALL_TIME)
-        .packed_counters("cgroup_syscall_sleep", &CGROUP_SYSCALL_SLEEP)
-        .packed_counters("cgroup_syscall_socket", &CGROUP_SYSCALL_SOCKET)
-        .packed_counters("cgroup_syscall_yield", &CGROUP_SYSCALL_YIELD)
-        .packed_counters("cgroup_syscall_filesystem", &CGROUP_SYSCALL_FILESYSTEM)
-        .packed_counters("cgroup_syscall_memory", &CGROUP_SYSCALL_MEMORY)
-        .packed_counters("cgroup_syscall_process", &CGROUP_SYSCALL_PROCESS)
-        .packed_counters("cgroup_syscall_query", &CGROUP_SYSCALL_QUERY)
-        .packed_counters("cgroup_syscall_ipc", &CGROUP_SYSCALL_IPC)
-        .packed_counters("cgroup_syscall_timer", &CGROUP_SYSCALL_TIMER)
-        .packed_counters("cgroup_syscall_event", &CGROUP_SYSCALL_EVENT)
-        .ringbuf_handler("cgroup_info", handle_event)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .counters("counters", counters)
+    .map("syscall_lut", syscall_lut())
+    .packed_counters("cgroup_syscall_other", &CGROUP_SYSCALL_OTHER)
+    .packed_counters("cgroup_syscall_read", &CGROUP_SYSCALL_READ)
+    .packed_counters("cgroup_syscall_write", &CGROUP_SYSCALL_WRITE)
+    .packed_counters("cgroup_syscall_poll", &CGROUP_SYSCALL_POLL)
+    .packed_counters("cgroup_syscall_lock", &CGROUP_SYSCALL_LOCK)
+    .packed_counters("cgroup_syscall_time", &CGROUP_SYSCALL_TIME)
+    .packed_counters("cgroup_syscall_sleep", &CGROUP_SYSCALL_SLEEP)
+    .packed_counters("cgroup_syscall_socket", &CGROUP_SYSCALL_SOCKET)
+    .packed_counters("cgroup_syscall_yield", &CGROUP_SYSCALL_YIELD)
+    .packed_counters("cgroup_syscall_filesystem", &CGROUP_SYSCALL_FILESYSTEM)
+    .packed_counters("cgroup_syscall_memory", &CGROUP_SYSCALL_MEMORY)
+    .packed_counters("cgroup_syscall_process", &CGROUP_SYSCALL_PROCESS)
+    .packed_counters("cgroup_syscall_query", &CGROUP_SYSCALL_QUERY)
+    .packed_counters("cgroup_syscall_ipc", &CGROUP_SYSCALL_IPC)
+    .packed_counters("cgroup_syscall_timer", &CGROUP_SYSCALL_TIMER)
+    .packed_counters("cgroup_syscall_event", &CGROUP_SYSCALL_EVENT)
+    .ringbuf_handler("cgroup_info", handle_event)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/syscall/linux/counts/mod.rs
+++ b/src/agent/samplers/syscall/linux/counts/mod.rs
@@ -116,7 +116,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &SYSCALL_EVENT,
     ];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .counters("counters", counters)
         .map("syscall_lut", syscall_lut())
         .packed_counters("cgroup_syscall_other", &CGROUP_SYSCALL_OTHER)

--- a/src/agent/samplers/syscall/linux/counts/stats.rs
+++ b/src/agent/samplers/syscall/linux/counts/stats.rs
@@ -3,6 +3,24 @@ use metriken::*;
 use crate::agent::*;
 
 /*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "syscall_counts"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "syscall_counts"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
  * system-wide
  */
 

--- a/src/agent/samplers/syscall/linux/latency/mod.rs
+++ b/src/agent/samplers/syscall/linux/latency/mod.rs
@@ -27,25 +27,31 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .histogram("other_latency", &SYSCALL_OTHER_LATENCY)
-        .histogram("read_latency", &SYSCALL_READ_LATENCY)
-        .histogram("write_latency", &SYSCALL_WRITE_LATENCY)
-        .histogram("poll_latency", &SYSCALL_POLL_LATENCY)
-        .histogram("lock_latency", &SYSCALL_LOCK_LATENCY)
-        .histogram("time_latency", &SYSCALL_TIME_LATENCY)
-        .histogram("sleep_latency", &SYSCALL_SLEEP_LATENCY)
-        .histogram("socket_latency", &SYSCALL_SOCKET_LATENCY)
-        .histogram("yield_latency", &SYSCALL_YIELD_LATENCY)
-        .histogram("filesystem_latency", &SYSCALL_FILESYSTEM_LATENCY)
-        .histogram("memory_latency", &SYSCALL_MEMORY_LATENCY)
-        .histogram("process_latency", &SYSCALL_PROCESS_LATENCY)
-        .histogram("query_latency", &SYSCALL_QUERY_LATENCY)
-        .histogram("ipc_latency", &SYSCALL_IPC_LATENCY)
-        .histogram("timer_latency", &SYSCALL_TIMER_LATENCY)
-        .histogram("event_latency", &SYSCALL_EVENT_LATENCY)
-        .map("syscall_lut", syscall_lut())
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .histogram("other_latency", &SYSCALL_OTHER_LATENCY)
+    .histogram("read_latency", &SYSCALL_READ_LATENCY)
+    .histogram("write_latency", &SYSCALL_WRITE_LATENCY)
+    .histogram("poll_latency", &SYSCALL_POLL_LATENCY)
+    .histogram("lock_latency", &SYSCALL_LOCK_LATENCY)
+    .histogram("time_latency", &SYSCALL_TIME_LATENCY)
+    .histogram("sleep_latency", &SYSCALL_SLEEP_LATENCY)
+    .histogram("socket_latency", &SYSCALL_SOCKET_LATENCY)
+    .histogram("yield_latency", &SYSCALL_YIELD_LATENCY)
+    .histogram("filesystem_latency", &SYSCALL_FILESYSTEM_LATENCY)
+    .histogram("memory_latency", &SYSCALL_MEMORY_LATENCY)
+    .histogram("process_latency", &SYSCALL_PROCESS_LATENCY)
+    .histogram("query_latency", &SYSCALL_QUERY_LATENCY)
+    .histogram("ipc_latency", &SYSCALL_IPC_LATENCY)
+    .histogram("timer_latency", &SYSCALL_TIMER_LATENCY)
+    .histogram("event_latency", &SYSCALL_EVENT_LATENCY)
+    .map("syscall_lut", syscall_lut())
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/syscall/linux/latency/mod.rs
+++ b/src/agent/samplers/syscall/linux/latency/mod.rs
@@ -27,7 +27,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .histogram("other_latency", &SYSCALL_OTHER_LATENCY)
         .histogram("read_latency", &SYSCALL_READ_LATENCY)
         .histogram("write_latency", &SYSCALL_WRITE_LATENCY)

--- a/src/agent/samplers/syscall/linux/latency/stats.rs
+++ b/src/agent/samplers/syscall/linux/latency/stats.rs
@@ -5,6 +5,28 @@ use metriken::*;
 // use 2^64-1 as the max value
 static LATENCY_HISTOGRAM_MAX: u8 = 64;
 
+/*
+ * bpf prog stats
+ */
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "syscall_latency"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "syscall_latency"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
+
+/*
+ * system-wide
+ */
+
 #[metric(
     name = "syscall_latency",
     description = "Distribution of syscall latencies",

--- a/src/agent/samplers/tcp/linux/connect_latency/mod.rs
+++ b/src/agent/samplers/tcp/linux/connect_latency/mod.rs
@@ -28,7 +28,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .histogram("latency", &TCP_CONNECT_LATENCY)
         .build()?;
 

--- a/src/agent/samplers/tcp/linux/connect_latency/mod.rs
+++ b/src/agent/samplers/tcp/linux/connect_latency/mod.rs
@@ -28,9 +28,15 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .histogram("latency", &TCP_CONNECT_LATENCY)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .histogram("latency", &TCP_CONNECT_LATENCY)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/tcp/linux/connect_latency/stats.rs
+++ b/src/agent/samplers/tcp/linux/connect_latency/stats.rs
@@ -8,3 +8,17 @@ use metriken::*;
 )]
 pub static TCP_CONNECT_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "tcp_connect_latency"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "tcp_connect_latency"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/tcp/linux/packet_latency/mod.rs
+++ b/src/agent/samplers/tcp/linux/packet_latency/mod.rs
@@ -27,7 +27,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .histogram("latency", &TCP_PACKET_LATENCY)
         .build()?;
 

--- a/src/agent/samplers/tcp/linux/packet_latency/mod.rs
+++ b/src/agent/samplers/tcp/linux/packet_latency/mod.rs
@@ -27,9 +27,15 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .histogram("latency", &TCP_PACKET_LATENCY)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .histogram("latency", &TCP_PACKET_LATENCY)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/tcp/linux/packet_latency/stats.rs
+++ b/src/agent/samplers/tcp/linux/packet_latency/stats.rs
@@ -7,3 +7,17 @@ use metriken::*;
     metadata = { unit = "nanoseconds" }
 )]
 pub static TCP_PACKET_LATENCY: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "tcp_packet_latency"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "tcp_packet_latency"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/tcp/linux/receive/mod.rs
+++ b/src/agent/samplers/tcp/linux/receive/mod.rs
@@ -26,10 +26,16 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .histogram("srtt", &TCP_SRTT)
-        .histogram("jitter", &TCP_JITTER)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .histogram("srtt", &TCP_SRTT)
+    .histogram("jitter", &TCP_JITTER)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/tcp/linux/receive/mod.rs
+++ b/src/agent/samplers/tcp/linux/receive/mod.rs
@@ -26,7 +26,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .histogram("srtt", &TCP_SRTT)
         .histogram("jitter", &TCP_JITTER)
         .build()?;

--- a/src/agent/samplers/tcp/linux/receive/stats.rs
+++ b/src/agent/samplers/tcp/linux/receive/stats.rs
@@ -14,3 +14,17 @@ pub static TCP_JITTER: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING
     metadata = { unit = "nanoseconds" }
 )]
 pub static TCP_SRTT: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "tcp_receive"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "tcp_receive"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/tcp/linux/retransmit/mod.rs
+++ b/src/agent/samplers/tcp/linux/retransmit/mod.rs
@@ -27,7 +27,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let counters = vec![&TCP_RETRANSMIT];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .counters("counters", counters)
         .build()?;
 

--- a/src/agent/samplers/tcp/linux/retransmit/mod.rs
+++ b/src/agent/samplers/tcp/linux/retransmit/mod.rs
@@ -27,9 +27,15 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let counters = vec![&TCP_RETRANSMIT];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .counters("counters", counters)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .counters("counters", counters)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/tcp/linux/retransmit/stats.rs
+++ b/src/agent/samplers/tcp/linux/retransmit/stats.rs
@@ -6,3 +6,17 @@ use metriken::*;
     metadata = { unit = "packets" }
 )]
 pub static TCP_RETRANSMIT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "tcp_retransmit"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "tcp_retransmit"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/tcp/linux/traffic/mod.rs
+++ b/src/agent/samplers/tcp/linux/traffic/mod.rs
@@ -38,7 +38,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &TCP_TX_PACKETS,
     ];
 
-    let bpf = BpfBuilder::new(ModSkelBuilder::default)
+    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
         .counters("counters", counters)
         .histogram("rx_size", &TCP_RX_SIZE)
         .histogram("tx_size", &TCP_TX_SIZE)

--- a/src/agent/samplers/tcp/linux/traffic/mod.rs
+++ b/src/agent/samplers/tcp/linux/traffic/mod.rs
@@ -38,11 +38,17 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &TCP_TX_PACKETS,
     ];
 
-    let bpf = BpfBuilder::new(BpfProgStats { run_time: &BPF_RUN_TIME, run_count: &BPF_RUN_COUNT }, ModSkelBuilder::default)
-        .counters("counters", counters)
-        .histogram("rx_size", &TCP_RX_SIZE)
-        .histogram("tx_size", &TCP_TX_SIZE)
-        .build()?;
+    let bpf = BpfBuilder::new(
+        BpfProgStats {
+            run_time: &BPF_RUN_TIME,
+            run_count: &BPF_RUN_COUNT,
+        },
+        ModSkelBuilder::default,
+    )
+    .counters("counters", counters)
+    .histogram("rx_size", &TCP_RX_SIZE)
+    .histogram("tx_size", &TCP_TX_SIZE)
+    .build()?;
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/tcp/linux/traffic/stats.rs
+++ b/src/agent/samplers/tcp/linux/traffic/stats.rs
@@ -42,3 +42,17 @@ pub static TCP_TX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
     metadata = { direction = "transmit", unit = "bytes" }
 )]
 pub static TCP_TX_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "rezolus_bpf_run_count",
+    description = "The number of times Rezolus BPF programs have been run",
+    metadata = { sampler = "tcp_traffic"}
+)]
+pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
+
+#[metric(
+    name = "rezolus_bpf_run_time",
+    description = "The amount of time Rezolus BPF programs have been executing",
+    metadata = { unit = "nanoseconds", sampler = "tcp_traffic"}
+)]
+pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);


### PR DESCRIPTION
Adds metrics for tracking bpf program executions and run time. To enable this, the kernel BPF stats must be enabled. One way is to: sysctl kernel.bpf_stats_enabled=1
