### PR TITLE
feat(agent): enable realtime scheduling on linux

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -146,7 +146,7 @@ jobs:
           cargo build ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }}
           sudo ./target/release/rezolus config/agent.toml & echo $! > agent.pid
           sleep 15
-          ./target/release/rezolus record --duration 30 http://127.0.0.1:4241 rezolus.parquet
+          ./target/release/rezolus record --duration 30s http://127.0.0.1:4241 rezolus.parquet
       - name: smoketest
         if: ${{ matrix.profile == 'debug' }}
         shell: bash
@@ -154,7 +154,7 @@ jobs:
           cargo build ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }}
           sudo ./target/debug/rezolus config/agent.toml & echo $! > agent.pid
           sleep 15
-          ./target/debug/rezolus record --duration 30 http://127.0.0.1:4241 rezolus.parquet
+          ./target/debug/rezolus record --duration 30s http://127.0.0.1:4241 rezolus.parquet
 
   check-success:
     name: verify all tests pass

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -82,7 +82,7 @@ jobs:
         run: cargo install cargo-audit
       - run: |
           cargo audit
-      
+
   rustfmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -129,7 +129,7 @@ jobs:
       - name: build
         shell: bash
         run: |
-          cargo build --workspace ${{ env.FEATURE_FLAGS }} --all-targets --locked ${{ env.FLAGS }} 
+          cargo build --workspace ${{ env.FEATURE_FLAGS }} --all-targets --locked ${{ env.FLAGS }}
       - name: test
         shell: bash
         run: |
@@ -140,11 +140,21 @@ jobs:
         run: |
           cargo test --workspace ${{ env.FEATURE_FLAGS }} --locked -- --test-threads 16
       - name: smoketest
+        if: ${{ matrix.profile == 'release' }}
         shell: bash
         run: |
-          cargo run ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }} --bin rezolus -- config/agent.toml & echo $! > agent.pid
+          cargo build ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }}
+          sudo ./target/release/rezolus config/agent.toml & echo $! > agent.pid
           sleep 15
-          cargo run ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }} --bin rezolus -- record --duration 60s http://127.0.0.1:4241 rezolus.parquet
+          ./target/release/rezolus record --duration 30 http://127.0.0.1:4241 rezolus.parquet
+      - name: smoketest
+        if: ${{ matrix.profile == 'debug' }}
+        shell: bash
+        run: |
+          cargo build ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }}
+          sudo ./target/debug/rezolus config/agent.toml & echo $! > agent.pid
+          sleep 15
+          ./target/debug/rezolus record --duration 30 http://127.0.0.1:4241 rezolus.parquet
 
   check-success:
     name: verify all tests pass

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -8,7 +8,7 @@ ttl = "10ms"
 [scheduler]
 # By default, Rezolus will use the SCHED_RR realtime scheduling policy to ensure
 # collection happens with minimal delay. Other policies are: `normal` and `fifo`
-policy = "round_robin"
+# policy = "round_robin"
 
 # When using `round_robin` or `fifo` realtime policies, a priority may be set
 # in the range 1..=99. Larger numbers are higher priority. Rezolus uses a

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -5,6 +5,10 @@ listen = "0.0.0.0:4241"
 # resource usage.
 ttl = "10ms"
 
+[scheduler]
+policy = "round_robin"
+rt_priority = 15
+
 [log]
 # Controls the log level: "error", "warn", "info", "debug", "trace"
 level = "info"

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -6,8 +6,19 @@ listen = "0.0.0.0:4241"
 ttl = "10ms"
 
 [scheduler]
+# By default, Rezolus will use the SCHED_RR realtime scheduling policy to ensure
+# collection happens with minimal delay. Other policies are: `normal` and `fifo`
 policy = "round_robin"
