### PR TITLE
feat(mcp): add describe metrics tool

### DIFF
--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -58,12 +58,6 @@ macro_rules! impl_cgroup_info {
 const CACHELINE_SIZE: usize = 64;
 const PAGE_SIZE: usize = 4096;
 
-// This is the maximum number of CPUs we track with BPF counters.
-pub const MAX_CPUS: usize = 1024;
-
-// This is the maximum number of cgroups we track with BPF counters.
-pub const MAX_CGROUPS: usize = 4096;
-
 const COUNTER_SIZE: usize = std::mem::size_of::<u64>();
 const COUNTERS_PER_CACHELINE: usize = CACHELINE_SIZE / COUNTER_SIZE;
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -20,6 +20,12 @@ use bpf::*;
 #[cfg(target_os = "linux")]
 pub use bpf::{process_cgroup_info, CgroupInfo};
 
+// This is the maximum number of CPUs we track with BPF counters.
+pub const MAX_CPUS: usize = 1024;
+
+// This is the maximum number of cgroups we track with BPF counters.
+pub const MAX_CGROUPS: usize = 4096;
+
 /// Runs Rezolus in `agent` mode in which it gathers systems telemetry and
 /// exposes metrics on an OTel/Prometheus compatible endpoint and a
 /// Rezolus-specific msgpack endpoint.

--- a/src/agent/samplers/blockio/linux/latency/stats.rs
+++ b/src/agent/samplers/blockio/linux/latency/stats.rs
@@ -25,7 +25,7 @@ pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_latency",
-    description = "Distribution of blockio read operation latency in nanoseconds",
+    description = "Distribution of blockio operation latency in nanoseconds",
     metadata = { op = "read", unit = "nanoseconds" }
 )]
 pub static BLOCKIO_READ_LATENCY: RwLockHistogram =
@@ -33,7 +33,7 @@ pub static BLOCKIO_READ_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "blockio_latency",
-    description = "Distribution of blockio write operation latency in nanoseconds",
+    description = "Distribution of blockio operation latency in nanoseconds",
     metadata = { op = "write", unit = "nanoseconds" }
 )]
 pub static BLOCKIO_WRITE_LATENCY: RwLockHistogram =
@@ -41,7 +41,7 @@ pub static BLOCKIO_WRITE_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "blockio_latency",
-    description = "Distribution of blockio flush operation latency in nanoseconds",
+    description = "Distribution of blockio operation latency in nanoseconds",
     metadata = { op = "flush", unit = "nanoseconds" }
 )]
 pub static BLOCKIO_FLUSH_LATENCY: RwLockHistogram =
@@ -49,7 +49,7 @@ pub static BLOCKIO_FLUSH_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "blockio_latency",
-    description = "Distribution of blockio discard operation latency in nanoseconds",
+    description = "Distribution of blockio operation latency in nanoseconds",
     metadata = { op = "discard", unit = "nanoseconds" }
 )]
 pub static BLOCKIO_DISCARD_LATENCY: RwLockHistogram =

--- a/src/agent/samplers/blockio/linux/requests/stats.rs
+++ b/src/agent/samplers/blockio/linux/requests/stats.rs
@@ -25,28 +25,28 @@ pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_size",
-    description = "Distribution of blockio read operation sizes in bytes",
+    description = "Distribution of blockio operation sizes in bytes",
     metadata = { op = "read", unit = "bytes" }
 )]
 pub static BLOCKIO_READ_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio_size",
-    description = "Distribution of blockio write operation sizes in bytes",
+    description = "Distribution of blockio operation sizes in bytes",
     metadata = { op = "write", unit = "bytes" }
 )]
 pub static BLOCKIO_WRITE_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio_size",
-    description = "Distribution of blockio flush operation sizes in bytes",
+    description = "Distribution of blockio operation sizes in bytes",
     metadata = { op = "flush", unit = "bytes" }
 )]
 pub static BLOCKIO_FLUSH_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio_size",
-    description = "Distribution of blockio discard operation sizes in bytes",
+    description = "Distribution of blockio operation sizes in bytes",
     metadata = { op = "discard", unit = "bytes" }
 )]
 pub static BLOCKIO_DISCARD_SIZE: RwLockHistogram =
@@ -54,56 +54,56 @@ pub static BLOCKIO_DISCARD_SIZE: RwLockHistogram =
 
 #[metric(
     name = "blockio_operations",
