### PR TITLE
feat(viewer): add Rezolus section

### DIFF
--- a/src/viewer/dashboard/mod.rs
+++ b/src/viewer/dashboard/mod.rs
@@ -5,6 +5,7 @@ mod cgroups;
 mod cpu;
 mod network;
 mod overview;
+mod rezolus;
 mod scheduler;
 mod softirq;
 mod syscall;
@@ -20,6 +21,7 @@ static SECTION_META: &[(&str, &str, Generator)] = &[
     ("Softirq", "/softirq", softirq::generate),
     ("BlockIO", "/blockio", blockio::generate),
     ("cgroups", "/cgroups", cgroups::generate),
+    ("Rezolus", "/rezolus", rezolus::generate),
 ];
 
 pub fn generate(data: &Tsdb) -> AppState {
@@ -64,6 +66,7 @@ mod tests {
                 "cpu.json",
                 "network.json",
                 "overview.json",
+                "rezolus.json",
                 "scheduler.json",
                 "softirq.json",
                 "syscall.json",

--- a/src/viewer/dashboard/rezolus.rs
+++ b/src/viewer/dashboard/rezolus.rs
@@ -11,24 +11,41 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     rezolus.plot(
         PlotOpts::line("CPU %", "cpu", Unit::Percentage),
-        data.counters("rezolus_cpu_usage", ()).map(|v| v.rate().sum() / 1e9),
+        data.counters("rezolus_cpu_usage", ())
+            .map(|v| v.rate().sum() / 1e9),
     );
 
     rezolus.plot(
         PlotOpts::line("Memory (RSS)", "memory", Unit::Bytes),
-        data.gauges("rezolus_memory_usage_resident_set_size", ()).map(|v| v.sum()),
+        data.gauges("rezolus_memory_usage_resident_set_size", ())
+            .map(|v| v.sum()),
     );
 
-    if let (Some(instructions), Some(cycles)) = (data.counters("cgroup_cpu_instructions", [("name", "/system.slice/rezolus.service")]).map(|v| v.rate().sum()), data.counters("cgroup_cpu_cycles", [("name", "/system.slice/rezolus.service")]).map(|v| v.rate().sum())) {
+    if let (Some(instructions), Some(cycles)) = (
+        data.counters(
+            "cgroup_cpu_instructions",
+            [("name", "/system.slice/rezolus.service")],
+        )
+        .map(|v| v.rate().sum()),
+        data.counters(
+            "cgroup_cpu_cycles",
+            [("name", "/system.slice/rezolus.service")],
+        )
+        .map(|v| v.rate().sum()),
+    ) {
         rezolus.plot(
             PlotOpts::line("IPC", "ipc", Unit::Count),
-            Some(instructions / cycles)
+            Some(instructions / cycles),
         );
     }
 
     rezolus.plot(
         PlotOpts::line("Syscalls", "syscalls", Unit::Rate),
-        data.counters("cgroup_syscall", [("name", "/system.slice/rezolus.service")]).map(|v| v.rate().sum())
+        data.counters(
+            "cgroup_syscall",
+            [("name", "/system.slice/rezolus.service")],
+        )
+        .map(|v| v.rate().sum()),
     );
 
     view.group(rezolus);

--- a/src/viewer/dashboard/rezolus.rs
+++ b/src/viewer/dashboard/rezolus.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+    let mut view = View::new(data, sections);
+
+    /*
+     * Rezolus
+     */
+
+    let mut rezolus = Group::new("Rezolus", "rezolus");
+
+    rezolus.plot(
+        PlotOpts::line("CPU %", "cpu", Unit::Percentage),
+        data.counters("rezolus_cpu_usage", ()).map(|v| v.rate().sum() / 1e9),
+    );
+
+    rezolus.plot(
+        PlotOpts::line("Memory (RSS)", "memory", Unit::Bytes),
+        data.gauges("rezolus_memory_usage_resident_set_size", ()).map(|v| v.sum()),
+    );
+
+    if let (Some(instructions), Some(cycles)) = (data.counters("cgroup_cpu_instructions", [("name", "/system.slice/rezolus.service")]).map(|v| v.rate().sum()), data.counters("cgroup_cpu_cycles", [("name", "/system.slice/rezolus.service")]).map(|v| v.rate().sum())) {
+        rezolus.plot(
+            PlotOpts::line("IPC", "ipc", Unit::Count),
+            Some(instructions / cycles)
+        );
+    }
+
+    rezolus.plot(
+        PlotOpts::line("Syscalls", "syscalls", Unit::Rate),
+        data.counters("cgroup_syscall", [("name", "/system.slice/rezolus.service")]).map(|v| v.rate().sum())
+    );
+
+    view.group(rezolus);
+
+    view
+}


### PR DESCRIPTION
Adds a section to the Rezolus Viewer that shows metrics for the Rezolus Agent.
