### PR TITLE
feat(agent): virtualization aware threading strategy for perf events

### DIFF
--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -85,8 +85,7 @@ impl PerfCounters {
             let pt_pending = Arc::new(AtomicUsize::new(perf_counters.inner.len()));
 
             debug!(
-                "{} launching {} threads to read perf counters",
-                self.name,
+                "launching {} threads to read perf counters",
                 pt_pending.load(Ordering::SeqCst)
             );
 
@@ -140,8 +139,7 @@ impl PerfCounters {
             let mut unpinned: Vec<_> = unpinned_rx.try_iter().collect();
 
             debug!(
-                "{} there are {} perf threads which could not be pinned",
-                self.name,
+                "there are {} perf threads which could not be pinned",
                 unpinned.len()
             );
 
@@ -169,7 +167,7 @@ impl PerfCounters {
                     .expect("failed to send perf thread sync primitive");
             }
 
-            debug!("{} all perf threads launched", self.name);
+            debug!("all perf threads launched");
         }
     }
 

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -75,6 +75,146 @@ impl PerfCounters {
         let counters = self.inner.entry(cpu).or_insert(CpuPerfCounters::new(cpu));
         counters.push(counter, group);
     }
+
+    fn spawn_multi(self, perf_threads_tx: Sender<_>, perf_sync_tx: Sender<_>) {
+        if !self.inner.is_empty() {
+            debug!("using multi-threaded perf counter collection");
+
+            let (unpinned_tx, unpinned_rx) = sync_channel(cpus);
+
+            let pt_pending = Arc::new(AtomicUsize::new(perf_counters.inner.len()));
+
+            debug!(
+                "{} launching {} threads to read perf counters",
+                self.name,
+                pt_pending.load(Ordering::SeqCst)
+            );
+
+            for (cpu, mut counters) in perf_counters.inner.into_iter() {
+                trace!("{} launching perf thread for cpu {}", self.name, cpu);
+
+                let psync = SyncPrimitive::new();
+                let psync2 = psync.clone();
+
+                let unpinned = unpinned_tx.clone();
+                let perf_threads = perf_threads_tx.clone();
+                let perf_sync = perf_sync_tx.clone();
+
+                let pt_pending = pt_pending.clone();
+
+                perf_threads
+                    .send(std::thread::spawn(move || {
+                        if !core_affinity::set_for_current(core_affinity::CoreId { id: cpu }) {
+                            unpinned
+                                .send(counters)
+                                .expect("failed to send unpinned perf counters");
+                            pt_pending.fetch_sub(1, Ordering::Relaxed);
+                            return;
+                        }
+
+                        pt_pending.fetch_sub(1, Ordering::Relaxed);
+
+                        loop {
+                            psync.wait_trigger();
+
+                            counters.refresh();
+
+                            psync.notify();
+                        }
+                    }))
+                    .expect("failed to send perf thread handle");
+
+                perf_sync
+                    .send(psync2)
+                    .expect("failed to send perf thread sync primitive");
+            }
+
+            debug!("{} waiting for perf threads to launch", self.name);
+
+            while pt_pending.load(Ordering::Relaxed) > 0 {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+
+            debug!("{} checking for unpinned perf threads", self.name);
+
+            let mut unpinned: Vec<_> = unpinned_rx.try_iter().collect();
+
+            debug!(
+                "{} there are {} perf threads which could not be pinned",
+                self.name,
+                unpinned.len()
+            );
+
+            if !unpinned.is_empty() {
+                let psync = SyncPrimitive::new();
+                let psync2 = psync.clone();
+
+                let perf_threads = perf_threads_tx.clone();
+                let perf_sync = perf_sync_tx.clone();
+
+                perf_threads
+                    .send(std::thread::spawn(move || loop {
+                        psync.wait_trigger();
+
+                        for counters in unpinned.iter_mut() {
+                            counters.refresh();
+                        }
+
+                        psync.notify();
+                    }))
+                    .expect("failed to send perf thread handle");
+
+                perf_sync
+                    .send(psync2)
+                    .expect("failed to send perf thread sync primitive");
+            }
+
+            debug!("{} all perf threads launched", self.name);
+        }
+    }
+
+    fn spawn_single(self, perf_threads_tx: Sender<_>, perf_sync_tx: Sender<_>) {
+        if !self.inner.is_empty() {
+            debug!("using single-threaded perf counter collection");
+
+            let mut counters: Vec<_> = perf_counters.inner.values().collect();
+
+            let psync = SyncPrimitive::new();
+            let psync2 = psync.clone();
+
+            let perf_threads = perf_threads_tx.clone();
+            let perf_sync = perf_sync_tx.clone();
+
+            perf_threads
+                .send(std::thread::spawn(move || loop {
+                    psync.wait_trigger();
+
+                    for c in counters.iter_mut() {
+                        c.refresh();
+                    }
+
+                    psync.notify();
+                }))
+                .expect("failed to send perf thread handle");
+
+            perf_sync
+                .send(psync2)
+                .expect("failed to send perf thread sync primitive");
+        }
+    }
+
+    pub fn spawn(self) {
+        if !self.inner.is_empty() {
+            // on virtualized environments, it is typically better to use
+            // multiple threads to read the perf counters to get more
+            // consistent snapshot latency
+            if is_virt() {
+                self.spawn_multi(perf_threads_tx, perf_sync_tx);
+            } else {
+                self.spawn_single(perf_threads_tx, perf_sync_tx);
+            }
+        }
+    }
 }
 
 enum Event {
@@ -230,133 +370,7 @@ where
                 }
             }
 
