### PR TITLE
fix(recorder): add message when converting recording to parquet

### DIFF
--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -295,7 +295,7 @@ pub fn run(config: Config) {
                 debug!("finished");
             }
             Format::Parquet => {
-                debug!("converting temp file to parquet");
+                info!("converting the recording to parquet... please wait");
 
                 let _ = writer.rewind();
 


### PR DESCRIPTION
Adds an info level log message before conversion to parquet. This provides feedback on when the recording has completed and the recording is being converted / finalized.
