### PR TITLE
feat(agent): add cgroup scheduler stats

### DIFF
--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -10,6 +10,7 @@
 // to calculate the runqueue latency, running time, and off-cpu time.
 
 #include <vmlinux.h>
+#include "../../../agent/bpf/cgroup_info.h"
 #include "../../../agent/bpf/helpers.h"
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
@@ -19,11 +20,14 @@
 #define HISTOGRAM_POWER 3
 #define MAX_CPUS 1024
 #define MAX_PID 4194304
+#define MAX_CGROUPS 4096
+#define RINGBUF_CAPACITY 262144
 
 #define TASK_RUNNING 0
 
 // counter positions
 #define IVCSW 0
+#define RUNQ_WAIT 1
 
 /**
  * commit 2f064a59a1 ("sched: Change task_struct::state") changes
@@ -83,7 +87,31 @@ struct {
 } running_at SEC(".maps");
 
 /*
- * histograms
+ * cgroup tracking
+ */
+
+// dummy instance for skeleton to generate definition
+struct cgroup_info _cgroup_info = {};
+
+// ringbuf to pass cgroup info
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(key_size, 0);
+	__uint(value_size, 0);
+	__uint(max_entries, RINGBUF_CAPACITY);
+} cgroup_info SEC(".maps");
+
+// holds known cgroup serial numbers to help determine new or changed groups
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_serial_numbers SEC(".maps");
+
+/*
+ * system histograms
  */
 
 struct {
@@ -109,6 +137,34 @@ struct {
 	__type(value, u64);
 	__uint(max_entries, HISTOGRAM_BUCKETS);
 } offcpu SEC(".maps");
+
+/*
+ * cgroup counters
+ */
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_ivcsw SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_runq_wait SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(map_flags, BPF_F_MMAPABLE);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(max_entries, MAX_CGROUPS);
+} cgroup_offcpu SEC(".maps");
 
 /* record enqueue timestamp */
 static __always_inline
@@ -152,12 +208,56 @@ int handle__sched_switch(u64 *ctx)
 	struct task_struct *prev = (struct task_struct *)ctx[1];
 	struct task_struct *next = (struct task_struct *)ctx[2];
 
-	u32 pid, idx;
-	u64 *tsp, delta_ns, offcpu_ns;
+	u32 pid, idx, cgroup_id;
+	u64 *tsp, delta_ns, offcpu_ns, *elem;
 
 	u32 processor_id = bpf_get_smp_processor_id();
 	u64 ts = bpf_ktime_get_ns();
 
+	// read the prev task cgroup details and push to ringbuf if new cgroup
+	void *prev_task_group = BPF_CORE_READ(prev, sched_task_group);
+	if (prev_task_group) {
+		cgroup_id = BPF_CORE_READ(prev, sched_task_group, css.id);
+		u64 serial_nr = BPF_CORE_READ(prev, sched_task_group, css.serial_nr);
+
+		if (cgroup_id && cgroup_id < MAX_CGROUPS) {
+
+			// we check to see if this is a new cgroup by checking the serial number
+
+			elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
+
+			if (elem && *elem != serial_nr) {
+				// zero the counters, they will not be exported until they are non-zero
+				u64 zero = 0;
+				bpf_map_update_elem(&cgroup_ivcsw, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_runq_wait, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_offcpu, &cgroup_id, &zero, BPF_ANY);
+
+				int level = BPF_CORE_READ(prev, sched_task_group, css.serial_nr);
+
+				// initialize the cgroup info
+				struct cgroup_info cginfo = {
+					.id = cgroup_id,
+					.level = BPF_CORE_READ(prev, sched_task_group, css.cgroup, level),
+				};
+
+				// read the cgroup name
+				bpf_probe_read_kernel_str(&cginfo.name, CGROUP_NAME_LEN, BPF_CORE_READ(prev, sched_task_group, css.cgroup, kn, name));
+
+				// read the cgroup parent name
+				bpf_probe_read_kernel_str(&cginfo.pname, CGROUP_NAME_LEN, BPF_CORE_READ(prev, sched_task_group, css.cgroup, kn, parent, name));
+
+				// read the cgroup grandparent name
+				bpf_probe_read_kernel_str(&cginfo.gpname, CGROUP_NAME_LEN, BPF_CORE_READ(prev, sched_task_group, css.cgroup, kn, parent, parent, name));
+
+				// push the cgroup info into the ringbuf
+				bpf_ringbuf_output(&cgroup_info, &cginfo, sizeof(cginfo), 0);
+
+				// update the serial number in the local map
+				bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
+			}
+		}
+	}
 
 	// if prev was TASK_RUNNING, calculate how long prev was running, increment hist
 	// if prev was TASK_RUNNING, increment ivcsw counter
@@ -167,9 +267,12 @@ int handle__sched_switch(u64 *ctx)
 	// - update prev->pid enqueued_at with now
 	// - calculate how long prev task was running and update hist
 	if (get_task_state(prev) == TASK_RUNNING) {
-		// count involuntary context switch
+		// count involuntary context switch system level
 		idx = COUNTER_GROUP_WIDTH * processor_id + IVCSW;
 		array_incr(&counters, idx);
+
+		// count cswitch for cgroup
+		array_incr(&cgroup_ivcsw, cgroup_id);
 
 		pid = prev->pid;
 
@@ -186,6 +289,8 @@ int handle__sched_switch(u64 *ctx)
 
 			*tsp = 0;
 		}