-    description = "The number of completed read operations for block devices",
+    description = "The number of completed operations for block devices",
     metadata = { op = "read", unit = "operations" }
 )]
 pub static BLOCKIO_READ_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_operations",
-    description = "The number of completed write operations for block devices",
+    description = "The number of completed operations for block devices",
     metadata = { op = "write", unit = "operations" }
 )]
 pub static BLOCKIO_WRITE_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_operations",
-    description = "The number of completed discard operations for block devices",
+    description = "The number of completed operations for block devices",
     metadata = { op = "discard", unit = "operations" }
 )]
 pub static BLOCKIO_DISCARD_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_operations",
-    description = "The number of completed flush operations for block devices",
+    description = "The number of completed operations for block devices",
     metadata = { op = "flush", unit = "operations" }
 )]
 pub static BLOCKIO_FLUSH_OPS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_bytes",
-    description = "The number of bytes read for block devices",
+    description = "The number of bytes transferred for block device operations",
     metadata = { op = "read", unit = "bytes" }
 )]
 pub static BLOCKIO_READ_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_bytes",
-    description = "The number of bytes written for block devices",
+    description = "The number of bytes transferred for block device operations",
     metadata = { op = "write", unit = "bytes" }
 )]
 pub static BLOCKIO_WRITE_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_bytes",
-    description = "The number of bytes discarded for block devices",
+    description = "The number of bytes transferred for block device operations",
     metadata = { op = "discard", unit = "bytes" }
 )]
 pub static BLOCKIO_DISCARD_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "blockio_bytes",
-    description = "The number of bytes flushed for block devices",
+    description = "The number of bytes transferred for block device operations",
     metadata = { op = "flush", unit = "bytes" }
 )]
 pub static BLOCKIO_FLUSH_BYTES: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/blockio/mod.rs
+++ b/src/agent/samplers/blockio/mod.rs
@@ -1,2 +1,13 @@
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod stats {
+    mod latency {
+        include!("./linux/latency/stats.rs");
+    }
+
+    mod requests {
+        include!("./linux/requests/stats.rs");
+    }
+}

--- a/src/agent/samplers/cpu/linux/perf/stats.rs
+++ b/src/agent/samplers/cpu/linux/perf/stats.rs
@@ -51,7 +51,7 @@ pub static CGROUP_CPU_CYCLES: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 #[metric(
     name = "cgroup_cpu_instructions",
-    description = "The number of elapsed CPU cycles on a per-cgroup basis",
+    description = "The number of instructions retired on a per-cgroup basis",
     metadata = { unit = "instructions" }
 )]
 pub static CGROUP_CPU_INSTRUCTIONS: CounterGroup = CounterGroup::new(MAX_CGROUPS);

--- a/src/agent/samplers/cpu/linux/usage/stats.rs
+++ b/src/agent/samplers/cpu/linux/usage/stats.rs
@@ -26,7 +26,7 @@ pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu_usage",
-   description = "The amount of CPU time spent executing normal tasks is user mode",
+   description = "The amount of CPU time spent in the given state",
     metadata = { state = "user", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_USER: CounterGroup = CounterGroup::new(MAX_CPUS);

--- a/src/agent/samplers/cpu/macos/usage/mod.rs
+++ b/src/agent/samplers/cpu/macos/usage/mod.rs
@@ -101,14 +101,11 @@ impl UsageInner {
                     );
                 }
 
-                let busy = user.wrapping_add(system.wrapping_add(nice));
-
                 CPU_CORES.set(num_cpu as i64);
 
                 CPU_USAGE_USER.set(user);
                 CPU_USAGE_SYSTEM.set(system);
                 CPU_USAGE_NICE.set(nice);
-                CPU_USAGE_BUSY.set(busy);
             }
         }
     }