-            if !perf_counters.inner.is_empty() {
-                // on virtualized environments, it is typically better to use
-                // multiple threads to read the perf counters to get more
-                // consistent snapshot latency
-                if is_virt() {
-                    debug!("using multi-threaded perf counter collection");
-
-                    let (unpinned_tx, unpinned_rx) = sync_channel(cpus);
-
-                    let pt_pending = Arc::new(AtomicUsize::new(perf_counters.inner.len()));
-
-                    debug!(
-                        "{} launching {} threads to read perf counters",
-                        self.name,
-                        pt_pending.load(Ordering::SeqCst)
-                    );
-
-                    for (cpu, mut counters) in perf_counters.inner.into_iter() {
-                        trace!("{} launching perf thread for cpu {}", self.name, cpu);
-
-                        let psync = SyncPrimitive::new();
-                        let psync2 = psync.clone();
-
-                        let unpinned = unpinned_tx.clone();
-                        let perf_threads = perf_threads_tx.clone();
-                        let perf_sync = perf_sync_tx.clone();
-
-                        let pt_pending = pt_pending.clone();
-
-                        perf_threads
-                            .send(std::thread::spawn(move || {
-                                if !core_affinity::set_for_current(core_affinity::CoreId { id: cpu }) {
-                                    unpinned
-                                        .send(counters)
-                                        .expect("failed to send unpinned perf counters");
-                                    pt_pending.fetch_sub(1, Ordering::Relaxed);
-                                    return;
-                                }
-
-                                pt_pending.fetch_sub(1, Ordering::Relaxed);
-
-                                loop {
-                                    psync.wait_trigger();
-
-                                    counters.refresh();
-
-                                    psync.notify();
-                                }
-                            }))
-                            .expect("failed to send perf thread handle");
-
-                        perf_sync
-                            .send(psync2)
-                            .expect("failed to send perf thread sync primitive");
-                    }
-
-                    debug!("{} waiting for perf threads to launch", self.name);
-
-                    while pt_pending.load(Ordering::Relaxed) > 0 {
-                        std::thread::sleep(Duration::from_millis(50));
-                    }
-
-                    debug!("{} checking for unpinned perf threads", self.name);
-
-                    let mut unpinned: Vec<_> = unpinned_rx.try_iter().collect();
-
-                    debug!(
-                        "{} there are {} perf threads which could not be pinned",
-                        self.name,
-                        unpinned.len()
-                    );
-
-                    if !unpinned.is_empty() {
-                        let psync = SyncPrimitive::new();
-                        let psync2 = psync.clone();
-
-                        let perf_threads = perf_threads_tx.clone();
-                        let perf_sync = perf_sync_tx.clone();
-
-                        perf_threads
-                            .send(std::thread::spawn(move || loop {
-                                psync.wait_trigger();
-
-                                for counters in unpinned.iter_mut() {
-                                    counters.refresh();
-                                }
-
-                                psync.notify();
-                            }))
-                            .expect("failed to send perf thread handle");
-
-                        perf_sync
-                            .send(psync2)
-                            .expect("failed to send perf thread sync primitive");
-                    }
-
-                    debug!("{} all perf threads launched", self.name);
-                } else {
-                    debug!("using single-threaded perf counter collection");
-
-                    let mut counters: Vec<_> = perf_counters.inner.into_iter().map(|(_, v)| v).collect();
-
-                    let psync = SyncPrimitive::new();
-                    let psync2 = psync.clone();
-
-                    let perf_threads = perf_threads_tx.clone();
-                    let perf_sync = perf_sync_tx.clone();
-
-                    perf_threads
-                        .send(std::thread::spawn(move || {
-                            loop {
-                                psync.wait_trigger();
-
-                                for c in counters.iter_mut() {
-                                    c.refresh();
-                                }
-
-                                psync.notify();
-                            }
-                        }))
-                        .expect("failed to send perf thread handle");
-
-                    perf_sync
-                        .send(psync2)
-                        .expect("failed to send perf thread sync primitive");
-                }
-            }
+            perf_counters.spawn();
 
             let ringbuffer: Option<RingBuffer> = if self.ringbuf_handler.is_empty() {
                 None

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -183,7 +183,7 @@ impl PerfCounters {
         if !self.inner.is_empty() {
             debug!("using single-threaded perf counter collection");
 
-            let mut counters: Vec<_> = self.inner.into_iter().map(|(_, v)| v).collect();
+            let mut counters: Vec<_> = self.inner.into_values().collect();
 
             let psync = SyncPrimitive::new();
             let psync2 = psync.clone();
@@ -259,6 +259,7 @@ pub struct Builder<T: 'static + SkelBuilder<'static>> {
     cpu_counters: Vec<(&'static str, Vec<&'static CounterGroup>)>,
     perf_events: Vec<(&'static str, PerfEvent, &'static CounterGroup)>,
     packed_counters: Vec<(&'static str, &'static CounterGroup)>,
+    #[allow(clippy::type_complexity)]
     ringbuf_handler: Vec<(&'static str, fn(&[u8]) -> i32)>,
 }
 

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -85,13 +85,6 @@ impl PerfCounters {
         if !self.inner.is_empty() {
             debug!("using multi-threaded perf counter collection");
 
-            let cpus = match crate::common::cpus() {
-                Ok(cpus) => cpus.last().copied().unwrap_or(1023),
-                Err(_) => 1023,
-            };
-
-            let cpus = cpus + 1;
-
             let pt_pending = Arc::new(AtomicUsize::new(self.inner.len()));
 
             debug!(

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -92,8 +92,6 @@ impl PerfCounters {
 
             let cpus = cpus + 1;
 
-            let (unpinned_tx, unpinned_rx) = sync_channel(cpus);
-
             let pt_pending = Arc::new(AtomicUsize::new(self.inner.len()));
 
             debug!(
@@ -107,7 +105,6 @@ impl PerfCounters {
                 let psync = SyncPrimitive::new();
                 let psync2 = psync.clone();
 
-                let unpinned = unpinned_tx.clone();
                 let perf_threads = perf_threads_tx.clone();
                 let perf_sync = perf_sync_tx.clone();
 

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -343,7 +343,9 @@ where
                             loop {
                                 psync.wait_trigger();
 
-                                counters.refresh();
+                                for c in counters.iter_mut() {
+                                    c.refresh();
+                                }
 
                                 psync.notify();
                             }

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -77,7 +77,11 @@ impl PerfCounters {
         counters.push(counter, group);
     }
 
-    fn spawn_multi(self, perf_threads_tx: SyncSender<JoinHandle<()>>, perf_sync_tx: SyncSender<SyncPrimitive>) {
+    fn spawn_multi(
+        self,
+        perf_threads_tx: SyncSender<JoinHandle<()>>,
+        perf_sync_tx: SyncSender<SyncPrimitive>,
+    ) {
         if !self.inner.is_empty() {
             debug!("using multi-threaded perf counter collection");
 
@@ -179,7 +183,11 @@ impl PerfCounters {
         }
     }
 
-    fn spawn_single(self, perf_threads_tx: SyncSender<JoinHandle<()>>, perf_sync_tx: SyncSender<SyncPrimitive>) {
+    fn spawn_single(
+        self,
+        perf_threads_tx: SyncSender<JoinHandle<()>>,
+        perf_sync_tx: SyncSender<SyncPrimitive>,
+    ) {
         if !self.inner.is_empty() {
             debug!("using single-threaded perf counter collection");
 
@@ -209,7 +217,11 @@ impl PerfCounters {
         }
     }
 
-    pub fn spawn(self, perf_threads_tx: SyncSender<JoinHandle<()>>, perf_sync_tx: SyncSender<SyncPrimitive>) {
+    pub fn spawn(
+        self,
+        perf_threads_tx: SyncSender<JoinHandle<()>>,
+        perf_sync_tx: SyncSender<SyncPrimitive>,
+    ) {
         if !self.inner.is_empty() {
             // on virtualized environments, it is typically better to use
             // multiple threads to read the perf counters to get more

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -330,7 +330,7 @@ where
                 } else {
                     debug!("using single-threaded perf counter collection");
 
-                    let mut counters = perf_counters.inner.into_iter().map(|(_, v)| v).collect();
+                    let mut counters: Vec<_> = perf_counters.inner.into_iter().map(|(_, v)| v).collect();
 
                     let psync = SyncPrimitive::new();
                     let psync2 = psync.clone();

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -76,7 +76,7 @@ impl PerfCounters {
         counters.push(counter, group);
     }
 
-    fn spawn_multi(self, perf_threads_tx: Sender<_>, perf_sync_tx: Sender<_>) {
+    fn spawn_multi(self, perf_threads_tx: SyncSender<JoinHandle<()>>, perf_sync_tx: SyncSender<SyncPrimitive>) {
         if !self.inner.is_empty() {
             debug!("using multi-threaded perf counter collection");
 
@@ -173,7 +173,7 @@ impl PerfCounters {
         }
     }
 
-    fn spawn_single(self, perf_threads_tx: Sender<_>, perf_sync_tx: Sender<_>) {
+    fn spawn_single(self, perf_threads_tx: SyncSender<JoinHandle<()>>, perf_sync_tx: SyncSender<SyncPrimitive>) {
         if !self.inner.is_empty() {
             debug!("using single-threaded perf counter collection");
 
@@ -203,7 +203,7 @@ impl PerfCounters {
         }
     }
 
-    pub fn spawn(self) {
+    pub fn spawn(self, perf_threads_tx: SyncSender<JoinHandle<()>>, perf_sync_tx: SyncSender<SyncPrimitive>) {
         if !self.inner.is_empty() {
             // on virtualized environments, it is typically better to use
             // multiple threads to read the perf counters to get more

--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -41,7 +41,7 @@ fn whole_pages<T>(count: usize) -> usize {
 
 use counters::{Counters, CpuCounters, PackedCounters};
 use histogram::Histogram;
-use sync_primitive::SyncPrimitive;
+pub use sync_primitive::SyncPrimitive;
 
 pub struct AsyncBpf {
     name: &'static str,

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -21,7 +21,6 @@ use tokio::sync::Mutex;
 use walkdir::WalkDir;
 
 use std::collections::BTreeSet;
-use std::sync::mpsc::sync_channel;
 use std::thread::JoinHandle;
 
 mod stats;

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -256,10 +256,18 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     let psync = SyncPrimitive::new();
     let psync2 = psync.clone();
 
+    let mut cores = Vec::new();
+
+    for core in logical_cores.drain(..) {
+        if let Ok(mut core) = Core::new(core) {
+            cores.push(core);
+        }
+    }
+
     perf_threads.push(std::thread::spawn(move || loop {
         psync.wait_trigger();
 
-        for core in logical_cores.iter_mut() {
+        for core in cores.iter_mut() {
             core.refresh();
         }
 

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -259,7 +259,7 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     let mut cores = Vec::new();
 
     for core in logical_cores.drain(..) {
-        if let Ok(mut core) = Core::new(core) {
+        if let Ok(core) = Core::new(core) {
             cores.push(core);
         }
     }

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -259,7 +259,7 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     perf_threads.push(std::thread::spawn(move || loop {
         psync.wait_trigger();
 
-        for core in unpinned.iter_mut() {
+        for core in logical_cores.iter_mut() {
             core.refresh();
         }
 

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -272,6 +272,8 @@ fn get_cores() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Err
             }));
 
             perf_sync.push(psync2);
+        } else {
+            pt_pending.fetch_sub(1, Ordering::Relaxed);
         }
     }
 

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -255,7 +255,9 @@ fn get_cores() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Err
 
             perf_threads.push(std::thread::spawn(move || {
                 if !core_affinity::set_for_current(core_affinity::CoreId { id: core.id }) {
-                    unpinned.send(core).expect("failed to send unpinned perf counters");
+                    unpinned
+                        .send(core)
+                        .expect("failed to send unpinned perf counters");
                     pt_pending.fetch_sub(1, Ordering::Relaxed);
                     return;
                 }

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -21,6 +21,8 @@ use tokio::sync::Mutex;
 use walkdir::WalkDir;
 
 use std::collections::BTreeSet;
+use std::sync::mpsc::sync_channel;
+use std::thread::JoinHandle;
 
 mod stats;
 
@@ -57,34 +59,39 @@ impl Sampler for Frequency {
 }
 
 struct FrequencyInner {
-    cores: Vec<Core>,
+    perf_threads: Vec<std::thread::JoinHandle<()>>,
+    perf_sync: Vec<SyncPrimitive>,
 }
 
 impl FrequencyInner {
     pub fn new() -> Result<Self, std::io::Error> {
-        let cores = get_cores()?;
+        let (perf_threads, perf_sync) = get_cores()?;
 
-        Ok(Self { cores })
+        Ok(Self {
+            perf_threads,
+            perf_sync,
+        })
     }
 
     pub async fn refresh(&mut self) -> Result<(), std::io::Error> {
-        for core in &mut self.cores {
-            if let Ok(group) = core.tsc.read_group() {
-                if let (Some(aperf), Some(mperf), Some(tsc)) = (
-                    group.get(&core.aperf),
-                    group.get(&core.mperf),
-                    group.get(&core.tsc),
-                ) {
-                    let aperf = aperf.value();
-                    let mperf = mperf.value();
-                    let tsc = tsc.value();
-
-                    let _ = CPU_APERF.set(core.id, aperf);
-                    let _ = CPU_MPERF.set(core.id, mperf);
-                    let _ = CPU_TSC.set(core.id, tsc);
-                }
+        // check that no perf threads have exited
+        for thread in self.perf_threads.iter() {
+            if thread.is_finished() {
+                panic!("{} perf thread exited early", NAME);
             }
         }
+
+        // trigger and wait on all perf threads
+        let perf_futures: Vec<_> = self
+            .perf_sync
+            .iter()
+            .map(|s| {
+                s.trigger();
+                s.wait_notify()
+            })
+            .collect();
+
+        futures::future::join_all(perf_futures.into_iter()).await;
 
         Ok(())
     }
@@ -184,6 +191,24 @@ impl Core {
             }
         }
     }
+
+    pub fn refresh(&mut self) {
+        if let Ok(group) = self.tsc.read_group() {
+            if let (Some(aperf), Some(mperf), Some(tsc)) = (
+                group.get(&self.aperf),
+                group.get(&self.mperf),
+                group.get(&self.tsc),
+            ) {
+                let aperf = aperf.value();
+                let mperf = mperf.value();
+                let tsc = tsc.value();
+
+                let _ = CPU_APERF.set(self.id, aperf);
+                let _ = CPU_MPERF.set(self.id, mperf);
+                let _ = CPU_TSC.set(self.id, tsc);
+            }
+        }
+    }
 }
 
 fn logical_cores() -> Result<Vec<usize>, std::io::Error> {
@@ -210,16 +235,78 @@ fn logical_cores() -> Result<Vec<usize>, std::io::Error> {
     Ok(cores.iter().copied().collect())
 }
 
-fn get_cores() -> Result<Vec<Core>, std::io::Error> {
+fn get_cores() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
     let mut logical_cores = logical_cores()?;
 
-    let mut cores = Vec::new();
+    let (unpinned_tx, unpinned_rx) = sync_channel(logical_cores.len());
+
+    let pt_pending = Arc::new(AtomicUsize::new(logical_cores.len()));
+
+    let mut perf_threads = Vec::new();
+    let mut perf_sync = Vec::new();
 
     for core in logical_cores.drain(..) {
-        if let Ok(core) = Core::new(core) {
-            cores.push(core);
+        if let Ok(mut core) = Core::new(core) {
+            let psync = SyncPrimitive::new();
+            let psync2 = psync.clone();
+
+            let unpinned = unpinned_tx.clone();
+            let pt_pending = pt_pending.clone();
+
+            perf_threads.push(std::thread::spawn(move || {
+                if !core_affinity::set_for_current(core_affinity::CoreId { id: core.id }) {
+                    unpinned.send(core).expect("failed to send unpinned perf counters");
+                    pt_pending.fetch_sub(1, Ordering::Relaxed);
+                    return;
+                }
+
+                pt_pending.fetch_sub(1, Ordering::Relaxed);
+
+                loop {
+                    psync.wait_trigger();
+
+                    core.refresh();
+
+                    psync.notify();
+                }
+            }));
+
+            perf_sync.push(psync2);
         }
     }
 
-    Ok(cores)
+    debug!("{} waiting for perf threads to launch", NAME);
+
+    while pt_pending.load(Ordering::Relaxed) > 0 {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    debug!("{} checking for unpinned perf threads", NAME);
+
+    let mut unpinned: Vec<Core> = unpinned_rx.try_iter().collect();
+
+    debug!(
+        "{} there are {} perf threads which could not be pinned",
+        NAME,
+        unpinned.len()
+    );
+
+    if !unpinned.is_empty() {
+        let psync = SyncPrimitive::new();
+        let psync2 = psync.clone();
+
+        perf_threads.push(std::thread::spawn(move || loop {
+            psync.wait_trigger();
+
+            for core in unpinned.iter_mut() {
+                core.refresh();
+            }
+
+            psync.notify();
+        }));
+
+        perf_sync.push(psync2);
+    }
+
+    Ok((perf_threads, perf_sync))
 }

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -284,8 +284,6 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
 
     let mut logical_cores = logical_cores()?;
 
-    let (unpinned_tx, unpinned_rx) = sync_channel(logical_cores.len());
-
     let pt_pending = Arc::new(AtomicUsize::new(logical_cores.len()));
 
     let mut perf_threads = Vec::new();
@@ -296,7 +294,6 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
             let psync = SyncPrimitive::new();
             let psync2 = psync.clone();
 
-            let unpinned = unpinned_tx.clone();
             let pt_pending = pt_pending.clone();
 
             perf_threads.push(std::thread::spawn(move || {

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -166,9 +166,7 @@ impl L3Cache {
 
     pub fn refresh(&mut self) {
         if let Ok(group) = self.access.read_group() {
-            if let (Some(access), Some(miss)) =
-                (group.get(&self.access), group.get(&self.miss))
-            {
+            if let (Some(access), Some(miss)) = (group.get(&self.access), group.get(&self.miss)) {
                 let access = access.value();
                 let miss = miss.value();
 
@@ -291,7 +289,6 @@ fn get_events() -> Option<(LowLevelEvent, LowLevelEvent)> {
     }
 }
 
-
 fn spawn_threads() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
     // on virtualized environments, it is typically better to use multiple
     // threads to read the perf counters to get more consistent snapshot latency
@@ -348,7 +345,9 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
         let pt_pending = pt_pending.clone();
 
         perf_threads.push(std::thread::spawn(move || {
-            if !core_affinity::set_for_current(core_affinity::CoreId { id: cache.shared_cores[0] }) {
+            if !core_affinity::set_for_current(core_affinity::CoreId {
+                id: cache.shared_cores[0],
+            }) {
                 unpinned
                     .send(cache)
                     .expect("failed to send unpinned perf counters");

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -340,7 +340,7 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
     let mut perf_threads = Vec::new();
     let mut perf_sync = Vec::new();
 
-    for cache in caches.drain(..) {
+    for mut cache in caches.drain(..) {
         let psync = SyncPrimitive::new();
         let psync2 = psync.clone();
 

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -381,7 +381,7 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
 
     debug!("{} checking for unpinned perf threads", NAME);
 
-    let mut unpinned: Vec<Core> = unpinned_rx.try_iter().collect();
+    let mut unpinned: Vec<L3Cache> = unpinned_rx.try_iter().collect();
 
     debug!(
         "{} there are {} perf threads which could not be pinned",

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -14,7 +14,6 @@ use tokio::sync::Mutex;
 use walkdir::WalkDir;
 
 use std::collections::HashSet;
-use std::sync::mpsc::sync_channel;
 use std::thread::JoinHandle;
 
 mod stats;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -80,3 +80,24 @@ pub fn utc_instant() -> (DateTime<Utc>, Instant) {
     eprintln!("could not get a UTC time and Instant pair");
     std::process::exit(1);
 }
+
+/// This function is best-effort detection of if the code is running inside of a
+/// virtual machine.
+pub fn is_virt() -> bool {
+    let sys_vendor = std::fs::read_to_string("/sys/class/dmi/id/sys_vendor")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    matches!(
+        sys_vendor.as_str(),
+        "Amazon EC2"
+            | "Google"
+            | "innotek GmbH"
+            | "Microsoft Corporation"
+            | "QEMU"
+            | "Red Hat"
+            | "VMware, Inc."
+            | "Xen"
+    )
+}


### PR DESCRIPTION
Previously, the perf groups for cpu_frequency sampler were read serially and blocked the sampler. On some systems, it can take several milliseconds to collect the readings in this way (m7i.8xl). However, switching to multi-threaded collection is not a clear win on all systems. 

This change adds basic virtualization detection and implements single and multi threaded collection for both the cpu_frequency sampler and all BPF-based perf samplers.

As a result the cpu_frequency sampler latency should improve on virtualized systems, and cpu_perf sampler cpu usage should decrease on baremetal systems.
