### PR TITLE
stricter build flags for BPF programs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,6 +45,8 @@ mod bpf {
                         "-Isrc/agent/bpf/x86_64",
                         "-fno-unwind-tables",
                         "-D__TARGET_ARCH_x86",
+                        "-Wall",
+                        "-Werror",
                     ])
                     .build_and_generate(&tgt)
                     .unwrap();
@@ -55,6 +57,8 @@ mod bpf {
                         "-Isrc/agent/bpf/aarch64",
                         "-fno-unwind-tables",
                         "-D__TARGET_ARCH_arm64",
+                        "-Wall",
+                        "-Werror",
                     ])
                     .build_and_generate(&tgt)
                     .unwrap();

--- a/src/agent/bpf/histogram.h
+++ b/src/agent/bpf/histogram.h
@@ -11,8 +11,6 @@
 // within BPF. But since we also can't loop, this is implemented as a binary
 // search with a maximum of 6 branches.
 static u32 clz(u64 value) {
-    u32 count = 0;
-
     // binary search to find number of leading zeros
     if (value & 0xFFFFFFFF00000000) {
         if (value & 0xFFFF000000000000) {

--- a/src/agent/samplers/blockio/linux/requests/mod.bpf.c
+++ b/src/agent/samplers/blockio/linux/requests/mod.bpf.c
@@ -74,7 +74,6 @@ struct {
 } discard_size SEC(".maps");
 
 static int handle_block_rq_complete(struct request* rq, int error, unsigned int nr_bytes) {
-    u64 delta, *tsp;
     u32 idx, op;
     unsigned int cmd_flags;
 

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
@@ -121,8 +121,6 @@ int tg_set_cfs_bandwidth(struct pt_regs* ctx) {
     if (cgroup_id >= MAX_CGROUPS)
         return 0;
 
-    u64 serial_nr = BPF_CORE_READ(css, serial_nr);
-
     int ret = handle_new_cgroup_from_css(css, &cgroup_serial_numbers, &cgroup_info);
 
     if (ret == 0) {
@@ -162,8 +160,6 @@ int throttle_cfs_rq(struct pt_regs* ctx) {
     u64 cgroup_id = BPF_CORE_READ(css, id);
     if (cgroup_id >= MAX_CGROUPS)
         return 0;
-
-    u64 serial_nr = BPF_CORE_READ(css, serial_nr);
 
     int ret = handle_new_cgroup_from_css(css, &cgroup_serial_numbers, &cgroup_info);
 

--- a/src/agent/samplers/cpu/linux/tlb_flush/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/tlb_flush/mod.bpf.c
@@ -103,7 +103,6 @@ struct {
 SEC("raw_tp/tlb_flush")
 int BPF_PROG(tlb_flush, int reason, u64 pages) {
     u32 offset, idx;
-    u64* elem;
 
     offset = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id();
 
@@ -116,7 +115,6 @@ int BPF_PROG(tlb_flush, int reason, u64 pages) {
     void* task_group = BPF_CORE_READ(current, sched_task_group);
     if (task_group) {
         int cgroup_id = BPF_CORE_READ(current, sched_task_group, css.id);
-        u64 serial_nr = BPF_CORE_READ(current, sched_task_group, css.serial_nr);
 
         if (cgroup_id < MAX_CGROUPS) {
 

--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -273,8 +273,6 @@ int softirq_exit(struct trace_event_raw_softirq* args) {
     u32 cpu = bpf_get_smp_processor_id();
     u64 *start_ts, dur = 0;
     u32 idx, cpuusage_idx;
-
-    u32 irq_id = 0;
     u32 start_idx = cpu * 8;
 
     // lookup the start time

--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -271,8 +271,8 @@ int softirq_enter(struct trace_event_raw_softirq* args) {
 SEC("tracepoint/irq/softirq_exit")
 int softirq_exit(struct trace_event_raw_softirq* args) {
     u32 cpu = bpf_get_smp_processor_id();
-    u64 *elem, *start_ts, dur = 0;
-    u32 idx, cpuusage_idx, group = 0;
+    u64 *start_ts, dur = 0;
+    u32 idx, cpuusage_idx;
 
     u32 irq_id = 0;
     u32 start_idx = cpu * 8;

--- a/src/agent/samplers/network/linux/traffic/mod.bpf.c
+++ b/src/agent/samplers/network/linux/traffic/mod.bpf.c
@@ -32,7 +32,6 @@ struct {
 SEC("raw_tp/netif_receive_skb")
 int BPF_PROG(netif_receive_skb, struct sk_buff* skb) {
     u64 len;
-    u64* cnt;
     u32 idx;
 
     len = BPF_CORE_READ(skb, len);
@@ -51,7 +50,6 @@ int BPF_PROG(netif_receive_skb, struct sk_buff* skb) {
 SEC("raw_tp/net_dev_start_xmit")
 int BPF_PROG(tcp_cleanup_rbuf, struct sk_buff* skb, struct net_device* dev, void* txq, bool more) {
     u64 len;
-    u64* cnt;
     u32 idx;
 
     len = BPF_CORE_READ(skb, len);

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -211,7 +211,6 @@ int handle__sched_switch(u64* ctx) {
     void* prev_task_group = BPF_CORE_READ(prev, sched_task_group);
     if (prev_task_group) {
         cgroup_id = BPF_CORE_READ(prev, sched_task_group, css.id);
-        u64 serial_nr = BPF_CORE_READ(prev, sched_task_group, css.serial_nr);
 
         if (cgroup_id < MAX_CGROUPS) {
 

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -211,6 +211,7 @@ int handle__sched_switch(u64* ctx) {
     void* prev_task_group = BPF_CORE_READ(prev, sched_task_group);
     if (prev_task_group) {
         cgroup_id = BPF_CORE_READ(prev, sched_task_group, css.id);
+        u64 serial_nr = BPF_CORE_READ(prev, sched_task_group, css.serial_nr);
 
         if (cgroup_id < MAX_CGROUPS) {
 
@@ -304,7 +305,6 @@ int handle__sched_switch(u64* ctx) {
     void* next_task_group = BPF_CORE_READ(next, sched_task_group);
     if (next_task_group) {
         cgroup_id = BPF_CORE_READ(next, sched_task_group, css.id);
-        u64 serial_nr = BPF_CORE_READ(next, sched_task_group, css.serial_nr);
 
         if (cgroup_id < MAX_CGROUPS) {
 

--- a/src/agent/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/agent/samplers/syscall/linux/counts/mod.bpf.c
@@ -199,7 +199,6 @@ struct {
 SEC("tracepoint/raw_syscalls/sys_enter")
 int sys_enter(struct trace_event_raw_sys_enter* args) {
     u32 offset, idx, group = 0;
-    u64* elem;
 
     if (args->id < 0) {
         return 0;
@@ -226,7 +225,6 @@ int sys_enter(struct trace_event_raw_sys_enter* args) {
 
     if (bpf_core_field_exists(current->sched_task_group)) {
         int cgroup_id = current->sched_task_group->css.id;
-        u64 serial_nr = current->sched_task_group->css.serial_nr;
 
         if (cgroup_id < MAX_CGROUPS) {
 

--- a/src/agent/samplers/tcp/linux/connect_latency/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/connect_latency/mod.bpf.c
@@ -54,8 +54,7 @@ static int trace_connect(struct sock* sk) {
 }
 
 static int handle_tcp_rcv_state_process(void* ctx, struct sock* sk) {
-    u32 idx;
-    u64 sock_ident, now, delta_ns, *cnt, *tsp;
+    u64 sock_ident, now, delta_ns, *tsp;
 
     if (BPF_CORE_READ(sk, __sk_common.skc_state) != TCP_SYN_SENT)
         return 0;
@@ -99,7 +98,7 @@ int BPF_KPROBE(tcp_rcv_state_process, struct sock* sk) {
 
 SEC("tracepoint/tcp/tcp_destroy_sock")
 int tcp_destroy_sock(struct trace_event_raw_tcp_event_sk* ctx) {
-    struct sock* sk = ctx->skaddr;
+    struct sock* sk = (struct sock*)(ctx->skaddr);
 
     u64 sock_ident = get_sock_ident(sk);
     bpf_map_delete_elem(&start, &sock_ident);

--- a/src/agent/samplers/tcp/linux/packet_latency/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/packet_latency/mod.bpf.c
@@ -43,7 +43,6 @@ static __always_inline __u64 get_sock_ident(struct sock* sk) {
 }
 
 static int handle_tcp_probe(struct sock* sk, struct sk_buff* skb) {
-    const struct inet_sock* inet = (struct inet_sock*)(sk);
     u64 sock_ident, ts, len, doff;
     const struct tcphdr* th;
 
@@ -61,14 +60,9 @@ static int handle_tcp_probe(struct sock* sk, struct sk_buff* skb) {
 }
 
 static int handle_tcp_rcv_space_adjust(void* ctx, struct sock* sk) {
-    const struct inet_sock* inet = (struct inet_sock*)(sk);
     u64 sock_ident = get_sock_ident(sk);
-    u64 id = bpf_get_current_pid_tgid(), *tsp;
-    u32 idx;
+    u64 *tsp;
     u64 now, delta_ns;
-    u32 pid = id >> 32, tid = id;
-    struct event* eventp;
-    u16 family;
 
     tsp = bpf_map_lookup_elem(&start, &sock_ident);
     if (!tsp) {

--- a/src/agent/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/receive/mod.bpf.c
@@ -37,10 +37,8 @@ struct {
 
 SEC("kprobe/tcp_rcv_established")
 int BPF_KPROBE(tcp_rcv_kprobe, struct sock* sk) {
-    const struct inet_sock* inet = (struct inet_sock*)(sk);
     struct tcp_sock* ts;
-    u64 key, slot;
-    u32 idx, mdev_us, srtt_us;
+    u32 mdev_us, srtt_us;
     u64 mdev_ns, srtt_ns;
 
     ts = (struct tcp_sock*)(sk);


### PR DESCRIPTION
Adds `-Wall` and `-Werror` to the BPF build options and addresses all current warnings.