--- a/src/agent/samplers/cpu/macos/usage/stats.rs
+++ b/src/agent/samplers/cpu/macos/usage/stats.rs
@@ -8,28 +8,21 @@ pub static CPU_CORES: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "cpu_usage",
-    description = "The amount of CPU time spent busy",
-    metadata = { state = "busy", unit = "nanoseconds" }
-)]
-pub static CPU_USAGE_BUSY: LazyCounter = LazyCounter::new(Counter::default);
-
-#[metric(
-    name = "cpu_usage",
-    description = "The amount of CPU time spent executing normal tasks is user mode",
+    description = "The amount of CPU time spent executing tasks",
     metadata = { state = "user", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_USER: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu_usage",
-    description = "The amount of CPU time spent executing low priority tasks in user mode",
+    description = "The amount of CPU time spent executing tasks",
     metadata = { state = "nice", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_NICE: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cpu_usage",
-    description = "The amount of CPU time spent executing tasks in kernel mode",
+    description = "The amount of CPU time spent executing tasks",
     metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static CPU_USAGE_SYSTEM: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/cpu/mod.rs
+++ b/src/agent/samplers/cpu/mod.rs
@@ -6,7 +6,7 @@ mod macos;
 
 #[cfg(not(target_os = "linux"))]
 pub mod stats {
-	mod cores {
+    mod cores {
         include!("./linux/cores/stats.rs");
     }
 

--- a/src/agent/samplers/cpu/mod.rs
+++ b/src/agent/samplers/cpu/mod.rs
@@ -3,3 +3,38 @@ mod linux;
 
 #[cfg(target_os = "macos")]
 mod macos;
+
+#[cfg(not(target_os = "linux"))]
+pub mod stats {
+	mod cores {
+        include!("./linux/cores/stats.rs");
+    }
+
+    mod bandwidth {
+        include!("./linux/bandwidth/stats.rs");
+    }
+
+    mod frequency {
+        include!("./linux/frequency/stats.rs");
+    }
+
+    mod l3 {
+        include!("./linux/l3/stats.rs");
+    }
+
+    mod migrations {
+        include!("./linux/migrations/stats.rs");
+    }
+
+    mod perf {
+        include!("./linux/perf/stats.rs");
+    }
+
+    mod tlb_flush {
+        include!("./linux/tlb_flush/stats.rs");
+    }
+
+    mod usage {
+        include!("./linux/usage/stats.rs");
+    }
+}

--- a/src/agent/samplers/gpu/mod.rs
+++ b/src/agent/samplers/gpu/mod.rs
@@ -1,2 +1,9 @@
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod stats {
+    mod nvidia {
+        include!("./linux/nvidia/stats.rs");
+    }
+}

--- a/src/agent/samplers/memory/mod.rs
+++ b/src/agent/samplers/memory/mod.rs
@@ -1,2 +1,13 @@
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod stats {
+    mod meminfo {
+        include!("./linux/meminfo/stats.rs");
+    }
+
+    mod vmstat {
+        include!("./linux/vmstat/stats.rs");
+    }
+}

--- a/src/agent/samplers/network/linux/traffic/stats.rs
+++ b/src/agent/samplers/network/linux/traffic/stats.rs
@@ -24,28 +24,28 @@ pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network_bytes",
-    description = "The number of bytes received over the network",
+    description = "The number of bytes transferred over the network",
     metadata = { direction = "receive", unit = "bytes" }
 )]
 pub static NETWORK_RX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network_packets",
-    description = "The number of packets received over the network",
+    description = "The number of packets transferred over the network",
     metadata = { direction = "receive", unit = "packets" }
 )]
 pub static NETWORK_RX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network_bytes",
-    description = "The number of bytes transmitted over the network",
+    description = "The number of bytes transferred over the network",
     metadata = { direction = "transmit", unit = "bytes" }
 )]
 pub static NETWORK_TX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "network_packets",
-    description = "The number of packets transmitted over the network",
+    description = "The number of packets transferred over the network",
     metadata = { direction = "transmit", unit = "packets" }
 )]
 pub static NETWORK_TX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/network/mod.rs
+++ b/src/agent/samplers/network/mod.rs
@@ -1,2 +1,13 @@
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod stats {
+	mod interfaces {
+		include!("./linux/interfaces/stats.rs");
+	}
+    
+    mod traffic {
+    	include!("./linux/traffic/stats.rs");
+    }
+}

--- a/src/agent/samplers/network/mod.rs
+++ b/src/agent/samplers/network/mod.rs
@@ -3,11 +3,11 @@ mod linux;
 
 #[cfg(not(target_os = "linux"))]
 mod stats {
-	mod interfaces {
-		include!("./linux/interfaces/stats.rs");
-	}
-    
+    mod interfaces {
+        include!("./linux/interfaces/stats.rs");
+    }
+
     mod traffic {
-    	include!("./linux/traffic/stats.rs");
+        include!("./linux/traffic/stats.rs");
     }
 }

