### PR TITLE
chore: fix github language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # ignore these vendored files in language statistics
-src/common/bpf/aarch64/vmlinux.h linguist-vendored
-src/common/bpf/x86_64/vmlinux.h linguist-vendored
+src/agent/bpf/aarch64/vmlinux.h linguist-vendored
+src/agent/bpf/x86_64/vmlinux.h linguist-vendored


### PR DESCRIPTION
The vmlinux.h files should be ignored from the language statistics as they are autogenerated.
