### PR TITLE
ensure tooltip background is present so that its text remains legible

### DIFF
--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -229,11 +229,11 @@ export function getBaseOption(title) {
                 fontSize: 12,
                 fontFamily: '"Inter", -apple-system, sans-serif',
             },
-            backgroundColor: 'rgba(13, 17, 23, 0.95)',
+            backgroundColor: '#0d1117',
             borderColor: COLORS.borderDefault,
             borderWidth: 1,
             padding: [12, 14],
-            extraCssText: 'box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); border-radius: 8px;',
+            extraCssText: 'background-color: #0d1117 !important; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4); border-radius: 8px;',
         },
         // This invisible toolbox is a workaround to have drag-to-zoom as the default behavior.
         // We programmatically activate the zoom tool and hide the interface.


### PR DESCRIPTION
Before this change, tooltips would have a transparent background. Now tooltips look like this:

<img width="562" height="470" alt="Screenshot 2026-03-09 at 14 18 46@2x" src="https://github.com/user-attachments/assets/8548ece2-54c8-4b8c-9ea6-50fb4853592c" />