--- a/src/agent/samplers/rezolus/rusage/stats.rs
+++ b/src/agent/samplers/rezolus/rusage/stats.rs
@@ -2,14 +2,14 @@ use metriken::*;
 
 #[metric(
     name = "rezolus_cpu_usage",
-    description = "The amount of CPU time Rezolus was executing in user mode",
+    description = "The amount of CPU time Rezolus was executing",
     metadata = { state = "user", unit = "nanoseconds" }
 )]
 pub static RU_UTIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_cpu_usage",
-    description = "The amount of CPU time Rezolus was executing in system mode",
+    description = "The amount of CPU time Rezolus was executing",
     metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static RU_STIME: LazyCounter = LazyCounter::new(Counter::default);
@@ -23,40 +23,40 @@ pub static RU_MAXRSS: LazyGauge = LazyGauge::new(Gauge::default);
 
 #[metric(
     name = "rezolus_memory_page_reclaims",
-    description = "The number of page faults which were serviced by reclaiming a page"
+    description = "The number of page faults which were serviced by reclaiming a page for Rezolus process"
 )]
 pub static RU_MINFLT: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_memory_page_faults",
-    description = "The number of page faults which required an I/O operation"
+    description = "The number of page faults which required an I/O operation for Rezolus process"
 )]
 pub static RU_MAJFLT: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_blockio_operations",
-    description = "The number of reads from the filesystem",
+    description = "The number of completed blockio operations initiated by Rezolus",
     metadata = { op = "read", unit = "operations" }
 )]
 pub static RU_INBLOCK: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_blockio_operations",
-    description = "The number of writes to the filesystem",
+    description = "The number of completed blockio operations initiated by Rezolus",
     metadata = { op = "write", unit = "operations" }
 )]
 pub static RU_OUBLOCK: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_context_switch",
-    description = "The number of voluntary context switches",
+    description = "The number of context switches for Rezolus process",
     metadata = { kind = "voluntary" }
 )]
 pub static RU_NVCSW: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_context_switch",
-    description = "The number of involuntary context switches",
+    description = "The number of context switches for Rezolus process",
     metadata = { kind = "involuntary" }
 )]
 pub static RU_NIVCSW: LazyCounter = LazyCounter::new(Counter::default);

--- a/src/agent/samplers/scheduler/mod.rs
+++ b/src/agent/samplers/scheduler/mod.rs
@@ -1,2 +1,9 @@
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod stats {
+    mod runqueue {
+        include!("./linux/runqueue/stats.rs");
+    }
+}

--- a/src/agent/samplers/syscall/mod.rs
+++ b/src/agent/samplers/syscall/mod.rs
@@ -1,2 +1,13 @@
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod stats {
+    mod counts {
+        include!("./linux/counts/stats.rs");
+    }
+
+    mod latency {
+        include!("./linux/latency/stats.rs");
+    }
+}

--- a/src/agent/samplers/tcp/linux/traffic/stats.rs
+++ b/src/agent/samplers/tcp/linux/traffic/stats.rs
@@ -3,42 +3,42 @@ use metriken::*;
 
 #[metric(
     name = "tcp_bytes",
-    description = "The number of bytes received over TCP",
+    description = "The number of bytes transferred over TCP",
     metadata = { direction = "receive", unit = "bytes" }
 )]
 pub static TCP_RX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "tcp_packets",
-    description = "The number of packets received over TCP",
+    description = "The number of packets transferred over TCP",
     metadata = { direction = "receive", unit = "packets" }
 )]
 pub static TCP_RX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "tcp_size",
-    description = "Distribution of the size of TCP packets received after reassembly",
+    description = "Distribution of the size of TCP packets transferred, ignoring fragmentation",
     metadata = { direction = "receive", unit = "bytes" }
 )]
 pub static TCP_RX_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "tcp_bytes",
-    description = "The number of bytes transmitted over TCP",
+    description = "The number of bytes transferred over TCP",
     metadata = { direction = "transmit", unit = "bytes" }
 )]
 pub static TCP_TX_BYTES: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "tcp_packets",
-    description = "The number of packets transmitted over TCP",
+    description = "The number of packets transferred over TCP",
     metadata = { direction = "transmit", unit = "packets" }
 )]
 pub static TCP_TX_PACKETS: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "tcp_size",
