### PR TITLE
fix(viewer): cgroup fixes, legend layout overhaul, and chart cleanup

### DIFF
--- a/site/viewer/lib/chart_controls.js
+++ b/site/viewer/lib/chart_controls.js
@@ -1,0 +1,1 @@
+../../../src/viewer/assets/lib/chart_controls.js

--- a/site/viewer/lib/charts/color_legend.js
+++ b/site/viewer/lib/charts/color_legend.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/charts/color_legend.js

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -378,6 +378,14 @@ async function loadDemo() {
         } catch { /* ignore */ }
 
         window._loading = false;
+
+        // Ensure ?demo is in the URL so bookmarks/refreshes auto-load the demo
+        if (!new URLSearchParams(window.location.search).has('demo')) {
+            const url = new URL(window.location);
+            url.searchParams.set('demo', '');
+            window.history.replaceState(null, '', url);
+        }
+
         initDashboardRouter();
     } catch (e) {
         window._loading = false;

--- a/src/viewer/assets/lib/cgroup_selector.js
+++ b/src/viewer/assets/lib/cgroup_selector.js
@@ -55,16 +55,22 @@ const transferBtn = (lrLabel, udLabel, title, disabled, onclick) =>
         m('span.arrow-ud', udLabel),
     ]);
 
+// ── Persisted state (survives component remount across navigations) ─
+
+let persistedSelectedCgroups = new Set();
+let persistedOriginalQueries = null; // Map<string, string>
+
 // ── Component ───────────────────────────────────────────────────────
 
 export const CgroupSelector = {
     oninit(vnode) {
-        vnode.state.selectedCgroups = new Set();
+        vnode.state.selectedCgroups = new Set(persistedSelectedCgroups);
         vnode.state.availableCgroups = new Set();
         vnode.state.loading = true;
         vnode.state.error = null;
         vnode.state.leftSelected = new Set();
         vnode.state.rightSelected = new Set();
+        vnode.state.originalQueries = persistedOriginalQueries;
 
         this.fetchAvailableCgroups(vnode);
     },
@@ -135,6 +141,7 @@ export const CgroupSelector = {
                     }
                 }
             }
+            persistedOriginalQueries = vnode.state.originalQueries;
         }
 
         const generation = ++vnode.state.updateGeneration || 1;
@@ -194,6 +201,7 @@ export const CgroupSelector = {
         for (const cg of items) {
             vnode.state.selectedCgroups[op](cg);
         }
+        persistedSelectedCgroups = new Set(vnode.state.selectedCgroups);
         vnode.state.leftSelected.clear();
         vnode.state.rightSelected.clear();
         this.debouncedUpdateQueries(vnode);

--- a/src/viewer/assets/lib/cgroup_selector.js
+++ b/src/viewer/assets/lib/cgroup_selector.js
@@ -179,6 +179,7 @@ export const CgroupSelector = {
                 } catch (error) {
                     console.error(`Failed query for ${plot.opts.title}:`, error);
                     plot.data = [];
+                    plot.series_names = [];
                 }
             }));
         }

