### PR TITLE
chore(agent): refactor userspace cgroup info handlers

### DIFF
--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -79,7 +79,6 @@ use counters::{Counters, CpuCounters, PackedCounters};
 use histogram::Histogram;
 pub use sync_primitive::SyncPrimitive;
 
-/// Generic function to process cgroup_info data and update metrics with cgroup name metadata
 pub fn process_cgroup_info<T>(data: &[u8], metrics: &[&dyn MetricGroup]) -> i32
 where
     T: CgroupInfo + plain::Plain + Default,

--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -7,6 +7,7 @@ pub use builder::Builder as BpfBuilder;
 pub use builder::{BpfProgStats, PerfEvent};
 
 use crate::agent::samplers::Sampler;
+use crate::agent::MetricGroup;
 use crate::*;
 
 pub trait OpenSkelExt {
@@ -17,6 +18,41 @@ pub trait OpenSkelExt {
 
 pub trait SkelExt {
     fn map(&self, name: &str) -> &libbpf_rs::Map;
+}
+
+pub trait CgroupInfo {
+    fn id(&self) -> i32;
+    fn level(&self) -> i32;
+    fn name(&self) -> &[u8];
+    fn pname(&self) -> &[u8];
+    fn gpname(&self) -> &[u8];
+}
+
+#[macro_export]
+macro_rules! impl_cgroup_info {
+    ($type:ty) => {
+        impl $crate::agent::bpf::CgroupInfo for $type {
+            fn id(&self) -> i32 {
+                self.id
+            }
+
+            fn level(&self) -> i32 {
+                self.level
+            }
+
+            fn name(&self) -> &[u8] {
+                &self.name
+            }
+
+            fn pname(&self) -> &[u8] {
+                &self.pname
+            }
+
+            fn gpname(&self) -> &[u8] {
+                &self.gpname
+            }
+        }
+    };
 }
 
 const CACHELINE_SIZE: usize = 64;
@@ -42,6 +78,57 @@ fn whole_pages<T>(count: usize) -> usize {
 use counters::{Counters, CpuCounters, PackedCounters};
 use histogram::Histogram;
 pub use sync_primitive::SyncPrimitive;
+
+/// Generic function to process cgroup_info data and update metrics with cgroup name metadata
+pub fn process_cgroup_info<T>(data: &[u8], metrics: &[&dyn MetricGroup]) -> i32
+where
+    T: CgroupInfo + plain::Plain + Default,
+{
+    let mut cgroup_info = T::default();
+
+    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
+        // Process name fields from bytes to strings
+        let name = std::str::from_utf8(cgroup_info.name())
+            .unwrap_or("")
+            .trim_end_matches(char::from(0))
+            .replace("\\x2d", "-");
+
+        let pname = std::str::from_utf8(cgroup_info.pname())
+            .unwrap_or("")
+            .trim_end_matches(char::from(0))
+            .replace("\\x2d", "-");
+
+        let gpname = std::str::from_utf8(cgroup_info.gpname())
+            .unwrap_or("")
+            .trim_end_matches(char::from(0))
+            .replace("\\x2d", "-");
+
+        // Construct hierarchical path based on level and available parent names
+        let path = if !gpname.is_empty() {
+            if cgroup_info.level() > 3 {
+                format!(".../{gpname}/{pname}/{name}")
+            } else {
+                format!("/{gpname}/{pname}/{name}")
+            }
+        } else if !pname.is_empty() {
+            format!("/{pname}/{name}")
+        } else if !name.is_empty() {
+            format!("/{name}")
+        } else {
+            "".to_string()
+        };
+
+        // Update metadata for all provided metrics
+        if !path.is_empty() {
+            let id = cgroup_info.id() as usize;
+            for metric in metrics {
+                metric.insert_metadata(id, "name".to_string(), path.clone());
+            }
+        }
+    }
+
+    0
+}
 
 pub struct AsyncBpf {
     name: &'static str,

--- a/src/agent/metrics/mod.rs
+++ b/src/agent/metrics/mod.rs
@@ -6,3 +6,12 @@ pub use counters::{CounterGroup, CounterGroupError};
 
 #[allow(unused_imports)]
 pub use gauges::{GaugeGroup, GaugeGroupError};
+
+use std::collections::HashMap;
+
+pub trait MetricGroup: Sync {
+    fn insert_metadata(&self, idx: usize, key: String, value: String);
+    fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>>;
+    fn clear_metadata(&self, idx: usize);
+    fn len(&self) -> usize;
+}

--- a/src/agent/metrics/mod.rs
+++ b/src/agent/metrics/mod.rs
@@ -9,6 +9,7 @@ pub use gauges::{GaugeGroup, GaugeGroupError};
 
 use std::collections::HashMap;
 
+#[allow(dead_code)]
 pub trait MetricGroup: Sync {
     fn insert_metadata(&self, idx: usize, key: String, value: String);
     fn load_metadata(&self, idx: usize) -> Option<HashMap<String, String>>;

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -9,13 +9,16 @@ use config::Config;
 use samplers::{Sampler, SamplerResult, SAMPLERS};
 
 #[allow(unused_imports)]
-use metrics::{CounterGroup, CounterGroupError, GaugeGroup, GaugeGroupError};
+use metrics::{CounterGroup, CounterGroupError, GaugeGroup, GaugeGroupError, MetricGroup};
 
 #[cfg(target_os = "linux")]
 mod bpf;
 
 #[cfg(target_os = "linux")]
 use bpf::*;
+
+#[cfg(target_os = "linux")]
+pub use bpf::{process_cgroup_info, CgroupInfo};
 
 /// Runs Rezolus in `agent` mode in which it gathers systems telemetry and
 /// exposes metrics on an OTel/Prometheus compatible endpoint and a

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.rs
@@ -67,11 +67,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    // Set metadata for root cgroup
-    for metric in CGROUP_METRICS {
-        metric.insert_metadata(1, "name".to_string(), "/".to_string());
-    }
-
     let bpf = BpfBuilder::new(
         NAME,
         BpfProgStats {
@@ -94,6 +89,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .ringbuf_handler("bandwidth_info", handle_bandwidth_info)
     .build()?;
+
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(1, "name".to_string(), "/".to_string());
+    }
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.rs
@@ -29,7 +29,6 @@ unsafe impl plain::Plain for bpf::types::bandwidth_info {}
 
 impl_cgroup_info!(bpf::types::cgroup_info);
 
-// Static slice of metrics that track cgroup-specific data
 static CGROUP_METRICS: &[&dyn MetricGroup] = &[
     &CGROUP_CPU_BANDWIDTH_QUOTA,
     &CGROUP_CPU_BANDWIDTH_PERIOD_DURATION,

--- a/src/agent/samplers/cpu/linux/migrations/mod.rs
+++ b/src/agent/samplers/cpu/linux/migrations/mod.rs
@@ -25,52 +25,13 @@ use crate::agent::*;
 use std::sync::Arc;
 
 unsafe impl plain::Plain for bpf::types::cgroup_info {}
+impl_cgroup_info!(bpf::types::cgroup_info);
 
-fn handle_event(data: &[u8]) -> i32 {
-    let mut cgroup_info = bpf::types::cgroup_info::default();
+// Static slice of metrics that track cgroup-specific data
+static CGROUP_METRICS: &[&dyn MetricGroup] = &[&CGROUP_CPU_MIGRATIONS];
 
-    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
-        let name = std::str::from_utf8(&cgroup_info.name)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let pname = std::str::from_utf8(&cgroup_info.pname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let gpname = std::str::from_utf8(&cgroup_info.gpname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let name = if !gpname.is_empty() {
-            if cgroup_info.level > 3 {
-                format!(".../{gpname}/{pname}/{name}")
-            } else {
-                format!("/{gpname}/{pname}/{name}")
-            }
-        } else if !pname.is_empty() {
-            format!("/{pname}/{name}")
-        } else if !name.is_empty() {
-            format!("/{name}")
-        } else {
-            "".to_string()
-        };
-
-        let id = cgroup_info.id;
-
-        set_name(id as usize, name)
-    }
-
-    0
-}
-
-fn set_name(id: usize, name: String) {
-    if !name.is_empty() {
-        CGROUP_CPU_MIGRATIONS.insert_metadata(id, "name".to_string(), name);
-    }
+fn handle_cgroup_info(data: &[u8]) -> i32 {
+    process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -79,7 +40,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    set_name(1, "/".to_string());
+    // Set metadata for root cgroup
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(1, "name".to_string(), "/".to_string());
+    }
 
     let migrations = vec![&CPU_MIGRATIONS_FROM, &CPU_MIGRATIONS_TO];
 
@@ -93,7 +57,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
     )
     .cpu_counters("migrations", migrations)
     .packed_counters("cgroup_cpu_migrations", &CGROUP_CPU_MIGRATIONS)
-    .ringbuf_handler("cgroup_info", handle_event)
+    .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
 
     Ok(Some(Box::new(bpf)))

--- a/src/agent/samplers/cpu/linux/migrations/mod.rs
+++ b/src/agent/samplers/cpu/linux/migrations/mod.rs
@@ -40,11 +40,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    // Set metadata for root cgroup
-    for metric in CGROUP_METRICS {
-        metric.insert_metadata(1, "name".to_string(), "/".to_string());
-    }
-
     let migrations = vec![&CPU_MIGRATIONS_FROM, &CPU_MIGRATIONS_TO];
 
     let bpf = BpfBuilder::new(
@@ -59,6 +54,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .packed_counters("cgroup_cpu_migrations", &CGROUP_CPU_MIGRATIONS)
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
+
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(1, "name".to_string(), "/".to_string());
+    }
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/migrations/mod.rs
+++ b/src/agent/samplers/cpu/linux/migrations/mod.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 unsafe impl plain::Plain for bpf::types::cgroup_info {}
 impl_cgroup_info!(bpf::types::cgroup_info);
 
-// Static slice of metrics that track cgroup-specific data
 static CGROUP_METRICS: &[&dyn MetricGroup] = &[&CGROUP_CPU_MIGRATIONS];
 
 fn handle_cgroup_info(data: &[u8]) -> i32 {

--- a/src/agent/samplers/cpu/linux/perf/mod.rs
+++ b/src/agent/samplers/cpu/linux/perf/mod.rs
@@ -31,7 +31,6 @@ use stats::*;
 unsafe impl plain::Plain for bpf::types::cgroup_info {}
 impl_cgroup_info!(bpf::types::cgroup_info);
 
-// Static slice of metrics that track cgroup-specific data
 static CGROUP_METRICS: &[&dyn MetricGroup] = &[&CGROUP_CPU_CYCLES, &CGROUP_CPU_INSTRUCTIONS];
 
 fn handle_event(data: &[u8]) -> i32 {

--- a/src/agent/samplers/cpu/linux/perf/mod.rs
+++ b/src/agent/samplers/cpu/linux/perf/mod.rs
@@ -29,53 +29,13 @@ mod stats;
 use stats::*;
 
 unsafe impl plain::Plain for bpf::types::cgroup_info {}
+impl_cgroup_info!(bpf::types::cgroup_info);
+
+// Static slice of metrics that track cgroup-specific data
+static CGROUP_METRICS: &[&dyn MetricGroup] = &[&CGROUP_CPU_CYCLES, &CGROUP_CPU_INSTRUCTIONS];
 
 fn handle_event(data: &[u8]) -> i32 {
-    let mut cgroup_info = bpf::types::cgroup_info::default();
-
-    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
-        let name = std::str::from_utf8(&cgroup_info.name)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let pname = std::str::from_utf8(&cgroup_info.pname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let gpname = std::str::from_utf8(&cgroup_info.gpname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let name = if !gpname.is_empty() {
-            if cgroup_info.level > 3 {
-                format!(".../{gpname}/{pname}/{name}")
-            } else {
-                format!("/{gpname}/{pname}/{name}")
-            }
-        } else if !pname.is_empty() {
-            format!("/{pname}/{name}")
-        } else if !name.is_empty() {
-            format!("/{name}")
-        } else {
-            "".to_string()
-        };
-
-        let id = cgroup_info.id;
-
-        set_name(id as usize, name)
-    }
-
-    0
-}
-
-fn set_name(id: usize, name: String) {
-    if !name.is_empty() {
-        CGROUP_CPU_CYCLES.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_INSTRUCTIONS.insert_metadata(id, "name".to_string(), name);
-    }
+    process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -84,7 +44,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    set_name(1, "/".to_string());
+    // Set metadata for root cgroup
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(1, "name".to_string(), "/".to_string());
+    }
 
     let bpf = BpfBuilder::new(
         NAME,

--- a/src/agent/samplers/cpu/linux/perf/mod.rs
+++ b/src/agent/samplers/cpu/linux/perf/mod.rs
@@ -44,11 +44,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    // Set metadata for root cgroup
-    for metric in CGROUP_METRICS {
-        metric.insert_metadata(1, "name".to_string(), "/".to_string());
-    }
-
     let bpf = BpfBuilder::new(
         NAME,
         BpfProgStats {
@@ -63,6 +58,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .packed_counters("cgroup_instructions", &CGROUP_CPU_INSTRUCTIONS)
     .ringbuf_handler("cgroup_info", handle_event)
     .build()?;
+
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(1, "name".to_string(), "/".to_string());
+    }
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
+++ b/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
@@ -24,56 +24,18 @@ mod stats;
 use stats::*;
 
 unsafe impl plain::Plain for bpf::types::cgroup_info {}
+impl_cgroup_info!(bpf::types::cgroup_info);
 
-fn handle_event(data: &[u8]) -> i32 {
-    let mut cgroup_info = bpf::types::cgroup_info::default();
+static CGROUP_METRICS: &[&dyn MetricGroup] = &[
+    &CGROUP_TLB_FLUSH_TASK_SWITCH,
+    &CGROUP_TLB_FLUSH_REMOTE_SHOOTDOWN,
+    &CGROUP_TLB_FLUSH_LOCAL_SHOOTDOWN,
+    &CGROUP_TLB_FLUSH_LOCAL_MM_SHOOTDOWN,
+    &CGROUP_TLB_FLUSH_REMOTE_SEND_IPI,
+];
 
-    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
-        let name = std::str::from_utf8(&cgroup_info.name)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let pname = std::str::from_utf8(&cgroup_info.pname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let gpname = std::str::from_utf8(&cgroup_info.gpname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let name = if !gpname.is_empty() {
-            if cgroup_info.level > 3 {
-                format!(".../{gpname}/{pname}/{name}")
-            } else {
-                format!("/{gpname}/{pname}/{name}")
-            }
-        } else if !pname.is_empty() {
-            format!("/{pname}/{name}")
-        } else if !name.is_empty() {
-            format!("/{name}")
-        } else {
-            "".to_string()
-        };
-
-        let id = cgroup_info.id;
-
-        set_name(id as usize, name)
-    }
-
-    0
-}
-
-fn set_name(id: usize, name: String) {
-    if !name.is_empty() {
-        CGROUP_TLB_FLUSH_TASK_SWITCH.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_TLB_FLUSH_REMOTE_SHOOTDOWN.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_TLB_FLUSH_LOCAL_SHOOTDOWN.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_TLB_FLUSH_LOCAL_MM_SHOOTDOWN.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_TLB_FLUSH_REMOTE_SEND_IPI.insert_metadata(id, "name".to_string(), name);
-    }
+fn handle_cgroup_info(data: &[u8]) -> i32 {
+    process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -110,8 +72,13 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &CGROUP_TLB_FLUSH_LOCAL_MM_SHOOTDOWN,
     )
     .packed_counters("cgroup_remote_send_ipi", &CGROUP_TLB_FLUSH_REMOTE_SEND_IPI)
-    .ringbuf_handler("cgroup_info", handle_event)
+    .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
+
+    // Set name metadata for root cgroup
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(0, "name".to_string(), "/".to_string());
+    }
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
+++ b/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
@@ -75,7 +75,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
 
-    // Set name metadata for root cgroup
     for metric in CGROUP_METRICS {
         metric.insert_metadata(0, "name".to_string(), "/".to_string());
     }

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -88,7 +88,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
 
-    // Set name metadata for root cgroup
     for metric in CGROUP_METRICS {
         metric.insert_metadata(0, "name".to_string(), "/".to_string());
     }

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -30,53 +30,12 @@ mod stats;
 use stats::*;
 
 unsafe impl plain::Plain for bpf::types::cgroup_info {}
+impl_cgroup_info!(bpf::types::cgroup_info);
 
-fn handle_event(data: &[u8]) -> i32 {
-    let mut cgroup_info = bpf::types::cgroup_info::default();
+static CGROUP_METRICS: &[&dyn MetricGroup] = &[&CGROUP_CPU_USAGE_USER, &CGROUP_CPU_USAGE_SYSTEM];
 
-    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
-        let name = std::str::from_utf8(&cgroup_info.name)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let pname = std::str::from_utf8(&cgroup_info.pname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let gpname = std::str::from_utf8(&cgroup_info.gpname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let name = if !gpname.is_empty() {
-            if cgroup_info.level > 3 {
-                format!(".../{gpname}/{pname}/{name}")
-            } else {
-                format!("/{gpname}/{pname}/{name}")
-            }
-        } else if !pname.is_empty() {
-            format!("/{pname}/{name}")
-        } else if !name.is_empty() {
-            format!("/{name}")
-        } else {
-            "".to_string()
-        };
-
-        let id = cgroup_info.id;
-
-        set_name(id as usize, name)
-    }
-
-    0
-}
-
-fn set_name(id: usize, name: String) {
-    if !name.is_empty() {
-        CGROUP_CPU_USAGE_USER.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_CPU_USAGE_SYSTEM.insert_metadata(id, "name".to_string(), name.clone());
-    }
+fn handle_cgroup_info(data: &[u8]) -> i32 {
+    process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -84,8 +43,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
     }
-
-    set_name(1, "/".to_string());
 
     let cpu_usage = vec![&CPU_USAGE_USER, &CPU_USAGE_SYSTEM];
 
@@ -128,8 +85,13 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .cpu_counters("softirq_time", softirq_time)
     .packed_counters("cgroup_user", &CGROUP_CPU_USAGE_USER)
     .packed_counters("cgroup_system", &CGROUP_CPU_USAGE_SYSTEM)
-    .ringbuf_handler("cgroup_info", handle_event)
+    .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
+
+    // Set name metadata for root cgroup
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(0, "name".to_string(), "/".to_string());
+    }
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -63,7 +63,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
 
-    // Set name metadata for root cgroup
     for metric in CGROUP_METRICS {
         metric.insert_metadata(0, "name".to_string(), "/".to_string());
     }

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -25,54 +25,16 @@ use crate::agent::*;
 use std::sync::Arc;
 
 unsafe impl plain::Plain for bpf::types::cgroup_info {}
+impl_cgroup_info!(bpf::types::cgroup_info);
 
-fn handle_event(data: &[u8]) -> i32 {
-    let mut cgroup_info = bpf::types::cgroup_info::default();
+static CGROUP_METRICS: &[&dyn MetricGroup] = &[
+    &CGROUP_SCHEDULER_IVCSW,
+    &CGROUP_SCHEDULER_OFFCPU,
+    &CGROUP_SCHEDULER_RUNQUEUE_WAIT,
+];
 
-    if plain::copy_from_bytes(&mut cgroup_info, data).is_ok() {
-        let name = std::str::from_utf8(&cgroup_info.name)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let pname = std::str::from_utf8(&cgroup_info.pname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let gpname = std::str::from_utf8(&cgroup_info.gpname)
-            .unwrap()
-            .trim_end_matches(char::from(0))
-            .replace("\\x2d", "-");
-
-        let name = if !gpname.is_empty() {
-            if cgroup_info.level > 3 {
-                format!(".../{gpname}/{pname}/{name}")
-            } else {
-                format!("/{gpname}/{pname}/{name}")
-            }
-        } else if !pname.is_empty() {
-            format!("/{pname}/{name}")
-        } else if !name.is_empty() {
-            format!("/{name}")
-        } else {
-            "".to_string()
-        };
-
-        let id = cgroup_info.id;
-
-        set_name(id as usize, name)
-    }
-
-    0
-}
-
-fn set_name(id: usize, name: String) {
-    if !name.is_empty() {
-        CGROUP_SCHEDULER_IVCSW.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SCHEDULER_OFFCPU.insert_metadata(id, "name".to_string(), name.clone());
-        CGROUP_SCHEDULER_RUNQUEUE_WAIT.insert_metadata(id, "name".to_string(), name.clone());
-    }
+fn handle_cgroup_info(data: &[u8]) -> i32 {
+    process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
 #[distributed_slice(SAMPLERS)]
@@ -80,8 +42,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
     }
-
-    set_name(1, "/".to_string());
 
     let counters = vec![&SCHEDULER_IVCSW, &SCHEDULER_RUNQUEUE_WAIT];
 
@@ -100,8 +60,13 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .packed_counters("cgroup_runq_wait", &CGROUP_SCHEDULER_RUNQUEUE_WAIT)
     .packed_counters("cgroup_offcpu", &CGROUP_SCHEDULER_OFFCPU)
     .packed_counters("cgroup_ivcsw", &CGROUP_SCHEDULER_IVCSW)
-    .ringbuf_handler("cgroup_info", handle_event)
+    .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
+
+    // Set name metadata for root cgroup
+    for metric in CGROUP_METRICS {
+        metric.insert_metadata(0, "name".to_string(), "/".to_string());
+    }
 
     Ok(Some(Box::new(bpf)))
 }

--- a/src/agent/samplers/syscall/linux/counts/mod.rs
+++ b/src/agent/samplers/syscall/linux/counts/mod.rs
@@ -101,7 +101,6 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .build()?;
 
-    // Set name metadata for root cgroup
     for metric in CGROUP_METRICS {
         metric.insert_metadata(0, "name".to_string(), "/".to_string());
     }


### PR DESCRIPTION
Add new traits to unify counter and gauge groups as well as the per-BPF cgroup_info structs. This allows us to reduce the repitition in the userspace cgroup info handlers.