-rt_priority = 15
+
+# When using `round_robin` or `fifo` realtime policies, a priority may be set
+# in the range 1..=99. Larger numbers are higher priority. Rezolus uses a
+# default priority of 15 to balance between realtime responsiveness and safety.
+# priority = 15
+
+# When using `normal` scheduling policy, Rezolus defaults to the normal niceness
+# value of 0. The value may be in the range -20..=19 with lower values getting
+# higher priority.
+# niceness = 0
 
 [log]
 # Controls the log level: "error", "warn", "info", "debug", "trace"

--- a/src/agent/config/mod.rs
+++ b/src/agent/config/mod.rs
@@ -10,10 +10,12 @@ use std::path::Path;
 mod general;
 mod log;
 mod sampler;
+mod scheduler;
 
 use general::General;
 use log::Log;
 use sampler::Sampler as SamplerConfig;
+use scheduler::Scheduler;
 
 fn enabled() -> bool {
     true
@@ -31,6 +33,8 @@ fn ttl() -> String {
 pub struct Config {
     #[serde(default)]
     general: General,
+    #[serde(default)]
+    scheduler: Scheduler,
     #[serde(default)]
     log: Log,
     #[serde(default)]
@@ -56,6 +60,7 @@ impl Config {
             .unwrap();
 
         config.general.check();
+        config.scheduler.check();
 
         config.defaults.check("default");
 
@@ -72,6 +77,11 @@ impl Config {
 
     pub fn general(&self) -> &General {
         &self.general
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn scheduler(&self) -> &Scheduler {
+        &self.scheduler
     }
 
     pub fn enabled(&self, name: &str) -> bool {

--- a/src/agent/config/scheduler.rs
+++ b/src/agent/config/scheduler.rs
@@ -56,7 +56,6 @@ impl Scheduler {
                     std::process::exit(1);
                 }
             }
-            // Mismatched policy and parameters
             _ => {
                 eprintln!(
                     "scheduler policy {:?} is incompatible with the provided parameters",
@@ -72,8 +71,8 @@ impl Scheduler {
         self.set_scheduler();
 
         match self.parameters {
-            Parameters::Realtime { priority } => self.set_realtime_scheduler(priority),
-            Parameters::Normal { niceness } => self.set_normal_scheduler(niceness),
+            Parameters::Normal { niceness } => self.set_niceness(niceness),
+            _ => {}
         }
     }
 

--- a/src/agent/config/scheduler.rs
+++ b/src/agent/config/scheduler.rs
@@ -66,9 +66,9 @@ impl Scheduler {
     fn set_scheduler(&self) {
         let (policy, priority) = match self {
             Self::Normal { .. } => (SCHED_NORMAL, 0),
-            Self::Fifo { priority } => (SCHED_FIFO, *priority),
-            Self::RoundRobin { priority } => (SCHED_RR, *priority),
-        } | SCHED_RESET_ON_FORK;
+            Self::Fifo { priority } => (SCHED_FIFO | SCHED_RESET_ON_FORK, *priority),
+            Self::RoundRobin { priority } => (SCHED_RR | SCHED_RESET_ON_FORK, *priority),
+        };
 
         let param = libc::sched_param {
             sched_priority: priority,

--- a/src/agent/config/scheduler.rs
+++ b/src/agent/config/scheduler.rs
@@ -97,7 +97,7 @@ impl Scheduler {
 
         if result == -1 {
             let e = std::io::Error::last_os_error();
-            eprintln!("could not set scheduler policy: {:?} error: {e}");
+            eprintln!("could not set scheduler policy: {:?} error: {e}", self.policy);
             std::process::exit(1);
         }
     }

--- a/src/agent/config/scheduler.rs
+++ b/src/agent/config/scheduler.rs
@@ -104,8 +104,6 @@ impl Scheduler {
 
     #[cfg(target_os = "linux")]
     fn set_niceness(&self, niceness: i32) {
-        assert!(self.policy != Policy::Normal);
-
         let result = unsafe { libc::setpriority(libc::PRIO_PROCESS, 0 as libc::id_t, niceness) };
 
         if result == -1 {

--- a/src/agent/config/scheduler.rs
+++ b/src/agent/config/scheduler.rs
@@ -74,8 +74,8 @@ impl Scheduler {
             let result = unsafe { libc::setpriority(libc::PRIO_PROCESS, 0, niceness) };
 
             if result == -1 {
-                let errno = std::io::Error::last_os_error();
-                eprintln!("could not set niceness: {}", errno.to_string());
+                let e = std::io::Error::last_os_error();
+                eprintln!("could not set niceness: {e}");
                 std::process::exit(1);
             }
         }

--- a/src/agent/config/scheduler.rs
+++ b/src/agent/config/scheduler.rs
@@ -13,15 +13,9 @@ use libc::{SCHED_FIFO, SCHED_NORMAL, SCHED_RESET_ON_FORK, SCHED_RR};
 
 #[derive(Debug, Clone)]
 pub enum Scheduler {
-    Normal {
-        niceness: i32,
-    },
-    Fifo {
-        priority: i32,
-    },
-    RoundRobin {
-        priority: i32,
-    },
+    Normal { niceness: i32 },
+    Fifo { priority: i32 },
+    RoundRobin { priority: i32 },
 }
 
 impl Scheduler {
@@ -106,39 +100,40 @@ impl<'de> Deserialize<'de> for Scheduler {
             Some("normal") => {
                 if helper.priority.is_some() {
                     Err(serde::de::Error::custom(
-                        "Cannot specify `priority` for scheduler policy: normal".to_string()
+                        "Cannot specify `priority` for scheduler policy: normal".to_string(),
                     ))
                 } else {
                     Ok(Scheduler::Normal {
-                        niceness: helper.niceness.unwrap_or_else(niceness)
+                        niceness: helper.niceness.unwrap_or_else(niceness),
                     })
                 }
             }
             Some("fifo") => {
                 if helper.niceness.is_some() {
                     Err(serde::de::Error::custom(
-                        "Cannot specify `niceness` for scheduler policy: fifo".to_string()
+                        "Cannot specify `niceness` for scheduler policy: fifo".to_string(),
                     ))
                 } else {
                     Ok(Scheduler::Fifo {
-                        priority: helper.priority.unwrap_or_else(priority)
+                        priority: helper.priority.unwrap_or_else(priority),
                     })
                 }
             }
             Some("round_robin") | None => {
                 if helper.niceness.is_some() {
                     Err(serde::de::Error::custom(
-                        "Cannot specify `niceness` for scheduler policy: fifo".to_string()
+                        "Cannot specify `niceness` for scheduler policy: fifo".to_string(),
                     ))
                 } else {
                     Ok(Scheduler::RoundRobin {
-                        priority: helper.priority.unwrap_or_else(priority)
+                        priority: helper.priority.unwrap_or_else(priority),
                     })
                 }
             }
-            Some(unknown) => Err(serde::de::Error::custom(
-                format!("Unknown scheduler policy: {}", unknown)
-            )),
+            Some(unknown) => Err(serde::de::Error::custom(format!(
+                "Unknown scheduler policy: {}",
+                unknown
+            ))),
         }
     }
 }

--- a/src/agent/config/scheduler.rs
+++ b/src/agent/config/scheduler.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+fn priority() -> i32 {
+    15
+}
+
+fn niceness() -> i32 {
+    0
+}
+
+#[cfg(target_os = "linux")]
+use libc::{SCHED_FIFO, SCHED_NORMAL, SCHED_RESET_ON_FORK, SCHED_RR};
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct Scheduler {
+    pub policy: Policy,
+    #[serde(flatten)]
+    pub parameters: Parameters,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Policy {
+    Normal,
+    Fifo,
+    RoundRobin,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+#[allow(dead_code)]
+pub enum Parameters {
+    Realtime {
+        #[serde(default = "priority")]
+        priority: i32,
+    },
+    Normal {
+        #[serde(default = "niceness")]
+        niceness: i32,
+    },
+}
+
+impl Scheduler {
+    pub fn check(&self) {
+        match (&self.policy, &self.parameters) {
+            (Policy::Fifo | Policy::RoundRobin, Parameters::Realtime { priority }) => {
+                if !(1..=99).contains(priority) {
+                    eprintln!("priority must be in the range 1..=99, got {}", priority);
+                    std::process::exit(1);
+                }
+            }
+            (Policy::Normal, Parameters::Normal { niceness }) => {
+                if !(-20..=19).contains(niceness) {
+                    eprintln!("niceness must be in the range -20..=19, got {}", niceness);
+                    std::process::exit(1);
+                }
+            }
+            // Mismatched policy and parameters
+            _ => {
+                eprintln!(
+                    "scheduler policy {:?} is incompatible with the provided parameters",
+                    self.policy
+                );
+            }
+        }
+    }
+
+    /// Apply this scheduling configuration
+    #[cfg(target_os = "linux")]
+    pub fn apply(&self) {
+        match self.parameters {
+            Parameters::Realtime { priority } => self.set_realtime_scheduler(priority),
+            Parameters::Normal { niceness } => self.set_normal_scheduler(niceness),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_realtime_scheduler(&self, priority: i32) {
+        let policy = match self.policy {
+            Policy::Fifo => SCHED_FIFO,
+            Policy::RoundRobin => SCHED_RR,
+            _ => unreachable!(),
+        } | SCHED_RESET_ON_FORK;
+
+        let param = libc::sched_param {
+            sched_priority: priority,
+        };
+
+        let result = unsafe { libc::sched_setscheduler(0 as libc::pid_t, policy, &param) };
+
+        if result == -1 {
+            let errno = std::io::Error::last_os_error();
+            match errno.raw_os_error().unwrap_or(0) {
+                libc::EPERM => {
+                    eprintln!("could not set scheduler policy to realtime: permission denied");
+                    std::process::exit(1);
+                }
+                _ => {
+                    eprintln!(
+                        "could not set scheduler policy to realtime: {}",
+                        errno.to_string()
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_normal_scheduler(&self, niceness: i32) {
+        let policy = SCHED_NORMAL | SCHED_RESET_ON_FORK;
+
+        // normal policy uses priority of 0
+        let param = libc::sched_param { sched_priority: 0 };
+
+        let result = unsafe { libc::sched_setscheduler(0 as libc::pid_t, policy, &param) };
+
+        if result == -1 {
+            let errno = std::io::Error::last_os_error();
+            eprintln!(
+                "could not set scheduler policy to normal: {}",
+                errno.to_string()
+            );
+            std::process::exit(1);
+        }
+
+        // set the niceness
+        let result = unsafe { libc::setpriority(libc::PRIO_PROCESS, 0 as libc::id_t, niceness) };
+        if result == -1 {
+            let errno = std::io::Error::last_os_error();
+            eprintln!("could not set niceness: {}", errno.to_string());
+            std::process::exit(1);
+        }
+    }
+}
+
+impl Default for Scheduler {
+    fn default() -> Self {
+        Scheduler {
+            policy: Policy::RoundRobin,
+            parameters: Parameters::Realtime {
+                priority: priority(),
+            },
+        }
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -35,6 +35,10 @@ pub fn run(config: PathBuf) {
         }
     };
 
+    // configure scheduler
+    #[cfg(target_os = "linux")]
+    config.scheduler().apply();
+
     // configure debug log
     let debug_output: Box<dyn Output> = Box::new(Stderr::new());
 


### PR DESCRIPTION
Adds scheduler configuration to the Rezolus Agent. This allows for a scheduler policy to be set and to adjust the priority/niceness.

By default, Rezolus Agent will run as a realtime service with a priority of 15 to balance between realtime responsiveness and safety.

As a result, metrics snapshots will be produced with better timing guarantees.
