### PR TITLE
feat: gate dump-dashboards behind xtask-commands feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ libbpf-cargo = { version = "0.25.0" }
 [features]
 default = []
 developer-mode = []
+xtask-commands = []
 
 [profile.bench]
 debug = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ fn main() {
         .subcommand(
             Command::new("dump-dashboards")
                 .about("Dump dashboard JSON definitions to a directory")
+                .hide(!cfg!(feature = "xtask-commands"))
                 .arg(
                     clap::Arg::new("OUTPUT_DIR")
                         .help("Output directory for generated JSON files")
@@ -111,6 +112,7 @@ fn main() {
 
             viewer::run(config)
         }
+        #[cfg(feature = "xtask-commands")]
         Some(("dump-dashboards", args)) => {
             let output_dir = args
                 .get_one::<PathBuf>("OUTPUT_DIR")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,7 +51,7 @@ fn generate_dashboards(args: impl Iterator<Item = String>) -> Result<()> {
     };
 
     run(Command::new("cargo")
-        .args(["run", "--", "dump-dashboards"])
+        .args(["run", "--features", "xtask-commands", "--", "dump-dashboards"])
         .arg(&output_dir))?;
 
     if check {


### PR DESCRIPTION
## Summary

- Adds an `xtask-commands` Cargo feature (off by default) to gate internal tooling subcommands
- `dump-dashboards` is hidden from `--help` and its match arm is `#[cfg]`-gated unless the feature is enabled
- `cargo xtask generate-dashboards` continues to work unchanged — xtask now passes `--features xtask-commands` when invoking `cargo run`

## Test plan

- [x] `cargo build` — clean, `dump-dashboards` not visible in `--help`
- [x] `cargo build --features xtask-commands` — clean, `dump-dashboards` visible
- [x] `cargo xtask generate-dashboards --check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)