### PR TITLE
add metric description tooltips to viewer charts

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,16 @@
 pub static HISTOGRAM_GROUPING_POWER: u8 = 3;
 
+/// Returns a map of metric names to their descriptions from the global metric registry.
+pub fn metric_descriptions() -> std::collections::HashMap<String, String> {
+    let mut descriptions = std::collections::HashMap::new();
+    for metric in metriken::metrics().iter() {
+        if let Some(description) = metric.description() {
+            descriptions.insert(metric.name().to_string(), description.to_string());
+        }
+    }
+    descriptions
+}
+
 // Time units with base unit as nanoseconds
 pub const SECONDS: u64 = 1_000 * MILLISECONDS;
 pub const MILLISECONDS: u64 = 1_000 * MICROSECONDS;

--- a/src/mcp/describe_metrics.rs
+++ b/src/mcp/describe_metrics.rs
@@ -2,20 +2,6 @@ use crate::viewer::tsdb::Tsdb;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Get a hashmap of metric names to their descriptions by querying metriken metrics
-fn get_metric_descriptions() -> HashMap<String, String> {
-    let mut descriptions = HashMap::new();
-
-    // Iterate through all registered metrics and extract their descriptions
-    for metric in metriken::metrics().iter() {
-        if let Some(description) = metric.description() {
-            descriptions.insert(metric.name().to_string(), description.to_string());
-        }
-    }
-
-    descriptions
-}
-
 /// Format metrics description for display
 pub fn format_metrics_description(tsdb: &Arc<Tsdb>) -> String {
     let mut output = String::new();
@@ -23,7 +9,7 @@ pub fn format_metrics_description(tsdb: &Arc<Tsdb>) -> String {
     output.push_str("===============================\n\n");
 
     // Get the descriptions from metriken metrics
-    let descriptions = get_metric_descriptions();
+    let descriptions = crate::common::metric_descriptions();
 
     // List counters
     let mut counter_names = tsdb.counter_names();

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -1334,10 +1334,16 @@ const Group = {
                                 min_value: heatmapData.min_value,
                                 max_value: heatmapData.max_value,
                             };
-                            return m(Chart, { spec: heatmapSpec, chartsState });
+                            return m('div.chart-wrapper', [
+                                m(Chart, { spec: heatmapSpec, chartsState }),
+                                heatmapSpec.opts.description && m('span.chart-info-icon', { title: heatmapSpec.opts.description }, '\u2139'),
+                            ]);
                         }
 
-                        return m(Chart, { spec, chartsState });
+                        return m('div.chart-wrapper', [
+                            m(Chart, { spec, chartsState }),
+                            spec.opts.description && m('span.chart-info-icon', { title: spec.opts.description }, '\u2139'),
+                        ]);
                     }),
                 ),
             ],

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -515,6 +515,25 @@ main {
     height: 420px;
 }
 
+.chart-wrapper {
+    position: relative;
+}
+
+.chart-info-icon {
+    position: absolute;
+    top: 12px;
+    right: 16px;
+    z-index: 10;
+    cursor: help;
+    font-size: 13px;
+    color: var(--fg-muted);
+    pointer-events: auto;
+}
+
+.chart-info-icon:hover {
+    color: var(--fg-secondary);
+}
+
 /* ==========================================================================
    Query Explorer
    ========================================================================== */

--- a/src/viewer/plot.rs
+++ b/src/viewer/plot.rs
@@ -175,7 +175,24 @@ impl Group {
         });
     }
 
-    pub fn plot_promql(&mut self, opts: PlotOpts, promql_query: String) {
+    pub fn plot_promql(&mut self, mut opts: PlotOpts, promql_query: String) {
+        // Auto-fill description from metric registry if not already set
+        if opts.description.is_none() {
+            use std::sync::OnceLock;
+            static DESCRIPTIONS: OnceLock<std::collections::HashMap<String, String>> =
+                OnceLock::new();
+            let descriptions =
+                DESCRIPTIONS.get_or_init(crate::common::metric_descriptions);
+
+            // Find the first metric name that appears in the query
+            for (name, desc) in descriptions {
+                if promql_query.contains(name.as_str()) {
+                    opts.description = Some(desc.clone());
+                    break;
+                }
+            }
+        }
+
         self.plots.push(Plot {
             opts,
             data: Vec::new(), // Will be populated by frontend
@@ -216,6 +233,8 @@ pub struct PlotOpts {
     style: String,
     // Unified configuration for value formatting, axis labels, etc.
     format: Option<FormatConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -245,6 +264,7 @@ impl PlotOpts {
             id: id.into(),
             style: "line".to_string(),
             format: Some(FormatConfig::new(unit)),
+            description: None,
         }
     }
 
@@ -254,6 +274,7 @@ impl PlotOpts {
             id: id.into(),
             style: "multi".to_string(),
             format: Some(FormatConfig::new(unit)),
+            description: None,
         }
     }
 
@@ -263,6 +284,7 @@ impl PlotOpts {
             id: id.into(),
             style: "scatter".to_string(),
             format: Some(FormatConfig::new(unit)),
+            description: None,
         }
     }
 
@@ -272,6 +294,7 @@ impl PlotOpts {
             id: id.into(),
             style: "heatmap".to_string(),
             format: Some(FormatConfig::new(unit)),
+            description: None,
         }
     }
 

--- a/src/viewer/plot.rs
+++ b/src/viewer/plot.rs
@@ -181,8 +181,7 @@ impl Group {
             use std::sync::OnceLock;
             static DESCRIPTIONS: OnceLock<std::collections::HashMap<String, String>> =
                 OnceLock::new();
-            let descriptions =
-                DESCRIPTIONS.get_or_init(crate::common::metric_descriptions);
+            let descriptions = DESCRIPTIONS.get_or_init(crate::common::metric_descriptions);
 
             // Find the first metric name that appears in the query
             for (name, desc) in descriptions {


### PR DESCRIPTION
adds the first step towards per-plot metric description tooltips (using the browser 'title' attribute).

extracts common description-related functionality between the mcp server and viewer, then uses them in `PlotOpts`.

Claude's description:

Extract metric_descriptions() into src/common/mod.rs for reuse, replacing the private copy in MCP. In the viewer, attach descriptions to plot options and render an info icon on each chart that shows the metric description on hover via a native title tooltip.

