### PR TITLE
feat(viewer): add more cgroup charts and cswitch chart

### DIFF
--- a/src/viewer/dashboard/cgroups.rs
+++ b/src/viewer/dashboard/cgroups.rs
@@ -34,7 +34,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     );
 
     cpu.multi(
-        PlotOpts::multi("CFS Throttled Time", "cgroup-cpu-migrations", Unit::Time),
+        PlotOpts::multi("CPU Throttled Time", "cgroup-cpu-migrations", Unit::Time),
         data.counters("cgroup_cpu_throttled_time", ())
             .map(|v| (v.rate().by_name()).top_n(5, average)),
     );
@@ -46,7 +46,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .map(|v| v.rate().by_name()),
     ) {
         cpu.multi(
-            PlotOpts::multi("CFS Throttle Latency", "cgroup-throttle-latency", Unit::Time),
+            PlotOpts::multi("CPU Throttle Latency", "cgroup-throttle-latency", Unit::Time),
             Some((cycles.clone() / instructions.clone()).top_n(5, average)),
         );
     }

--- a/src/viewer/dashboard/cgroups.rs
+++ b/src/viewer/dashboard/cgroups.rs
@@ -46,7 +46,11 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .map(|v| v.rate().by_name()),
     ) {
         cpu.multi(
-            PlotOpts::multi("CPU Throttle Latency", "cgroup-throttle-latency", Unit::Time),
+            PlotOpts::multi(
+                "CPU Throttle Latency",
+                "cgroup-throttle-latency",
+                Unit::Time,
+            ),
             Some((cycles.clone() / instructions.clone()).top_n(5, average)),
         );
     }

--- a/src/viewer/dashboard/cgroups.rs
+++ b/src/viewer/dashboard/cgroups.rs
@@ -86,7 +86,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     tlb.multi(
         PlotOpts::multi("Total", "cgroup-tlb-flush", Unit::Count),
-        data.counters("cgroup_tlb_flush", ())
+        data.counters("cgroup_cpu_tlb_flush", ())
             .map(|v| (v.rate().by_name()).top_n(5, average)),
     );
 

--- a/src/viewer/dashboard/scheduler.rs
+++ b/src/viewer/dashboard/scheduler.rs
@@ -33,6 +33,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         data.percentiles("scheduler_offcpu", (), PERCENTILES),
     );
 
+    scheduler.plot(
+        PlotOpts::line("Context Switch", "cswitch", Unit::Rate),
+        data.counters("scheduler_context_switch", ())
+            .map(|v| v.rate().sum()),
+    );
+
     view.group(scheduler);
 
     view


### PR DESCRIPTION
Adds charts for cgroup cpu throttling and fixes the cgroup tlb flush chart. 

Adds a context switch chart to the scheduler section