### PR TITLE
feat(agent): add a snapshot TTL

### DIFF
--- a/config/agent.toml
+++ b/config/agent.toml
@@ -1,6 +1,10 @@
 [general]
 listen = "0.0.0.0:4241"
 
+# Metric snapshots are cached with the following TTL to prevent excessive
+# resource usage.
+ttl = "10ms"
+
 [log]
 # Controls the log level: "error", "warn", "info", "debug", "trace"
 level = "info"

--- a/src/agent/config/general.rs
+++ b/src/agent/config/general.rs
@@ -4,10 +4,20 @@ use super::*;
 pub struct General {
     #[serde(default = "listen")]
     listen: String,
+
+    // the agent caches metrics snapshots with the following TTL to prevent
+    // excessive resource utilization
+    #[serde(default = "ttl")]
+    ttl: String,
 }
 
 impl General {
-    pub fn check(&self) {}
+    pub fn check(&self) {
+        if let Err(e) = self.ttl.parse::<humantime::Duration>() {
+            eprintln!("ttl couldn't be parsed: {e}");
+            std::process::exit(1);
+        }
+    }
 
     pub fn listen(&self) -> SocketAddr {
         self.listen
@@ -23,5 +33,9 @@ impl General {
                 std::process::exit(1);
             })
             .unwrap()
+    }
+
+    pub fn ttl(&self) -> std::time::Duration {
+        *self.ttl.parse::<humantime::Duration>().unwrap()
     }
 }

--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -23,6 +23,10 @@ fn listen() -> String {
     "0.0.0.0:4241".into()
 }
 
+fn ttl() -> String {
+    "10ms".into()
+}
+
 #[derive(Deserialize, Default)]
 pub struct Config {
     #[serde(default)]

--- a/src/agent/exposition/http/mod.rs
+++ b/src/agent/exposition/http/mod.rs
@@ -40,14 +40,20 @@ fn app(state: Arc<Mutex<SnapshotBuilder>>) -> Router {
 }
 
 async fn msgpack(State(state): State<Arc<Mutex<SnapshotBuilder>>>) -> Vec<u8> {
+    let now = Instant::now();
+
     let mut snapshot_builder = state.lock().await;
-    let snapshot = snapshot_builder.build().await;
+    let snapshot = snapshot_builder.build(now).await;
+
     rmp_serde::encode::to_vec(&snapshot).expect("failed to serialize snapshot")
 }
 
 async fn json(State(state): State<Arc<Mutex<SnapshotBuilder>>>) -> String {
+    let now = Instant::now();
+
     let mut snapshot_builder = state.lock().await;
-    let snapshot = snapshot_builder.build().await;
+    let snapshot = snapshot_builder.build(now).await;
+
     serde_json::to_string(&snapshot).expect("failed to serialize snapshot")
 }
 

--- a/src/agent/exposition/http/mod.rs
+++ b/src/agent/exposition/http/mod.rs
@@ -1,38 +1,19 @@
+use tokio::sync::Mutex;
 use crate::agent::*;
 
 use axum::extract::State;
 use axum::routing::get;
 use axum::Router;
-use metriken_exposition::Snapshot;
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_http::{compression::CompressionLayer, decompression::RequestDecompressionLayer};
 
-use std::time::{Instant, SystemTime};
-
 mod snapshot;
 
-struct AppState {
-    samplers: Arc<Box<[Box<dyn Sampler>]>>,
-}
-
-impl AppState {
-    async fn refresh(&self) {
-        let s: Vec<_> = self
-            .samplers
-            .iter()
-            .map(|s| s.refresh_with_logging())
-            .collect();
-
-        let start = Instant::now();
-        futures::future::join_all(s).await;
-        let duration = start.elapsed().as_micros();
-        debug!("sampling latency: {duration} us");
-    }
-}
+use snapshot::SnapshotBuilder;
 
 pub async fn serve(config: Arc<Config>, samplers: Arc<Box<[Box<dyn Sampler>]>>) {
-    let state = Arc::new(AppState { samplers });
+    let state = Arc::new(Mutex::new(SnapshotBuilder::new(config.clone(), samplers)));
 
     let app: Router = app(state);
 
@@ -45,7 +26,7 @@ pub async fn serve(config: Arc<Config>, samplers: Arc<Box<[Box<dyn Sampler>]>>) 
         .expect("failed to run http server");
 }
 
-fn app(state: Arc<AppState>) -> Router {
+fn app(state: Arc<Mutex<SnapshotBuilder>>) -> Router {
     Router::new()
         .route("/", get(root))
         .route("/metrics/binary", get(msgpack))
@@ -58,22 +39,15 @@ fn app(state: Arc<AppState>) -> Router {
         )
 }
 
-async fn take_snapshot(state: Arc<AppState>) -> Snapshot {
-    let timestamp = SystemTime::now();
-    let start = Instant::now();
-
-    state.refresh().await;
-
-    snapshot::create(timestamp, start.elapsed())
-}
-
-async fn msgpack(State(state): State<Arc<AppState>>) -> Vec<u8> {
-    let snapshot = take_snapshot(state).await;
+async fn msgpack(State(state): State<Arc<Mutex<SnapshotBuilder>>>) -> Vec<u8> {
+    let mut snapshot_builder = state.lock().await;
+    let snapshot = snapshot_builder.build().await;
     rmp_serde::encode::to_vec(&snapshot).expect("failed to serialize snapshot")
 }
 
-async fn json(State(state): State<Arc<AppState>>) -> String {
-    let snapshot = take_snapshot(state).await;
+async fn json(State(state): State<Arc<Mutex<SnapshotBuilder>>>) -> String {
+    let mut snapshot_builder = state.lock().await;
+    let snapshot = snapshot_builder.build().await;
     serde_json::to_string(&snapshot).expect("failed to serialize snapshot")
 }
 

--- a/src/agent/exposition/http/mod.rs
+++ b/src/agent/exposition/http/mod.rs
@@ -1,10 +1,10 @@
-use tokio::sync::Mutex;
 use crate::agent::*;
 
 use axum::extract::State;
 use axum::routing::get;
 use axum::Router;
 use tokio::net::TcpListener;
+use tokio::sync::Mutex;
 use tower::ServiceBuilder;
 use tower_http::{compression::CompressionLayer, decompression::RequestDecompressionLayer};
 

--- a/src/agent/exposition/http/snapshot.rs
+++ b/src/agent/exposition/http/snapshot.rs
@@ -53,7 +53,9 @@ impl SnapshotBuilder {
     }
 
     pub async fn build(&mut self, now: Instant) -> &Snapshot {
-        if self.cached.is_none() || now.duration_since(self.cached.as_ref().unwrap().timestamp) < self.ttl {
+        if self.cached.is_none()
+            || now.duration_since(self.cached.as_ref().unwrap().timestamp) < self.ttl
+        {
             self.refresh().await;
         }
 


### PR DESCRIPTION
Adds a configurable snapshot TTL to the Rezolus Agent to allow serving cached snapshots if they are not older than the TTL.

This helps prevent excessive resource utilization.
