### PR TITLE
remove redundant log message

### DIFF
--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -58,8 +58,6 @@ impl Sampler for AsyncBpf {
     }
 
     async fn refresh(&self) {
-        let start = std::time::Instant::now();
-
         // check that the thread has not exited
         if self.thread.is_finished() {
             panic!("{} bpf thread exited early", self.name);
@@ -89,8 +87,5 @@ impl Sampler for AsyncBpf {
             .collect();
 
         futures::future::join_all(perf_futures.into_iter()).await;
-
-        let latency = start.elapsed().as_micros();
-        debug!("{} took {}us to sample", self.name, latency);
     }
 }


### PR DESCRIPTION
We are logging each sampler's latency with a wrapper function in the AsyncSampler trait. This makes the log message inside the BPF sampler implementation redundant.

Removes the log message from the BPF sampler.