--- a/src/viewer/assets/lib/chart_controls.js
+++ b/src/viewer/assets/lib/chart_controls.js
@@ -1,0 +1,35 @@
+// Shared chart control buttons (Expand / Select) used by both the
+// regular Group component and the cgroup section renderer.
+
+import { isSelected, toggleSelection } from './selection.js';
+
+const EXPAND_ICON_PATH = 'M10 1h5v5h-1.5V3.56L9.78 7.28 8.72 6.22l3.72-3.72H10V1zM1 6V1h5v1.5H3.56l3.72 3.72-1.06 1.06L2.5 3.56V6H1zm5 4H1v5h5v-1.5H3.56l3.72-3.72-1.06-1.06L2.5 12.44V10zm4 0v1.5h2.44l-3.72 3.72 1.06 1.06 3.72-3.72V15H15v-5h-5z';
+
+export const expandLink = (spec, sectionRoute) => {
+    if (!spec.promql_query) return null;
+    const href = `${sectionRoute}/chart/${encodeURIComponent(spec.opts.id)}`;
+    return m('a.chart-expand', {
+        href, target: '_blank', title: 'Open in new tab',
+        onclick: (e) => e.stopPropagation(),
+    }, [
+        'Expand ',
+        m('svg', { width: 12, height: 12, viewBox: '0 0 16 16', fill: 'currentColor' },
+            m('path', { d: EXPAND_ICON_PATH }),
+        ),
+    ]);
+};
+
+export const selectButton = (spec, sectionRoute, sectionName) => {
+    if (!spec.promql_query) return null;
+    const sectionKey = sectionRoute.replace(/^\//, '');
+    const selected = isSelected(spec.opts.id);
+    return m('button.chart-select', {
+        class: selected ? 'chart-selected' : '',
+        onclick: (e) => {
+            e.stopPropagation();
+            toggleSelection(spec, sectionKey, sectionName);
+            m.redraw();
+        },
+        title: selected ? 'Remove from selection' : 'Add to selection',
+    }, selected ? 'Selected' : 'Select');
+};

--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -134,7 +134,7 @@ export function getBaseOption() {
         grid: {
             left: '12',
             right: '17',
-            top: '56',
+            top: '62',
             bottom: '24',
             containLabel: true,
         },

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -457,8 +457,8 @@ export class Chart {
             opts
         } = this.spec;
 
-        // Clean up histogram heatmap DOM overlays when switching to a different chart type
-        if (opts.style !== 'histogram_heatmap') {
+        // Clean up heatmap DOM legend bar when switching to a different chart type
+        if (opts.style !== 'histogram_heatmap' && opts.style !== 'heatmap') {
             this.domNode?.parentNode?.querySelector('.heatmap-legend-bar')?.remove();
         }
 

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -459,11 +459,7 @@ export class Chart {
 
         // Clean up histogram heatmap DOM overlays when switching to a different chart type
         if (opts.style !== 'histogram_heatmap') {
-            for (const cls of ['heatmap-label-min', 'heatmap-label-max']) {
-                this.domNode?.querySelector('.' + cls)?.remove();
-            }
-            // Toggle lives in the wrapper (parent), not the canvas container
-            this.domNode?.parentNode?.querySelector('.histogram-toggle')?.remove();
+            this.domNode?.parentNode?.querySelector('.heatmap-legend-bar')?.remove();
         }
 
         // Handle different chart types by delegating to specialized modules

--- a/src/viewer/assets/lib/charts/color_legend.js
+++ b/src/viewer/assets/lib/charts/color_legend.js
@@ -1,0 +1,113 @@
+// color_legend.js — shared DOM color legend bar for heatmap chart types.
+//
+// Renders [minLabel] [gradient bar] [maxLabel] in a flex row, optionally
+// followed by extra elements (e.g. a checkbox toggle).
+
+import { COLORS, FONTS } from './base.js';
+
+// Bar geometry constants
+export const BAR_WIDTH = 120;
+export const BAR_HEIGHT = 10;
+export const BAR_TOP = 42;
+export const LABEL_GAP = 4;
+
+/**
+ * Turn an array of CSS color strings into a color function (0..1 → color)
+ * by building a tiny canvas gradient and sampling it.
+ * @param {string[]} colors - array of CSS color stops
+ * @returns {function} maps 0..1 to a CSS color string
+ */
+export function colorArrayToFn(colors) {
+    const size = 256;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = 1;
+    const ctx = canvas.getContext('2d');
+    const grad = ctx.createLinearGradient(0, 0, size, 0);
+    for (let i = 0; i < colors.length; i++) {
+        grad.addColorStop(i / (colors.length - 1), colors[i]);
+    }
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, size, 1);
+    const imageData = ctx.getImageData(0, 0, size, 1).data;
+    return (t) => {
+        const idx = Math.min(size - 1, Math.max(0, Math.round(t * (size - 1)))) * 4;
+        return `rgb(${imageData[idx]},${imageData[idx + 1]},${imageData[idx + 2]})`;
+    };
+}
+
+/**
+ * Build a gradient bar canvas from a color function.
+ * @param {function} colorFn - maps a value in 0..1 to a CSS color string
+ * @returns {HTMLCanvasElement}
+ */
+export function buildGradientCanvas(colorFn) {
+    const canvas = document.createElement('canvas');
+    canvas.width = BAR_WIDTH;
+    canvas.height = BAR_HEIGHT;
+    const ctx = canvas.getContext('2d');
+    for (let x = 0; x < BAR_WIDTH; x++) {
+        ctx.fillStyle = colorFn(x / (BAR_WIDTH - 1));
+        ctx.fillRect(x, 0, 1, BAR_HEIGHT);
+    }
+    return canvas;
+}
+
+/**
+ * Create or reuse the legend bar container.
+ *
+ * On first call, builds: [minLabel] [colorBar] [maxLabel] + any extraElements,
+ * appends the container to `wrapper`, and returns element references.
+ *
+ * On subsequent calls (same wrapper), returns existing element references.
+ *
+ * @param {HTMLElement} wrapper - parent element (chart-wrapper)
+ * @param {HTMLCanvasElement} barCanvas - pre-rendered gradient canvas
+ * @param {HTMLElement[]} [extraElements] - additional elements appended after maxLabel
+ * @returns {{ minLabel: HTMLElement, maxLabel: HTMLElement }}
+ */
+export function ensureLegendBar(wrapper, barCanvas, extraElements) {
+    let container = wrapper.querySelector('.heatmap-legend-bar');
+    if (container) {
+        return {
+            minLabel: container.querySelector('.heatmap-label-min'),
+            maxLabel: container.querySelector('.heatmap-label-max'),
+        };
+    }
+
+    container = document.createElement('div');
+    container.className = 'heatmap-legend-bar';
+    container.style.cssText = `
+        position: absolute;
+        top: ${BAR_TOP}px;
+        right: 16px;
+        display: flex;
+        align-items: center;
+        gap: ${LABEL_GAP}px;
+        z-index: 10;
+    `;
+
+    const minLabel = document.createElement('span');
+    minLabel.className = 'heatmap-label-min';
+    minLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
+
+    const bar = document.createElement('canvas');
+    bar.width = barCanvas.width;
+    bar.height = barCanvas.height;
+    bar.style.cssText = `width: ${BAR_WIDTH}px; height: ${BAR_HEIGHT}px; display: block;`;
+    bar.getContext('2d').drawImage(barCanvas, 0, 0);
+
+    const maxLabel = document.createElement('span');
+    maxLabel.className = 'heatmap-label-max';
+    maxLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
+
+    container.appendChild(minLabel);
+    container.appendChild(bar);
+    container.appendChild(maxLabel);
+    if (extraElements) {
+        for (const el of extraElements) container.appendChild(el);
+    }
+    wrapper.appendChild(container);
+
+    return { minLabel, maxLabel };
+}

--- a/src/viewer/assets/lib/charts/color_legend.js
+++ b/src/viewer/assets/lib/charts/color_legend.js
@@ -12,31 +12,6 @@ export const BAR_TOP = 42;
 export const LABEL_GAP = 4;
 
 /**
- * Turn an array of CSS color strings into a color function (0..1 → color)
- * by building a tiny canvas gradient and sampling it.
- * @param {string[]} colors - array of CSS color stops
- * @returns {function} maps 0..1 to a CSS color string
- */
-export function colorArrayToFn(colors) {
-    const size = 256;
-    const canvas = document.createElement('canvas');
-    canvas.width = size;
-    canvas.height = 1;
-    const ctx = canvas.getContext('2d');
-    const grad = ctx.createLinearGradient(0, 0, size, 0);
-    for (let i = 0; i < colors.length; i++) {
-        grad.addColorStop(i / (colors.length - 1), colors[i]);
-    }
-    ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, size, 1);
-    const imageData = ctx.getImageData(0, 0, size, 1).data;
-    return (t) => {
-        const idx = Math.min(size - 1, Math.max(0, Math.round(t * (size - 1)))) * 4;
-        return `rgb(${imageData[idx]},${imageData[idx + 1]},${imageData[idx + 2]})`;
-    };
-}
-
-/**
  * Build a gradient bar canvas from a color function.
  * @param {function} colorFn - maps a value in 0..1 to a CSS color string
  * @returns {HTMLCanvasElement}

--- a/src/viewer/assets/lib/charts/color_legend.js
+++ b/src/viewer/assets/lib/charts/color_legend.js
@@ -8,7 +8,7 @@ import { COLORS, FONTS } from './base.js';
 // Bar geometry constants
 export const BAR_WIDTH = 120;
 export const BAR_HEIGHT = 10;
-export const BAR_TOP = 42;
+export const BAR_TOP = 45;
 export const LABEL_GAP = 4;
 
 /**

--- a/src/viewer/assets/lib/charts/color_legend.js
+++ b/src/viewer/assets/lib/charts/color_legend.js
@@ -8,7 +8,7 @@ import { COLORS, FONTS } from './base.js';
 // Bar geometry constants
 export const BAR_WIDTH = 120;
 export const BAR_HEIGHT = 10;
-export const BAR_TOP = 45;
+export const BAR_TOP = 47;
 export const LABEL_GAP = 4;
 
 /**

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -15,6 +15,12 @@ import {
 } from './base.js';
 import { VIRIDIS_COLORS } from './util/colormap.js';
 
+// Color bar geometry — shared between visualMap and graphic labels
+const BAR_RIGHT = 24;
+const BAR_WIDTH = 120;
+const BAR_TOP = 44;
+const LABEL_GAP = 4;
+
 /**
  * Configures the Chart based on Chart.spec
  * Responsible for calling setOption on the echart instance, and for setting up any
@@ -244,10 +250,10 @@ export function configureHeatmap(chart) {
             calculable: false,
             show: true,
             orient: 'horizontal',
-            top: 44,
-            right: 16,
+            top: BAR_TOP,
+            right: BAR_RIGHT,
             itemWidth: 10,
-            itemHeight: 120,
+            itemHeight: BAR_WIDTH,
             text: ['', ''],
             inRange: {
                 color: VIRIDIS_COLORS,
@@ -256,8 +262,8 @@ export function configureHeatmap(chart) {
         graphic: {
             elements: [{
                 type: 'text',
-                right: 142,
-                top: 46,
+                right: BAR_RIGHT + BAR_WIDTH + LABEL_GAP,
+                top: BAR_TOP + 6,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(minValue),
                     fill: COLORS.fgLabel,
@@ -266,8 +272,8 @@ export function configureHeatmap(chart) {
                 },
             }, {
                 type: 'text',
-                right: 10,
-                top: 46,
+                right: BAR_RIGHT - LABEL_GAP,
+                top: BAR_TOP + 6,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(effectiveMax),
                     fill: COLORS.fgLabel,

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -266,7 +266,7 @@ export function configureHeatmap(chart) {
                 top: BAR_TOP + 6,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(minValue),
-                    fill: COLORS.fgLabel,
+                    fill: COLORS.fgSecondary,
                     font: FONTS.footnoteFont,
                     textAlign: 'right',
                 },
@@ -276,7 +276,7 @@ export function configureHeatmap(chart) {
                 top: BAR_TOP + 6,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(effectiveMax),
-                    fill: COLORS.fgLabel,
+                    fill: COLORS.fgSecondary,
                     font: FONTS.footnoteFont,
                     textAlign: 'left',
                 },

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -206,7 +206,7 @@ export function configureHeatmap(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '76' },
+        grid: { ...baseOption.grid, top: '82' },
         yAxis,
         // Echarts has two render modes for hover effects. When number of chart elements is
         // below this threshold, it just draws the hover effect onto the same canvas.
@@ -244,7 +244,7 @@ export function configureHeatmap(chart) {
             calculable: false,
             show: true,
             orient: 'horizontal',
-            top: 34,
+            top: 42,
             right: 16,
             itemWidth: 10,
             itemHeight: 120,
@@ -256,23 +256,23 @@ export function configureHeatmap(chart) {
         graphic: {
             elements: [{
                 type: 'text',
-                right: 136,
-                top: 56,
+                right: 142,
+                top: 43,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(minValue),
                     fill: COLORS.fgLabel,
                     font: FONTS.footnoteFont,
-                    textAlign: 'center',
+                    textAlign: 'right',
                 },
             }, {
                 type: 'text',
-                right: 16,
-                top: 56,
+                right: 10,
+                top: 43,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(effectiveMax),
                     fill: COLORS.fgLabel,
                     font: FONTS.footnoteFont,
-                    textAlign: 'center',
+                    textAlign: 'left',
                 },
             }],
         },

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -206,7 +206,7 @@ export function configureHeatmap(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '56' },
+        grid: { ...baseOption.grid, top: '76' },
         yAxis,
         // Echarts has two render modes for hover effects. When number of chart elements is
         // below this threshold, it just draws the hover effect onto the same canvas.
@@ -244,7 +244,7 @@ export function configureHeatmap(chart) {
             calculable: false,
             show: true,
             orient: 'horizontal',
-            top: 13,
+            top: 34,
             right: 16,
             itemWidth: 10,
             itemHeight: 120,
@@ -257,7 +257,7 @@ export function configureHeatmap(chart) {
             elements: [{
                 type: 'text',
                 right: 136,
-                top: 35,
+                top: 56,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(minValue),
                     fill: COLORS.fgLabel,
@@ -267,7 +267,7 @@ export function configureHeatmap(chart) {
             }, {
                 type: 'text',
                 right: 16,
-                top: 35,
+                top: 56,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(effectiveMax),
                     fill: COLORS.fgLabel,
@@ -300,39 +300,6 @@ export function configureHeatmap(chart) {
     };
 
     applyChartOption(chart, option);
-
-    // Narrow charts: move color legend below the title/description instead of beside it
-    const NARROW_THRESHOLD = 480;
-    const chartWidth = chart.echart.getWidth();
-    if (chartWidth && chartWidth < NARROW_THRESHOLD) {
-        chart.echart.setOption({
-            visualMap: { top: 54 },
-            graphic: {
-                elements: [{
-                    type: 'text',
-                    right: 136,
-                    top: 76,
-                    style: {
-                        text: createAxisLabelFormatter(unitSystem || 'count')(minValue),
-                        fill: COLORS.fgLabel,
-                        font: FONTS.footnoteFont,
-                        textAlign: 'center',
-                    },
-                }, {
-                    type: 'text',
-                    right: 16,
-                    top: 76,
-                    style: {
-                        text: createAxisLabelFormatter(unitSystem || 'count')(effectiveMax),
-                        fill: COLORS.fgLabel,
-                        font: FONTS.footnoteFont,
-                        textAlign: 'center',
-                    },
-                }],
-            },
-            grid: { top: '100' },
-        });
-    }
 
     // When this echart's zoom level changes, pick which set of potentially downsampled data to use.
     chart.echart.on('datazoom', (event) => {

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -15,11 +15,76 @@ import {
 } from './base.js';
 import { VIRIDIS_COLORS } from './util/colormap.js';
 
-// Color bar geometry — shared between visualMap and graphic labels
-const BAR_RIGHT = 24;
+// Color bar geometry — shared between the bar, labels, and container
 const BAR_WIDTH = 120;
-const BAR_TOP = 44;
+const BAR_HEIGHT = 10;
+const BAR_TOP = 42;
 const LABEL_GAP = 4;
+
+/**
+ * Build a gradient bar canvas from an array of color stops.
+ * @param {string[]} colors - array of CSS color strings
+ * @returns {HTMLCanvasElement}
+ */
+function buildGradientCanvas(colors) {
+    const canvas = document.createElement('canvas');
+    canvas.width = BAR_WIDTH;
+    canvas.height = BAR_HEIGHT;
+    const ctx = canvas.getContext('2d');
+    const grad = ctx.createLinearGradient(0, 0, BAR_WIDTH, 0);
+    for (let i = 0; i < colors.length; i++) {
+        grad.addColorStop(i / (colors.length - 1), colors[i]);
+    }
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, BAR_WIDTH, BAR_HEIGHT);
+    return canvas;
+}
+
+/**
+ * Create or reuse the legend bar container (min label, color bar, max label).
+ * Returns references to the updatable label elements.
+ */
+function ensureLegendBar(wrapper, barCanvas) {
+    let container = wrapper.querySelector('.heatmap-legend-bar');
+    if (container) {
+        return {
+            minLabel: container.querySelector('.heatmap-label-min'),
+            maxLabel: container.querySelector('.heatmap-label-max'),
+        };
+    }
+    container = document.createElement('div');
+    container.className = 'heatmap-legend-bar';
+    container.style.cssText = `
+        position: absolute;
+        top: ${BAR_TOP}px;
+        right: 16px;
+        display: flex;
+        align-items: center;
+        gap: ${LABEL_GAP}px;
+        z-index: 10;
+    `;
+
+    const minLabel = document.createElement('span');
+    minLabel.className = 'heatmap-label-min';
+    minLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
+
+    const bar = document.createElement('canvas');
+    bar.width = barCanvas.width;
+    bar.height = barCanvas.height;
+    bar.style.cssText = `width: ${BAR_WIDTH}px; height: ${BAR_HEIGHT}px; display: block;`;
+    bar.getContext('2d').drawImage(barCanvas, 0, 0);
+
+    const maxLabel = document.createElement('span');
+    maxLabel.className = 'heatmap-label-max';
+    maxLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
+
+    container.appendChild(minLabel);
+    container.appendChild(bar);
+    container.appendChild(maxLabel);
+    wrapper.appendChild(container);
+
+    return { minLabel, maxLabel };
+}
 
 /**
  * Configures the Chart based on Chart.spec
@@ -248,39 +313,10 @@ export function configureHeatmap(chart) {
             min: minValue,
             max: effectiveMax,
             calculable: false,
-            show: true,
-            orient: 'horizontal',
-            top: BAR_TOP,
-            right: BAR_RIGHT,
-            itemWidth: 10,
-            itemHeight: BAR_WIDTH,
-            text: ['', ''],
+            show: false,
             inRange: {
                 color: VIRIDIS_COLORS,
             }
-        },
-        graphic: {
-            elements: [{
-                type: 'text',
-                right: BAR_RIGHT + BAR_WIDTH + LABEL_GAP,
-                top: BAR_TOP + 6,
-                style: {
-                    text: createAxisLabelFormatter(unitSystem || 'count')(minValue),
-                    fill: COLORS.fgSecondary,
-                    font: FONTS.footnoteFont,
-                    textAlign: 'right',
-                },
-            }, {
-                type: 'text',
-                right: BAR_RIGHT - LABEL_GAP,
-                top: BAR_TOP + 6,
-                style: {
-                    text: createAxisLabelFormatter(unitSystem || 'count')(effectiveMax),
-                    fill: COLORS.fgSecondary,
-                    font: FONTS.footnoteFont,
-                    textAlign: 'left',
-                },
-            }],
         },
         series: [{
             name: chart.spec.opts.title,
@@ -306,6 +342,14 @@ export function configureHeatmap(chart) {
     };
 
     applyChartOption(chart, option);
+
+    // DOM legend bar: [minLabel] [colorBar] [maxLabel] in a flex row
+    const formatter = createAxisLabelFormatter(unitSystem || 'count');
+    const wrapper = chart.domNode.parentNode;
+    const barCanvas = buildGradientCanvas(VIRIDIS_COLORS);
+    const { minLabel, maxLabel } = ensureLegendBar(wrapper, barCanvas);
+    minLabel.textContent = formatter(minValue);
+    maxLabel.textContent = formatter(effectiveMax);
 
     // When this echart's zoom level changes, pick which set of potentially downsampled data to use.
     chart.echart.on('datazoom', (event) => {

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -244,7 +244,7 @@ export function configureHeatmap(chart) {
             calculable: false,
             show: true,
             orient: 'horizontal',
-            top: 42,
+            top: 44,
             right: 16,
             itemWidth: 10,
             itemHeight: 120,
@@ -257,7 +257,7 @@ export function configureHeatmap(chart) {
             elements: [{
                 type: 'text',
                 right: 142,
-                top: 43,
+                top: 46,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(minValue),
                     fill: COLORS.fgLabel,
@@ -267,7 +267,7 @@ export function configureHeatmap(chart) {
             }, {
                 type: 'text',
                 right: 10,
-                top: 43,
+                top: 46,
                 style: {
                     text: createAxisLabelFormatter(unitSystem || 'count')(effectiveMax),
                     fill: COLORS.fgLabel,

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -206,7 +206,7 @@ export function configureHeatmap(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '82' },
+        grid: { ...baseOption.grid, top: '71' },
         yAxis,
         // Echarts has two render modes for hover effects. When number of chart elements is
         // below this threshold, it just draws the hover effect onto the same canvas.

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -13,7 +13,7 @@ import {
     COLORS,
     FONTS,
 } from './base.js';
-import { VIRIDIS_COLORS, colorArrayToFn } from './util/colormap.js';
+import { VIRIDIS_COLORS, viridisColor } from './util/colormap.js';
 import { buildGradientCanvas, ensureLegendBar } from './color_legend.js';
 
 /**
@@ -276,7 +276,7 @@ export function configureHeatmap(chart) {
     // DOM legend bar: [minLabel] [colorBar] [maxLabel] in a flex row
     const formatter = createAxisLabelFormatter(unitSystem || 'count');
     const wrapper = chart.domNode.parentNode;
-    const barCanvas = buildGradientCanvas(colorArrayToFn(VIRIDIS_COLORS));
+    const barCanvas = buildGradientCanvas(viridisColor);
     const { minLabel, maxLabel } = ensureLegendBar(wrapper, barCanvas);
     minLabel.textContent = formatter(minValue);
     maxLabel.textContent = formatter(effectiveMax);

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -13,8 +13,8 @@ import {
     COLORS,
     FONTS,
 } from './base.js';
-import { VIRIDIS_COLORS } from './util/colormap.js';
-import { colorArrayToFn, buildGradientCanvas, ensureLegendBar } from './color_legend.js';
+import { VIRIDIS_COLORS, colorArrayToFn } from './util/colormap.js';
+import { buildGradientCanvas, ensureLegendBar } from './color_legend.js';
 
 /**
  * Configures the Chart based on Chart.spec

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -14,77 +14,7 @@ import {
     FONTS,
 } from './base.js';
 import { VIRIDIS_COLORS } from './util/colormap.js';
-
-// Color bar geometry — shared between the bar, labels, and container
-const BAR_WIDTH = 120;
-const BAR_HEIGHT = 10;
-const BAR_TOP = 42;
-const LABEL_GAP = 4;
-
-/**
- * Build a gradient bar canvas from an array of color stops.
- * @param {string[]} colors - array of CSS color strings
- * @returns {HTMLCanvasElement}
- */
-function buildGradientCanvas(colors) {
-    const canvas = document.createElement('canvas');
-    canvas.width = BAR_WIDTH;
-    canvas.height = BAR_HEIGHT;
-    const ctx = canvas.getContext('2d');
-    const grad = ctx.createLinearGradient(0, 0, BAR_WIDTH, 0);
-    for (let i = 0; i < colors.length; i++) {
-        grad.addColorStop(i / (colors.length - 1), colors[i]);
-    }
-    ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, BAR_WIDTH, BAR_HEIGHT);
-    return canvas;
-}
-
-/**
- * Create or reuse the legend bar container (min label, color bar, max label).
- * Returns references to the updatable label elements.
- */
-function ensureLegendBar(wrapper, barCanvas) {
-    let container = wrapper.querySelector('.heatmap-legend-bar');
-    if (container) {
-        return {
-            minLabel: container.querySelector('.heatmap-label-min'),
-            maxLabel: container.querySelector('.heatmap-label-max'),
-        };
-    }
-    container = document.createElement('div');
-    container.className = 'heatmap-legend-bar';
-    container.style.cssText = `
-        position: absolute;
-        top: ${BAR_TOP}px;
-        right: 16px;
-        display: flex;
-        align-items: center;
-        gap: ${LABEL_GAP}px;
-        z-index: 10;
-    `;
-
-    const minLabel = document.createElement('span');
-    minLabel.className = 'heatmap-label-min';
-    minLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
-
-    const bar = document.createElement('canvas');
-    bar.width = barCanvas.width;
-    bar.height = barCanvas.height;
-    bar.style.cssText = `width: ${BAR_WIDTH}px; height: ${BAR_HEIGHT}px; display: block;`;
-    bar.getContext('2d').drawImage(barCanvas, 0, 0);
-
-    const maxLabel = document.createElement('span');
-    maxLabel.className = 'heatmap-label-max';
-    maxLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
-
-    container.appendChild(minLabel);
-    container.appendChild(bar);
-    container.appendChild(maxLabel);
-    wrapper.appendChild(container);
-
-    return { minLabel, maxLabel };
-}
+import { colorArrayToFn, buildGradientCanvas, ensureLegendBar } from './color_legend.js';
 
 /**
  * Configures the Chart based on Chart.spec
@@ -346,7 +276,7 @@ export function configureHeatmap(chart) {
     // DOM legend bar: [minLabel] [colorBar] [maxLabel] in a flex row
     const formatter = createAxisLabelFormatter(unitSystem || 'count');
     const wrapper = chart.domNode.parentNode;
-    const barCanvas = buildGradientCanvas(VIRIDIS_COLORS);
+    const barCanvas = buildGradientCanvas(colorArrayToFn(VIRIDIS_COLORS));
     const { minLabel, maxLabel } = ensureLegendBar(wrapper, barCanvas);
     minLabel.textContent = formatter(minValue);
     maxLabel.textContent = formatter(effectiveMax);

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -44,11 +44,17 @@ export function configureHistogramHeatmap(chart) {
 
     const baseOption = getBaseOption();
 
+    // Access format properties using snake_case naming to match Rust serialization
+    const format = opts.format || {};
+    const range = format.range;
+
     // Find the range of buckets that actually have data
     let minBucketIdx = Infinity;
     let maxBucketIdx = -Infinity;
     for (const [_, bucketIdx, count] of data) {
         if (count > 0) {
+            // Skip buckets above the configured range max (OOB values are ignored)
+            if (range?.max != null && bucketBounds[bucketIdx] > range.max) continue;
             minBucketIdx = Math.min(minBucketIdx, bucketIdx);
             maxBucketIdx = Math.max(maxBucketIdx, bucketIdx);
         }
@@ -61,7 +67,8 @@ export function configureHistogramHeatmap(chart) {
     // Get the visible bucket bounds for log scale, snapped to powers of 10
     // so ECharts places ticks at clean decade boundaries (1ns, 10ns, 100ns, ...)
     const rawMinBucket = minBucketIdx > 0 ? Math.max(1, bucketBounds[minBucketIdx - 1]) : 1;
-    const rawMaxBucket = bucketBounds[maxBucketIdx];
+    let rawMaxBucket = bucketBounds[maxBucketIdx];
+    if (range?.max != null) rawMaxBucket = Math.min(rawMaxBucket, range.max);
     const minBucketValue = Math.pow(10, Math.floor(Math.log10(rawMinBucket)));
     const maxBucketValue = Math.pow(10, Math.ceil(Math.log10(rawMaxBucket)));
 
@@ -113,7 +120,7 @@ export function configureHistogramHeatmap(chart) {
         }
     }
 
-    // Build the final cell data from the aggregated values
+    // Build the final cell data from the aggregated values, skipping OOB buckets
     const allCellsData = [];
     for (let dt = 0; dt < dsTimeCount; dt++) {
         const timestampMs = dsTimeData[dt] * 1000;
@@ -122,6 +129,7 @@ export function configureHistogramHeatmap(chart) {
             if (count === 0) continue;
 
             const bucketIdx = bo + minBucketIdx;
+            if (range?.max != null && bucketBounds[bucketIdx] > range.max) continue;
             const lowerBound = bucketIdx > 0 ? Math.max(1, bucketBounds[bucketIdx - 1]) : 1;
             const upperBound = bucketBounds[bucketIdx];
 

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -22,81 +22,7 @@ import { infernoColor } from './util/colormap.js';
 // Reuse the shared time formatter for latency bucket labels
 const formatLatencyBucket = createAxisLabelFormatter('time');
 
-// Color bar geometry — shared between the bar graphic, DOM labels, and checkbox
-const BAR_RIGHT = 32;
-const BAR_WIDTH = 120;
-const BAR_HEIGHT = 10;
-const BAR_TOP = 42;
-const LABEL_GAP = 4;
-
-/**
- * Build the gradient bar as a canvas element for the DOM legend container.
- * @param {function} colorFn - maps 0..1 to an RGB color string
- * @returns {HTMLCanvasElement}
- */
-function buildHeatmapGradientCanvas(colorFn) {
-    const canvas = document.createElement('canvas');
-    canvas.width = BAR_WIDTH;
-    canvas.height = BAR_HEIGHT;
-    const ctx = canvas.getContext('2d');
-    for (let x = 0; x < BAR_WIDTH; x++) {
-        ctx.fillStyle = colorFn(x / (BAR_WIDTH - 1));
-        ctx.fillRect(x, 0, 1, BAR_HEIGHT);
-    }
-    return canvas;
-}
-
-/**
- * Create or reuse the legend bar container (min label, color bar, max label, checkbox).
- * Returns an object with references to the updatable elements.
- */
-function ensureLegendBar(wrapper, barCanvas) {
-    let container = wrapper.querySelector('.heatmap-legend-bar');
-    if (container) {
-        return {
-            minLabel: container.querySelector('.heatmap-label-min'),
-            maxLabel: container.querySelector('.heatmap-label-max'),
-            checkbox: container.querySelector('.histogram-toggle'),
-        };
-    }
-    container = document.createElement('div');
-    container.className = 'heatmap-legend-bar';
-    container.style.cssText = `
-        position: absolute;
-        top: ${BAR_TOP}px;
-        right: 16px;
-        display: flex;
-        align-items: center;
-        gap: ${LABEL_GAP}px;
-        z-index: 10;
-    `;
-
-    const minLabel = document.createElement('span');
-    minLabel.className = 'heatmap-label-min';
-    minLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
-
-    const bar = document.createElement('canvas');
-    bar.width = barCanvas.width;
-    bar.height = barCanvas.height;
-    bar.style.cssText = `width: ${BAR_WIDTH}px; height: ${BAR_HEIGHT}px; display: block;`;
-    bar.getContext('2d').drawImage(barCanvas, 0, 0);
-
-    const maxLabel = document.createElement('span');
-    maxLabel.className = 'heatmap-label-max';
-    maxLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
-
-    const checkbox = document.createElement('span');
-    checkbox.className = 'histogram-toggle';
-    checkbox.style.cssText = `${FONTS.cssControl} cursor: pointer; user-select: none; margin-left: ${LABEL_GAP}px; margin-top: -2px;`;
-
-    container.appendChild(minLabel);
-    container.appendChild(bar);
-    container.appendChild(maxLabel);
-    container.appendChild(checkbox);
-    wrapper.appendChild(container);
-
-    return { minLabel, maxLabel, checkbox };
-}
+import { buildGradientCanvas, ensureLegendBar, LABEL_GAP } from './color_legend.js';
 
 /**
  * Configures the Chart for histogram heatmap visualization
@@ -412,9 +338,20 @@ export function configureHistogramHeatmap(chart) {
 
     // DOM legend bar: [minLabel] [colorBar] [maxLabel] [checkbox] in a flex row
     const wrapper = chart.domNode.parentNode;
-    const barCanvas = buildHeatmapGradientCanvas(infernoColor);
-    const { minLabel: minLabelEl, maxLabel: maxLabelEl, checkbox: checkboxEl } =
-        ensureLegendBar(wrapper, barCanvas);
+    const barCanvas = buildGradientCanvas(infernoColor);
+
+    // Build the checkbox element to pass as an extra element into the shared legend bar
+    let checkboxEl = wrapper.querySelector('.heatmap-legend-bar .histogram-toggle');
+    const checkboxExtra = [];
+    if (!checkboxEl) {
+        checkboxEl = document.createElement('span');
+        checkboxEl.className = 'histogram-toggle';
+        checkboxEl.style.cssText = `${FONTS.cssControl} cursor: pointer; user-select: none; margin-left: ${LABEL_GAP}px; margin-top: -2px;`;
+        checkboxExtra.push(checkboxEl);
+    }
+
+    const { minLabel: minLabelEl, maxLabel: maxLabelEl } =
+        ensureLegendBar(wrapper, barCanvas, checkboxExtra);
 
     const updateLabels = () => {
         const isRaw = chart.histogramDisplayMode === 'raw';

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -22,6 +22,13 @@ import { infernoColor } from './util/colormap.js';
 // Reuse the shared time formatter for latency bucket labels
 const formatLatencyBucket = createAxisLabelFormatter('time');
 
+// Color bar geometry — shared between the bar graphic, DOM labels, and checkbox
+const BAR_RIGHT = 32;
+const BAR_WIDTH = 120;
+const BAR_HEIGHT = 10;
+const BAR_TOP = 44;
+const LABEL_GAP = 4;
+
 /**
  * Build the gradient bar canvas for the heatmap legend (ECharts graphic).
  * Labels are rendered as DOM elements so they can update without triggering a canvas redraw.
@@ -29,28 +36,25 @@ const formatLatencyBucket = createAxisLabelFormatter('time');
  * @returns {Object} echarts graphic config (bar image only)
  */
 function buildHeatmapGradientBar(colorFn) {
-    const barWidth = 120;
-    const barHeight = 10;
-
     const canvas = document.createElement('canvas');
-    canvas.width = barWidth;
-    canvas.height = barHeight;
+    canvas.width = BAR_WIDTH;
+    canvas.height = BAR_HEIGHT;
     const ctx = canvas.getContext('2d');
-    for (let x = 0; x < barWidth; x++) {
-        ctx.fillStyle = colorFn(x / (barWidth - 1));
-        ctx.fillRect(x, 0, 1, barHeight);
+    for (let x = 0; x < BAR_WIDTH; x++) {
+        ctx.fillStyle = colorFn(x / (BAR_WIDTH - 1));
+        ctx.fillRect(x, 0, 1, BAR_HEIGHT);
     }
 
     return {
         elements: [{
             type: 'image',
             id: 'heatmap-gradient-bar',
-            right: 24,
-            top: 44,
+            right: BAR_RIGHT,
+            top: BAR_TOP,
             style: {
                 image: canvas,
-                width: barWidth,
-                height: barHeight,
+                width: BAR_WIDTH,
+                height: BAR_HEIGHT,
             },
         }],
     };
@@ -63,16 +67,16 @@ function buildHeatmapGradientBar(colorFn) {
  * @param {string} rightPx - CSS right position
  * @returns {HTMLElement}
  */
-function ensureDomLabel(container, className, rightPx) {
+function ensureDomLabel(container, className, rightPx, transform) {
     let el = container.querySelector('.' + className);
     if (!el) {
         el = document.createElement('span');
         el.className = className;
         el.style.cssText = `
             position: absolute;
-            top: 45px;
-            right: ${rightPx};
-            transform: translateX(50%);
+            top: ${BAR_TOP - 1}px;
+            right: ${rightPx}px;
+            ${transform ? `transform: ${transform};` : ''}
             ${FONTS.cssFootnote}
             color: ${COLORS.fgLabel};
             z-index: 10;
@@ -398,8 +402,8 @@ export function configureHistogramHeatmap(chart) {
 
     // DOM labels for gradient bar min/max — update without canvas redraw
     chart.domNode.style.position = 'relative';
-    const minLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-min', '144px');
-    const maxLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-max', '24px');
+    const minLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-min', BAR_RIGHT + BAR_WIDTH + LABEL_GAP);
+    const maxLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-max', BAR_RIGHT - LABEL_GAP, 'translateX(100%)');
 
     const updateLabels = () => {
         const isRaw = chart.histogramDisplayMode === 'raw';
@@ -419,8 +423,8 @@ export function configureHistogramHeatmap(chart) {
     }
     checkboxEl.style.cssText = `
         position: absolute;
-        top: 42px;
-        right: 180px;
+        top: ${BAR_TOP - 2}px;
+        right: ${BAR_RIGHT + BAR_WIDTH + LABEL_GAP + 50}px;
         ${FONTS.cssControl}
         cursor: pointer;
         user-select: none;

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -308,7 +308,7 @@ export function configureHistogramHeatmap(chart) {
         grid: {
             left: '12',
             right: '17',
-            top: '82',
+            top: '71',
             bottom: '24',
             containLabel: true,
         },

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -46,7 +46,7 @@ function buildHeatmapGradientBar(colorFn) {
             type: 'image',
             id: 'heatmap-gradient-bar',
             right: 24,
-            top: 42,
+            top: 44,
             style: {
                 image: canvas,
                 width: barWidth,
@@ -70,7 +70,7 @@ function ensureDomLabel(container, className, rightPx) {
         el.className = className;
         el.style.cssText = `
             position: absolute;
-            top: 43px;
+            top: 45px;
             right: ${rightPx};
             transform: translateX(50%);
             ${FONTS.cssFootnote}
@@ -419,7 +419,7 @@ export function configureHistogramHeatmap(chart) {
     }
     checkboxEl.style.cssText = `
         position: absolute;
-        top: 10px;
+        top: 42px;
         right: 180px;
         ${FONTS.cssControl}
         cursor: pointer;

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -423,8 +423,8 @@ export function configureHistogramHeatmap(chart) {
     }
     checkboxEl.style.cssText = `
         position: absolute;
-        top: ${BAR_TOP - 2}px;
-        right: ${BAR_RIGHT + BAR_WIDTH + LABEL_GAP + 50}px;
+        top: ${BAR_TOP - 1}px;
+        right: 4px;
         ${FONTS.cssControl}
         cursor: pointer;
         user-select: none;

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -87,7 +87,7 @@ function ensureLegendBar(wrapper, barCanvas) {
 
     const checkbox = document.createElement('span');
     checkbox.className = 'histogram-toggle';
-    checkbox.style.cssText = `${FONTS.cssControl} cursor: pointer; user-select: none; margin-left: ${LABEL_GAP}px;`;
+    checkbox.style.cssText = `${FONTS.cssControl} cursor: pointer; user-select: none; margin-left: ${LABEL_GAP}px; margin-top: -2px;`;
 
     container.appendChild(minLabel);
     container.appendChild(bar);

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -46,7 +46,7 @@ function buildHeatmapGradientBar(colorFn) {
             type: 'image',
             id: 'heatmap-gradient-bar',
             right: 24,
-            top: 13,
+            top: 34,
             style: {
                 image: canvas,
                 width: barWidth,
@@ -308,7 +308,7 @@ export function configureHistogramHeatmap(chart) {
         grid: {
             left: '12',
             right: '17',
-            top: '56',
+            top: '76',
             bottom: '24',
             containLabel: true,
         },
@@ -371,34 +371,6 @@ export function configureHistogramHeatmap(chart) {
         }],
         graphic: buildHeatmapGradientBar(infernoColor),
     };
-
-    // Narrow charts: move color legend below the title/description instead of beside it
-    const NARROW_THRESHOLD = 480;
-    const chartWidth = chart.echart.getWidth();
-    const isNarrow = chartWidth && chartWidth < NARROW_THRESHOLD;
-
-    if (isNarrow) {
-        option.graphic = {
-            elements: [{
-                type: 'image',
-                id: 'heatmap-gradient-bar',
-                right: 24,
-                top: 54,
-                style: {
-                    image: option.graphic.elements[0].style.image,
-                    width: 120,
-                    height: 10,
-                },
-            }],
-        };
-        option.grid = {
-            left: '12',
-            right: '17',
-            top: '100',
-            bottom: '24',
-            containLabel: true,
-        };
-    }
 
     applyChartOption(chart, option);
 

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -46,7 +46,7 @@ function buildHeatmapGradientBar(colorFn) {
             type: 'image',
             id: 'heatmap-gradient-bar',
             right: 24,
-            top: 34,
+            top: 42,
             style: {
                 image: canvas,
                 width: barWidth,
@@ -70,7 +70,7 @@ function ensureDomLabel(container, className, rightPx) {
         el.className = className;
         el.style.cssText = `
             position: absolute;
-            top: 35px;
+            top: 43px;
             right: ${rightPx};
             transform: translateX(50%);
             ${FONTS.cssFootnote}
@@ -308,7 +308,7 @@ export function configureHistogramHeatmap(chart) {
         grid: {
             left: '12',
             right: '17',
-            top: '76',
+            top: '82',
             bottom: '24',
             containLabel: true,
         },
@@ -400,10 +400,6 @@ export function configureHistogramHeatmap(chart) {
     chart.domNode.style.position = 'relative';
     const minLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-min', '144px');
     const maxLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-max', '24px');
-    if (isNarrow) {
-        minLabelEl.style.top = '76px';
-        maxLabelEl.style.top = '76px';
-    }
 
     const updateLabels = () => {
         const isRaw = chart.histogramDisplayMode === 'raw';
@@ -423,7 +419,7 @@ export function configureHistogramHeatmap(chart) {
     }
     checkboxEl.style.cssText = `
         position: absolute;
-        top: ${isNarrow ? '52px' : '10px'};
+        top: 10px;
         right: 180px;
         ${FONTS.cssControl}
         cursor: pointer;

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -78,7 +78,7 @@ function ensureDomLabel(container, className, rightPx, transform) {
             right: ${rightPx}px;
             ${transform ? `transform: ${transform};` : ''}
             ${FONTS.cssFootnote}
-            color: ${COLORS.fgLabel};
+            color: ${COLORS.fgSecondary};
             z-index: 10;
             pointer-events: none;
         `;

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -30,12 +30,11 @@ const BAR_TOP = 44;
 const LABEL_GAP = 4;
 
 /**
- * Build the gradient bar canvas for the heatmap legend (ECharts graphic).
- * Labels are rendered as DOM elements so they can update without triggering a canvas redraw.
+ * Build the gradient bar as a canvas element for the DOM legend container.
  * @param {function} colorFn - maps 0..1 to an RGB color string
- * @returns {Object} echarts graphic config (bar image only)
+ * @returns {HTMLCanvasElement}
  */
-function buildHeatmapGradientBar(colorFn) {
+function buildHeatmapGradientCanvas(colorFn) {
     const canvas = document.createElement('canvas');
     canvas.width = BAR_WIDTH;
     canvas.height = BAR_HEIGHT;
@@ -44,47 +43,59 @@ function buildHeatmapGradientBar(colorFn) {
         ctx.fillStyle = colorFn(x / (BAR_WIDTH - 1));
         ctx.fillRect(x, 0, 1, BAR_HEIGHT);
     }
-
-    return {
-        elements: [{
-            type: 'image',
-            id: 'heatmap-gradient-bar',
-            right: BAR_RIGHT,
-            top: BAR_TOP,
-            style: {
-                image: canvas,
-                width: BAR_WIDTH,
-                height: BAR_HEIGHT,
-            },
-        }],
-    };
+    return canvas;
 }
 
 /**
- * Create or update a DOM label element positioned over the chart.
- * @param {HTMLElement} container - the chart DOM node
- * @param {string} className - CSS class for querySelector
- * @param {string} rightPx - CSS right position
- * @returns {HTMLElement}
+ * Create or reuse the legend bar container (min label, color bar, max label, checkbox).
+ * Returns an object with references to the updatable elements.
  */
-function ensureDomLabel(container, className, rightPx, transform) {
-    let el = container.querySelector('.' + className);
-    if (!el) {
-        el = document.createElement('span');
-        el.className = className;
-        el.style.cssText = `
-            position: absolute;
-            top: ${BAR_TOP - 1}px;
-            right: ${rightPx}px;
-            ${transform ? `transform: ${transform};` : ''}
-            ${FONTS.cssFootnote}
-            color: ${COLORS.fgSecondary};
-            z-index: 10;
-            pointer-events: none;
-        `;
-        container.appendChild(el);
+function ensureLegendBar(wrapper, barCanvas) {
+    let container = wrapper.querySelector('.heatmap-legend-bar');
+    if (container) {
+        return {
+            minLabel: container.querySelector('.heatmap-label-min'),
+            maxLabel: container.querySelector('.heatmap-label-max'),
+            checkbox: container.querySelector('.histogram-toggle'),
+        };
     }
-    return el;
+    container = document.createElement('div');
+    container.className = 'heatmap-legend-bar';
+    container.style.cssText = `
+        position: absolute;
+        top: ${BAR_TOP}px;
+        right: 16px;
+        display: flex;
+        align-items: center;
+        gap: ${LABEL_GAP}px;
+        z-index: 10;
+    `;
+
+    const minLabel = document.createElement('span');
+    minLabel.className = 'heatmap-label-min';
+    minLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
+
+    const bar = document.createElement('canvas');
+    bar.width = barCanvas.width;
+    bar.height = barCanvas.height;
+    bar.style.cssText = `width: ${BAR_WIDTH}px; height: ${BAR_HEIGHT}px; display: block;`;
+    bar.getContext('2d').drawImage(barCanvas, 0, 0);
+
+    const maxLabel = document.createElement('span');
+    maxLabel.className = 'heatmap-label-max';
+    maxLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
+
+    const checkbox = document.createElement('span');
+    checkbox.className = 'histogram-toggle';
+    checkbox.style.cssText = `${FONTS.cssControl} cursor: pointer; user-select: none; margin-left: ${LABEL_GAP}px;`;
+
+    container.appendChild(minLabel);
+    container.appendChild(bar);
+    container.appendChild(maxLabel);
+    container.appendChild(checkbox);
+    wrapper.appendChild(container);
+
+    return { minLabel, maxLabel, checkbox };
 }
 
 /**
@@ -373,7 +384,6 @@ export function configureHistogramHeatmap(chart) {
             progressiveThreshold: 3000,
             animation: false,
         }],
-        graphic: buildHeatmapGradientBar(infernoColor),
     };
 
     applyChartOption(chart, option);
@@ -400,10 +410,11 @@ export function configureHistogramHeatmap(chart) {
     const pctMinLabel = pctMin.toFixed(1) + '%';
     const pctMaxLabel = pctMax.toFixed(1) + '%';
 
-    // DOM labels for gradient bar min/max — update without canvas redraw
-    chart.domNode.style.position = 'relative';
-    const minLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-min', BAR_RIGHT + BAR_WIDTH + LABEL_GAP);
-    const maxLabelEl = ensureDomLabel(chart.domNode, 'heatmap-label-max', BAR_RIGHT - LABEL_GAP, 'translateX(100%)');
+    // DOM legend bar: [minLabel] [colorBar] [maxLabel] [checkbox] in a flex row
+    const wrapper = chart.domNode.parentNode;
+    const barCanvas = buildHeatmapGradientCanvas(infernoColor);
+    const { minLabel: minLabelEl, maxLabel: maxLabelEl, checkbox: checkboxEl } =
+        ensureLegendBar(wrapper, barCanvas);
 
     const updateLabels = () => {
         const isRaw = chart.histogramDisplayMode === 'raw';
@@ -411,25 +422,6 @@ export function configureHistogramHeatmap(chart) {
         maxLabelEl.textContent = isRaw ? rawMaxLabel : pctMaxLabel;
     };
     updateLabels();
-
-    // DOM checkbox overlay for percentage/raw count toggle.
-    // Lives in the chart-wrapper (parent of canvas) so it aligns with the DOM title row.
-    const wrapper = chart.domNode.parentNode;
-    let checkboxEl = wrapper.querySelector('.histogram-toggle');
-    if (!checkboxEl) {
-        checkboxEl = document.createElement('span');
-        checkboxEl.className = 'histogram-toggle';
-        wrapper.appendChild(checkboxEl);
-    }
-    checkboxEl.style.cssText = `
-        position: absolute;
-        top: ${BAR_TOP - 1}px;
-        right: 4px;
-        ${FONTS.cssControl}
-        cursor: pointer;
-        user-select: none;
-        z-index: 3;
-    `;
 
     const updateCheckbox = () => {
         const isRaw = chart.histogramDisplayMode === 'raw';

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -26,7 +26,7 @@ const formatLatencyBucket = createAxisLabelFormatter('time');
 const BAR_RIGHT = 32;
 const BAR_WIDTH = 120;
 const BAR_HEIGHT = 10;
-const BAR_TOP = 44;
+const BAR_TOP = 42;
 const LABEL_GAP = 4;
 
 /**

--- a/src/viewer/assets/lib/charts/multi.js
+++ b/src/viewer/assets/lib/charts/multi.js
@@ -107,10 +107,10 @@ export function configureMultiSeriesChart(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '76' },
+        grid: { ...baseOption.grid, top: '82' },
         legend: {
             show: true,
-            top: '34',
+            top: '42',
             right: '16',
             icon: 'roundRect',
             itemWidth: 10,

--- a/src/viewer/assets/lib/charts/multi.js
+++ b/src/viewer/assets/lib/charts/multi.js
@@ -107,7 +107,7 @@ export function configureMultiSeriesChart(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '82' },
+        grid: { ...baseOption.grid, top: '71' },
         legend: {
             show: true,
             top: '42',

--- a/src/viewer/assets/lib/charts/multi.js
+++ b/src/viewer/assets/lib/charts/multi.js
@@ -107,10 +107,10 @@ export function configureMultiSeriesChart(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '60' },
+        grid: { ...baseOption.grid, top: '76' },
         legend: {
             show: true,
-            top: '10',
+            top: '34',
             right: '16',
             icon: 'roundRect',
             itemWidth: 10,

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -221,7 +221,7 @@ export function configureScatterChart(chart) {
     }));
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '82' },
+        grid: { ...baseOption.grid, top: '71' },
         legend: { ...legendShared, top: '42', data: legendInitData(uniqueNamesForLayout) },
         dataZoom: getDataZoomConfig(minZoomSpan),
         yAxis: yAxisConfig,

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -158,7 +158,6 @@ export function configureScatterChart(chart) {
     const minZoomSpan = calculateMinZoomSpan(timeData);
 
     const uniqueNamesForLayout = [...new Set(series.map(s => s.name))];
-    const hasTwoRowLegend = uniqueNamesForLayout.some(n => n.includes('.'));
 
     // Build yAxis config — when OOB is active, skip the last label at range.max
     const baseYAxis = getBaseYAxisOption(logScale, unitSystem);
@@ -220,21 +219,10 @@ export function configureScatterChart(chart) {
             width: legendItemW,
         },
     }));
-    const legendRow1 = uniqueNamesForLayout.filter(n => !n.includes('.'));
-    const legendRow2 = uniqueNamesForLayout.filter(n => n.includes('.'));
-
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: hasTwoRowLegend ? '86' : '76' },
-        legend: (() => {
-            if (legendRow2.length === 0) {
-                return { ...legendShared, top: '34', data: legendInitData(legendRow1) };
-            }
-            return [
-                { ...legendShared, top: '34', data: legendInitData(legendRow1) },
-                { ...legendShared, top: '50', data: legendInitData(legendRow2) },
-            ];
-        })(),
+        grid: { ...baseOption.grid, top: '82' },
+        legend: { ...legendShared, top: '42', data: legendInitData(uniqueNamesForLayout) },
         dataZoom: getDataZoomConfig(minZoomSpan),
         yAxis: yAxisConfig,
         tooltip: {
@@ -348,11 +336,7 @@ export function configureScatterChart(chart) {
             };
         });
 
-        const row1 = uniqueNames.filter(n => !n.includes('.'));
-        const row2 = uniqueNames.filter(n => n.includes('.'));
-        const legendUpdate = row2.length === 0
-            ? { data: makeLegendData(row1) }
-            : [{ data: makeLegendData(row1) }, { data: makeLegendData(row2) }];
+        const legendUpdate = { data: makeLegendData(uniqueNames) };
 
         chart.echart.setOption({ series: updatedSeries, legend: legendUpdate });
     };
@@ -363,11 +347,7 @@ export function configureScatterChart(chart) {
         // Undo the default toggle — re-select all series
         const selected = {};
         uniqueNames.forEach(name => { selected[name] = true; });
-        if (Array.isArray(option.legend)) {
-            chart.echart.setOption({ legend: option.legend.map(() => ({ selected })) });
-        } else {
-            chart.echart.setOption({ legend: { selected } });
-        }
+        chart.echart.setOption({ legend: { selected } });
 
         const name = params.name;
         if (ctrlHeld) {

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -225,14 +225,14 @@ export function configureScatterChart(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: hasTwoRowLegend ? '68' : '60' },
+        grid: { ...baseOption.grid, top: hasTwoRowLegend ? '86' : '76' },
         legend: (() => {
             if (legendRow2.length === 0) {
-                return { ...legendShared, top: '10', data: legendInitData(legendRow1) };
+                return { ...legendShared, top: '34', data: legendInitData(legendRow1) };
             }
             return [
-                { ...legendShared, top: '4', data: legendInitData(legendRow1) },
-                { ...legendShared, top: '20', data: legendInitData(legendRow2) },
+                { ...legendShared, top: '34', data: legendInitData(legendRow1) },
+                { ...legendShared, top: '50', data: legendInitData(legendRow2) },
             ];
         })(),
         dataZoom: getDataZoomConfig(minZoomSpan),
@@ -268,23 +268,6 @@ export function configureScatterChart(chart) {
     }
 
     applyChartOption(chart, option);
-
-    // Narrow charts: move legend below the title/description instead of beside it
-    const NARROW_THRESHOLD = 480;
-    const chartWidth = chart.echart.getWidth();
-    if (chartWidth && chartWidth < NARROW_THRESHOLD) {
-        // Legend drops below header; push grid down to make room
-        const legendTop = hasTwoRowLegend ? '38' : '34';
-        const legendTop2 = '54';
-        const gridTop = hasTwoRowLegend ? '86' : '76';
-        const narrowLegend = legendRow2.length === 0
-            ? { ...legendShared, top: legendTop, right: '16', data: legendInitData(legendRow1) }
-            : [
-                { ...legendShared, top: legendTop, right: '16', data: legendInitData(legendRow1) },
-                { ...legendShared, top: legendTop2, right: '16', data: legendInitData(legendRow2) },
-            ];
-        chart.echart.setOption({ legend: narrowLegend, grid: { top: gridTop } });
-    }
 
     // Pin feature: click a legend item to keep it highlighted.
     // Ctrl/Cmd+click to multi-select. Click again to unpin.

--- a/src/viewer/assets/lib/charts/util/colormap.js
+++ b/src/viewer/assets/lib/charts/util/colormap.js
@@ -152,6 +152,31 @@ export function infernoColor(t) {
     return interpolateRamp(INFERNO_RGB, t);
 }
 
+/**
+ * Turn an array of CSS color strings into a color function (0..1 → color)
+ * by building a tiny canvas gradient and sampling it.
+ * @param {string[]} colors - array of CSS color stops
+ * @returns {function} maps 0..1 to a CSS color string
+ */
+export function colorArrayToFn(colors) {
+    const size = 256;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = 1;
+    const ctx = canvas.getContext('2d');
+    const grad = ctx.createLinearGradient(0, 0, size, 0);
+    for (let i = 0; i < colors.length; i++) {
+        grad.addColorStop(i / (colors.length - 1), colors[i]);
+    }
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, size, 1);
+    const imageData = ctx.getImageData(0, 0, size, 1).data;
+    return (t) => {
+        const idx = Math.min(size - 1, Math.max(0, Math.round(t * (size - 1)))) * 4;
+        return `rgb(${imageData[idx]},${imageData[idx + 1]},${imageData[idx + 2]})`;
+    };
+}
+
 // ── Cgroup color mapper ──────────────────────────────────────────────
 
 /**

--- a/src/viewer/assets/lib/charts/util/colormap.js
+++ b/src/viewer/assets/lib/charts/util/colormap.js
@@ -119,19 +119,33 @@ function interpolateRamp(ramp, t) {
     return `rgb(${r},${g},${b})`;
 }
 
-/** Viridis hex ramp for echarts visualMap (darkest stops removed for visibility on dark bg) */
-export const VIRIDIS_COLORS = [
-    '#414487', '#2a788e', '#22a884',
-    '#7ad151', '#fde725',
+/** Viridis RGB ramp (darkest stops removed for visibility on dark bg) */
+const VIRIDIS_RGB = [
+    [71, 45, 123],
+    [59, 82, 139],
+    [44, 114, 142],
+    [35, 137, 142],
+    [42, 176, 127],
+    [78, 195, 107],
+    [162, 218, 55],
+    [253, 231, 37],
 ];
 
-/** Inferno hex ramp for echarts visualMap (darkest stops removed for visibility on dark bg) */
-export const INFERNO_COLORS = [
-    '#4a0c6b', '#781c6d', '#a52c60',
-    '#cf4446', '#ed6925', '#fb9b06', '#f7d13d', '#fcffa4',
-];
+/**
+ * Viridis colormap — interpolates through the RGB ramp.
+ * @param {number} t - 0..1
+ * @returns {string} `rgb(r,g,b)`
+ */
+export function viridisColor(t) {
+    return interpolateRamp(VIRIDIS_RGB, t);
+}
 
-/** Inferno RGB ramp for custom renderItem (darkest stops removed) */
+/** Viridis hex ramp for echarts visualMap inRange */
+export const VIRIDIS_COLORS = VIRIDIS_RGB.map(([r, g, b]) =>
+    '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join(''),
+);
+
+/** Inferno RGB ramp (darkest stops removed for visibility on dark bg) */
 const INFERNO_RGB = [
     [74, 12, 107],
     [120, 28, 109],
@@ -150,31 +164,6 @@ const INFERNO_RGB = [
  */
 export function infernoColor(t) {
     return interpolateRamp(INFERNO_RGB, t);
-}
-
-/**
- * Turn an array of CSS color strings into a color function (0..1 → color)
- * by building a tiny canvas gradient and sampling it.
- * @param {string[]} colors - array of CSS color stops
- * @returns {function} maps 0..1 to a CSS color string
- */
-export function colorArrayToFn(colors) {
-    const size = 256;
-    const canvas = document.createElement('canvas');
-    canvas.width = size;
-    canvas.height = 1;
-    const ctx = canvas.getContext('2d');
-    const grad = ctx.createLinearGradient(0, 0, size, 0);
-    for (let i = 0; i < colors.length; i++) {
-        grad.addColorStop(i / (colors.length - 1), colors[i]);
-    }
-    ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, size, 1);
-    const imageData = ctx.getImageData(0, 0, size, 1).data;
-    return (t) => {
-        const idx = Math.min(size - 1, Math.max(0, Math.round(t * (size - 1)))) * 4;
-        return `rgb(${imageData[idx]},${imageData[idx + 1]},${imageData[idx + 2]})`;
-    };
 }
 
 // ── Cgroup color mapper ──────────────────────────────────────────────

--- a/src/viewer/assets/lib/charts/util/colormap.js
+++ b/src/viewer/assets/lib/charts/util/colormap.js
@@ -119,17 +119,23 @@ function interpolateRamp(ramp, t) {
     return `rgb(${r},${g},${b})`;
 }
 
-/** Viridis RGB ramp (darkest stops removed for visibility on dark bg) */
-const VIRIDIS_RGB = [
-    [71, 45, 123],
-    [59, 82, 139],
-    [44, 114, 142],
-    [35, 137, 142],
-    [42, 176, 127],
-    [78, 195, 107],
-    [162, 218, 55],
-    [253, 231, 37],
+/** Parse a hex color array into an RGB ramp for interpolateRamp. */
+function hexToRgbRamp(colors) {
+    return colors.map(hex => [
+        parseInt(hex.slice(1, 3), 16),
+        parseInt(hex.slice(3, 5), 16),
+        parseInt(hex.slice(5, 7), 16),
+    ]);
+}
+
+/** Viridis hex ramp (darkest stops removed for visibility on dark bg) */
+export const VIRIDIS_COLORS = [
+    '#472d7b', '#3b528b', '#2c728e',
+    '#23898e', '#2ab07f', '#4ec36b',
+    '#a2da37', '#fde725',
 ];
+
+const VIRIDIS_RGB = hexToRgbRamp(VIRIDIS_COLORS);
 
 /**
  * Viridis colormap — interpolates through the RGB ramp.
@@ -140,22 +146,13 @@ export function viridisColor(t) {
     return interpolateRamp(VIRIDIS_RGB, t);
 }
 
-/** Viridis hex ramp for echarts visualMap inRange */
-export const VIRIDIS_COLORS = VIRIDIS_RGB.map(([r, g, b]) =>
-    '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join(''),
-);
-
-/** Inferno RGB ramp (darkest stops removed for visibility on dark bg) */
-const INFERNO_RGB = [
-    [74, 12, 107],
-    [120, 28, 109],
-    [165, 44, 96],
-    [207, 68, 70],
-    [237, 105, 37],
-    [251, 155, 6],
-    [247, 209, 61],
-    [252, 255, 164],
+/** Inferno hex ramp (darkest stops removed for visibility on dark bg) */
+const INFERNO_COLORS = [
+    '#4a0c6b', '#781c6d', '#a52c60',
+    '#cf4446', '#ed6925', '#fb9b06', '#f7d13d', '#fcffa4',
 ];
+
+const INFERNO_RGB = hexToRgbRamp(INFERNO_COLORS);
 
 /**
  * Inferno colormap — interpolates through the RGB ramp.

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -108,6 +108,7 @@ const applyResultToPlot = (plot, result) => {
                     plot.series_names = seriesNames;
                 } else {
                     plot.data = [];
+                    plot.series_names = [];
                 }
             }
         } else {
@@ -122,6 +123,7 @@ const applyResultToPlot = (plot, result) => {
         }
     } else {
         plot.data = [];
+        plot.series_names = [];
     }
 };
 

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -5,7 +5,8 @@ import globalColorMapper from './charts/util/colormap.js';
 import { TopNav, Sidebar, countCharts, formatSize } from './layout.js';
 import { CpuTopology } from './topology.js';
 import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData } from './data.js';
-import { reportStore, toggleSelection, isSelected, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
+import { reportStore, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
+import { expandLink, selectButton } from './chart_controls.js';
 import { notify, showSaveModal, SaveModal } from './overlays.js';
 import { ViewerApi } from './viewer_api.js';
 import { FileUpload } from './landing.js';
@@ -226,8 +227,6 @@ const SectionContent = {
                 substituteCgroupPattern,
                 setActiveCgroupPattern: (p) => { activeCgroupPattern = p; },
                 globalColorMapper,
-                isSelected,
-                toggleSelection,
             });
         }
 
@@ -333,35 +332,6 @@ const Group = {
             opts.description && m('span.chart-subtitle', opts.description),
         ]);
 
-        const expandLink = (spec) => {
-            if (!spec.promql_query) return null;
-            const href = `${sectionRoute}/chart/${encodeURIComponent(spec.opts.id)}`;
-            return m('a.chart-expand', {
-                href, target: '_blank', title: 'Open in new tab',
-                onclick: (e) => e.stopPropagation(),
-            }, [
-                'Expand ',
-                m('svg', { width: 12, height: 12, viewBox: '0 0 16 16', fill: 'currentColor' },
-                    m('path', { d: 'M10 1h5v5h-1.5V3.56L9.78 7.28 8.72 6.22l3.72-3.72H10V1zM1 6V1h5v1.5H3.56l3.72 3.72-1.06 1.06L2.5 3.56V6H1zm5 4H1v5h5v-1.5H3.56l3.72-3.72-1.06-1.06L2.5 12.44V10zm4 0v1.5h2.44l-3.72 3.72 1.06 1.06 3.72-3.72V15H15v-5h-5z' }),
-                ),
-            ]);
-        };
-
-        const selectButton = (spec) => {
-            if (!spec.promql_query) return null;
-            const sectionKey = sectionRoute.replace(/^\//, '');
-            const selected = isSelected(spec.opts.id);
-            return m('button.chart-select', {
-                class: selected ? 'chart-selected' : '',
-                onclick: (e) => {
-                    e.stopPropagation();
-                    toggleSelection(spec, sectionKey, sectionName);
-                    m.redraw();
-                },
-                title: selected ? 'Remove from selection' : 'Add to selection',
-            }, selected ? 'Selected' : 'Select');
-        };
-
         return m(
             'div.group',
             {
@@ -393,8 +363,8 @@ const Group = {
                             return m('div.chart-wrapper', [
                                 chartHeader(heatmapSpec.opts),
                                 m(Chart, { spec: heatmapSpec, chartsState, interval }),
-                                expandLink(spec),
-                                selectButton(spec),
+                                expandLink(spec, sectionRoute),
+                                selectButton(spec, sectionRoute, sectionName),
                             ]);
                         }
 
@@ -402,8 +372,8 @@ const Group = {
                         return m('div.chart-wrapper', [
                             chartHeader(prefixedSpec.opts),
                             m(Chart, { spec: prefixedSpec, chartsState, interval }),
-                            expandLink(spec),
-                            selectButton(spec),
+                            expandLink(spec, sectionRoute),
+                            selectButton(spec, sectionRoute, sectionName),
                         ]);
                     }),
                 ),

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -226,6 +226,8 @@ const SectionContent = {
                 substituteCgroupPattern,
                 setActiveCgroupPattern: (p) => { activeCgroupPattern = p; },
                 globalColorMapper,
+                isSelected,
+                toggleSelection,
             });
         }
 
@@ -627,8 +629,11 @@ const bootstrap = async () => {
                     // Clear chart instances (they'll be recreated), but preserve zoom.
                     chartsState.charts.clear();
 
-                    // Reset cgroup pattern so it doesn't leak between sections.
-                    activeCgroupPattern = null;
+                    // Reset cgroup pattern so it doesn't leak between sections,
+                    // but preserve it when navigating back to cgroups.
+                    if (params.section !== 'cgroups') {
+                        activeCgroupPattern = null;
+                    }
 
                     // Reset scroll position.
                     window.scrollTo(0, 0);

--- a/src/viewer/assets/lib/section_views.js
+++ b/src/viewer/assets/lib/section_views.js
@@ -1,3 +1,5 @@
+import { expandLink, selectButton } from './chart_controls.js';
+
 const createSystemInfoView = ({ CpuTopology, formatBytes }) => ({
     view({ attrs }) {
         const info = attrs.data;
@@ -101,8 +103,6 @@ const renderCgroupSection = ({
     substituteCgroupPattern,
     setActiveCgroupPattern,
     globalColorMapper,
-    isSelected,
-    toggleSelection,
 }) => {
     const sectionRoute = '/cgroups';
     const sectionName = 'Cgroups';
@@ -127,35 +127,6 @@ const renderCgroupSection = ({
         }
     }
 
-    const expandLink = (spec) => {
-        if (!spec.promql_query) return null;
-        const href = `${sectionRoute}/chart/${encodeURIComponent(spec.opts.id)}`;
-        return m('a.chart-expand', {
-            href, target: '_blank', title: 'Open in new tab',
-            onclick: (e) => e.stopPropagation(),
-        }, [
-            'Expand ',
-            m('svg', { width: 12, height: 12, viewBox: '0 0 16 16', fill: 'currentColor' },
-                m('path', { d: 'M10 1h5v5h-1.5V3.56L9.78 7.28 8.72 6.22l3.72-3.72H10V1zM1 6V1h5v1.5H3.56l3.72 3.72-1.06 1.06L2.5 3.56V6H1zm5 4H1v5h5v-1.5H3.56l3.72-3.72-1.06-1.06L2.5 12.44V10zm4 0v1.5h2.44l-3.72 3.72 1.06 1.06 3.72-3.72V15H15v-5h-5z' }),
-            ),
-        ]);
-    };
-
-    const selectButton = (spec) => {
-        if (!spec.promql_query) return null;
-        const sectionKey = sectionRoute.replace(/^\//, '');
-        const selected = isSelected(spec.opts.id);
-        return m('button.chart-select', {
-            class: selected ? 'chart-selected' : '',
-            onclick: (e) => {
-                e.stopPropagation();
-                toggleSelection(spec, sectionKey, sectionName);
-                m.redraw();
-            },
-            title: selected ? 'Remove from selection' : 'Add to selection',
-        }, selected ? 'Selected' : 'Select');
-    };
-
     const renderCgroupChart = (spec, label, legend) => {
         if (!spec) return null;
         const prefixedSpec = { ...spec, opts: { ...spec.opts }, noCollapse: true, compactGrid: true };
@@ -163,8 +134,8 @@ const renderCgroupSection = ({
             m('span.cgroup-chart-label', label),
             m('div.chart-wrapper', [
                 m(Chart, { spec: prefixedSpec, chartsState, interval }),
-                expandLink(spec),
-                selectButton(spec),
+                expandLink(spec, sectionRoute),
+                selectButton(spec, sectionRoute, sectionName),
             ]),
             legend,
         ]);

--- a/src/viewer/assets/lib/section_views.js
+++ b/src/viewer/assets/lib/section_views.js
@@ -101,7 +101,12 @@ const renderCgroupSection = ({
     substituteCgroupPattern,
     setActiveCgroupPattern,
     globalColorMapper,
+    isSelected,
+    toggleSelection,
 }) => {
+    const sectionRoute = '/cgroups';
+    const sectionName = 'Cgroups';
+
     const leftGroups = attrs.groups.filter((g) => g.metadata?.side === 'left');
     const rightGroups = attrs.groups.filter((g) => g.metadata?.side === 'right');
 
@@ -122,6 +127,35 @@ const renderCgroupSection = ({
         }
     }
 
+    const expandLink = (spec) => {
+        if (!spec.promql_query) return null;
+        const href = `${sectionRoute}/chart/${encodeURIComponent(spec.opts.id)}`;
+        return m('a.chart-expand', {
+            href, target: '_blank', title: 'Open in new tab',
+            onclick: (e) => e.stopPropagation(),
+        }, [
+            'Expand ',
+            m('svg', { width: 12, height: 12, viewBox: '0 0 16 16', fill: 'currentColor' },
+                m('path', { d: 'M10 1h5v5h-1.5V3.56L9.78 7.28 8.72 6.22l3.72-3.72H10V1zM1 6V1h5v1.5H3.56l3.72 3.72-1.06 1.06L2.5 3.56V6H1zm5 4H1v5h5v-1.5H3.56l3.72-3.72-1.06-1.06L2.5 12.44V10zm4 0v1.5h2.44l-3.72 3.72 1.06 1.06 3.72-3.72V15H15v-5h-5z' }),
+            ),
+        ]);
+    };
+
+    const selectButton = (spec) => {
+        if (!spec.promql_query) return null;
+        const sectionKey = sectionRoute.replace(/^\//, '');
+        const selected = isSelected(spec.opts.id);
+        return m('button.chart-select', {
+            class: selected ? 'chart-selected' : '',
+            onclick: (e) => {
+                e.stopPropagation();
+                toggleSelection(spec, sectionKey, sectionName);
+                m.redraw();
+            },
+            title: selected ? 'Remove from selection' : 'Add to selection',
+        }, selected ? 'Selected' : 'Select');
+    };
+
     const renderCgroupChart = (spec, label, legend) => {
         if (!spec) return null;
         const prefixedSpec = { ...spec, opts: { ...spec.opts }, noCollapse: true, compactGrid: true };
@@ -129,6 +163,8 @@ const renderCgroupSection = ({
             m('span.cgroup-chart-label', label),
             m('div.chart-wrapper', [
                 m(Chart, { spec: prefixedSpec, chartsState, interval }),
+                expandLink(spec),
+                selectButton(spec),
             ]),
             legend,
         ]);

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -951,7 +951,7 @@ main {
 
 .chart-expand {
     position: absolute;
-    bottom: 12px;
+    bottom: 2px;
     left: 16px;
     font-family: var(--font-mono);
     font-size: 11px;
@@ -976,7 +976,7 @@ main {
 
 .chart-select {
     position: absolute;
-    bottom: 12px;
+    bottom: 2px;
     right: 16px;
     font-family: var(--font-mono);
     font-size: 10px;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -47,6 +47,9 @@
     --danger: #f85149;
     --info: #58a6ff;
 
+    /* Gradients */
+    --bg-card-gradient: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
+
     /* Layout dimensions */
     --sidebar-width: 180px;
     --header-height: 56px;
@@ -231,9 +234,6 @@ body::after {
     mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
     mask-size: contain;
     mask-repeat: no-repeat;
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
-    -webkit-mask-size: contain;
-    -webkit-mask-repeat: no-repeat;
 }
 
 #topnav .logo .live-indicator {
@@ -921,7 +921,7 @@ main {
     position: relative;
     min-width: 0;
     overflow: hidden;
-    background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
+    background: var(--bg-card-gradient);
     border: 1px solid var(--border-default);
     border-radius: var(--card-radius);
     transition: all var(--transition-base);
@@ -1064,7 +1064,6 @@ main {
     font-size: var(--font-size-sm);
     line-height: 1.6;
     transition: all var(--transition-base);
-    box-sizing: border-box;
 }
 
 .field-input:focus,
@@ -1242,7 +1241,7 @@ main {
 }
 
 .query-chart {
-    background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
+    background: var(--bg-card-gradient);
     border: 1px solid var(--border-default);
     border-radius: var(--card-radius);
     height: 336px;
@@ -1251,7 +1250,7 @@ main {
 .example-queries {
     margin-top: 1.5rem;
     padding: 1.25rem;
-    background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
+    background: var(--bg-card-gradient);
     border: 1px solid var(--border-subtle);
     border-radius: var(--card-radius);
 }
@@ -1369,7 +1368,7 @@ main {
 }
 
 .cgroup-selector {
-    background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
+    background: var(--bg-card-gradient);
     border: 1px solid var(--border-subtle);
     border-radius: var(--card-radius);
     padding: 1.25rem;
@@ -1513,7 +1512,7 @@ main {
 }
 
 .sysinfo-group {
-    background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
+    background: var(--bg-card-gradient);
     border: 1px solid var(--border-default);
     border-radius: var(--card-radius);
     padding: 1.25rem;
@@ -1624,7 +1623,7 @@ main {
 
 .topo-canvas {
     margin-top: 1.5rem;
-    background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
+    background: var(--bg-card-gradient);
     border: 1px solid var(--border-default);
     border-radius: var(--card-radius);
     padding: 1.25rem;
@@ -1736,7 +1735,6 @@ main {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    box-sizing: border-box;
     min-height: 8px;
     min-width: 0;
     padding: 4px 2px;
@@ -1782,7 +1780,6 @@ main {
     border: var(--topo-border, 2px) solid rgba(249, 115, 22, 0.6);
     border-radius: 3px;
     padding: 3px 4px;
-    box-sizing: border-box;
     min-width: 0;
     overflow: hidden;
 }
@@ -1816,7 +1813,6 @@ main {
     justify-content: center;
     gap: 1px;
     padding: 3px 6px;
-    box-sizing: border-box;
     min-width: 0;
     overflow: hidden;
 }
@@ -2563,7 +2559,6 @@ main {
 
     .sysinfo-table {
         overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
     }
 
     /* ── Selection cards: stack vertically ── */
@@ -2592,8 +2587,8 @@ main {
 }
 
 .upload-card {
-    background: var(--bg-secondary, #141820);
-    border: 1px solid var(--border-default, #2a2e3a);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-default);
     border-radius: 12px;
     padding: 3rem;
     max-width: 520px;
@@ -2605,24 +2600,24 @@ main {
     font-size: 2rem;
     font-weight: 700;
     margin: 0 0 0.5rem;
-    color: var(--fg, #e0e0e0);
+    color: var(--fg);
 }
 
 .upload-subtitle {
-    color: var(--fg-secondary, #b0b4c0);
+    color: var(--fg-secondary);
     margin: 0 0 0.25rem;
     font-size: 0.95rem;
 }
 
 .upload-privacy {
-    color: var(--accent, #5b9bd5);
+    color: var(--accent);
     margin: 0 0 2rem;
     font-size: 0.85rem;
     font-weight: 500;
 }
 
 .upload-dropzone {
-    border: 2px dashed var(--border-default, #2a2e3a);
+    border: 2px dashed var(--border-default);
     border-radius: 8px;
     padding: 2.5rem 1.5rem;
     transition: border-color 0.15s, background 0.15s;
@@ -2630,24 +2625,24 @@ main {
 }
 
 .upload-dropzone.dragover {
-    border-color: var(--accent, #5b9bd5);
+    border-color: var(--accent);
     background: rgba(91, 155, 213, 0.05);
 }
 
 .upload-icon {
-    color: var(--fg-muted, #8b8fa3);
+    color: var(--fg-muted);
     margin-bottom: 1rem;
 }
 
 .upload-dropzone p {
     margin: 0.25rem 0;
-    color: var(--fg-secondary, #b0b4c0);
+    color: var(--fg-secondary);
     font-size: 0.9rem;
 }
 
 .upload-or {
-    font-size: 0.8rem !important;
-    color: var(--fg-secondary, #b0b4c0);
+    font-size: 0.8rem;
+    color: var(--fg-secondary);
     opacity: 0.6;
 }
 
@@ -2655,7 +2650,7 @@ main {
     display: inline-block;
     margin-top: 0.75rem;
     padding: 0.5rem 1.5rem;
-    background: var(--accent, #5b9bd5);
+    background: var(--accent);
     color: #fff;
     border: none;
     border-radius: 6px;
@@ -2676,7 +2671,7 @@ main {
 }
 
 .upload-loading {
-    color: var(--accent, #5b9bd5);
+    color: var(--accent);
     margin-top: 1rem;
     font-size: 0.85rem;
 }
@@ -2689,7 +2684,7 @@ main {
 }
 
 .upload-connect-label {
-    color: var(--fg-secondary, #b0b4c0);
+    color: var(--fg-secondary);
     font-size: 0.9rem;
     margin: 0 0 0.25rem;
 }
@@ -2699,23 +2694,22 @@ main {
     width: 100%;
     margin-top: 0.75rem;
     padding: 0.5rem 0.75rem;
-    background: var(--bg-primary, #0a0e14);
-    color: var(--fg, #e0e0e0);
-    border: 1px solid var(--border-default, #2a2e3a);
+    background: var(--bg-void);
+    color: var(--fg);
+    border: 1px solid var(--border-default);
     border-radius: 6px;
     font-size: 0.9rem;
     font-family: 'JetBrains Mono', monospace;
     outline: none;
     transition: border-color 0.15s;
-    box-sizing: border-box;
     text-align: center;
 }
 
 .connect-input:focus {
-    border-color: var(--accent, #5b9bd5);
+    border-color: var(--accent);
 }
 
 .connect-input::placeholder {
-    color: var(--fg-muted, #8b8fa3);
+    color: var(--fg-muted);
     opacity: 0.6;
 }

--- a/src/viewer/assets/lib/theme.js
+++ b/src/viewer/assets/lib/theme.js
@@ -15,7 +15,7 @@ export let themeVersion = 0;
 function getPreferred() {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored === 'light' || stored === 'dark') return stored;
-    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    return 'dark';
 }
 
 function apply(theme) {


### PR DESCRIPTION
## Summary

### Cgroup fixes
- **Selection persistence**: Cgroup selections now survive navigation away and back — selected cgroups, original query templates, and active pattern are preserved at module level
- **Expand/Select buttons**: Added missing Expand and Select buttons to cgroup charts (aggregate and individual), extracted shared `chart_controls.js` module to avoid duplication with the Group component
- **Legend cleanup**: Cgroup chart legends (series names) are now cleared when cgroups are unselected

### Legend layout overhaul
- **Position**: All chart legends (color swatches, percentile labels, heatmap gradient bars) moved below title/description row, right-aligned
- **Single-row percentiles**: Merged the two-row percentile legend (p50/p90/p99 + p99.9/p99.99) into a single row
- **Heatmap color legends**: Replaced ECharts `visualMap` and `graphic` text with DOM flex containers (`color_legend.js`) — both heatmap types now share the same legend implementation: `[minLabel] [gradient bar] [maxLabel]` with flexbox alignment
- **Histogram heatmap checkbox**: "Raw count" toggle moved to the right of the max label, vertically aligned with legend text
- **Color label styling**: Legend label color changed from `--fg-muted` to `--fg-secondary` to match axis label text
- **Spacing**: Reduced gap between legend row and chart canvas; added 6px padding below description for single-line charts (no legend)

### Color system cleanup
- **`viridisColor(t)`**: New function matching `infernoColor(t)` pattern — 8-point RGB ramp via `interpolateRamp`, sampled from matplotlib viridis data
- **`hexToRgbRamp()`**: Both colormaps now define readable hex arrays, with RGB ramps derived automatically
- **`colorArrayToFn`**: Removed (no longer needed)
- **Shared module**: `color_legend.js` provides `buildGradientCanvas`, `ensureLegendBar`, and bar geometry constants

### Histogram heatmap
- **Y value range**: Now reads `opts.format.range` and filters out OOB buckets (ignored, not shown in OOB band)

### CSS cleanup
- Fixed undefined `--bg-primary` → `--bg-void`
- Removed incorrect hardcoded fallbacks from upload section
- Extracted repeated gradient to `--bg-card-gradient` CSS variable
- Removed redundant `box-sizing: border-box` (4 instances), deprecated `-webkit-overflow-scrolling`, redundant `-webkit-mask-*` prefixes

### Other fixes
- **Dark theme default**: No longer follows OS `prefers-color-scheme`; defaults to dark
- **Demo URL**: Clicking "Demo" on the site landing page now adds `?demo` to the URL so refreshes auto-load the demo
- **Site symlinks**: Added missing symlinks for `chart_controls.js` and `color_legend.js`

## Test plan
- [x] Open viewer with a parquet file containing cgroup data; verify selection persists across navigation
- [x] Verify Expand/Select buttons appear on cgroup charts and work correctly
- [x] Check legend positioning on multi-series, scatter, heatmap, and histogram heatmap charts
- [x] Toggle between heatmap and percentile views; verify legend DOM cleanup
- [x] Verify histogram heatmap respects Y value range
- [x] Test dark/light theme toggle
- [x] Resize browser to narrow width; verify legends remain properly positioned
