### PR TITLE
Disable "Reset Zoom" button when already zoomed out

### DIFF
--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -38,6 +38,10 @@ export class ChartsState {
         this.charts.clear();
     }
 
+    isDefaultZoom() {
+        return !this.zoomLevel || (this.zoomLevel.start === 0 && this.zoomLevel.end === 100);
+    }
+
     // Reset zoom level on all charts
     resetZoom() {
         this.zoomLevel = {
@@ -261,6 +265,7 @@ export class Chart {
                     endValue,
                 });
             });
+            m.redraw();
         });
 
         // Enable drag-to-zoom
@@ -286,6 +291,7 @@ export class Chart {
                     end: 100,
                 });
             });
+            m.redraw();
         })
     }
 

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -6,7 +6,10 @@ const TopNav = {
         return m('div#topnav', [
             m('div.logo', 'REZOLUS'),
             m('div.topnav-actions', [
-                m('button', { onclick: () => chartsState.resetZoom() }, 'RESET ZOOM'),
+                m('button', {
+                    onclick: () => chartsState.resetZoom(),
+                    disabled: chartsState.isDefaultZoom(),
+                }, 'RESET ZOOM'),
             ]),
         ]);
     },

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -206,12 +206,7 @@ body::after {
     color: var(--fg-muted);
     cursor: not-allowed;
     opacity: 0.5;
-}
-
-#topnav .topnav-actions button:disabled:hover {
-    background: var(--bg-tertiary);
-    border-color: var(--border-default);
-    box-shadow: none;
+    pointer-events: none;
 }
 
 

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -202,6 +202,18 @@ body::after {
     box-shadow: var(--shadow-glow);
 }
 
+#topnav .topnav-actions button:disabled {
+    color: var(--fg-muted);
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+#topnav .topnav-actions button:disabled:hover {
+    background: var(--bg-tertiary);
+    border-color: var(--border-default);
+    box-shadow: none;
+}
+
 
 /* ==========================================================================
    Header - File Info Section


### PR DESCRIPTION
Problem

the reset zoom button currently stays enabled regardless of whether or not the zoom level has already been reset.

Solution

this PR disables the button when clicking it would not do anything.

Result

The zoom button now tracks the zoom level. 