-    description = "Distribution of the size of TCP packets transmitted before fragmentation",
+    description = "Distribution of the size of TCP packets transferred, ignoring fragmentation",
     metadata = { direction = "transmit", unit = "bytes" }
 )]
 pub static TCP_TX_SIZE: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);

--- a/src/agent/samplers/tcp/mod.rs
+++ b/src/agent/samplers/tcp/mod.rs
@@ -1,2 +1,25 @@
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(not(target_os = "linux"))]
+mod stats {
+	mod connect_latency {
+		include!("./linux/connect_latency/stats.rs");
+	}
+    
+    mod packet_latency {
+    	include!("./linux/packet_latency/stats.rs");
+    }
+
+    mod receive {
+    	include!("./linux/receive/stats.rs");
+    }
+
+    mod retransmit {
+    	include!("./linux/retransmit/stats.rs");
+    }
+
+    mod traffic {
+    	include!("./linux/traffic/stats.rs");
+    }
+}

--- a/src/agent/samplers/tcp/mod.rs
+++ b/src/agent/samplers/tcp/mod.rs
@@ -3,23 +3,23 @@ mod linux;
 
 #[cfg(not(target_os = "linux"))]
 mod stats {
-	mod connect_latency {
-		include!("./linux/connect_latency/stats.rs");
-	}
-    
+    mod connect_latency {
+        include!("./linux/connect_latency/stats.rs");
+    }
+
     mod packet_latency {
-    	include!("./linux/packet_latency/stats.rs");
+        include!("./linux/packet_latency/stats.rs");
     }
 
     mod receive {
-    	include!("./linux/receive/stats.rs");
+        include!("./linux/receive/stats.rs");
     }
 
     mod retransmit {
-    	include!("./linux/retransmit/stats.rs");
+        include!("./linux/retransmit/stats.rs");
     }
 
     mod traffic {
-    	include!("./linux/traffic/stats.rs");
+        include!("./linux/traffic/stats.rs");
     }
 }

