### PR TITLE
refactor cpu usage metrics

### DIFF
--- a/src/exposition/http/mod.rs
+++ b/src/exposition/http/mod.rs
@@ -90,10 +90,6 @@ async fn prometheus(State(state): State<Arc<AppState>>) -> String {
             continue;
         }
 
-        if name == "cpu/usage" && metric.metadata().get("state") == Some("busy") {
-            continue;
-        }
-
         let metadata: Vec<String> = metric
             .metadata()
             .iter()

--- a/src/samplers/cpu/linux/usage/mod.rs
+++ b/src/samplers/cpu/linux/usage/mod.rs
@@ -54,7 +54,14 @@ fn handle_event(data: &[u8]) -> i32 {
         let id = cgroup_info.id;
 
         if !name.is_empty() {
-            CGROUP_CPU_USAGE_BUSY.insert_metadata(id as usize, "name".to_string(), name);
+            CGROUP_CPU_USAGE_USER.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_CPU_USAGE_NICE.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_CPU_USAGE_SYSTEM.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_CPU_USAGE_SOFTIRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_CPU_USAGE_IRQ.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_CPU_USAGE_STEAL.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_CPU_USAGE_GUEST.insert_metadata(id as usize, "name".to_string(), name.clone());
+            CGROUP_CPU_USAGE_GUEST_NICE.insert_metadata(id as usize, "name".to_string(), name);
         }
     }
 
@@ -68,7 +75,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
     }
 
     let counters = vec![
-        &CPU_USAGE_BUSY,
         &CPU_USAGE_USER,
         &CPU_USAGE_NICE,
         &CPU_USAGE_SYSTEM,
@@ -81,7 +87,14 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     let bpf = BpfBuilder::new(ModSkelBuilder::default)
         .cpu_counters("counters", counters)
-        .packed_counters("cgroup_busy", &CGROUP_CPU_USAGE_BUSY)
+        .packed_counters("cgroup_user", &CGROUP_CPU_USAGE_USER)
+        .packed_counters("cgroup_nice", &CGROUP_CPU_USAGE_NICE)
+        .packed_counters("cgroup_system", &CGROUP_CPU_USAGE_SYSTEM)
+        .packed_counters("cgroup_softirq", &CGROUP_CPU_USAGE_SOFTIRQ)
+        .packed_counters("cgroup_irq", &CGROUP_CPU_USAGE_IRQ)
+        .packed_counters("cgroup_steal", &CGROUP_CPU_USAGE_STEAL)
+        .packed_counters("cgroup_guest", &CGROUP_CPU_USAGE_GUEST)
+        .packed_counters("cgroup_guest_nice", &CGROUP_CPU_USAGE_GUEST_NICE)
         .ringbuf_handler("cgroup_info", handle_event)
         .build()?;
 
@@ -92,7 +105,14 @@ impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map {
         match name {
             "cgroup_info" => &self.maps.cgroup_info,
-            "cgroup_busy" => &self.maps.cgroup_busy,
+            "cgroup_user" => &self.maps.cgroup_user,
+            "cgroup_nice" => &self.maps.cgroup_nice,
+            "cgroup_system" => &self.maps.cgroup_system,
+            "cgroup_softirq" => &self.maps.cgroup_softirq,
+            "cgroup_irq" => &self.maps.cgroup_irq,
+            "cgroup_steal" => &self.maps.cgroup_steal,
+            "cgroup_guest" => &self.maps.cgroup_guest,
+            "cgroup_guest_nice" => &self.maps.cgroup_guest_nice,
             "counters" => &self.maps.counters,
             _ => unimplemented!(),
         }

--- a/src/samplers/cpu/linux/usage/stats.rs
+++ b/src/samplers/cpu/linux/usage/stats.rs
@@ -2,12 +2,9 @@ use metriken::*;
 
 use crate::common::*;
 
-#[metric(
-    name = "cpu_usage",
-    description = "The amount of CPU time spent busy",
-    metadata = { state = "busy", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_BUSY: CounterGroup = CounterGroup::new(MAX_CPUS);
+/*
+ * per-cpu metrics
+ */
 
 #[metric(
     name = "cpu_usage",
@@ -65,9 +62,62 @@ pub static CPU_USAGE_GUEST: CounterGroup = CounterGroup::new(MAX_CPUS);
 )]
 pub static CPU_USAGE_GUEST_NICE: CounterGroup = CounterGroup::new(MAX_CPUS);
 
+/*
+ * per-cgroup metrics
+ */
+
 #[metric(
     name = "cgroup_cpu_usage",
     description = "The amount of CPU time spent busy on a per-cgroup basis",
-    metadata = { state = "busy", unit = "nanoseconds" }
+    metadata = { state = "user", unit = "nanoseconds" }
 )]
-pub static CGROUP_CPU_USAGE_BUSY: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+pub static CGROUP_CPU_USAGE_USER: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage",
+    description = "The amount of CPU time spent executing low priority tasks in user mode on a per-cgroup basis",
+    metadata = { state = "nice", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_NICE: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage",
+    description = "The amount of CPU time spent executing tasks in kernel mode on a per-cgroup basis",
+    metadata = { state = "system", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_SYSTEM: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage",
+    description = "The amount of CPU time spent servicing softirqs on a per-cgroup basis",
+    metadata = { state = "softirq", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_SOFTIRQ: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage",
+    description = "The amount of CPU time spent servicing interrupts on a per-cgroup basis",
+    metadata = { state = "irq", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_IRQ: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage",
+    description = "The amount of CPU time stolen by the hypervisor on a per-cgroup basis",
+    metadata = { state = "steal", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_STEAL: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage",
+    description = "The amount of CPU time spent running a virtual CPU for a guest on a per-cgroup basis",
+    metadata = { state = "guest", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_GUEST: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage",
+    description = "The amount of CPU time spent running a virtual CPU for a guest in low priority mode on a per-cgroup basis",
+    metadata = { state = "guest_nice", unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_GUEST_NICE: CounterGroup = CounterGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
Drop the total busy metric in favor of complete breakdown of cpu usage by state for both per-cpu and per-cgroup metrics.