+
+
 	}
 
 	// for all tasks: track when it went off-cpu
@@ -193,11 +298,56 @@ int handle__sched_switch(u64 *ctx)
 
 	// mark off-cpu at
 	bpf_map_update_elem(&offcpu_at, &pid, &ts, 0);
-	
+
 	// next task has moved into running
 	// - update next->pid running_at with now
 	// - calculate how long next task was enqueued, update hist
 	pid = next->pid;
+
+	// read the next task cgroup details and push to ringbuf if new cgroup
+	void *next_task_group = BPF_CORE_READ(next, sched_task_group);
+	if (next_task_group) {
+		cgroup_id = BPF_CORE_READ(next, sched_task_group, css.id);
+		u64 serial_nr = BPF_CORE_READ(next, sched_task_group, css.serial_nr);
+
+		if (cgroup_id && cgroup_id < MAX_CGROUPS) {
+
+			// we check to see if this is a new cgroup by checking the serial number
+
+			elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
+
+			if (elem && *elem != serial_nr) {
+				// zero the counters, they will not be exported until they are non-zero
+				u64 zero = 0;
+				bpf_map_update_elem(&cgroup_ivcsw, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_runq_wait, &cgroup_id, &zero, BPF_ANY);
+				bpf_map_update_elem(&cgroup_offcpu, &cgroup_id, &zero, BPF_ANY);
+
+				int level = BPF_CORE_READ(next, sched_task_group, css.serial_nr);
+
+				// initialize the cgroup info
+				struct cgroup_info cginfo = {
+					.id = cgroup_id,
+					.level = BPF_CORE_READ(next, sched_task_group, css.cgroup, level),
+				};
+
+				// read the cgroup name
+				bpf_probe_read_kernel_str(&cginfo.name, CGROUP_NAME_LEN, BPF_CORE_READ(next, sched_task_group, css.cgroup, kn, name));
+
+				// read the cgroup parent name
+				bpf_probe_read_kernel_str(&cginfo.pname, CGROUP_NAME_LEN, BPF_CORE_READ(next, sched_task_group, css.cgroup, kn, parent, name));
+
+				// read the cgroup grandparent name
+				bpf_probe_read_kernel_str(&cginfo.gpname, CGROUP_NAME_LEN, BPF_CORE_READ(next, sched_task_group, css.cgroup, kn, parent, parent, name));
+
+				// push the cgroup info into the ringbuf
+				bpf_ringbuf_output(&cgroup_info, &cginfo, sizeof(cginfo), 0);
+
+				// update the serial number in the local map
+				bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
+			}
+		}
+	}
 
 	// update running_at
 	bpf_map_update_elem(&running_at, &pid, &ts, 0);
@@ -209,6 +359,13 @@ int handle__sched_switch(u64 *ctx)
 
 		// update the histogram
 		histogram_incr(&runqlat, HISTOGRAM_POWER, delta_ns);
+
+		// update the system counter
+		idx = COUNTER_GROUP_WIDTH * processor_id + RUNQ_WAIT;
+		array_add(&counters, idx, delta_ns);
+
+		// update the cgroup counter
+		array_add(&cgroup_runq_wait, cgroup_id, delta_ns);
 
 		*tsp = 0;
 
@@ -223,6 +380,9 @@ int handle__sched_switch(u64 *ctx)
 
 				// update the histogram
 				histogram_incr(&offcpu, HISTOGRAM_POWER, offcpu_ns);
+
+				// update the cgroup counter
+				array_add(&cgroup_offcpu, cgroup_id, delta_ns);
 			}
 
 			*tsp = 0;

--- a/src/agent/samplers/scheduler/linux/runqueue/stats.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/stats.rs
@@ -1,6 +1,8 @@
 use crate::common::HISTOGRAM_GROUPING_POWER;
 use metriken::*;
 
+use crate::agent::*;
+
 /*
  * bpf prog stats
  */
@@ -50,4 +52,36 @@ pub static SCHEDULER_OFFCPU: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GR
     description = "The number of involuntary context switches",
     metadata = { kind = "involuntary" }
 )]
-pub static SCHEDULER_IVCSW: LazyCounter = LazyCounter::new(Counter::default);
+pub static SCHEDULER_IVCSW: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+#[metric(
+    name = "scheduler_runqueue_wait",
+    description = "Tracks time spent in the runqueue on a per-CPU basis",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static SCHEDULER_RUNQUEUE_WAIT: CounterGroup = CounterGroup::new(MAX_CPUS);
+
+/*
+ * per-cgroup
+ */
+
+#[metric(
+    name = "cgroup_scheduler_runqueue_wait",
+    description = "Tracks time spent in the runqueue on a per-cgroup basis",
+    metadata = { state = "wait", unit = "nanoseconds" }
+)]
+pub static CGROUP_SCHEDULER_RUNQUEUE_WAIT: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_scheduler_offcpu",
+    description = "Tracks the time when tasks were off-CPU on a per-cgroup basis",
+    metadata = { state = "offcpu", unit = "nanoseconds" }
+)]
+pub static CGROUP_SCHEDULER_OFFCPU: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_scheduler_context_switch",
+    description = "The number of involuntary context switches on a per-cgroup basis",
+    metadata = { kind = "involuntary" }
+)]
+pub static CGROUP_SCHEDULER_IVCSW: CounterGroup = CounterGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
Adds scheduler runqueue waiting time as a metric on a per-cgroup and per-CPU basis.

Adds involuntary context switch and offcpu time on a per-cgroup basis.