--- a/src/mcp/describe_metrics.rs
+++ b/src/mcp/describe_metrics.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use crate::viewer::tsdb::Tsdb;
+
+/// Get a hashmap of metric names to their descriptions by querying metriken metrics
+fn get_metric_descriptions() -> HashMap<String, String> {
+    let mut descriptions = HashMap::new();
+    
+    // Iterate through all registered metrics and extract their descriptions
+    for metric in metriken::metrics().iter() {
+        if let Some(description) = metric.description() {
+            descriptions.insert(metric.name().to_string(), description.to_string());
+        }
+    }
+    
+    descriptions
+}
+
+/// Format metrics description for display
+pub fn format_metrics_description(tsdb: &Arc<Tsdb>) -> String {
+    let mut output = String::new();
+    output.push_str("Available Metrics in Recording\n");
+    output.push_str("===============================\n\n");
+
+    // Get the descriptions from metriken metrics
+    let descriptions = get_metric_descriptions();
+
+    // List counters
+    let mut counter_names = tsdb.counter_names();
+    if !counter_names.is_empty() {
+        counter_names.sort();
+        output.push_str("COUNTERS (monotonically increasing values):\n");
+        output.push_str("-------------------------------------------\n");
+        for name in counter_names {
+            output.push_str(&format!("• {name}\n"));
+            // Add description if available
+            if let Some(desc) = descriptions.get(name) {
+                output.push_str(&format!("  Description: {desc}\n"));
+            }
+            if let Some(labels_list) = tsdb.counter_labels(name) {
+                if !labels_list.is_empty() {
+                    // Get unique label keys
+                    let mut all_keys = std::collections::HashSet::new();
+                    for labels in &labels_list {
+                        for (key, _) in labels.inner.iter() {
+                            all_keys.insert(key.clone());
+                        }
+                    }
+                    if !all_keys.is_empty() {
+                        let mut keys: Vec<_> = all_keys.into_iter().collect();
+                        keys.sort();
+                        output.push_str(&format!("  Labels: {}\n", keys.join(", ")));
+                    }
+                    output.push_str(&format!("  Series count: {}\n", labels_list.len()));
+                }
+            }
+            output.push('\n');
+        }
+    }
+
+    // List gauges
+    let mut gauge_names = tsdb.gauge_names();
+    if !gauge_names.is_empty() {
+        gauge_names.sort();
+        output.push_str("\nGAUGES (values that can go up or down):\n");
+        output.push_str("----------------------------------------\n");
+        for name in gauge_names {
+            output.push_str(&format!("• {name}\n"));
+            // Add description if available
+            if let Some(desc) = descriptions.get(name) {
+                output.push_str(&format!("  Description: {desc}\n"));
+            }
+            if let Some(labels_list) = tsdb.gauge_labels(name) {
+                if !labels_list.is_empty() {
+                    // Get unique label keys
+                    let mut all_keys = std::collections::HashSet::new();
+                    for labels in &labels_list {
+                        for (key, _) in labels.inner.iter() {
+                            all_keys.insert(key.clone());
+                        }
+                    }
+                    if !all_keys.is_empty() {
+                        let mut keys: Vec<_> = all_keys.into_iter().collect();
+                        keys.sort();
+                        output.push_str(&format!("  Labels: {}\n", keys.join(", ")));
+                    }
+                    output.push_str(&format!("  Series count: {}\n", labels_list.len()));
+                }
+            }
+            output.push('\n');
+        }
+    }
+
+    // List histograms
+    let mut histogram_names = tsdb.histogram_names();
+    if !histogram_names.is_empty() {
+        histogram_names.sort();
+        output.push_str("\nHISTOGRAMS (distributions of values):\n");
+        output.push_str("--------------------------------------\n");
+        for name in histogram_names {
+            output.push_str(&format!("• {name}\n"));
+            // Add description if available
+            if let Some(desc) = descriptions.get(name) {
+                output.push_str(&format!("  Description: {desc}\n"));
+            }
+            if let Some(labels_list) = tsdb.histogram_labels(name) {
+                if !labels_list.is_empty() {
+                    // Get unique label keys
+                    let mut all_keys = std::collections::HashSet::new();
+                    for labels in &labels_list {
+                        for (key, _) in labels.inner.iter() {
+                            all_keys.insert(key.clone());
+                        }
+                    }
+                    if !all_keys.is_empty() {
+                        let mut keys: Vec<_> = all_keys.into_iter().collect();
+                        keys.sort();
+                        output.push_str(&format!("  Labels: {}\n", keys.join(", ")));
+                    }
+                    output.push_str(&format!("  Series count: {}\n", labels_list.len()));
+                }
+            }
+            output.push('\n');
+        }
+    }
+
+    // Add summary statistics
+    let total_counters = tsdb.counter_names().len();
+    let total_gauges = tsdb.gauge_names().len();
+    let total_histograms = tsdb.histogram_names().len();
+    let total_metrics = total_counters + total_gauges + total_histograms;
+
+    output.push_str("\nSUMMARY:\n");
+    output.push_str("--------\n");
+    output.push_str(&format!("Total unique metrics: {total_metrics}\n"));
+    output.push_str(&format!("  Counters: {total_counters}\n"));
+    output.push_str(&format!("  Gauges: {total_gauges}\n"));
+    output.push_str(&format!("  Histograms: {total_histograms}\n"));
+    output.push_str(&format!("\nSampling interval: {}ms\n", tsdb.interval() * 1000.0));
+
+    output
+}

--- a/src/mcp/describe_metrics.rs
+++ b/src/mcp/describe_metrics.rs
@@ -1,18 +1,18 @@
+use crate::viewer::tsdb::Tsdb;
 use std::collections::HashMap;
 use std::sync::Arc;
-use crate::viewer::tsdb::Tsdb;
 
 /// Get a hashmap of metric names to their descriptions by querying metriken metrics
 fn get_metric_descriptions() -> HashMap<String, String> {
     let mut descriptions = HashMap::new();
-    
+
     // Iterate through all registered metrics and extract their descriptions
     for metric in metriken::metrics().iter() {
         if let Some(description) = metric.description() {
             descriptions.insert(metric.name().to_string(), description.to_string());
         }
     }
-    
+
     descriptions
 }
 
