### PR TITLE
feat(viewer): add bpf sampler stats to rezolus section

### DIFF
--- a/src/viewer/dashboard/rezolus.rs
+++ b/src/viewer/dashboard/rezolus.rs
@@ -50,30 +50,33 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     rezolus.plot(
         PlotOpts::line("Total BPF Overhead", "bpf-overhead", Unit::Count),
-        data.counters(
-            "rezolus_bpf_run_time",
-            (),
-        )
-        .map(|v| v.rate().sum() / 1e9),
+        data.counters("rezolus_bpf_run_time", ())
+            .map(|v| v.rate().sum() / 1e9),
     );
 
     rezolus.multi(
-        PlotOpts::multi("BPF Per-Sampler Overhead", "bpf-sampler-overhead", Unit::Count),
-        data.counters(
-            "rezolus_bpf_run_time",
-            (),
-        )
-        .map(|v| v.rate().by_sampler() / 1e9).map(|v| v.top_n(20, average))
+        PlotOpts::multi(
+            "BPF Per-Sampler Overhead",
+            "bpf-sampler-overhead",
+            Unit::Count,
+        ),
+        data.counters("rezolus_bpf_run_time", ())
+            .map(|v| v.rate().by_sampler() / 1e9)
+            .map(|v| v.top_n(20, average)),
     );
 
     if let (Some(run_time), Some(run_count)) = (
         data.counters("rezolus_bpf_run_time", ())
             .map(|v| v.rate().by_sampler() / 1e9),
-         data.counters("rezolus_bpf_run_count", ())
+        data.counters("rezolus_bpf_run_count", ())
             .map(|v| v.rate().by_sampler() / 1e9),
     ) {
         rezolus.multi(
-            PlotOpts::multi("BPF Per-Sampler Execution Time", "bpf-execution-time", Unit::Time),
+            PlotOpts::multi(
+                "BPF Per-Sampler Execution Time",
+                "bpf-execution-time",
+                Unit::Time,
+            ),
             Some((run_time / run_count).top_n(20, average)),
         );
     }

--- a/src/viewer/tsdb/collection/untyped.rs
+++ b/src/viewer/tsdb/collection/untyped.rs
@@ -83,4 +83,27 @@ impl UntypedCollection {
 
         NamedSeries { inner: result }
     }
+
+    pub fn by_sampler(&self) -> NamedSeries {
+        let mut result = BTreeMap::default();
+        let mut names = BTreeSet::new();
+
+        for labels in self.inner.keys() {
+            if let Some(name) = labels.inner.get("sampler").cloned() {
+                names.insert(name);
+            }
+        }
+
+        for name in names {
+            let series = self
+                .filter(&Labels {
+                    inner: [("sampler".to_string(), name.to_string())].into(),
+                })
+                .sum();
+
+            result.insert(name, series);
+        }
+
+        NamedSeries { inner: result }
+    }
 }


### PR DESCRIPTION
Adds the BPF sampler stats to the Rezolus section of the dashboard.
