### PR TITLE
fix(agent): bug in cached snapshot expiration check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.0.2-alpha.0"
+version = "5.0.2-alpha.1"
 dependencies = [
  "anyhow",
  "archspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "5.0.2-alpha.0"
+version = "5.0.2-alpha.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "High resolution systems performance telemetry agent"

--- a/src/agent/exposition/http/snapshot.rs
+++ b/src/agent/exposition/http/snapshot.rs
@@ -54,7 +54,7 @@ impl SnapshotBuilder {
 
     pub async fn build(&mut self, now: Instant) -> &Snapshot {
         if self.cached.is_none()
-            || now.duration_since(self.cached.as_ref().unwrap().timestamp) < self.ttl
+            || now.duration_since(self.cached.as_ref().unwrap().timestamp) > self.ttl
         {
             self.refresh().await;
         }


### PR DESCRIPTION
Inversed logic operator in the snapshot expiration check results in
a single snapshot being used for the lifetime of the agent.

This bug exists in the unreleased 5.0.2-alpha.0