@@ -136,7 +136,10 @@ pub fn format_metrics_description(tsdb: &Arc<Tsdb>) -> String {
     output.push_str(&format!("  Counters: {total_counters}\n"));
     output.push_str(&format!("  Gauges: {total_gauges}\n"));
     output.push_str(&format!("  Histograms: {total_histograms}\n"));
-    output.push_str(&format!("\nSampling interval: {}ms\n", tsdb.interval() * 1000.0));
+    output.push_str(&format!(
+        "\nSampling interval: {}ms\n",
+        tsdb.interval() * 1000.0
+    ));
 
     output
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -189,7 +189,6 @@ fn run_describe_metrics(file: PathBuf) {
     println!("{output}");
 }
 
-
 /// MCP operation mode
 pub enum Mode {
     Server,

--- a/src/viewer/tsdb/collection/counter.rs
+++ b/src/viewer/tsdb/collection/counter.rs
@@ -15,6 +15,10 @@ impl CounterCollection {
         self.inner.entry(labels)
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (&Labels, &CounterSeries)> {
+        self.inner.iter()
+    }
+
     /// Old filter method that clones - kept for compatibility but should be avoided
     pub fn filter(&self, labels: &Labels) -> Self {
         let mut result = Self::default();

--- a/src/viewer/tsdb/collection/histogram.rs
+++ b/src/viewer/tsdb/collection/histogram.rs
@@ -15,6 +15,10 @@ impl HistogramCollection {
         self.inner.entry(labels)
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (&Labels, &HistogramSeries)> {
+        self.inner.iter()
+    }
+
     pub fn filter(&self, labels: &Labels) -> Self {
         let mut result = Self::default();
 

--- a/src/viewer/tsdb/mod.rs
+++ b/src/viewer/tsdb/mod.rs
@@ -302,6 +302,42 @@ impl Tsdb {
     pub fn filename(&self) -> &str {
         &self.filename
     }
+
+    // Get all counter metric names
+    pub fn counter_names(&self) -> Vec<&str> {
+        self.counters.keys().map(|s| s.as_str()).collect()
+    }
+
+    // Get all gauge metric names
+    pub fn gauge_names(&self) -> Vec<&str> {
+        self.gauges.keys().map(|s| s.as_str()).collect()
+    }
+
+    // Get all histogram metric names
+    pub fn histogram_names(&self) -> Vec<&str> {
+        self.histograms.keys().map(|s| s.as_str()).collect()
+    }
+
+    // Get labels for a specific counter metric
+    pub fn counter_labels(&self, name: &str) -> Option<Vec<Labels>> {
+        self.counters.get(name).map(|collection| {
+            collection.iter().map(|(labels, _)| labels.clone()).collect()
+        })
+    }
+
+    // Get labels for a specific gauge metric
+    pub fn gauge_labels(&self, name: &str) -> Option<Vec<Labels>> {
+        self.gauges.get(name).map(|collection| {
+            collection.iter().map(|(labels, _)| labels.clone()).collect()
+        })
+    }
+
+    // Get labels for a specific histogram metric
+    pub fn histogram_labels(&self, name: &str) -> Option<Vec<Labels>> {
+        self.histograms.get(name).map(|collection| {
+            collection.iter().map(|(labels, _)| labels.clone()).collect()
+        })
+    }
 }
 
 #[derive(Default, Clone)]

--- a/src/viewer/tsdb/mod.rs
+++ b/src/viewer/tsdb/mod.rs
@@ -321,21 +321,30 @@ impl Tsdb {
     // Get labels for a specific counter metric
     pub fn counter_labels(&self, name: &str) -> Option<Vec<Labels>> {
         self.counters.get(name).map(|collection| {
-            collection.iter().map(|(labels, _)| labels.clone()).collect()
+            collection
+                .iter()
+                .map(|(labels, _)| labels.clone())
+                .collect()
         })
     }
 
     // Get labels for a specific gauge metric
     pub fn gauge_labels(&self, name: &str) -> Option<Vec<Labels>> {
         self.gauges.get(name).map(|collection| {
-            collection.iter().map(|(labels, _)| labels.clone()).collect()
+            collection
+                .iter()
+                .map(|(labels, _)| labels.clone())
+                .collect()
         })
     }
 
     // Get labels for a specific histogram metric
     pub fn histogram_labels(&self, name: &str) -> Option<Vec<Labels>> {
         self.histograms.get(name).map(|collection| {
-            collection.iter().map(|(labels, _)| labels.clone()).collect()
+            collection
+                .iter()
+                .map(|(labels, _)| labels.clone())
+                .collect()
         })
     }
 }


### PR DESCRIPTION
Adds a describe_metrics tool to the MCP server with a corresponding CLI command. This allows reading the metric descriptions (as defined in the agent code) when analyzing a Rezolus recording. 

Fixes some metric descriptions so that metrics sharing a name (with different labels) use a unified description. 

Fixes macos cpu_usage sampler by removing separately exposed "busy" metric. This enables more natural aggregations.