### PR TITLE
fix(viewer): require explicit aggregation for promql

### DIFF
--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -53,13 +53,38 @@ export function getNoDataOption(title) {
  */
 export function getTooltipFormatter(valueFormatter) {
     return (paramsArray) => {
+        // Sort the params array alphabetically by series name
+        // Special handling: 'id' should come first in the sort if present
+        const sortedParams = [...paramsArray].sort((a, b) => {
+            const aName = a.seriesName;
+            const bName = b.seriesName;
+
+            // Extract id values if present (format is like "id=0, state=user")
+            const aHasId = aName.startsWith('id=');
+            const bHasId = bName.startsWith('id=');
+
+            if (aHasId && bHasId) {
+                // Both have ids, compare the full string naturally
+                return aName.localeCompare(bName, undefined, { numeric: true });
+            } else if (aHasId) {
+                // a has id, b doesn't - a comes first
+                return -1;
+            } else if (bHasId) {
+                // b has id, a doesn't - b comes first
+                return 1;
+            } else {
+                // Neither has id, normal alphabetical sort
+                return aName.localeCompare(bName, undefined, { numeric: true });
+            }
+        });
+
         const result =
             `<div>
                 <div>
                     ${formatDateTime(paramsArray[0].value[0])}
                 </div>
                 <div style="margin-top: 5px;">
-                    ${paramsArray.map(p => `<div>
+                    ${sortedParams.map(p => `<div>
                         ${p.marker}
                         <span style="margin-left: 2px;">
                             ${p.seriesName}

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -79,6 +79,18 @@ export class Chart {
         this.observer = observer;
     }
 
+    onupdate(vnode) {
+        // Update the spec reference
+        const oldSpec = this.spec;
+        this.spec = vnode.attrs.spec;
+
+        // If the chart is already initialized and data has changed, update it
+        if (this.echart && oldSpec.data !== this.spec.data) {
+            // Instead of reinitializing, just update the chart configuration
+            this.configureChartByType();
+        }
+    }
+
     onremove() {
         // Clean up chart instance and event handlers
         if (this.observer) {
@@ -127,11 +139,14 @@ export class Chart {
 
         // Initialize the chart
         this.echart = echarts.init(this.domNode);
-        const startTime = new Date();
-        this.echart.on('finished', () => {
-            this.echart.off('finished');
-            console.log(`Chart ${this.chartId} rendered in ${new Date() - startTime}ms`);
-        })
+        // Only log initial chart creation in debug mode
+        if (window.location.search.includes('debug')) {
+            const startTime = new Date();
+            this.echart.on('finished', () => {
+                this.echart.off('finished');
+                console.log(`Chart ${this.chartId} rendered in ${new Date() - startTime}ms`);
+            });
+        }
 
         // Store original time data for human-friendly tick calculation
         if (this.spec.data && this.spec.data.length > 0) {

--- a/src/viewer/dashboard/cpu.rs
+++ b/src/viewer/dashboard/cpu.rs
@@ -12,7 +12,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Average CPU busy percentage across all cores
     utilization.plot_promql(
         PlotOpts::line("Busy %", "busy-pct", Unit::Percentage),
-        "irate(cpu_usage[5m]) / cpu_cores / 1000000000".to_string(),
+        "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU busy percentage heatmap
@@ -33,7 +33,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
                 format!("{state}-pct"),
                 Unit::Percentage,
             ),
-            format!("irate(cpu_usage{{state=\"{state}\"}}[5m]) / cpu_cores / 1000000000"),
+            format!("sum(irate(cpu_usage{{state=\"{state}\"}}[5m])) / cpu_cores / 1000000000"),
         );
 
         // Per-CPU for this state
@@ -58,7 +58,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // IPC (Instructions per Cycle)
     performance.plot_promql(
         PlotOpts::line("Instructions per Cycle (IPC)", "ipc", Unit::Count),
-        "irate(cpu_instructions[5m]) / irate(cpu_cycles[5m])".to_string(),
+        "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m]))".to_string(),
     );
 
     // Per-CPU IPC
@@ -72,7 +72,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Complex calculation: instructions / cycles * tsc * aperf / mperf / 1e9 / cores
     performance.plot_promql(
         PlotOpts::line("Instructions per Nanosecond (IPNS)", "ipns", Unit::Count),
-        "irate(cpu_instructions[5m]) / irate(cpu_cycles[5m]) * irate(cpu_tsc[5m]) * irate(cpu_aperf[5m]) / irate(cpu_mperf[5m]) / 1000000000 / cpu_cores".to_string(),
+        "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m])) * sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / 1000000000 / cpu_cores".to_string(),
     );
 
     // Per-CPU IPNS
@@ -84,7 +84,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // L3 Cache Hit Rate
     performance.plot_promql(
         PlotOpts::line("L3 Hit %", "l3-hit", Unit::Percentage),
-        "(1 - irate(cpu_l3_miss[5m]) / irate(cpu_l3_access[5m])) * 100".to_string(),
+        "(1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))) * 100".to_string(),
     );
 
     // Per-CPU L3 Hit Rate
@@ -97,7 +97,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // CPU Frequency
     performance.plot_promql(
         PlotOpts::line("Frequency", "frequency", Unit::Frequency),
-        "irate(cpu_tsc[5m]) * irate(cpu_aperf[5m]) / irate(cpu_mperf[5m]) / cpu_cores".to_string(),
+        "sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / cpu_cores".to_string(),
     );
 
     // Per-CPU Frequency
@@ -117,7 +117,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Migrations To
     migrations.plot_promql(
         PlotOpts::line("To", "cpu-migrations-to", Unit::Rate),
-        "irate(cpu_migrations{direction=\"to\"}[5m])".to_string(),
+        "sum(irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
     );
 
     // Per-CPU Migrations To
@@ -129,7 +129,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Migrations From
     migrations.plot_promql(
         PlotOpts::line("From", "cpu-migrations-from", Unit::Rate),
-        "irate(cpu_migrations{direction=\"from\"}[5m])".to_string(),
+        "sum(irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
     );
 
     // Per-CPU Migrations From
@@ -149,7 +149,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Total TLB Flushes
     tlb.plot_promql(
         PlotOpts::line("Total", "tlb-total", Unit::Rate),
-        "irate(cpu_tlb_flush[5m])".to_string(),
+        "sum(irate(cpu_tlb_flush[5m]))".to_string(),
     );
 
     // Per-CPU TLB Flushes
@@ -170,7 +170,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
 
         tlb.plot_promql(
             PlotOpts::line(*label, &id, Unit::Rate),
-            format!("irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m])"),
+            format!("sum(irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
         );
 
         tlb.plot_promql(

--- a/src/viewer/dashboard/overview.rs
+++ b/src/viewer/dashboard/overview.rs
@@ -12,7 +12,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Average CPU busy percentage
     cpu.plot_promql(
         PlotOpts::line("Busy %", "cpu-busy", Unit::Percentage),
-        "irate(cpu_usage[5m]) / cpu_cores / 1000000000".to_string(),
+        "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU busy percentage heatmap
@@ -133,7 +133,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Average CPU % spent in softirq
     softirq.plot_promql(
         PlotOpts::line("CPU %", "softirq-total-time", Unit::Percentage),
-        "irate(softirq_time[5m]) / cpu_cores / 1000000000".to_string(),
+        "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU % spent in softirq heatmap

--- a/src/viewer/dashboard/softirq.rs
+++ b/src/viewer/dashboard/softirq.rs
@@ -24,7 +24,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
     // Average CPU % spent in softirq
     softirq.plot_promql(
         PlotOpts::line("CPU %", "softirq-total-time", Unit::Percentage),
-        "irate(softirq_time[5m]) / cpu_cores / 1000000000".to_string(),
+        "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU % spent in softirq heatmap
@@ -68,7 +68,7 @@ pub fn generate(data: &Arc<Tsdb>, sections: Vec<Section>) -> View {
         // Average CPU % for this softirq kind
         group.plot_promql(
             PlotOpts::line("CPU %", format!("softirq-{kind}-time"), Unit::Percentage),
-            format!("irate(softirq_time{{kind=\"{kind}\"}}[5m]) / cpu_cores / 1000000000"),
+            format!("sum(irate(softirq_time{{kind=\"{kind}\"}}[5m])) / cpu_cores / 1000000000"),
         );
 
         // Per-CPU % heatmap for this softirq kind


### PR DESCRIPTION
Fixes the promql handling to require explicit aggregation for queries like `irate(cpu_usage[1m])`. This prevents the auto sum() that was happening before and makes the behavior match expectations.
