### PR TITLE
Refactor metric types from style-based to semantic type system

### DIFF
--- a/.claude/scripts/post-fmt-check.sh
+++ b/.claude/scripts/post-fmt-check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Post-format reminder: after running cargo fmt / cargo xtask fmt, check
+# whether dashboard JSON needs regenerating (formatting can change Rust
+# source which may affect generated output).
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Check if any dashboard-related Rust files were modified (staged or unstaged)
+modified=$(git diff --name-only 2>/dev/null || true)
+need_check=false
+while IFS= read -r f; do
+    case "$f" in
+        src/viewer/dashboard/*|src/viewer/plot.rs|src/viewer/mod.rs)
+            need_check=true ;;
+    esac
+done <<< "$modified"
+
+if $need_check; then
+    if ! cargo xtask generate-dashboards --check >/dev/null 2>&1; then
+        echo "NOTE: dashboard JSON may be out of date after formatting — run: cargo xtask generate-dashboards"
+    fi
+fi
+
+exit 0

--- a/.claude/scripts/pre-commit-check.sh
+++ b/.claude/scripts/pre-commit-check.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Pre-commit validation for the Rezolus viewer.
+# Checks:
+#   1. site/viewer symlinks are in sync with src/viewer/assets
+#   2. Generated dashboard JSON is up to date with Rust definitions
+#
+# Exit 0  = all good
+# Exit 2  = blocking failure (outputs JSON to deny the commit)
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+SRC="$ROOT/src/viewer/assets/lib"
+SITE="$ROOT/site/viewer/lib"
+
+# Files in site/viewer/lib/ that are standalone (not symlinked)
+STANDALONE_TOP="data.js script.js dashboards.js viewer_api.js"
+
+errors=()
+
+# ── 1. Check symlinks ───────────────────────────────────────────────
+
+check_symlinks() {
+    # Walk every .js and .css file under src/viewer/assets/lib/
+    while IFS= read -r src_file; do
+        rel="${src_file#$SRC/}"          # e.g. "charts/metric_types.js" or "theme.js"
+        base="$(basename "$rel")"
+        dir="$(dirname "$rel")"          # "." for top-level
+
+        # Skip top-level standalone files
+        if [ "$dir" = "." ]; then
+            skip=false
+            for s in $STANDALONE_TOP; do
+                [ "$base" = "$s" ] && skip=true && break
+            done
+            if $skip; then
+                # Special case: data.js -> data_base.js
+                if [ "$base" = "data.js" ]; then
+                    link="$SITE/data_base.js"
+                    if [ ! -L "$link" ]; then
+                        errors+=("missing symlink: site/viewer/lib/data_base.js -> $src_file")
+                    fi
+                fi
+                continue
+            fi
+        fi
+
+        link="$SITE/$rel"
+        if [ ! -L "$link" ]; then
+            errors+=("missing symlink: site/viewer/lib/$rel")
+        fi
+    done < <(find "$SRC" -type f \( -name '*.js' -o -name '*.css' \))
+}
+
+# ── 2. Check dashboard JSON is up to date ────────────────────────────
+
+check_dashboards() {
+    # Only check if any dashboard-related Rust files are staged
+    staged=$(git diff --cached --name-only 2>/dev/null || true)
+    need_check=false
+    while IFS= read -r f; do
+        case "$f" in
+            src/viewer/dashboard/*|src/viewer/plot.rs|src/viewer/mod.rs)
+                need_check=true ;;
+        esac
+    done <<< "$staged"
+
+    if $need_check; then
+        if ! cargo xtask generate-dashboards --check >/dev/null 2>&1; then
+            errors+=("dashboard JSON is out of date — run: cargo xtask generate-dashboards")
+        fi
+    fi
+}
+
+# ── Run checks ───────────────────────────────────────────────────────
+
+check_symlinks
+check_dashboards
+
+if [ ${#errors[@]} -gt 0 ]; then
+    msg=$(printf '%s\n' "${errors[@]}")
+    # Output JSON to block the commit via Claude Code hook protocol
+    cat <<EOJSON
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Pre-commit checks failed:\n$msg"}}
+EOJSON
+    exit 2
+fi
+
+exit 0

--- a/.claude/scripts/pre-commit-check.sh
+++ b/.claude/scripts/pre-commit-check.sh
@@ -2,8 +2,9 @@
 # Pre-commit validation for the Rezolus viewer.
 # Checks:
 #   1. Rust formatting (cargo fmt --check)
-#   2. site/viewer symlinks are in sync with src/viewer/assets
-#   3. Generated dashboard JSON is up to date with Rust definitions
+#   2. Clippy (warnings are errors)
+#   3. site/viewer symlinks are in sync with src/viewer/assets
+#   4. Generated dashboard JSON is up to date with Rust definitions
 #
 # Exit 0  = all good
 # Exit 2  = blocking failure (outputs JSON to deny the commit)
@@ -38,7 +39,25 @@ check_formatting() {
     fi
 }
 
-# ── 2. Check symlinks ───────────────────────────────────────────────
+# ── 2. Clippy (deny warnings) ───────────────────────────────────────
+
+check_clippy() {
+    staged=$(git diff --cached --name-only 2>/dev/null || true)
+    has_rust=false
+    while IFS= read -r f; do
+        case "$f" in
+            *.rs) has_rust=true ;;
+        esac
+    done <<< "$staged"
+
+    if $has_rust; then
+        if ! cargo clippy -- -D warnings >/dev/null 2>&1; then
+            errors+=("clippy warnings found — run: cargo clippy -- -D warnings")
+        fi
+    fi
+}
+
+# ── 3. Check symlinks ───────────────────────────────────────────────
 
 check_symlinks() {
     # Walk every .js and .css file under src/viewer/assets/lib/
@@ -72,7 +91,7 @@ check_symlinks() {
     done < <(find "$SRC" -type f \( -name '*.js' -o -name '*.css' \))
 }
 
-# ── 3. Check dashboard JSON is up to date ────────────────────────────
+# ── 4. Check dashboard JSON is up to date ────────────────────────────
 
 check_dashboards() {
     # Only check if any dashboard-related Rust files are staged
@@ -95,6 +114,7 @@ check_dashboards() {
 # ── Run checks ───────────────────────────────────────────────────────
 
 check_formatting
+check_clippy
 check_symlinks
 check_dashboards
 

--- a/.claude/scripts/pre-commit-check.sh
+++ b/.claude/scripts/pre-commit-check.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Pre-commit validation for the Rezolus viewer.
 # Checks:
-#   1. site/viewer symlinks are in sync with src/viewer/assets
-#   2. Generated dashboard JSON is up to date with Rust definitions
+#   1. Rust formatting (cargo fmt --check)
+#   2. site/viewer symlinks are in sync with src/viewer/assets
+#   3. Generated dashboard JSON is up to date with Rust definitions
 #
 # Exit 0  = all good
 # Exit 2  = blocking failure (outputs JSON to deny the commit)
@@ -18,7 +19,26 @@ STANDALONE_TOP="data.js script.js dashboards.js viewer_api.js"
 
 errors=()
 
-# ── 1. Check symlinks ───────────────────────────────────────────────
+# ── 1. Check Rust formatting ────────────────────────────────────────
+
+check_formatting() {
+    # Only check if any Rust files are staged
+    staged=$(git diff --cached --name-only 2>/dev/null || true)
+    has_rust=false
+    while IFS= read -r f; do
+        case "$f" in
+            *.rs) has_rust=true ;;
+        esac
+    done <<< "$staged"
+
+    if $has_rust; then
+        if ! cargo fmt --check >/dev/null 2>&1; then
+            errors+=("Rust code is not formatted — run: cargo xtask fmt")
+        fi
+    fi
+}
+
+# ── 2. Check symlinks ───────────────────────────────────────────────
 
 check_symlinks() {
     # Walk every .js and .css file under src/viewer/assets/lib/
@@ -52,7 +72,7 @@ check_symlinks() {
     done < <(find "$SRC" -type f \( -name '*.js' -o -name '*.css' \))
 }
 
-# ── 2. Check dashboard JSON is up to date ────────────────────────────
+# ── 3. Check dashboard JSON is up to date ────────────────────────────
 
 check_dashboards() {
     # Only check if any dashboard-related Rust files are staged
@@ -74,6 +94,7 @@ check_dashboards() {
 
 # ── Run checks ───────────────────────────────────────────────────────
 
+check_formatting
 check_symlinks
 check_dashboards
 

--- a/.claude/skills/sync-viewer-symlinks/SKILL.md
+++ b/.claude/skills/sync-viewer-symlinks/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: sync-viewer-symlinks
+description: Ensure site/viewer/lib has correct symlinks to src/viewer/assets/lib
+---
+
+Synchronize symlinks in `site/viewer/lib/` so that the site viewer picks up
+all shared modules from `src/viewer/assets/lib/`.
+
+## Context
+
+The site viewer (`site/viewer/`) shares most of its JavaScript and CSS with
+the agent viewer (`src/viewer/assets/`). Shared files are kept as **symlinks**
+in `site/viewer/lib/` pointing into `src/viewer/assets/lib/`. A small set of
+site-specific files are standalone (not symlinked).
+
+When new files are added to `src/viewer/assets/lib/`, the corresponding
+symlink in `site/viewer/lib/` must be created manually. This skill detects
+and fixes any missing symlinks.
+
+## Standalone files (never symlinked)
+
+These files in `site/viewer/lib/` are site-specific and must NOT be replaced
+with symlinks:
+
+- `data.js` — site-specific wrapper that imports shared logic from `data_base.js`
+- `script.js` — site-specific entry point
+- `dashboards.js` — site-specific dashboard definitions
+- `viewer_api.js` — site-specific API transport layer
+
+## Special mapping
+
+- `src/viewer/assets/lib/data.js` is symlinked as `site/viewer/lib/data_base.js`
+  (different name, because site has its own `data.js` wrapper)
+
+## Steps
+
+1. **Scan** `src/viewer/assets/lib/` recursively for all `.js` and `.css` files
+
+2. **For each source file**, determine the expected symlink path in
+   `site/viewer/lib/` using these rules:
+   - Skip files that have standalone site-specific versions:
+     `script.js`, `viewer_api.js` (top-level only)
+   - Map `data.js` (top-level) → `data_base.js` symlink
+   - Everything else → same relative path
+
+3. **Check** whether the expected symlink exists and points to the correct
+   target. Compute the relative path from the symlink location back to the
+   source file (e.g., `../../../src/viewer/assets/lib/charts/chart.js` for a
+   file in `site/viewer/lib/charts/`).
+
+4. **Create** any missing symlinks. Create parent directories if needed.
+   Report each symlink created.
+
+5. **Detect** any stale symlinks in `site/viewer/lib/` that point to
+   non-existent source files, and report them (but don't delete without
+   asking).
+
+6. **Stage** newly created symlinks with `git add`.
+
+7. **Report** a summary: how many symlinks checked, how many created, any
+   stale links found.

--- a/.claude/skills/sync-viewer-symlinks/SKILL.md
+++ b/.claude/skills/sync-viewer-symlinks/SKILL.md
@@ -59,3 +59,38 @@ with symlinks:
 
 7. **Report** a summary: how many symlinks checked, how many created, any
    stale links found.
+
+## Pre-commit hook
+
+A Claude Code hook at `.claude/settings.json` runs
+`.claude/scripts/pre-commit-check.sh` before every `git commit`. It blocks
+the commit if:
+
+- Any expected symlinks are missing in `site/viewer/lib/`
+- Dashboard JSON is out of date with Rust definitions (only when
+  `src/viewer/dashboard/` or `src/viewer/plot.rs` files are staged)
+
+Both files are git-ignored (`.claude/*` excluding skills). To set up the
+hook on a fresh checkout, create `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/scripts/pre-commit-check.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+And copy or recreate `.claude/scripts/pre-commit-check.sh` (see the
+existing copy in this repo's working tree for reference).

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 !.cargo/config.toml
 .claude/*
 !.claude/skills/
+!.claude/scripts/
 target
 **/*.rs.bk

--- a/site/viewer/dashboards/blockio.json
+++ b/site/viewer/dashboards/blockio.json
@@ -18,8 +18,8 @@
               "y_axis_label": null
             },
             "id": "blockio-throughput-total",
-            "style": "line",
-            "title": "Total Throughput"
+            "title": "Total Throughput",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_bytes[5m]))"
         },
@@ -36,8 +36,8 @@
               "y_axis_label": null
             },
             "id": "blockio-iops-total",
-            "style": "line",
-            "title": "Total IOPS"
+            "title": "Total IOPS",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_operations[5m]))"
         },
@@ -54,8 +54,8 @@
               "y_axis_label": null
             },
             "id": "throughput-read",
-            "style": "line",
-            "title": "Read Throughput"
+            "title": "Read Throughput",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_bytes{op=\"read\"}[5m]))"
         },
@@ -72,8 +72,8 @@
               "y_axis_label": null
             },
             "id": "iops-read",
-            "style": "line",
-            "title": "Read IOPS"
+            "title": "Read IOPS",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_operations{op=\"read\"}[5m]))"
         },
@@ -90,8 +90,8 @@
               "y_axis_label": null
             },
             "id": "throughput-write",
-            "style": "line",
-            "title": "Write Throughput"
+            "title": "Write Throughput",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_bytes{op=\"write\"}[5m]))"
         },
@@ -108,8 +108,8 @@
               "y_axis_label": null
             },
             "id": "iops-write",
-            "style": "line",
-            "title": "Write IOPS"
+            "title": "Write IOPS",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_operations{op=\"write\"}[5m]))"
         }
@@ -136,10 +136,11 @@
               "y_axis_label": null
             },
             "id": "latency-read",
-            "style": "scatter",
-            "title": "Read"
+            "subtype": "percentiles",
+            "title": "Read",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], blockio_latency{op=\"read\"})"
+          "promql_query": "blockio_latency{op=\"read\"}"
         },
         {
           "data": [],
@@ -158,10 +159,11 @@
               "y_axis_label": null
             },
             "id": "latency-write",
-            "style": "scatter",
-            "title": "Write"
+            "subtype": "percentiles",
+            "title": "Write",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], blockio_latency{op=\"write\"})"
+          "promql_query": "blockio_latency{op=\"write\"}"
         }
       ]
     },
@@ -182,10 +184,11 @@
               "y_axis_label": null
             },
             "id": "size-read",
-            "style": "scatter",
-            "title": "Read"
+            "subtype": "percentiles",
+            "title": "Read",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], blockio_size{op=\"read\"})"
+          "promql_query": "blockio_size{op=\"read\"}"
         },
         {
           "data": [],
@@ -200,10 +203,11 @@
               "y_axis_label": null
             },
             "id": "size-write",
-            "style": "scatter",
-            "title": "Write"
+            "subtype": "percentiles",
+            "title": "Write",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], blockio_size{op=\"write\"})"
+          "promql_query": "blockio_size{op=\"write\"}"
         }
       ]
     }

--- a/site/viewer/dashboards/cgroups.json
+++ b/site/viewer/dashboards/cgroups.json
@@ -21,8 +21,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-total-cores",
-            "style": "line",
-            "title": "Total CPU Cores"
+            "title": "Total CPU Cores",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_usage{name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
         },
@@ -39,8 +39,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-user-cores",
-            "style": "line",
-            "title": "User CPU Cores"
+            "title": "User CPU Cores",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_usage{state=\"user\",name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
         },
@@ -57,8 +57,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-system-cores",
-            "style": "line",
-            "title": "System CPU Cores"
+            "title": "System CPU Cores",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_usage{state=\"system\",name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
         },
@@ -75,8 +75,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-cpu-migrations",
-            "style": "line",
-            "title": "CPU Migrations"
+            "title": "CPU Migrations",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_migrations{name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -93,8 +93,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-cpu-throttled-time",
-            "style": "line",
-            "title": "CPU Throttled Time"
+            "title": "CPU Throttled Time",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_throttled_time{name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -111,8 +111,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-ipc",
-            "style": "line",
-            "title": "IPC"
+            "title": "IPC",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_instructions{name!~\"__SELECTED_CGROUPS__\"}[5m])) / sum(irate(cgroup_cpu_cycles{name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -129,8 +129,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-tlb-flush",
-            "style": "line",
-            "title": "TLB Flushes"
+            "title": "TLB Flushes",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_tlb_flush{name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -147,8 +147,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall",
-            "style": "line",
-            "title": "Syscalls"
+            "title": "Syscalls",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -165,8 +165,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-read",
-            "style": "line",
-            "title": "Syscall Read"
+            "title": "Syscall Read",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"read\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -183,8 +183,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-write",
-            "style": "line",
-            "title": "Syscall Write"
+            "title": "Syscall Write",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"write\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -201,8 +201,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-poll",
-            "style": "line",
-            "title": "Syscall Poll"
+            "title": "Syscall Poll",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"poll\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -219,8 +219,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-socket",
-            "style": "line",
-            "title": "Syscall Socket"
+            "title": "Syscall Socket",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"socket\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -237,8 +237,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-lock",
-            "style": "line",
-            "title": "Syscall Lock"
+            "title": "Syscall Lock",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"lock\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -255,8 +255,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-time",
-            "style": "line",
-            "title": "Syscall Time"
+            "title": "Syscall Time",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"time\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -273,8 +273,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-sleep",
-            "style": "line",
-            "title": "Syscall Sleep"
+            "title": "Syscall Sleep",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"sleep\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -291,8 +291,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-yield",
-            "style": "line",
-            "title": "Syscall Yield"
+            "title": "Syscall Yield",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"yield\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -309,8 +309,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-filesystem",
-            "style": "line",
-            "title": "Syscall Filesystem"
+            "title": "Syscall Filesystem",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"filesystem\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -327,8 +327,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-memory",
-            "style": "line",
-            "title": "Syscall Memory"
+            "title": "Syscall Memory",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"memory\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -345,8 +345,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-process",
-            "style": "line",
-            "title": "Syscall Process"
+            "title": "Syscall Process",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"process\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -363,8 +363,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-query",
-            "style": "line",
-            "title": "Syscall Query"
+            "title": "Syscall Query",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"query\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -381,8 +381,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-ipc",
-            "style": "line",
-            "title": "Syscall IPC"
+            "title": "Syscall IPC",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"ipc\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -399,8 +399,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-timer",
-            "style": "line",
-            "title": "Syscall Timer"
+            "title": "Syscall Timer",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"timer\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -417,8 +417,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-event",
-            "style": "line",
-            "title": "Syscall Event"
+            "title": "Syscall Event",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"event\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -435,8 +435,8 @@
               "y_axis_label": null
             },
             "id": "aggregate-syscall-other",
-            "style": "line",
-            "title": "Syscall Other"
+            "title": "Syscall Other",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{op=\"other\",name!~\"__SELECTED_CGROUPS__\"}[5m]))"
         }
@@ -462,8 +462,8 @@
               "y_axis_label": null
             },
             "id": "individual-total-cores",
-            "style": "multi",
-            "title": "Total CPU Cores"
+            "title": "Total CPU Cores",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_cpu_usage{name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
         },
@@ -480,8 +480,8 @@
               "y_axis_label": null
             },
             "id": "individual-user-cores",
-            "style": "multi",
-            "title": "User CPU Cores"
+            "title": "User CPU Cores",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_cpu_usage{state=\"user\",name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
         },
@@ -498,8 +498,8 @@
               "y_axis_label": null
             },
             "id": "individual-system-cores",
-            "style": "multi",
-            "title": "System CPU Cores"
+            "title": "System CPU Cores",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_cpu_usage{state=\"system\",name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
         },
@@ -516,8 +516,8 @@
               "y_axis_label": null
             },
             "id": "individual-cpu-migrations",
-            "style": "multi",
-            "title": "CPU Migrations"
+            "title": "CPU Migrations",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_cpu_migrations{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -534,8 +534,8 @@
               "y_axis_label": null
             },
             "id": "individual-cpu-throttled-time",
-            "style": "multi",
-            "title": "CPU Throttled Time"
+            "title": "CPU Throttled Time",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_cpu_throttled_time{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -552,8 +552,8 @@
               "y_axis_label": null
             },
             "id": "individual-ipc",
-            "style": "multi",
-            "title": "IPC"
+            "title": "IPC",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_cpu_instructions{name=~\"__SELECTED_CGROUPS__\"}[5m])) / sum by (name) (irate(cgroup_cpu_cycles{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -570,8 +570,8 @@
               "y_axis_label": null
             },
             "id": "individual-tlb-flush",
-            "style": "multi",
-            "title": "TLB Flushes"
+            "title": "TLB Flushes",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_cpu_tlb_flush{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -588,8 +588,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall",
-            "style": "multi",
-            "title": "Syscalls"
+            "title": "Syscalls",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -606,8 +606,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-read",
-            "style": "multi",
-            "title": "Syscall Read"
+            "title": "Syscall Read",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"read\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -624,8 +624,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-write",
-            "style": "multi",
-            "title": "Syscall Write"
+            "title": "Syscall Write",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"write\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -642,8 +642,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-poll",
-            "style": "multi",
-            "title": "Syscall Poll"
+            "title": "Syscall Poll",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"poll\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -660,8 +660,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-socket",
-            "style": "multi",
-            "title": "Syscall Socket"
+            "title": "Syscall Socket",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"socket\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -678,8 +678,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-lock",
-            "style": "multi",
-            "title": "Syscall Lock"
+            "title": "Syscall Lock",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"lock\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -696,8 +696,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-time",
-            "style": "multi",
-            "title": "Syscall Time"
+            "title": "Syscall Time",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"time\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -714,8 +714,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-sleep",
-            "style": "multi",
-            "title": "Syscall Sleep"
+            "title": "Syscall Sleep",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"sleep\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -732,8 +732,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-yield",
-            "style": "multi",
-            "title": "Syscall Yield"
+            "title": "Syscall Yield",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"yield\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -750,8 +750,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-filesystem",
-            "style": "multi",
-            "title": "Syscall Filesystem"
+            "title": "Syscall Filesystem",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"filesystem\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -768,8 +768,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-memory",
-            "style": "multi",
-            "title": "Syscall Memory"
+            "title": "Syscall Memory",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"memory\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -786,8 +786,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-process",
-            "style": "multi",
-            "title": "Syscall Process"
+            "title": "Syscall Process",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"process\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -804,8 +804,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-query",
-            "style": "multi",
-            "title": "Syscall Query"
+            "title": "Syscall Query",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"query\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -822,8 +822,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-ipc",
-            "style": "multi",
-            "title": "Syscall IPC"
+            "title": "Syscall IPC",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"ipc\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -840,8 +840,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-timer",
-            "style": "multi",
-            "title": "Syscall Timer"
+            "title": "Syscall Timer",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"timer\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -858,8 +858,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-event",
-            "style": "multi",
-            "title": "Syscall Event"
+            "title": "Syscall Event",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"event\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         },
@@ -876,8 +876,8 @@
               "y_axis_label": null
             },
             "id": "individual-syscall-other",
-            "style": "multi",
-            "title": "Syscall Other"
+            "title": "Syscall Other",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (name) (irate(cgroup_syscall{op=\"other\",name=~\"__SELECTED_CGROUPS__\"}[5m]))"
         }

--- a/site/viewer/dashboards/cpu.json
+++ b/site/viewer/dashboards/cpu.json
@@ -22,8 +22,8 @@
               "y_axis_label": null
             },
             "id": "busy-pct",
-            "style": "line",
-            "title": "Busy %"
+            "title": "Busy %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000"
         },
@@ -44,8 +44,8 @@
               "y_axis_label": null
             },
             "id": "busy-pct-per-cpu",
-            "style": "heatmap",
-            "title": "Busy % (Per-CPU)"
+            "title": "Busy % (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_usage[5m])) / 1000000000"
         },
@@ -66,8 +66,8 @@
               "y_axis_label": null
             },
             "id": "user-pct",
-            "style": "line",
-            "title": "User %"
+            "title": "User %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_usage{state=\"user\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -88,8 +88,8 @@
               "y_axis_label": null
             },
             "id": "user-pct-per-cpu",
-            "style": "heatmap",
-            "title": "User % (Per-CPU)"
+            "title": "User % (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_usage{state=\"user\"}[5m])) / 1000000000"
         },
@@ -110,8 +110,8 @@
               "y_axis_label": null
             },
             "id": "system-pct",
-            "style": "line",
-            "title": "System %"
+            "title": "System %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_usage{state=\"system\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -132,8 +132,8 @@
               "y_axis_label": null
             },
             "id": "system-pct-per-cpu",
-            "style": "heatmap",
-            "title": "System % (Per-CPU)"
+            "title": "System % (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_usage{state=\"system\"}[5m])) / 1000000000"
         }
@@ -156,8 +156,8 @@
               "y_axis_label": null
             },
             "id": "ipc",
-            "style": "line",
-            "title": "Instructions per Cycle (IPC)"
+            "title": "Instructions per Cycle (IPC)",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m]))"
         },
@@ -174,8 +174,8 @@
               "y_axis_label": null
             },
             "id": "ipc-per-cpu",
-            "style": "heatmap",
-            "title": "IPC (Per-CPU)"
+            "title": "IPC (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m]))"
         },
@@ -192,8 +192,8 @@
               "y_axis_label": null
             },
             "id": "ipns",
-            "style": "line",
-            "title": "Instructions per Nanosecond (IPNS)"
+            "title": "Instructions per Nanosecond (IPNS)",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m])) * sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / 1000000000 / cpu_cores"
         },
@@ -210,8 +210,8 @@
               "y_axis_label": null
             },
             "id": "ipns-per-cpu",
-            "style": "heatmap",
-            "title": "IPNS (Per-CPU)"
+            "title": "IPNS (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m])) * sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m])) / 1000000000"
         },
@@ -232,8 +232,8 @@
               "y_axis_label": null
             },
             "id": "l3-hit",
-            "style": "line",
-            "title": "L3 Hit %"
+            "title": "L3 Hit %",
+            "type": "delta_counter"
           },
           "promql_query": "1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))"
         },
@@ -254,8 +254,8 @@
               "y_axis_label": null
             },
             "id": "l3-hit-per-cpu",
-            "style": "heatmap",
-            "title": "L3 Hit % (Per-CPU)"
+            "title": "L3 Hit % (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "1 - sum by (id) (irate(cpu_l3_miss[5m])) / sum by (id) (irate(cpu_l3_access[5m]))"
         },
@@ -272,8 +272,8 @@
               "y_axis_label": null
             },
             "id": "frequency",
-            "style": "line",
-            "title": "Frequency"
+            "title": "Frequency",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / cpu_cores"
         },
@@ -289,8 +289,8 @@
               "y_axis_label": null
             },
             "id": "frequency-per-cpu",
-            "style": "heatmap",
-            "title": "Frequency (Per-CPU)"
+            "title": "Frequency (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m]))"
         }
@@ -317,8 +317,8 @@
               "y_axis_label": null
             },
             "id": "branch-miss-rate",
-            "style": "line",
-            "title": "Misprediction Rate %"
+            "title": "Misprediction Rate %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_branch_misses[5m])) / sum(irate(cpu_branch_instructions[5m]))"
         },
@@ -339,8 +339,8 @@
               "y_axis_label": null
             },
             "id": "branch-miss-rate-per-cpu",
-            "style": "heatmap",
-            "title": "Misprediction Rate % (Per-CPU)"
+            "title": "Misprediction Rate % (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_branch_misses[5m])) / sum by (id) (irate(cpu_branch_instructions[5m]))"
         },
@@ -357,8 +357,8 @@
               "y_axis_label": null
             },
             "id": "branch-instructions",
-            "style": "line",
-            "title": "Instructions"
+            "title": "Instructions",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_branch_instructions[5m]))"
         },
@@ -375,8 +375,8 @@
               "y_axis_label": null
             },
             "id": "branch-instructions-per-cpu",
-            "style": "heatmap",
-            "title": "Instructions (Per-CPU)"
+            "title": "Instructions (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_branch_instructions[5m]))"
         },
@@ -393,8 +393,8 @@
               "y_axis_label": null
             },
             "id": "branch-misses",
-            "style": "line",
-            "title": "Misses"
+            "title": "Misses",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_branch_misses[5m]))"
         },
@@ -411,8 +411,8 @@
               "y_axis_label": null
             },
             "id": "branch-misses-per-cpu",
-            "style": "heatmap",
-            "title": "Misses (Per-CPU)"
+            "title": "Misses (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_branch_misses[5m]))"
         }
@@ -435,8 +435,8 @@
               "y_axis_label": null
             },
             "id": "dtlb-misses",
-            "style": "line",
-            "title": "Misses"
+            "title": "Misses",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_dtlb_miss[5m]))"
         },
@@ -453,8 +453,8 @@
               "y_axis_label": null
             },
             "id": "dtlb-misses-per-cpu",
-            "style": "heatmap",
-            "title": "Misses (Per-CPU)"
+            "title": "Misses (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_dtlb_miss[5m]))"
         },
@@ -471,8 +471,8 @@
               "y_axis_label": null
             },
             "id": "dtlb-mpki",
-            "style": "line",
-            "title": "MPKI"
+            "title": "MPKI",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_dtlb_miss[5m])) / sum(irate(cpu_instructions[5m])) * 1000"
         },
@@ -489,8 +489,8 @@
               "y_axis_label": null
             },
             "id": "dtlb-mpki-per-cpu",
-            "style": "heatmap",
-            "title": "MPKI (Per-CPU)"
+            "title": "MPKI (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_dtlb_miss[5m])) / sum by (id) (irate(cpu_instructions[5m])) * 1000"
         }
@@ -513,8 +513,8 @@
               "y_axis_label": null
             },
             "id": "cpu-migrations-to",
-            "style": "line",
-            "title": "To"
+            "title": "To",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_migrations{direction=\"to\"}[5m]))"
         },
@@ -531,8 +531,8 @@
               "y_axis_label": null
             },
             "id": "cpu-migrations-to-per-cpu",
-            "style": "heatmap",
-            "title": "To (Per-CPU)"
+            "title": "To (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_migrations{direction=\"to\"}[5m]))"
         },
@@ -549,8 +549,8 @@
               "y_axis_label": null
             },
             "id": "cpu-migrations-from",
-            "style": "line",
-            "title": "From"
+            "title": "From",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_migrations{direction=\"from\"}[5m]))"
         },
@@ -567,8 +567,8 @@
               "y_axis_label": null
             },
             "id": "cpu-migrations-from-per-cpu",
-            "style": "heatmap",
-            "title": "From (Per-CPU)"
+            "title": "From (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_migrations{direction=\"from\"}[5m]))"
         }
@@ -591,8 +591,8 @@
               "y_axis_label": null
             },
             "id": "tlb-total",
-            "style": "line",
-            "title": "Total"
+            "title": "Total",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_tlb_flush[5m]))"
         },
@@ -609,8 +609,8 @@
               "y_axis_label": null
             },
             "id": "tlb-total-per-cpu",
-            "style": "heatmap",
-            "title": "Total (Per-CPU)"
+            "title": "Total (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_tlb_flush[5m]))"
         },
@@ -627,8 +627,8 @@
               "y_axis_label": null
             },
             "id": "tlb-local-mm-shootdown",
-            "style": "line",
-            "title": "Local MM Shootdown"
+            "title": "Local MM Shootdown",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_tlb_flush{reason=\"local_mm_shootdown\"}[5m]))"
         },
@@ -645,8 +645,8 @@
               "y_axis_label": null
             },
             "id": "tlb-local-mm-shootdown-per-cpu",
-            "style": "heatmap",
-            "title": "Local MM Shootdown (Per-CPU)"
+            "title": "Local MM Shootdown (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_tlb_flush{reason=\"local_mm_shootdown\"}[5m]))"
         },
@@ -663,8 +663,8 @@
               "y_axis_label": null
             },
             "id": "tlb-remote-send-ipi",
-            "style": "line",
-            "title": "Remote Send IPI"
+            "title": "Remote Send IPI",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_tlb_flush{reason=\"remote_send_ipi\"}[5m]))"
         },
@@ -681,8 +681,8 @@
               "y_axis_label": null
             },
             "id": "tlb-remote-send-ipi-per-cpu",
-            "style": "heatmap",
-            "title": "Remote Send IPI (Per-CPU)"
+            "title": "Remote Send IPI (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_tlb_flush{reason=\"remote_send_ipi\"}[5m]))"
         },
@@ -699,8 +699,8 @@
               "y_axis_label": null
             },
             "id": "tlb-remote-shootdown",
-            "style": "line",
-            "title": "Remote Shootdown"
+            "title": "Remote Shootdown",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_tlb_flush{reason=\"remote_shootdown\"}[5m]))"
         },
@@ -717,8 +717,8 @@
               "y_axis_label": null
             },
             "id": "tlb-remote-shootdown-per-cpu",
-            "style": "heatmap",
-            "title": "Remote Shootdown (Per-CPU)"
+            "title": "Remote Shootdown (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_tlb_flush{reason=\"remote_shootdown\"}[5m]))"
         },
@@ -735,8 +735,8 @@
               "y_axis_label": null
             },
             "id": "tlb-task-switch",
-            "style": "line",
-            "title": "Task Switch"
+            "title": "Task Switch",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_tlb_flush{reason=\"task_switch\"}[5m]))"
         },
@@ -753,8 +753,8 @@
               "y_axis_label": null
             },
             "id": "tlb-task-switch-per-cpu",
-            "style": "heatmap",
-            "title": "Task Switch (Per-CPU)"
+            "title": "Task Switch (Per-CPU)",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_tlb_flush{reason=\"task_switch\"}[5m]))"
         }

--- a/site/viewer/dashboards/gpu.json
+++ b/site/viewer/dashboards/gpu.json
@@ -22,8 +22,8 @@
               "y_axis_label": null
             },
             "id": "gpu-pct",
-            "style": "line",
-            "title": "GPU %"
+            "title": "GPU %",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_utilization) / 100"
         },
@@ -44,8 +44,8 @@
               "y_axis_label": null
             },
             "id": "gpu-pct-per-gpu",
-            "style": "heatmap",
-            "title": "GPU % (Per-GPU)"
+            "title": "GPU % (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_utilization) / 100"
         },
@@ -66,8 +66,8 @@
               "y_axis_label": null
             },
             "id": "mem-ctrl-pct",
-            "style": "line",
-            "title": "Memory Controller %"
+            "title": "Memory Controller %",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_memory_utilization) / 100"
         },
@@ -88,8 +88,8 @@
               "y_axis_label": null
             },
             "id": "mem-ctrl-pct-per-gpu",
-            "style": "heatmap",
-            "title": "Memory Controller % (Per-GPU)"
+            "title": "Memory Controller % (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_memory_utilization) / 100"
         }
@@ -116,8 +116,8 @@
               "y_axis_label": null
             },
             "id": "gpu-tensor-act",
-            "style": "line",
-            "title": "GPU Tensor Activity %"
+            "title": "GPU Tensor Activity %",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_tensor_utilization) / 100"
         },
@@ -138,8 +138,8 @@
               "y_axis_label": null
             },
             "id": "gpu-tensor-act-per-gpu",
-            "style": "heatmap",
-            "title": "GPU Tensor Activity % (Per-GPU)"
+            "title": "GPU Tensor Activity % (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_tensor_utilization) / 100"
         },
@@ -160,8 +160,8 @@
               "y_axis_label": null
             },
             "id": "gpu-dram-act",
-            "style": "line",
-            "title": "GPU DRAM Activity %"
+            "title": "GPU DRAM Activity %",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_dram_bandwidth_utilization) / 100"
         },
@@ -182,8 +182,8 @@
               "y_axis_label": null
             },
             "id": "gpu-dram-act-per-gpu",
-            "style": "heatmap",
-            "title": "GPU DRAM Activity % (Per-GPU)"
+            "title": "GPU DRAM Activity % (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_dram_bandwidth_utilization) / 100"
         },
@@ -204,8 +204,8 @@
               "y_axis_label": null
             },
             "id": "gpu-sm-act",
-            "style": "line",
-            "title": "GPU SM Activity %"
+            "title": "GPU SM Activity %",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_sm_utilization) / 100"
         },
@@ -226,8 +226,8 @@
               "y_axis_label": null
             },
             "id": "gpu-sm-act-per-gpu",
-            "style": "heatmap",
-            "title": "GPU SM Activity % (Per-GPU)"
+            "title": "GPU SM Activity % (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_sm_utilization) / 100"
         },
@@ -248,8 +248,8 @@
               "y_axis_label": null
             },
             "id": "gpu-sm-ocp",
-            "style": "line",
-            "title": "GPU SM Occupancy %"
+            "title": "GPU SM Occupancy %",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_sm_occupancy) / 100"
         },
@@ -270,8 +270,8 @@
               "y_axis_label": null
             },
             "id": "gpu-sm-ocp-per-gpu",
-            "style": "heatmap",
-            "title": "GPU SM Occupancy % (Per-GPU)"
+            "title": "GPU SM Occupancy % (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_sm_occupancy) / 100"
         }
@@ -294,8 +294,8 @@
               "y_axis_label": null
             },
             "id": "mem-used",
-            "style": "line",
-            "title": "Used"
+            "title": "Used",
+            "type": "gauge"
           },
           "promql_query": "sum(gpu_memory{state=\"used\"})"
         },
@@ -312,8 +312,8 @@
               "y_axis_label": null
             },
             "id": "mem-used-per-gpu",
-            "style": "heatmap",
-            "title": "Used (Per-GPU)"
+            "title": "Used (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_memory{state=\"used\"})"
         },
@@ -330,8 +330,8 @@
               "y_axis_label": null
             },
             "id": "mem-free",
-            "style": "line",
-            "title": "Free"
+            "title": "Free",
+            "type": "gauge"
           },
           "promql_query": "sum(gpu_memory{state=\"free\"})"
         },
@@ -348,8 +348,8 @@
               "y_axis_label": null
             },
             "id": "mem-free-per-gpu",
-            "style": "heatmap",
-            "title": "Free (Per-GPU)"
+            "title": "Free (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_memory{state=\"free\"})"
         },
@@ -370,8 +370,8 @@
               "y_axis_label": null
             },
             "id": "mem-util-pct",
-            "style": "line",
-            "title": "Utilization %"
+            "title": "Utilization %",
+            "type": "gauge"
           },
           "promql_query": "sum(gpu_memory{state=\"used\"}) / (sum(gpu_memory{state=\"used\"}) + sum(gpu_memory{state=\"free\"}))"
         }
@@ -394,8 +394,8 @@
               "y_axis_label": "Watts"
             },
             "id": "power-watts",
-            "style": "line",
-            "title": "Power (W)"
+            "title": "Power (W)",
+            "type": "gauge"
           },
           "promql_query": "sum(gpu_power_usage) / 1000"
         },
@@ -412,8 +412,8 @@
               "y_axis_label": "Watts"
             },
             "id": "power-watts-per-gpu",
-            "style": "heatmap",
-            "title": "Power (Per-GPU)"
+            "title": "Power (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_power_usage) / 1000"
         },
@@ -430,8 +430,8 @@
               "y_axis_label": "Watts"
             },
             "id": "energy-rate",
-            "style": "line",
-            "title": "Energy Rate (W)"
+            "title": "Energy Rate (W)",
+            "type": "delta_counter"
           },
           "promql_query": "sum(rate(gpu_energy_consumption[5m])) / 1000"
         }
@@ -454,8 +454,8 @@
               "y_axis_label": "°C"
             },
             "id": "temp-avg",
-            "style": "line",
-            "title": "Average (°C)"
+            "title": "Average (°C)",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_temperature)"
         },
@@ -472,8 +472,8 @@
               "y_axis_label": "°C"
             },
             "id": "temp-max",
-            "style": "line",
-            "title": "Max (°C)"
+            "title": "Max (°C)",
+            "type": "gauge"
           },
           "promql_query": "max(gpu_temperature)"
         },
@@ -490,8 +490,8 @@
               "y_axis_label": "°C"
             },
             "id": "temp-per-gpu",
-            "style": "heatmap",
-            "title": "Temperature (Per-GPU)"
+            "title": "Temperature (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_temperature)"
         }
@@ -514,8 +514,8 @@
               "y_axis_label": null
             },
             "id": "clock-graphics",
-            "style": "line",
-            "title": "Graphics"
+            "title": "Graphics",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_clock{clock=\"graphics\"})"
         },
@@ -532,8 +532,8 @@
               "y_axis_label": null
             },
             "id": "clock-graphics-per-gpu",
-            "style": "heatmap",
-            "title": "Graphics (Per-GPU)"
+            "title": "Graphics (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_clock{clock=\"graphics\"})"
         },
@@ -550,8 +550,8 @@
               "y_axis_label": null
             },
             "id": "clock-memory",
-            "style": "line",
-            "title": "Memory"
+            "title": "Memory",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_clock{clock=\"memory\"})"
         },
@@ -568,8 +568,8 @@
               "y_axis_label": null
             },
             "id": "clock-memory-per-gpu",
-            "style": "heatmap",
-            "title": "Memory (Per-GPU)"
+            "title": "Memory (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_clock{clock=\"memory\"})"
         },
@@ -586,8 +586,8 @@
               "y_axis_label": null
             },
             "id": "clock-compute",
-            "style": "line",
-            "title": "Compute"
+            "title": "Compute",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_clock{clock=\"compute\"})"
         },
@@ -604,8 +604,8 @@
               "y_axis_label": null
             },
             "id": "clock-video",
-            "style": "line",
-            "title": "Video"
+            "title": "Video",
+            "type": "gauge"
           },
           "promql_query": "avg(gpu_clock{clock=\"video\"})"
         }
@@ -628,8 +628,8 @@
               "y_axis_label": null
             },
             "id": "pcie-bandwidth",
-            "style": "line",
-            "title": "Bandwidth"
+            "title": "Bandwidth",
+            "type": "gauge"
           },
           "promql_query": "sum(gpu_pcie_bandwidth)"
         },
@@ -646,8 +646,8 @@
               "y_axis_label": null
             },
             "id": "pcie-rx",
-            "style": "line",
-            "title": "Receive"
+            "title": "Receive",
+            "type": "gauge"
           },
           "promql_query": "sum(gpu_pcie_throughput{direction=\"receive\"})"
         },
@@ -664,8 +664,8 @@
               "y_axis_label": null
             },
             "id": "pcie-rx-per-gpu",
-            "style": "heatmap",
-            "title": "Receive (Per-GPU)"
+            "title": "Receive (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_pcie_throughput{direction=\"receive\"})"
         },
@@ -682,8 +682,8 @@
               "y_axis_label": null
             },
             "id": "pcie-tx",
-            "style": "line",
-            "title": "Transmit"
+            "title": "Transmit",
+            "type": "gauge"
           },
           "promql_query": "sum(gpu_pcie_throughput{direction=\"transmit\"})"
         },
@@ -700,8 +700,8 @@
               "y_axis_label": null
             },
             "id": "pcie-tx-per-gpu",
-            "style": "heatmap",
-            "title": "Transmit (Per-GPU)"
+            "title": "Transmit (Per-GPU)",
+            "type": "gauge"
           },
           "promql_query": "sum by (id) (gpu_pcie_throughput{direction=\"transmit\"})"
         }

--- a/site/viewer/dashboards/memory.json
+++ b/site/viewer/dashboards/memory.json
@@ -18,8 +18,8 @@
               "y_axis_label": null
             },
             "id": "total",
-            "style": "line",
-            "title": "Total"
+            "title": "Total",
+            "type": "gauge"
           },
           "promql_query": "memory_total"
         },
@@ -36,8 +36,8 @@
               "y_axis_label": null
             },
             "id": "available",
-            "style": "line",
-            "title": "Available"
+            "title": "Available",
+            "type": "gauge"
           },
           "promql_query": "memory_available"
         },
@@ -54,8 +54,8 @@
               "y_axis_label": null
             },
             "id": "free",
-            "style": "line",
-            "title": "Free"
+            "title": "Free",
+            "type": "gauge"
           },
           "promql_query": "memory_free"
         },
@@ -72,8 +72,8 @@
               "y_axis_label": null
             },
             "id": "buffers",
-            "style": "line",
-            "title": "Buffers"
+            "title": "Buffers",
+            "type": "gauge"
           },
           "promql_query": "memory_buffers"
         },
@@ -90,8 +90,8 @@
               "y_axis_label": null
             },
             "id": "cached",
-            "style": "line",
-            "title": "Cached"
+            "title": "Cached",
+            "type": "gauge"
           },
           "promql_query": "memory_cached"
         },
@@ -108,8 +108,8 @@
               "y_axis_label": null
             },
             "id": "used",
-            "style": "line",
-            "title": "Used"
+            "title": "Used",
+            "type": "gauge"
           },
           "promql_query": "memory_total - memory_available"
         },
@@ -130,8 +130,8 @@
               "y_axis_label": null
             },
             "id": "utilization-pct",
-            "style": "line",
-            "title": "Utilization %"
+            "title": "Utilization %",
+            "type": "gauge"
           },
           "promql_query": "(memory_total - memory_available) / memory_total"
         }
@@ -154,8 +154,8 @@
               "y_axis_label": null
             },
             "id": "numa-local-rate",
-            "style": "line",
-            "title": "Local Rate"
+            "title": "Local Rate",
+            "type": "delta_counter"
           },
           "promql_query": "rate(memory_numa_local[5m])"
         },
@@ -172,8 +172,8 @@
               "y_axis_label": null
             },
             "id": "numa-remote-rate",
-            "style": "line",
-            "title": "Remote Rate"
+            "title": "Remote Rate",
+            "type": "delta_counter"
           },
           "promql_query": "rate(memory_numa_foreign[5m])"
         }

--- a/site/viewer/dashboards/network.json
+++ b/site/viewer/dashboards/network.json
@@ -18,8 +18,8 @@
               "y_axis_label": null
             },
             "id": "bandwidth-tx",
-            "style": "line",
-            "title": "Bandwidth Transmit"
+            "title": "Bandwidth Transmit",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_bytes{direction=\"transmit\"}[5m])) * 8"
         },
@@ -36,8 +36,8 @@
               "y_axis_label": null
             },
             "id": "bandwidth-rx",
-            "style": "line",
-            "title": "Bandwidth Receive"
+            "title": "Bandwidth Receive",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_bytes{direction=\"receive\"}[5m])) * 8"
         },
@@ -54,8 +54,8 @@
               "y_axis_label": null
             },
             "id": "packets-tx",
-            "style": "line",
-            "title": "Packets Transmit"
+            "title": "Packets Transmit",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_packets{direction=\"transmit\"}[5m]))"
         },
@@ -72,8 +72,8 @@
               "y_axis_label": null
             },
             "id": "packets-rx",
-            "style": "line",
-            "title": "Packets Receive"
+            "title": "Packets Receive",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_packets{direction=\"receive\"}[5m]))"
         }
@@ -96,8 +96,8 @@
               "y_axis_label": null
             },
             "id": "packet-drops",
-            "style": "line",
-            "title": "Packet Drops"
+            "title": "Packet Drops",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_drop[5m]))"
         },
@@ -114,8 +114,8 @@
               "y_axis_label": null
             },
             "id": "tcp-retransmits",
-            "style": "line",
-            "title": "TCP Retransmits"
+            "title": "TCP Retransmits",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(tcp_retransmit[5m]))"
         }
@@ -142,10 +142,11 @@
               "y_axis_label": "Latency"
             },
             "id": "tcp-packet-latency",
-            "style": "scatter",
-            "title": "TCP Packet Latency"
+            "subtype": "percentiles",
+            "title": "TCP Packet Latency",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999], tcp_packet_latency)"
+          "promql_query": "tcp_packet_latency"
         }
       ]
     }

--- a/site/viewer/dashboards/overview.json
+++ b/site/viewer/dashboards/overview.json
@@ -22,8 +22,8 @@
               "y_axis_label": null
             },
             "id": "cpu-busy",
-            "style": "line",
-            "title": "Busy %"
+            "title": "Busy %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000"
         },
@@ -44,8 +44,8 @@
               "y_axis_label": null
             },
             "id": "cpu-busy-heatmap",
-            "style": "heatmap",
-            "title": "Busy %"
+            "title": "Busy %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(cpu_usage[5m])) / 1000000000"
         }
@@ -68,8 +68,8 @@
               "y_axis_label": null
             },
             "id": "network-transmit-bandwidth",
-            "style": "line",
-            "title": "Transmit Bandwidth"
+            "title": "Transmit Bandwidth",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_bytes{direction=\"transmit\"}[5m])) * 8"
         },
@@ -86,8 +86,8 @@
               "y_axis_label": null
             },
             "id": "network-receive-bandwidth",
-            "style": "line",
-            "title": "Receive Bandwidth"
+            "title": "Receive Bandwidth",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_bytes{direction=\"receive\"}[5m])) * 8"
         },
@@ -104,8 +104,8 @@
               "y_axis_label": null
             },
             "id": "network-transmit-packets",
-            "style": "line",
-            "title": "Transmit Packets"
+            "title": "Transmit Packets",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_packets{direction=\"transmit\"}[5m]))"
         },
@@ -122,8 +122,8 @@
               "y_axis_label": null
             },
             "id": "network-receive-packets",
-            "style": "line",
-            "title": "Receive Packets"
+            "title": "Receive Packets",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(network_packets{direction=\"receive\"}[5m]))"
         },
@@ -144,10 +144,11 @@
               "y_axis_label": "Latency"
             },
             "id": "tcp-packet-latency",
-            "style": "scatter",
-            "title": "TCP Packet Latency"
+            "subtype": "percentiles",
+            "title": "TCP Packet Latency",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], tcp_packet_latency)"
+          "promql_query": "tcp_packet_latency"
         }
       ]
     },
@@ -172,10 +173,11 @@
               "y_axis_label": "Latency"
             },
             "id": "scheduler-runqueue-latency",
-            "style": "scatter",
-            "title": "Runqueue Latency"
+            "subtype": "percentiles",
+            "title": "Runqueue Latency",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_runqueue_latency)"
+          "promql_query": "scheduler_runqueue_latency"
         }
       ]
     },
@@ -196,8 +198,8 @@
               "y_axis_label": null
             },
             "id": "syscall-total",
-            "style": "line",
-            "title": "Total"
+            "title": "Total",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall[5m]))"
         },
@@ -218,10 +220,11 @@
               "y_axis_label": null
             },
             "id": "syscall-total-latency",
-            "style": "scatter",
-            "title": "Total"
+            "subtype": "percentiles",
+            "title": "Total",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency)"
+          "promql_query": "syscall_latency"
         }
       ]
     },
@@ -242,8 +245,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq[5m]))"
         },
@@ -260,8 +263,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq[5m]))"
         },
@@ -282,8 +285,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000"
         },
@@ -304,8 +307,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time[5m])) / 1000000000"
         }
@@ -328,8 +331,8 @@
               "y_axis_label": null
             },
             "id": "blockio-throughput-read",
-            "style": "line",
-            "title": "Read Throughput"
+            "title": "Read Throughput",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_bytes{op=\"read\"}[5m]))"
         },
@@ -346,8 +349,8 @@
               "y_axis_label": null
             },
             "id": "blockio-throughput-write",
-            "style": "line",
-            "title": "Write Throughput"
+            "title": "Write Throughput",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_bytes{op=\"write\"}[5m]))"
         },
@@ -364,8 +367,8 @@
               "y_axis_label": null
             },
             "id": "blockio-iops-read",
-            "style": "line",
-            "title": "Read IOPS"
+            "title": "Read IOPS",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_operations{op=\"read\"}[5m]))"
         },
@@ -382,8 +385,8 @@
               "y_axis_label": null
             },
             "id": "blockio-iops-write",
-            "style": "line",
-            "title": "Write IOPS"
+            "title": "Write IOPS",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(blockio_operations{op=\"write\"}[5m]))"
         }

--- a/site/viewer/dashboards/rezolus.json
+++ b/site/viewer/dashboards/rezolus.json
@@ -22,8 +22,8 @@
               "y_axis_label": null
             },
             "id": "cpu",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(rezolus_cpu_usage[5m])) / 1000000000"
         },
@@ -40,8 +40,8 @@
               "y_axis_label": null
             },
             "id": "memory",
-            "style": "line",
-            "title": "Memory (RSS)"
+            "title": "Memory (RSS)",
+            "type": "gauge"
           },
           "promql_query": "sum(rezolus_memory_usage_resident_set_size)"
         },
@@ -58,8 +58,8 @@
               "y_axis_label": null
             },
             "id": "ipc",
-            "style": "line",
-            "title": "IPC"
+            "title": "IPC",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_cpu_instructions{name=\"/system.slice/rezolus.service\"}[5m])) / sum(irate(cgroup_cpu_cycles{name=\"/system.slice/rezolus.service\"}[5m]))"
         },
@@ -76,8 +76,8 @@
               "y_axis_label": null
             },
             "id": "syscalls",
-            "style": "line",
-            "title": "Syscalls"
+            "title": "Syscalls",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(cgroup_syscall{name=\"/system.slice/rezolus.service\"}[5m]))"
         },
@@ -94,8 +94,8 @@
               "y_axis_label": null
             },
             "id": "bpf-overhead",
-            "style": "line",
-            "title": "Total BPF Overhead"
+            "title": "Total BPF Overhead",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(rezolus_bpf_run_time[5m])) / 1000000000"
         },
@@ -112,8 +112,8 @@
               "y_axis_label": null
             },
             "id": "bpf-sampler-overhead",
-            "style": "multi",
-            "title": "BPF Per-Sampler Overhead"
+            "title": "BPF Per-Sampler Overhead",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (sampler) (irate(rezolus_bpf_run_time[5m])) / 1000000000"
         },
@@ -130,8 +130,8 @@
               "y_axis_label": null
             },
             "id": "bpf-execution-time",
-            "style": "multi",
-            "title": "BPF Per-Sampler Execution Time"
+            "title": "BPF Per-Sampler Execution Time",
+            "type": "delta_counter"
           },
           "promql_query": "(sum by (sampler) (irate(rezolus_bpf_run_time[5m])) / sum by (sampler) (irate(rezolus_bpf_run_count[5m]))) / 1000000000"
         }

--- a/site/viewer/dashboards/scheduler.json
+++ b/site/viewer/dashboards/scheduler.json
@@ -22,10 +22,11 @@
               "y_axis_label": "Latency"
             },
             "id": "scheduler-runqueue-latency",
-            "style": "scatter",
-            "title": "Runqueue Latency"
+            "subtype": "percentiles",
+            "title": "Runqueue Latency",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_runqueue_latency)"
+          "promql_query": "scheduler_runqueue_latency"
         },
         {
           "data": [],
@@ -44,10 +45,11 @@
               "y_axis_label": "Time"
             },
             "id": "off-cpu-time",
-            "style": "scatter",
-            "title": "Off CPU Time"
+            "subtype": "percentiles",
+            "title": "Off CPU Time",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_offcpu)"
+          "promql_query": "scheduler_offcpu"
         },
         {
           "data": [],
@@ -66,10 +68,11 @@
               "y_axis_label": "Time"
             },
             "id": "running-time",
-            "style": "scatter",
-            "title": "Running Time"
+            "subtype": "percentiles",
+            "title": "Running Time",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_running)"
+          "promql_query": "scheduler_running"
         },
         {
           "data": [],
@@ -84,8 +87,8 @@
               "y_axis_label": null
             },
             "id": "cswitch",
-            "style": "line",
-            "title": "Context Switch"
+            "title": "Context Switch",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(scheduler_context_switch[5m]))"
         }

--- a/site/viewer/dashboards/softirq.json
+++ b/site/viewer/dashboards/softirq.json
@@ -18,8 +18,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq[5m]))"
         },
@@ -36,8 +36,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq[5m]))"
         },
@@ -58,8 +58,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000"
         },
@@ -80,8 +80,8 @@
               "y_axis_label": null
             },
             "id": "softirq-total-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time[5m])) / 1000000000"
         }
@@ -104,8 +104,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hi-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"hi\"}[5m]))"
         },
@@ -122,8 +122,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hi-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"hi\"}[5m]))"
         },
@@ -144,8 +144,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hi-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"hi\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -166,8 +166,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hi-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"hi\"}[5m])) / 1000000000"
         }
@@ -190,8 +190,8 @@
               "y_axis_label": null
             },
             "id": "softirq-irq_poll-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"irq_poll\"}[5m]))"
         },
@@ -208,8 +208,8 @@
               "y_axis_label": null
             },
             "id": "softirq-irq_poll-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"irq_poll\"}[5m]))"
         },
@@ -230,8 +230,8 @@
               "y_axis_label": null
             },
             "id": "softirq-irq_poll-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"irq_poll\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -252,8 +252,8 @@
               "y_axis_label": null
             },
             "id": "softirq-irq_poll-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"irq_poll\"}[5m])) / 1000000000"
         }
@@ -276,8 +276,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_tx-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"net_tx\"}[5m]))"
         },
@@ -294,8 +294,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_tx-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"net_tx\"}[5m]))"
         },
@@ -316,8 +316,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_tx-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"net_tx\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -338,8 +338,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_tx-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"net_tx\"}[5m])) / 1000000000"
         }
@@ -362,8 +362,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_rx-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"net_rx\"}[5m]))"
         },
@@ -380,8 +380,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_rx-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"net_rx\"}[5m]))"
         },
@@ -402,8 +402,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_rx-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"net_rx\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -424,8 +424,8 @@
               "y_axis_label": null
             },
             "id": "softirq-net_rx-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"net_rx\"}[5m])) / 1000000000"
         }
@@ -448,8 +448,8 @@
               "y_axis_label": null
             },
             "id": "softirq-rcu-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"rcu\"}[5m]))"
         },
@@ -466,8 +466,8 @@
               "y_axis_label": null
             },
             "id": "softirq-rcu-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"rcu\"}[5m]))"
         },
@@ -488,8 +488,8 @@
               "y_axis_label": null
             },
             "id": "softirq-rcu-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"rcu\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -510,8 +510,8 @@
               "y_axis_label": null
             },
             "id": "softirq-rcu-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"rcu\"}[5m])) / 1000000000"
         }
@@ -534,8 +534,8 @@
               "y_axis_label": null
             },
             "id": "softirq-sched-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"sched\"}[5m]))"
         },
@@ -552,8 +552,8 @@
               "y_axis_label": null
             },
             "id": "softirq-sched-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"sched\"}[5m]))"
         },
@@ -574,8 +574,8 @@
               "y_axis_label": null
             },
             "id": "softirq-sched-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"sched\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -596,8 +596,8 @@
               "y_axis_label": null
             },
             "id": "softirq-sched-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"sched\"}[5m])) / 1000000000"
         }
@@ -620,8 +620,8 @@
               "y_axis_label": null
             },
             "id": "softirq-tasklet-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"tasklet\"}[5m]))"
         },
@@ -638,8 +638,8 @@
               "y_axis_label": null
             },
             "id": "softirq-tasklet-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"tasklet\"}[5m]))"
         },
@@ -660,8 +660,8 @@
               "y_axis_label": null
             },
             "id": "softirq-tasklet-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"tasklet\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -682,8 +682,8 @@
               "y_axis_label": null
             },
             "id": "softirq-tasklet-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"tasklet\"}[5m])) / 1000000000"
         }
@@ -706,8 +706,8 @@
               "y_axis_label": null
             },
             "id": "softirq-timer-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"timer\"}[5m]))"
         },
@@ -724,8 +724,8 @@
               "y_axis_label": null
             },
             "id": "softirq-timer-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"timer\"}[5m]))"
         },
@@ -746,8 +746,8 @@
               "y_axis_label": null
             },
             "id": "softirq-timer-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"timer\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -768,8 +768,8 @@
               "y_axis_label": null
             },
             "id": "softirq-timer-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"timer\"}[5m])) / 1000000000"
         }
@@ -792,8 +792,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hrtimer-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"hrtimer\"}[5m]))"
         },
@@ -810,8 +810,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hrtimer-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"hrtimer\"}[5m]))"
         },
@@ -832,8 +832,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hrtimer-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"hrtimer\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -854,8 +854,8 @@
               "y_axis_label": null
             },
             "id": "softirq-hrtimer-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"hrtimer\"}[5m])) / 1000000000"
         }
@@ -878,8 +878,8 @@
               "y_axis_label": null
             },
             "id": "softirq-block-rate",
-            "style": "line",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq{kind=\"block\"}[5m]))"
         },
@@ -896,8 +896,8 @@
               "y_axis_label": null
             },
             "id": "softirq-block-rate-heatmap",
-            "style": "heatmap",
-            "title": "Rate"
+            "title": "Rate",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq{kind=\"block\"}[5m]))"
         },
@@ -918,8 +918,8 @@
               "y_axis_label": null
             },
             "id": "softirq-block-time",
-            "style": "line",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(softirq_time{kind=\"block\"}[5m])) / cpu_cores / 1000000000"
         },
@@ -940,8 +940,8 @@
               "y_axis_label": null
             },
             "id": "softirq-block-time-heatmap",
-            "style": "heatmap",
-            "title": "CPU %"
+            "title": "CPU %",
+            "type": "delta_counter"
           },
           "promql_query": "sum by (id) (irate(softirq_time{kind=\"block\"}[5m])) / 1000000000"
         }

--- a/site/viewer/dashboards/syscall.json
+++ b/site/viewer/dashboards/syscall.json
@@ -18,8 +18,8 @@
               "y_axis_label": null
             },
             "id": "syscall-total",
-            "style": "line",
-            "title": "Total"
+            "title": "Total",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall[5m]))"
         },
@@ -40,10 +40,11 @@
               "y_axis_label": null
             },
             "id": "syscall-total-latency",
-            "style": "scatter",
-            "title": "Total"
+            "subtype": "percentiles",
+            "title": "Total",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency)"
+          "promql_query": "syscall_latency"
         },
         {
           "data": [],
@@ -58,8 +59,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Read",
-            "style": "line",
-            "title": "Read"
+            "title": "Read",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"read\"}[5m]))"
         },
@@ -80,10 +81,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Read-latency",
-            "style": "scatter",
-            "title": "Read"
+            "subtype": "percentiles",
+            "title": "Read",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"read\"})"
+          "promql_query": "syscall_latency{op=\"read\"}"
         },
         {
           "data": [],
@@ -98,8 +100,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Write",
-            "style": "line",
-            "title": "Write"
+            "title": "Write",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"write\"}[5m]))"
         },
@@ -120,10 +122,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Write-latency",
-            "style": "scatter",
-            "title": "Write"
+            "subtype": "percentiles",
+            "title": "Write",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"write\"})"
+          "promql_query": "syscall_latency{op=\"write\"}"
         },
         {
           "data": [],
@@ -138,8 +141,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Poll",
-            "style": "line",
-            "title": "Poll"
+            "title": "Poll",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"poll\"}[5m]))"
         },
@@ -160,10 +163,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Poll-latency",
-            "style": "scatter",
-            "title": "Poll"
+            "subtype": "percentiles",
+            "title": "Poll",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"poll\"})"
+          "promql_query": "syscall_latency{op=\"poll\"}"
         },
         {
           "data": [],
@@ -178,8 +182,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Socket",
-            "style": "line",
-            "title": "Socket"
+            "title": "Socket",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"socket\"}[5m]))"
         },
@@ -200,10 +204,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Socket-latency",
-            "style": "scatter",
-            "title": "Socket"
+            "subtype": "percentiles",
+            "title": "Socket",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"socket\"})"
+          "promql_query": "syscall_latency{op=\"socket\"}"
         },
         {
           "data": [],
@@ -218,8 +223,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Lock",
-            "style": "line",
-            "title": "Lock"
+            "title": "Lock",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"lock\"}[5m]))"
         },
@@ -240,10 +245,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Lock-latency",
-            "style": "scatter",
-            "title": "Lock"
+            "subtype": "percentiles",
+            "title": "Lock",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"lock\"})"
+          "promql_query": "syscall_latency{op=\"lock\"}"
         },
         {
           "data": [],
@@ -258,8 +264,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Time",
-            "style": "line",
-            "title": "Time"
+            "title": "Time",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"time\"}[5m]))"
         },
@@ -280,10 +286,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Time-latency",
-            "style": "scatter",
-            "title": "Time"
+            "subtype": "percentiles",
+            "title": "Time",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"time\"})"
+          "promql_query": "syscall_latency{op=\"time\"}"
         },
         {
           "data": [],
@@ -298,8 +305,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Sleep",
-            "style": "line",
-            "title": "Sleep"
+            "title": "Sleep",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"sleep\"}[5m]))"
         },
@@ -320,10 +327,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Sleep-latency",
-            "style": "scatter",
-            "title": "Sleep"
+            "subtype": "percentiles",
+            "title": "Sleep",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"sleep\"})"
+          "promql_query": "syscall_latency{op=\"sleep\"}"
         },
         {
           "data": [],
@@ -338,8 +346,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Yield",
-            "style": "line",
-            "title": "Yield"
+            "title": "Yield",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"yield\"}[5m]))"
         },
@@ -360,10 +368,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Yield-latency",
-            "style": "scatter",
-            "title": "Yield"
+            "subtype": "percentiles",
+            "title": "Yield",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"yield\"})"
+          "promql_query": "syscall_latency{op=\"yield\"}"
         },
         {
           "data": [],
@@ -378,8 +387,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Filesystem",
-            "style": "line",
-            "title": "Filesystem"
+            "title": "Filesystem",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"filesystem\"}[5m]))"
         },
@@ -400,10 +409,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Filesystem-latency",
-            "style": "scatter",
-            "title": "Filesystem"
+            "subtype": "percentiles",
+            "title": "Filesystem",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"filesystem\"})"
+          "promql_query": "syscall_latency{op=\"filesystem\"}"
         },
         {
           "data": [],
@@ -418,8 +428,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Memory",
-            "style": "line",
-            "title": "Memory"
+            "title": "Memory",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"memory\"}[5m]))"
         },
@@ -440,10 +450,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Memory-latency",
-            "style": "scatter",
-            "title": "Memory"
+            "subtype": "percentiles",
+            "title": "Memory",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"memory\"})"
+          "promql_query": "syscall_latency{op=\"memory\"}"
         },
         {
           "data": [],
@@ -458,8 +469,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Process",
-            "style": "line",
-            "title": "Process"
+            "title": "Process",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"process\"}[5m]))"
         },
@@ -480,10 +491,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Process-latency",
-            "style": "scatter",
-            "title": "Process"
+            "subtype": "percentiles",
+            "title": "Process",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"process\"})"
+          "promql_query": "syscall_latency{op=\"process\"}"
         },
         {
           "data": [],
@@ -498,8 +510,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Query",
-            "style": "line",
-            "title": "Query"
+            "title": "Query",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"query\"}[5m]))"
         },
@@ -520,10 +532,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Query-latency",
-            "style": "scatter",
-            "title": "Query"
+            "subtype": "percentiles",
+            "title": "Query",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"query\"})"
+          "promql_query": "syscall_latency{op=\"query\"}"
         },
         {
           "data": [],
@@ -538,8 +551,8 @@
               "y_axis_label": null
             },
             "id": "syscall-IPC",
-            "style": "line",
-            "title": "IPC"
+            "title": "IPC",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"ipc\"}[5m]))"
         },
@@ -560,10 +573,11 @@
               "y_axis_label": null
             },
             "id": "syscall-IPC-latency",
-            "style": "scatter",
-            "title": "IPC"
+            "subtype": "percentiles",
+            "title": "IPC",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"ipc\"})"
+          "promql_query": "syscall_latency{op=\"ipc\"}"
         },
         {
           "data": [],
@@ -578,8 +592,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Timer",
-            "style": "line",
-            "title": "Timer"
+            "title": "Timer",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"timer\"}[5m]))"
         },
@@ -600,10 +614,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Timer-latency",
-            "style": "scatter",
-            "title": "Timer"
+            "subtype": "percentiles",
+            "title": "Timer",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"timer\"})"
+          "promql_query": "syscall_latency{op=\"timer\"}"
         },
         {
           "data": [],
@@ -618,8 +633,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Event",
-            "style": "line",
-            "title": "Event"
+            "title": "Event",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"event\"}[5m]))"
         },
@@ -640,10 +655,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Event-latency",
-            "style": "scatter",
-            "title": "Event"
+            "subtype": "percentiles",
+            "title": "Event",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"event\"})"
+          "promql_query": "syscall_latency{op=\"event\"}"
         },
         {
           "data": [],
@@ -658,8 +674,8 @@
               "y_axis_label": null
             },
             "id": "syscall-Other",
-            "style": "line",
-            "title": "Other"
+            "title": "Other",
+            "type": "delta_counter"
           },
           "promql_query": "sum(irate(syscall{op=\"other\"}[5m]))"
         },
@@ -680,10 +696,11 @@
               "y_axis_label": null
             },
             "id": "syscall-Other-latency",
-            "style": "scatter",
-            "title": "Other"
+            "subtype": "percentiles",
+            "title": "Other",
+            "type": "histogram"
           },
-          "promql_query": "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{op=\"other\"})"
+          "promql_query": "syscall_latency{op=\"other\"}"
         }
       ]
     }

--- a/site/viewer/lib/charts/metric_types.js
+++ b/site/viewer/lib/charts/metric_types.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/charts/metric_types.js

--- a/src/agent/bpf/cgroup.h
+++ b/src/agent/bpf/cgroup.h
@@ -55,7 +55,8 @@ static __always_inline int handle_new_cgroup(struct task_struct* task, void* cgr
     }
 
     // Reserve ringbuf space to avoid stack allocation of cgroup_info
-    struct cgroup_info *cginfo = bpf_ringbuf_reserve(cgroup_info_ringbuf, sizeof(struct cgroup_info), 0);
+    struct cgroup_info* cginfo =
+        bpf_ringbuf_reserve(cgroup_info_ringbuf, sizeof(struct cgroup_info), 0);
     if (!cginfo) {
         // Still update serial number even if ringbuf is full
         bpf_map_update_elem(cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
@@ -80,9 +81,7 @@ static __always_inline int handle_new_cgroup(struct task_struct* task, void* cgr
     if (cginfo->level > 0) {
         struct kernfs_node* kn = BPF_CORE_READ(task, sched_task_group, css.cgroup, kn);
         struct kernfs_node* parent = get_kernfs_node_parent(kn);
-        bpf_probe_read_kernel_str(
-            &cginfo->pname, CGROUP_NAME_LEN,
-            BPF_CORE_READ(parent, name));
+        bpf_probe_read_kernel_str(&cginfo->pname, CGROUP_NAME_LEN, BPF_CORE_READ(parent, name));
     }
 
     // For cgroups at level 2 or higher, read grandparent
@@ -90,9 +89,8 @@ static __always_inline int handle_new_cgroup(struct task_struct* task, void* cgr
         struct kernfs_node* kn = BPF_CORE_READ(task, sched_task_group, css.cgroup, kn);
         struct kernfs_node* parent = get_kernfs_node_parent(kn);
         struct kernfs_node* grandparent = get_kernfs_node_parent(parent);
-        bpf_probe_read_kernel_str(
-            &cginfo->gpname, CGROUP_NAME_LEN,
-            BPF_CORE_READ(grandparent, name));
+        bpf_probe_read_kernel_str(&cginfo->gpname, CGROUP_NAME_LEN,
+                                  BPF_CORE_READ(grandparent, name));
     }
 
     // Submit the cgroup info
@@ -141,7 +139,8 @@ static __always_inline int handle_new_cgroup_from_css(struct cgroup_subsys_state
     }
 
     // Reserve ringbuf space to avoid stack allocation of cgroup_info
-    struct cgroup_info *cginfo = bpf_ringbuf_reserve(cgroup_info_ringbuf, sizeof(struct cgroup_info), 0);
+    struct cgroup_info* cginfo =
+        bpf_ringbuf_reserve(cgroup_info_ringbuf, sizeof(struct cgroup_info), 0);
     if (!cginfo) {
         // Still update serial number even if ringbuf is full
         bpf_map_update_elem(cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
@@ -166,8 +165,7 @@ static __always_inline int handle_new_cgroup_from_css(struct cgroup_subsys_state
     if (cginfo->level > 0) {
         struct kernfs_node* kn = BPF_CORE_READ(css, cgroup, kn);
         struct kernfs_node* parent = get_kernfs_node_parent(kn);
-        bpf_probe_read_kernel_str(&cginfo->pname, CGROUP_NAME_LEN,
-                                  BPF_CORE_READ(parent, name));
+        bpf_probe_read_kernel_str(&cginfo->pname, CGROUP_NAME_LEN, BPF_CORE_READ(parent, name));
     }
 
     // For cgroups at level 2 or higher, read grandparent

--- a/src/agent/bpf/task.h
+++ b/src/agent/bpf/task.h
@@ -37,13 +37,11 @@ struct task_exit {
  *
  * Populates the task_info with pid, tgid, comm, and cgroup hierarchy.
  */
-static __always_inline void populate_task_info(struct task_struct* task,
-                                                struct task_info* info) {
+static __always_inline void populate_task_info(struct task_struct* task, struct task_info* info) {
     info->pid = BPF_CORE_READ(task, pid);
     info->tgid = BPF_CORE_READ(task, tgid);
 
-    bpf_probe_read_kernel_str(&info->comm, TASK_COMM_LEN,
-                              BPF_CORE_READ(task, comm));
+    bpf_probe_read_kernel_str(&info->comm, TASK_COMM_LEN, BPF_CORE_READ(task, comm));
 
     // Read cgroup info if available
     struct task_group* tg = BPF_CORE_READ(task, sched_task_group);
@@ -58,9 +56,8 @@ static __always_inline void populate_task_info(struct task_struct* task,
         if (info->cgroup_level > 0) {
             struct kernfs_node* kn = BPF_CORE_READ(tg, css.cgroup, kn);
             struct kernfs_node* parent = get_kernfs_node_parent(kn);
-            bpf_probe_read_kernel_str(
-                &info->cgroup_pname, TASK_CGROUP_NAME_LEN,
-                BPF_CORE_READ(parent, name));
+            bpf_probe_read_kernel_str(&info->cgroup_pname, TASK_CGROUP_NAME_LEN,
+                                      BPF_CORE_READ(parent, name));
         }
 
         // Read grandparent cgroup name
@@ -68,9 +65,8 @@ static __always_inline void populate_task_info(struct task_struct* task,
             struct kernfs_node* kn = BPF_CORE_READ(tg, css.cgroup, kn);
             struct kernfs_node* parent = get_kernfs_node_parent(kn);
             struct kernfs_node* grandparent = get_kernfs_node_parent(parent);
-            bpf_probe_read_kernel_str(
-                &info->cgroup_gpname, TASK_CGROUP_NAME_LEN,
-                BPF_CORE_READ(grandparent, name));
+            bpf_probe_read_kernel_str(&info->cgroup_gpname, TASK_CGROUP_NAME_LEN,
+                                      BPF_CORE_READ(grandparent, name));
         }
     }
 }

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
@@ -134,7 +134,8 @@ int tg_set_cfs_bandwidth(struct pt_regs* ctx) {
     }
 
     // get the bandwidth info and send to userspace
-    struct bandwidth_info *bw_info = bpf_ringbuf_reserve(&bandwidth_info, sizeof(struct bandwidth_info), 0);
+    struct bandwidth_info* bw_info =
+        bpf_ringbuf_reserve(&bandwidth_info, sizeof(struct bandwidth_info), 0);
     if (bw_info) {
         bw_info->id = cgroup_id;
         bw_info->quota = BPF_CORE_READ(cfs_b, quota);
@@ -173,7 +174,8 @@ int throttle_cfs_rq(struct pt_regs* ctx) {
         bpf_map_update_elem(&throttled_count, &cgroup_id, &zero, BPF_ANY);
 
         // get the bandwidth info and send to userspace
-        struct bandwidth_info *bw_info = bpf_ringbuf_reserve(&bandwidth_info, sizeof(struct bandwidth_info), 0);
+        struct bandwidth_info* bw_info =
+            bpf_ringbuf_reserve(&bandwidth_info, sizeof(struct bandwidth_info), 0);
         if (bw_info) {
             bw_info->id = cgroup_id;
             bw_info->quota = BPF_CORE_READ(tg, cfs_bandwidth.quota);

--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -221,7 +221,7 @@ static __noinline int handle_new_task(struct task_struct* task) {
     bpf_map_update_elem(&task_start_times, &pid, &start_time, BPF_ANY);
 
     // Populate and send task info (use ringbuf_reserve to avoid stack allocation)
-    struct task_info *info = bpf_ringbuf_reserve(&task_info, sizeof(struct task_info), 0);
+    struct task_info* info = bpf_ringbuf_reserve(&task_info, sizeof(struct task_info), 0);
     if (!info)
         return 0;
 
@@ -312,7 +312,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, struct task_struct* task, u32 index
     }
 
     // Additional accounting on a per-cgroup basis
-    struct task_group *tg = BPF_CORE_READ(task, sched_task_group);
+    struct task_group* tg = BPF_CORE_READ(task, sched_task_group);
     if (!tg)
         return 0;
 
@@ -359,7 +359,7 @@ int handle__sched_process_exit(u64* ctx) {
     bpf_map_update_elem(&task_start_times, &pid, &zero, BPF_ANY);
 
     // Notify userspace to clear metadata
-    struct task_exit *exit_event = bpf_ringbuf_reserve(&task_exit, sizeof(struct task_exit), 0);
+    struct task_exit* exit_event = bpf_ringbuf_reserve(&task_exit, sizeof(struct task_exit), 0);
     if (exit_event) {
         exit_event->pid = pid;
         bpf_ringbuf_submit(exit_event, 0);

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -205,7 +205,8 @@ int handle__sched_switch(u64* ctx) {
                 bpf_map_update_elem(&cgroup_offcpu, &cgroup_id, &zero, BPF_ANY);
 
                 // reserve ringbuf space to avoid stack allocation of cgroup_info
-                struct cgroup_info *cginfo = bpf_ringbuf_reserve(&cgroup_info, sizeof(struct cgroup_info), 0);
+                struct cgroup_info* cginfo =
+                    bpf_ringbuf_reserve(&cgroup_info, sizeof(struct cgroup_info), 0);
                 if (!cginfo) {
                     bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
                 } else {
@@ -221,15 +222,13 @@ int handle__sched_switch(u64* ctx) {
                     // read the cgroup parent name
                     struct kernfs_node* kn = BPF_CORE_READ(prev, sched_task_group, css.cgroup, kn);
                     struct kernfs_node* parent = get_kernfs_node_parent(kn);
-                    bpf_probe_read_kernel_str(
-                        &cginfo->pname, CGROUP_NAME_LEN,
-                        BPF_CORE_READ(parent, name));
+                    bpf_probe_read_kernel_str(&cginfo->pname, CGROUP_NAME_LEN,
+                                              BPF_CORE_READ(parent, name));
 
                     // read the cgroup grandparent name
                     struct kernfs_node* grandparent = get_kernfs_node_parent(parent);
-                    bpf_probe_read_kernel_str(
-                        &cginfo->gpname, CGROUP_NAME_LEN,
-                        BPF_CORE_READ(grandparent, name));
+                    bpf_probe_read_kernel_str(&cginfo->gpname, CGROUP_NAME_LEN,
+                                              BPF_CORE_READ(grandparent, name));
 
                     // submit the cgroup info
                     bpf_ringbuf_submit(cginfo, 0);

--- a/src/agent/samplers/tcp/linux/packet_latency/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/packet_latency/mod.bpf.c
@@ -61,7 +61,7 @@ static int handle_tcp_probe(struct sock* sk, struct sk_buff* skb) {
 
 static int handle_tcp_rcv_space_adjust(void* ctx, struct sock* sk) {
     u64 sock_ident = get_sock_ident(sk);
-    u64 *tsp;
+    u64* tsp;
     u64 now, delta_ns;
 
     tsp = bpf_map_lookup_elem(&start, &sock_ident);

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -50,6 +50,14 @@ export class ChartsState {
         return !this.zoomLevel || (this.zoomLevel.start === 0 && this.zoomLevel.end === 100);
     }
 
+    /** Returns true when any chart has a local zoom, frozen tooltip, or pinned series. */
+    hasActiveSelection() {
+        const hasLocalZoom = this.zoomSource === 'local' && !this.isDefaultZoom();
+        return hasLocalZoom ||
+            Array.from(this.charts.values()).some(
+                c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
+    }
+
     // Reset zoom level on all charts
     resetZoom() {
         this.zoomLevel = { start: 0, end: 100 };

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -362,7 +362,7 @@ export class Chart {
     _rescaleYAxis() {
         if (!this.echart) return;
 
-        const style = this.spec.opts.style;
+        const style = this.spec.opts.style || this.spec._resolvedStyle;
         // Only for chart types with a value/log Y-axis
         if (style === 'heatmap' || style === 'histogram_heatmap') return;
 
@@ -453,28 +453,27 @@ export class Chart {
     }
 
     configureChartByType() {
-        const {
-            opts
-        } = this.spec;
+        // Use explicit style (query explorer) or resolved style (from metric type)
+        const style = this.spec.opts.style || this.spec._resolvedStyle;
 
         // Clean up heatmap DOM legend bar when switching to a different chart type
-        if (opts.style !== 'histogram_heatmap' && opts.style !== 'heatmap') {
+        if (style !== 'histogram_heatmap' && style !== 'heatmap') {
             this.domNode?.parentNode?.querySelector('.heatmap-legend-bar')?.remove();
         }
 
         // Handle different chart types by delegating to specialized modules
-        if (opts.style === 'line') {
+        if (style === 'line') {
             configureLineChart(this, this.spec, this.chartsState);
-        } else if (opts.style === 'heatmap') {
+        } else if (style === 'heatmap') {
             configureHeatmap(this, this.spec, this.chartsState);
-        } else if (opts.style === 'histogram_heatmap') {
+        } else if (style === 'histogram_heatmap') {
             configureHistogramHeatmap(this, this.spec, this.chartsState);
-        } else if (opts.style === 'scatter') {
+        } else if (style === 'scatter') {
             configureScatterChart(this, this.spec, this.chartsState);
-        } else if (opts.style === 'multi') {
+        } else if (style === 'multi') {
             configureMultiSeriesChart(this, this.spec, this.chartsState);
         } else {
-            throw new Error(`Unknown chart style: ${opts.style}`);
+            throw new Error(`Unknown chart style: ${style}`);
         }
 
         // Compact layout for cgroup paired charts: same grid for both, hide echarts legend

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -72,3 +72,40 @@ export function buildHistogramQuery(baseQuery, subtype) {
     // Default to percentiles
     return `histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], ${baseQuery})`;
 }
+
+/**
+ * Returns true if the given plot spec represents a histogram chart.
+ * Checks the semantic type first, with a legacy fallback for specs that
+ * still use the old histogram_percentiles query format.
+ *
+ * @param {object} plot - A plot spec with opts and optional promql_query
+ * @returns {boolean}
+ */
+export function isHistogramPlot(plot) {
+    return plot.opts?.type === 'histogram' ||
+        (plot.promql_query && plot.promql_query.includes('histogram_percentiles'));
+}
+
+/**
+ * Builds a histogram_heatmap chart spec by merging heatmap data into a base
+ * scatter plot spec.
+ *
+ * @param {object} spec - The original scatter plot spec
+ * @param {object} heatmapData - Data from fetchHeatmapForPlot()
+ * @param {object} [optsOverrides] - Additional opts to merge (e.g. prefixed title)
+ * @returns {object} A new spec configured for histogram_heatmap rendering
+ */
+export function buildHistogramHeatmapSpec(spec, heatmapData, optsOverrides) {
+    return {
+        ...spec,
+        opts: {
+            ...(optsOverrides || spec.opts),
+            style: 'histogram_heatmap',
+        },
+        time_data: heatmapData.time_data,
+        bucket_bounds: heatmapData.bucket_bounds,
+        data: heatmapData.data,
+        min_value: heatmapData.min_value,
+        max_value: heatmapData.max_value,
+    };
+}

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -1,0 +1,74 @@
+/**
+ * Maps semantic metric types to compatible chart styles.
+ *
+ * The backend specifies *what* the metric is (gauge, delta_counter, histogram),
+ * and this module determines *how* it should be rendered.
+ */
+
+/**
+ * Returns the list of chart styles compatible with the given metric type.
+ *
+ * @param {string} type_ - The metric type: 'gauge', 'delta_counter', or 'histogram'
+ * @returns {string[]} Compatible chart style names
+ */
+export function compatibleStyles(type_) {
+    switch (type_) {
+        case 'gauge':
+        case 'delta_counter':
+            return ['line', 'heatmap', 'multi'];
+        case 'histogram':
+            return ['scatter', 'histogram_heatmap'];
+        default:
+            return ['line'];
+    }
+}
+
+/**
+ * Resolves the concrete chart style from a metric type, optional subtype,
+ * and query result shape.
+ *
+ * For gauge/delta_counter the style is inferred from the query result:
+ *   - Single series          -> 'line'
+ *   - Multi-series with `id` -> 'heatmap'
+ *   - Multi-series otherwise -> 'multi'
+ *
+ * For histogram the subtype selects the style:
+ *   - 'percentiles' (default) -> 'scatter'
+ *   - 'buckets'               -> 'histogram_heatmap'
+ *
+ * @param {string} type_    - Metric type from the plot spec
+ * @param {string} [subtype] - Optional subtype (e.g. 'percentiles', 'buckets')
+ * @param {object} [result]  - PromQL query result (used for gauge/counter inference)
+ * @returns {string} The resolved chart style name
+ */
+export function resolveStyle(type_, subtype, result) {
+    if (type_ === 'histogram') {
+        return subtype === 'buckets' ? 'histogram_heatmap' : 'scatter';
+    }
+
+    // gauge or delta_counter: infer from result shape
+    if (result?.data?.result?.length > 1) {
+        const first = result.data.result[0];
+        if (first.metric && first.metric.id != null) {
+            return 'heatmap';
+        }
+        return 'multi';
+    }
+    return 'line';
+}
+
+/**
+ * Wraps a base histogram metric selector with the appropriate PromQL function
+ * based on the subtype.
+ *
+ * @param {string} baseQuery - The raw metric selector (e.g. 'tcp_packet_latency')
+ * @param {string} [subtype]  - 'percentiles' or 'buckets'
+ * @returns {string} The wrapped PromQL query
+ */
+export function buildHistogramQuery(baseQuery, subtype) {
+    if (subtype === 'buckets') {
+        return `histogram_heatmap(${baseQuery})`;
+    }
+    // Default to percentiles
+    return `histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], ${baseQuery})`;
+}

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -1,4 +1,5 @@
 import { ViewerApi } from './viewer_api.js';
+import { resolveStyle, buildHistogramQuery } from './charts/metric_types.js';
 
 const defaultGetMetadata = () => ViewerApi.getMetadata();
 const defaultQueryRange = (query, start, end, step) =>
@@ -21,15 +22,23 @@ const applyResultToPlot = (plot, result) => {
         result.data.result &&
         result.data.result.length > 0
     ) {
+        // Resolve chart style from metric type (if present) or fall back to
+        // explicit style (used by query explorer dynamic specs).
+        const style = plot.opts.style || resolveStyle(
+            plot.opts.type,
+            plot.opts.subtype,
+            result,
+        );
+        plot._resolvedStyle = style;
+
         const hasMultipleSeries =
             result.data.result.length > 1 ||
-            (plot.opts &&
-                (plot.opts.style === 'multi' ||
-                    plot.opts.style === 'scatter' ||
-                    plot.opts.style === 'heatmap'));
+            (style === 'multi' ||
+                style === 'scatter' ||
+                style === 'heatmap');
 
         if (hasMultipleSeries) {
-            if (plot.opts && plot.opts.style === 'heatmap') {
+            if (style === 'heatmap') {
                 const heatmapData = [];
                 const timeSet = new Set();
 
@@ -167,15 +176,21 @@ const createDataApi = ({
             for (const plot of group.plots || []) {
                 if (plot.promql_query) {
                     let queryToRun = plot.promql_query;
-                    if (plot.promql_query.includes('__SELECTED_CGROUPS__')) {
+
+                    // Wrap histogram queries with the appropriate function
+                    if (plot.opts.type === 'histogram') {
+                        queryToRun = buildHistogramQuery(queryToRun, plot.opts.subtype);
+                    }
+
+                    if (queryToRun.includes('__SELECTED_CGROUPS__')) {
                         if (activeCgroupPattern) {
                             queryToRun = substituteCgroupPattern(
-                                plot.promql_query,
+                                queryToRun,
                                 activeCgroupPattern,
                             );
-                        } else if (plot.promql_query.includes('!~')) {
+                        } else if (queryToRun.includes('!~')) {
                             queryToRun = substituteCgroupPattern(
-                                plot.promql_query,
+                                queryToRun,
                                 null,
                             );
                         } else {
@@ -212,12 +227,21 @@ const createDataApi = ({
 
     const fetchHeatmapForPlot = async (plot) => {
         const query = plot.promql_query;
-        if (!query || !query.includes('histogram_percentiles')) return null;
+        if (!query) return null;
 
-        const match = query.match(/histogram_percentiles\s*\(\s*\[[^\]]*\]\s*,\s*(.+)\)$/);
-        if (!match) return null;
+        // For typed histogram specs, promql_query is already the base metric selector
+        let metricSelector;
+        if (plot.opts.type === 'histogram') {
+            metricSelector = query;
+        } else if (query.includes('histogram_percentiles')) {
+            // Legacy fallback: extract base metric from wrapped query
+            const match = query.match(/histogram_percentiles\s*\(\s*\[[^\]]*\]\s*,\s*(.+)\)$/);
+            if (!match) return null;
+            metricSelector = match[1].trim();
+        } else {
+            return null;
+        }
 
-        const metricSelector = match[1].trim();
         const result = await executePromQLRangeQuery(`histogram_heatmap(${metricSelector})`);
 
         if (result.status === 'success' && result.data && result.data.resultType === 'histogram_heatmap') {
@@ -237,7 +261,10 @@ const createDataApi = ({
         const plots = [];
         for (const group of groups || []) {
             for (const plot of group.plots || []) {
-                if (plot.promql_query && plot.promql_query.includes('histogram_percentiles')) {
+                if (plot.promql_query && (
+                    plot.opts.type === 'histogram' ||
+                    plot.promql_query.includes('histogram_percentiles')
+                )) {
                     plots.push(plot);
                 }
             }

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -1,5 +1,5 @@
 import { ViewerApi } from './viewer_api.js';
-import { resolveStyle, buildHistogramQuery } from './charts/metric_types.js';
+import { resolveStyle, buildHistogramQuery, isHistogramPlot } from './charts/metric_types.js';
 
 const defaultGetMetadata = () => ViewerApi.getMetadata();
 const defaultQueryRange = (query, start, end, step) =>
@@ -261,10 +261,7 @@ const createDataApi = ({
         const plots = [];
         for (const group of groups || []) {
             for (const plot of group.plots || []) {
-                if (plot.promql_query && (
-                    plot.opts.type === 'histogram' ||
-                    plot.promql_query.includes('histogram_percentiles')
-                )) {
+                if (plot.promql_query && isHistogramPlot(plot)) {
                     plots.push(plot);
                 }
             }

--- a/src/viewer/assets/lib/explorers.js
+++ b/src/viewer/assets/lib/explorers.js
@@ -344,7 +344,8 @@ export const SingleChartView = {
             });
         };
 
-        const isHistogram = plot.promql_query && plot.promql_query.includes('histogram_percentiles');
+        const isHistogram = plot.opts.type === 'histogram' ||
+            (plot.promql_query && plot.promql_query.includes('histogram_percentiles'));
 
         const toggleHeatmap = async () => {
             if (st.heatmapMode) {

--- a/src/viewer/assets/lib/explorers.js
+++ b/src/viewer/assets/lib/explorers.js
@@ -2,6 +2,7 @@
 
 import { ChartsState, Chart } from './charts/chart.js';
 import { executePromQLRangeQuery, fetchHeatmapForPlot } from './data.js';
+import { isHistogramPlot, buildHistogramHeatmapSpec } from './charts/metric_types.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -344,8 +345,7 @@ export const SingleChartView = {
             });
         };
 
-        const isHistogram = plot.opts.type === 'histogram' ||
-            (plot.promql_query && plot.promql_query.includes('histogram_percentiles'));
+        const isHistogram = isHistogramPlot(plot);
 
         const toggleHeatmap = async () => {
             if (st.heatmapMode) {
@@ -369,22 +369,11 @@ export const SingleChartView = {
             m.redraw();
         };
 
-        const hasLocalZoom = st.singleChartsState.zoomSource === 'local' && !st.singleChartsState.isDefaultZoom();
-        const hasSelection = hasLocalZoom ||
-            Array.from(st.singleChartsState.charts.values()).some(
-                c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
+        const hasSelection = st.singleChartsState.hasActiveSelection();
 
         let chartSpec = spec;
         if (st.heatmapMode && st.heatmapData) {
-            chartSpec = {
-                ...spec,
-                opts: { ...spec.opts, style: 'histogram_heatmap' },
-                time_data: st.heatmapData.time_data,
-                bucket_bounds: st.heatmapData.bucket_bounds,
-                data: st.heatmapData.data,
-                min_value: st.heatmapData.min_value,
-                max_value: st.heatmapData.max_value,
-            };
+            chartSpec = buildHistogramHeatmapSpec(spec, st.heatmapData);
         }
 
         return m('div.single-chart-view', [

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -13,6 +13,7 @@ import { FileUpload } from './landing.js';
 import { createSystemInfoView, renderCgroupSection } from './section_views.js';
 import { buildTopNavAttrs, createMainComponent } from './navigation.js';
 import { initTheme } from './theme.js';
+import { isHistogramPlot, buildHistogramHeatmapSpec } from './charts/metric_types.js';
 
 initTheme();
 
@@ -230,13 +231,10 @@ const SectionContent = {
             });
         }
 
-        const hasLocalZoom = chartsState.zoomSource === 'local' && !chartsState.isDefaultZoom();
-        const hasSelection = hasLocalZoom ||
-            Array.from(chartsState.charts.values()).some(c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
+        const hasSelection = chartsState.hasActiveSelection();
 
         const hasHistogramCharts = (attrs.groups || []).some(g =>
-            (g.plots || []).some(p => p.opts.type === 'histogram' ||
-                (p.promql_query && p.promql_query.includes('histogram_percentiles')))
+            (g.plots || []).some(p => isHistogramPlot(p))
         );
 
         return m('div#section-content', [
@@ -344,24 +342,12 @@ const Group = {
                     'div.charts',
                     attrs.plots.map((spec) => {
                         // Check if this is a histogram chart and we're in heatmap mode
-                        const isHistogramChart = spec.opts.type === 'histogram' ||
-                            (spec.promql_query && spec.promql_query.includes('histogram_percentiles'));
+                        const isHistogramChart = isHistogramPlot(spec);
 
                         if (isHistogramChart && isHeatmapMode && sectionHeatmapData?.has(spec.opts.id)) {
                             // Create heatmap spec from the fetched data
                             const heatmapData = sectionHeatmapData.get(spec.opts.id);
-                            const heatmapSpec = {
-                                ...spec,
-                                opts: {
-                                    ...prefixTitle(spec.opts),
-                                    style: 'histogram_heatmap',
-                                },
-                                time_data: heatmapData.time_data,
-                                bucket_bounds: heatmapData.bucket_bounds,
-                                data: heatmapData.data,
-                                min_value: heatmapData.min_value,
-                                max_value: heatmapData.max_value,
-                            };
+                            const heatmapSpec = buildHistogramHeatmapSpec(spec, heatmapData, prefixTitle(spec.opts));
                             return m('div.chart-wrapper', [
                                 chartHeader(heatmapSpec.opts),
                                 m(Chart, { spec: heatmapSpec, chartsState, interval }),

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -235,7 +235,8 @@ const SectionContent = {
             Array.from(chartsState.charts.values()).some(c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
 
         const hasHistogramCharts = (attrs.groups || []).some(g =>
-            (g.plots || []).some(p => p.promql_query && p.promql_query.includes('histogram_percentiles'))
+            (g.plots || []).some(p => p.opts.type === 'histogram' ||
+                (p.promql_query && p.promql_query.includes('histogram_percentiles')))
         );
 
         return m('div#section-content', [
@@ -343,7 +344,8 @@ const Group = {
                     'div.charts',
                     attrs.plots.map((spec) => {
                         // Check if this is a histogram chart and we're in heatmap mode
-                        const isHistogramChart = spec.promql_query && spec.promql_query.includes('histogram_percentiles');
+                        const isHistogramChart = spec.opts.type === 'histogram' ||
+                            (spec.promql_query && spec.promql_query.includes('histogram_percentiles'));
 
                         if (isHistogramChart && isHeatmapMode && sectionHeatmapData?.has(spec.opts.id)) {
                             // Create heatmap spec from the fetched data

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -5,6 +5,7 @@
 import { ChartsState, Chart } from './charts/chart.js';
 import { executePromQLRangeQuery, applyResultToPlot } from './data.js';
 import { notify, showSaveModal } from './overlays.js';
+import { isHistogramPlot } from './charts/metric_types.js';
 
 // ── UUIDv7 (RFC 9562) ──────────────────────────────────────────────
 
@@ -381,11 +382,8 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
 
         const interval = attrs.interval || 1;
         const cs = attrs.chartsState;
-        const hasLocalZoom = cs?.zoomSource === 'local' && !cs?.isDefaultZoom();
-        const hasChartSelection = hasLocalZoom ||
-            Array.from(cs?.charts?.values() || []).some(c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
-        const hasHistograms = selectionStore.entries.some(e => e.opts?.type === 'histogram' ||
-            (e.promql_query && e.promql_query.includes('histogram_percentiles')));
+        const hasChartSelection = cs?.hasActiveSelection();
+        const hasHistograms = selectionStore.entries.some(e => isHistogramPlot(e));
 
         const header = m('div.selection-header', [
             m('div.section-header-row', [
@@ -475,11 +473,8 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
 
         const interval = attrs.interval || 1;
         const cs = attrs.chartsState;
-        const hasLocalZoom = cs?.zoomSource === 'local' && !cs?.isDefaultZoom();
-        const hasChartSelection = hasLocalZoom ||
-            Array.from(cs?.charts?.values() || []).some(c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
-        const hasHistograms = reportStore.entries.some(e => e.opts?.type === 'histogram' ||
-            (e.promql_query && e.promql_query.includes('histogram_percentiles')));
+        const hasChartSelection = cs?.hasActiveSelection();
+        const hasHistograms = reportStore.entries.some(e => isHistogramPlot(e));
 
         const fmtTs = (ms) => {
             const d = new Date(ms);

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -384,7 +384,8 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
         const hasLocalZoom = cs?.zoomSource === 'local' && !cs?.isDefaultZoom();
         const hasChartSelection = hasLocalZoom ||
             Array.from(cs?.charts?.values() || []).some(c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
-        const hasHistograms = selectionStore.entries.some(e => e.promql_query && e.promql_query.includes('histogram_percentiles'));
+        const hasHistograms = selectionStore.entries.some(e => e.opts?.type === 'histogram' ||
+            (e.promql_query && e.promql_query.includes('histogram_percentiles')));
 
         const header = m('div.selection-header', [
             m('div.section-header-row', [
@@ -477,7 +478,8 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
         const hasLocalZoom = cs?.zoomSource === 'local' && !cs?.isDefaultZoom();
         const hasChartSelection = hasLocalZoom ||
             Array.from(cs?.charts?.values() || []).some(c => c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0));
-        const hasHistograms = reportStore.entries.some(e => e.promql_query && e.promql_query.includes('histogram_percentiles'));
+        const hasHistograms = reportStore.entries.some(e => e.opts?.type === 'histogram' ||
+            (e.promql_query && e.promql_query.includes('histogram_percentiles')));
 
         const fmtTs = (ms) => {
             const d = new Date(ms);

--- a/src/viewer/dashboard/blockio.rs
+++ b/src/viewer/dashboard/blockio.rs
@@ -63,14 +63,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         let op_lower = op.to_lowercase();
 
         latency.plot_promql(
-            PlotOpts::histogram(
-                *op,
-                format!("latency-{op_lower}"),
-                Unit::Time,
-                "percentiles",
-            )
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
+            PlotOpts::histogram_latency(*op, format!("latency-{op_lower}")),
             format!("blockio_latency{{op=\"{op_lower}\"}}"),
         );
     }

--- a/src/viewer/dashboard/blockio.rs
+++ b/src/viewer/dashboard/blockio.rs
@@ -11,7 +11,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total throughput (bytes/sec)
     operations.plot_promql(
-        PlotOpts::line(
+        PlotOpts::counter(
             "Total Throughput",
             "blockio-throughput-total",
             Unit::Datarate,
@@ -21,7 +21,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total IOPS
     operations.plot_promql(
-        PlotOpts::line("Total IOPS", "blockio-iops-total", Unit::Count),
+        PlotOpts::counter("Total IOPS", "blockio-iops-total", Unit::Count),
         "sum(irate(blockio_operations[5m]))".to_string(),
     );
 
@@ -31,7 +31,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Throughput for this operation
         operations.plot_promql(
-            PlotOpts::line(
+            PlotOpts::counter(
                 format!("{op} Throughput"),
                 format!("throughput-{op_lower}"),
                 Unit::Datarate,
@@ -41,7 +41,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // IOPS for this operation
         operations.plot_promql(
-            PlotOpts::line(
+            PlotOpts::counter(
                 format!("{op} IOPS"),
                 format!("iops-{op_lower}"),
                 Unit::Count,
@@ -63,10 +63,15 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         let op_lower = op.to_lowercase();
 
         latency.plot_promql(
-            PlotOpts::scatter(*op, format!("latency-{op_lower}"), Unit::Time)
-                .with_log_scale(true)
-                .range(0.0, 100_000_000_000.0),
-            format!("histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], blockio_latency{{op=\"{op_lower}\"}})"),
+            PlotOpts::histogram(
+                *op,
+                format!("latency-{op_lower}"),
+                Unit::Time,
+                "percentiles",
+            )
+            .with_log_scale(true)
+            .range(0.0, 100_000_000_000.0),
+            format!("blockio_latency{{op=\"{op_lower}\"}}"),
         );
     }
 
@@ -83,10 +88,9 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         let op_lower = op.to_lowercase();
 
         size.plot_promql(
-            PlotOpts::scatter(*op, format!("size-{op_lower}"), Unit::Bytes).with_log_scale(true),
-            format!(
-                "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], blockio_size{{op=\"{op_lower}\"}})"
-            ),
+            PlotOpts::histogram(*op, format!("size-{op_lower}"), Unit::Bytes, "percentiles")
+                .with_log_scale(true),
+            format!("blockio_size{{op=\"{op_lower}\"}}"),
         );
     }
 

--- a/src/viewer/dashboard/cgroups.rs
+++ b/src/viewer/dashboard/cgroups.rs
@@ -33,31 +33,31 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // CPU Total Cores - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line("Total CPU Cores", "aggregate-total-cores", Unit::Count),
+        PlotOpts::counter("Total CPU Cores", "aggregate-total-cores", Unit::Count),
         "sum(irate(cgroup_cpu_usage{name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
     );
 
     // CPU User Cores - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line("User CPU Cores", "aggregate-user-cores", Unit::Count),
+        PlotOpts::counter("User CPU Cores", "aggregate-user-cores", Unit::Count),
         "sum(irate(cgroup_cpu_usage{state=\"user\",name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
     );
 
     // CPU System Cores - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line("System CPU Cores", "aggregate-system-cores", Unit::Count),
+        PlotOpts::counter("System CPU Cores", "aggregate-system-cores", Unit::Count),
         "sum(irate(cgroup_cpu_usage{state=\"system\",name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
     );
 
     // CPU Migrations - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line("CPU Migrations", "aggregate-cpu-migrations", Unit::Rate),
+        PlotOpts::counter("CPU Migrations", "aggregate-cpu-migrations", Unit::Rate),
         "sum(irate(cgroup_cpu_migrations{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
     );
 
     // CPU Throttled Time - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line(
+        PlotOpts::counter(
             "CPU Throttled Time",
             "aggregate-cpu-throttled-time",
             Unit::Time,
@@ -67,19 +67,19 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // IPC - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line("IPC", "aggregate-ipc", Unit::Count),
+        PlotOpts::counter("IPC", "aggregate-ipc", Unit::Count),
         "sum(irate(cgroup_cpu_instructions{name!~\"__SELECTED_CGROUPS__\"}[5m])) / sum(irate(cgroup_cpu_cycles{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
     );
 
     // TLB Flushes - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line("TLB Flushes", "aggregate-tlb-flush", Unit::Rate),
+        PlotOpts::counter("TLB Flushes", "aggregate-tlb-flush", Unit::Rate),
         "sum(irate(cgroup_cpu_tlb_flush{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
     );
 
     // Syscalls - aggregate of non-selected
     aggregate.plot_promql(
-        PlotOpts::line("Syscalls", "aggregate-syscall", Unit::Rate),
+        PlotOpts::counter("Syscalls", "aggregate-syscall", Unit::Rate),
         "sum(irate(cgroup_syscall{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
     );
 
@@ -103,7 +103,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         "Other",
     ] {
         aggregate.plot_promql(
-            PlotOpts::line(
+            PlotOpts::counter(
                 format!("Syscall {op}"),
                 format!("aggregate-syscall-{}", op.to_lowercase()),
                 Unit::Rate,
@@ -128,33 +128,33 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // CPU Total Cores - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi("Total CPU Cores", "individual-total-cores", Unit::Count),
+        PlotOpts::counter("Total CPU Cores", "individual-total-cores", Unit::Count),
         "sum by (name) (irate(cgroup_cpu_usage{name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
             .to_string(),
     );
 
     // CPU User Cores - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi("User CPU Cores", "individual-user-cores", Unit::Count),
+        PlotOpts::counter("User CPU Cores", "individual-user-cores", Unit::Count),
         "sum by (name) (irate(cgroup_cpu_usage{state=\"user\",name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
     );
 
     // CPU System Cores - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi("System CPU Cores", "individual-system-cores", Unit::Count),
+        PlotOpts::counter("System CPU Cores", "individual-system-cores", Unit::Count),
         "sum by (name) (irate(cgroup_cpu_usage{state=\"system\",name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
     );
 
     // CPU Migrations - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi("CPU Migrations", "individual-cpu-migrations", Unit::Rate),
+        PlotOpts::counter("CPU Migrations", "individual-cpu-migrations", Unit::Rate),
         "sum by (name) (irate(cgroup_cpu_migrations{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
             .to_string(),
     );
 
     // CPU Throttled Time - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi(
+        PlotOpts::counter(
             "CPU Throttled Time",
             "individual-cpu-throttled-time",
             Unit::Time,
@@ -165,20 +165,20 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // IPC - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi("IPC", "individual-ipc", Unit::Count),
+        PlotOpts::counter("IPC", "individual-ipc", Unit::Count),
         "sum by (name) (irate(cgroup_cpu_instructions{name=~\"__SELECTED_CGROUPS__\"}[5m])) / sum by (name) (irate(cgroup_cpu_cycles{name=~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
     );
 
     // TLB Flushes - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi("TLB Flushes", "individual-tlb-flush", Unit::Rate),
+        PlotOpts::counter("TLB Flushes", "individual-tlb-flush", Unit::Rate),
         "sum by (name) (irate(cgroup_cpu_tlb_flush{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
             .to_string(),
     );
 
     // Syscalls - per selected cgroup
     individual.plot_promql(
-        PlotOpts::multi("Syscalls", "individual-syscall", Unit::Rate),
+        PlotOpts::counter("Syscalls", "individual-syscall", Unit::Rate),
         "sum by (name) (irate(cgroup_syscall{name=~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
     );
 
@@ -202,7 +202,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         "Other",
     ] {
         individual.plot_promql(
-            PlotOpts::multi(format!("Syscall {op}"), format!("individual-syscall-{}", op.to_lowercase()), Unit::Rate),
+            PlotOpts::counter(format!("Syscall {op}"), format!("individual-syscall-{}", op.to_lowercase()), Unit::Rate),
             format!("sum by (name) (irate(cgroup_syscall{{op=\"{}\",name=~\"__SELECTED_CGROUPS__\"}}[5m]))", op.to_lowercase()),
         );
     }

--- a/src/viewer/dashboard/cgroups.rs
+++ b/src/viewer/dashboard/cgroups.rs
@@ -11,11 +11,10 @@ fn add_cgroup_metrics(group: &mut Group, individual: bool) {
         "aggregate"
     };
 
-    // Build the query templates: aggregate uses sum(...{name!~}), individual uses sum by (name) (...{name=~})
-    let (agg_fn, filter) = if individual {
-        ("sum by (name) ", "name=~\"__SELECTED_CGROUPS__\"")
+    let filter = if individual {
+        "name=~\"__SELECTED_CGROUPS__\""
     } else {
-        ("sum", "name!~\"__SELECTED_CGROUPS__\"")
+        "name!~\"__SELECTED_CGROUPS__\""
     };
 
     let rate = |metric: &str| {

--- a/src/viewer/dashboard/cgroups.rs
+++ b/src/viewer/dashboard/cgroups.rs
@@ -1,10 +1,146 @@
 use super::*;
 
+/// Adds the standard cgroup metric plots for either aggregate or individual mode.
+///
+/// In aggregate mode, metrics are summed across non-selected cgroups.
+/// In individual mode, metrics are broken down by cgroup name.
+fn add_cgroup_metrics(group: &mut Group, individual: bool) {
+    let prefix = if individual {
+        "individual"
+    } else {
+        "aggregate"
+    };
+
+    // Build the query templates: aggregate uses sum(...{name!~}), individual uses sum by (name) (...{name=~})
+    let (agg_fn, filter) = if individual {
+        ("sum by (name) ", "name=~\"__SELECTED_CGROUPS__\"")
+    } else {
+        ("sum", "name!~\"__SELECTED_CGROUPS__\"")
+    };
+
+    let rate = |metric: &str| {
+        if individual {
+            format!("sum by (name) (irate({metric}{{{filter}}}[5m]))")
+        } else {
+            format!("sum(irate({metric}{{{filter}}}[5m]))")
+        }
+    };
+
+    // CPU Total Cores
+    group.plot_promql(
+        PlotOpts::counter(
+            "Total CPU Cores",
+            format!("{prefix}-total-cores"),
+            Unit::Count,
+        ),
+        format!("{} / 1000000000", rate("cgroup_cpu_usage")),
+    );
+
+    // CPU User Cores
+    group.plot_promql(
+        PlotOpts::counter("User CPU Cores", format!("{prefix}-user-cores"), Unit::Count),
+        if individual {
+            format!("sum by (name) (irate(cgroup_cpu_usage{{state=\"user\",{filter}}}[5m])) / 1000000000")
+        } else {
+            format!("sum(irate(cgroup_cpu_usage{{state=\"user\",{filter}}}[5m])) / 1000000000")
+        },
+    );
+
+    // CPU System Cores
+    group.plot_promql(
+        PlotOpts::counter(
+            "System CPU Cores",
+            format!("{prefix}-system-cores"),
+            Unit::Count,
+        ),
+        if individual {
+            format!("sum by (name) (irate(cgroup_cpu_usage{{state=\"system\",{filter}}}[5m])) / 1000000000")
+        } else {
+            format!("sum(irate(cgroup_cpu_usage{{state=\"system\",{filter}}}[5m])) / 1000000000")
+        },
+    );
+
+    // CPU Migrations
+    group.plot_promql(
+        PlotOpts::counter(
+            "CPU Migrations",
+            format!("{prefix}-cpu-migrations"),
+            Unit::Rate,
+        ),
+        rate("cgroup_cpu_migrations"),
+    );
+
+    // CPU Throttled Time
+    group.plot_promql(
+        PlotOpts::counter(
+            "CPU Throttled Time",
+            format!("{prefix}-cpu-throttled-time"),
+            Unit::Time,
+        ),
+        rate("cgroup_cpu_throttled_time"),
+    );
+
+    // IPC
+    group.plot_promql(
+        PlotOpts::counter("IPC", format!("{prefix}-ipc"), Unit::Count),
+        if individual {
+            format!("sum by (name) (irate(cgroup_cpu_instructions{{{filter}}}[5m])) / sum by (name) (irate(cgroup_cpu_cycles{{{filter}}}[5m]))")
+        } else {
+            format!("sum(irate(cgroup_cpu_instructions{{{filter}}}[5m])) / sum(irate(cgroup_cpu_cycles{{{filter}}}[5m]))")
+        },
+    );
+
+    // TLB Flushes
+    group.plot_promql(
+        PlotOpts::counter("TLB Flushes", format!("{prefix}-tlb-flush"), Unit::Rate),
+        rate("cgroup_cpu_tlb_flush"),
+    );
+
+    // Syscalls
+    group.plot_promql(
+        PlotOpts::counter("Syscalls", format!("{prefix}-syscall"), Unit::Rate),
+        rate("cgroup_syscall"),
+    );
+
+    // Per-syscall operation breakdown
+    for op in &[
+        "Read",
+        "Write",
+        "Poll",
+        "Socket",
+        "Lock",
+        "Time",
+        "Sleep",
+        "Yield",
+        "Filesystem",
+        "Memory",
+        "Process",
+        "Query",
+        "IPC",
+        "Timer",
+        "Event",
+        "Other",
+    ] {
+        let op_lower = op.to_lowercase();
+        group.plot_promql(
+            PlotOpts::counter(
+                format!("Syscall {op}"),
+                format!("{prefix}-syscall-{op_lower}"),
+                Unit::Rate,
+            ),
+            if individual {
+                format!("sum by (name) (irate(cgroup_syscall{{op=\"{op_lower}\",{filter}}}[5m]))")
+            } else {
+                format!("sum(irate(cgroup_syscall{{op=\"{op_lower}\",{filter}}}[5m]))")
+            },
+        );
+    }
+}
+
 pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections.clone());
 
     // Add metadata for cgroup selection UI
-    // This will be used by the frontend to build the selection interface
     view.metadata.insert(
         "cgroup_selector".to_string(),
         serde_json::json!({
@@ -22,191 +158,20 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         }),
     );
 
-    /*
-     * Aggregate (Left Side) - Sum of non-selected cgroups
-     */
-
+    // Aggregate (Left Side) - Sum of non-selected cgroups
     let mut aggregate = Group::new("Aggregate Cgroups", "aggregate");
     aggregate
         .metadata
         .insert("side".to_string(), serde_json::json!("left"));
-
-    // CPU Total Cores - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter("Total CPU Cores", "aggregate-total-cores", Unit::Count),
-        "sum(irate(cgroup_cpu_usage{name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
-    );
-
-    // CPU User Cores - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter("User CPU Cores", "aggregate-user-cores", Unit::Count),
-        "sum(irate(cgroup_cpu_usage{state=\"user\",name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
-    );
-
-    // CPU System Cores - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter("System CPU Cores", "aggregate-system-cores", Unit::Count),
-        "sum(irate(cgroup_cpu_usage{state=\"system\",name!~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
-    );
-
-    // CPU Migrations - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter("CPU Migrations", "aggregate-cpu-migrations", Unit::Rate),
-        "sum(irate(cgroup_cpu_migrations{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
-    );
-
-    // CPU Throttled Time - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter(
-            "CPU Throttled Time",
-            "aggregate-cpu-throttled-time",
-            Unit::Time,
-        ),
-        "sum(irate(cgroup_cpu_throttled_time{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
-    );
-
-    // IPC - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter("IPC", "aggregate-ipc", Unit::Count),
-        "sum(irate(cgroup_cpu_instructions{name!~\"__SELECTED_CGROUPS__\"}[5m])) / sum(irate(cgroup_cpu_cycles{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
-    );
-
-    // TLB Flushes - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter("TLB Flushes", "aggregate-tlb-flush", Unit::Rate),
-        "sum(irate(cgroup_cpu_tlb_flush{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
-    );
-
-    // Syscalls - aggregate of non-selected
-    aggregate.plot_promql(
-        PlotOpts::counter("Syscalls", "aggregate-syscall", Unit::Rate),
-        "sum(irate(cgroup_syscall{name!~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
-    );
-
-    // Per-syscall operation breakdown for aggregate (non-selected) cgroups
-    for op in &[
-        "Read",
-        "Write",
-        "Poll",
-        "Socket",
-        "Lock",
-        "Time",
-        "Sleep",
-        "Yield",
-        "Filesystem",
-        "Memory",
-        "Process",
-        "Query",
-        "IPC",
-        "Timer",
-        "Event",
-        "Other",
-    ] {
-        aggregate.plot_promql(
-            PlotOpts::counter(
-                format!("Syscall {op}"),
-                format!("aggregate-syscall-{}", op.to_lowercase()),
-                Unit::Rate,
-            ),
-            format!(
-                "sum(irate(cgroup_syscall{{op=\"{}\",name!~\"__SELECTED_CGROUPS__\"}}[5m]))",
-                op.to_lowercase()
-            ),
-        );
-    }
-
+    add_cgroup_metrics(&mut aggregate, false);
     view.group(aggregate);
 
-    /*
-     * Individual (Right Side) - Selected cgroups with one line per cgroup
-     */
-
+    // Individual (Right Side) - Selected cgroups with one line per cgroup
     let mut individual = Group::new("Individual Cgroups", "individual");
     individual
         .metadata
         .insert("side".to_string(), serde_json::json!("right"));
-
-    // CPU Total Cores - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter("Total CPU Cores", "individual-total-cores", Unit::Count),
-        "sum by (name) (irate(cgroup_cpu_usage{name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000"
-            .to_string(),
-    );
-
-    // CPU User Cores - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter("User CPU Cores", "individual-user-cores", Unit::Count),
-        "sum by (name) (irate(cgroup_cpu_usage{state=\"user\",name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
-    );
-
-    // CPU System Cores - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter("System CPU Cores", "individual-system-cores", Unit::Count),
-        "sum by (name) (irate(cgroup_cpu_usage{state=\"system\",name=~\"__SELECTED_CGROUPS__\"}[5m])) / 1000000000".to_string(),
-    );
-
-    // CPU Migrations - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter("CPU Migrations", "individual-cpu-migrations", Unit::Rate),
-        "sum by (name) (irate(cgroup_cpu_migrations{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
-            .to_string(),
-    );
-
-    // CPU Throttled Time - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter(
-            "CPU Throttled Time",
-            "individual-cpu-throttled-time",
-            Unit::Time,
-        ),
-        "sum by (name) (irate(cgroup_cpu_throttled_time{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
-            .to_string(),
-    );
-
-    // IPC - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter("IPC", "individual-ipc", Unit::Count),
-        "sum by (name) (irate(cgroup_cpu_instructions{name=~\"__SELECTED_CGROUPS__\"}[5m])) / sum by (name) (irate(cgroup_cpu_cycles{name=~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
-    );
-
-    // TLB Flushes - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter("TLB Flushes", "individual-tlb-flush", Unit::Rate),
-        "sum by (name) (irate(cgroup_cpu_tlb_flush{name=~\"__SELECTED_CGROUPS__\"}[5m]))"
-            .to_string(),
-    );
-
-    // Syscalls - per selected cgroup
-    individual.plot_promql(
-        PlotOpts::counter("Syscalls", "individual-syscall", Unit::Rate),
-        "sum by (name) (irate(cgroup_syscall{name=~\"__SELECTED_CGROUPS__\"}[5m]))".to_string(),
-    );
-
-    // Per-syscall operation breakdown for selected cgroups
-    for op in &[
-        "Read",
-        "Write",
-        "Poll",
-        "Socket",
-        "Lock",
-        "Time",
-        "Sleep",
-        "Yield",
-        "Filesystem",
-        "Memory",
-        "Process",
-        "Query",
-        "IPC",
-        "Timer",
-        "Event",
-        "Other",
-    ] {
-        individual.plot_promql(
-            PlotOpts::counter(format!("Syscall {op}"), format!("individual-syscall-{}", op.to_lowercase()), Unit::Rate),
-            format!("sum by (name) (irate(cgroup_syscall{{op=\"{}\",name=~\"__SELECTED_CGROUPS__\"}}[5m]))", op.to_lowercase()),
-        );
-    }
-
+    add_cgroup_metrics(&mut individual, true);
     view.group(individual);
 
     view

--- a/src/viewer/dashboard/cpu.rs
+++ b/src/viewer/dashboard/cpu.rs
@@ -11,14 +11,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Average CPU busy percentage across all cores
     utilization.plot_promql(
-        PlotOpts::line("Busy %", "busy-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy %", "busy-pct", Unit::Percentage).range(0.0, 1.0),
         "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU busy percentage heatmap
-    // cpu_heatmap("cpu_usage", ()) becomes: sum by (id) (irate(cpu_usage[5m])) / 1e9
     utilization.plot_promql(
-        PlotOpts::heatmap("Busy % (Per-CPU)", "busy-pct-per-cpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy % (Per-CPU)", "busy-pct-per-cpu", Unit::Percentage).range(0.0, 1.0),
         "sum by (id) (irate(cpu_usage[5m])) / 1000000000".to_string(),
     );
 
@@ -28,7 +27,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Average across all cores for this state
         utilization.plot_promql(
-            PlotOpts::line(
+            PlotOpts::counter(
                 format!("{capitalized} %"),
                 format!("{state}-pct"),
                 Unit::Percentage,
@@ -39,7 +38,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Per-CPU for this state
         utilization.plot_promql(
-            PlotOpts::heatmap(
+            PlotOpts::counter(
                 format!("{capitalized} % (Per-CPU)"),
                 format!("{state}-pct-per-cpu"),
                 Unit::Percentage,
@@ -59,13 +58,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // IPC (Instructions per Cycle)
     performance.plot_promql(
-        PlotOpts::line("Instructions per Cycle (IPC)", "ipc", Unit::Count),
+        PlotOpts::counter("Instructions per Cycle (IPC)", "ipc", Unit::Count),
         "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m]))".to_string(),
     );
 
     // Per-CPU IPC
     performance.plot_promql(
-        PlotOpts::heatmap("IPC (Per-CPU)", "ipc-per-cpu", Unit::Count),
+        PlotOpts::counter("IPC (Per-CPU)", "ipc-per-cpu", Unit::Count),
         "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m]))"
             .to_string(),
     );
@@ -73,38 +72,38 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     // IPNS (Instructions per Nanosecond)
     // Complex calculation: instructions / cycles * tsc * aperf / mperf / 1e9 / cores
     performance.plot_promql(
-        PlotOpts::line("Instructions per Nanosecond (IPNS)", "ipns", Unit::Count),
+        PlotOpts::counter("Instructions per Nanosecond (IPNS)", "ipns", Unit::Count),
         "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m])) * sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / 1000000000 / cpu_cores".to_string(),
     );
 
     // Per-CPU IPNS
     performance.plot_promql(
-        PlotOpts::heatmap("IPNS (Per-CPU)", "ipns-per-cpu", Unit::Count),
+        PlotOpts::counter("IPNS (Per-CPU)", "ipns-per-cpu", Unit::Count),
         "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m])) * sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m])) / 1000000000".to_string(),
     );
 
     // L3 Cache Hit Rate
     performance.plot_promql(
-        PlotOpts::line("L3 Hit %", "l3-hit", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("L3 Hit %", "l3-hit", Unit::Percentage).range(0.0, 1.0),
         "1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))".to_string(),
     );
 
     // Per-CPU L3 Hit Rate
     performance.plot_promql(
-        PlotOpts::heatmap("L3 Hit % (Per-CPU)", "l3-hit-per-cpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("L3 Hit % (Per-CPU)", "l3-hit-per-cpu", Unit::Percentage).range(0.0, 1.0),
         "1 - sum by (id) (irate(cpu_l3_miss[5m])) / sum by (id) (irate(cpu_l3_access[5m]))"
             .to_string(),
     );
 
     // CPU Frequency
     performance.plot_promql(
-        PlotOpts::line("Frequency", "frequency", Unit::Frequency),
+        PlotOpts::counter("Frequency", "frequency", Unit::Frequency),
         "sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / cpu_cores".to_string(),
     );
 
     // Per-CPU Frequency
     performance.plot_promql(
-        PlotOpts::heatmap("Frequency (Per-CPU)", "frequency-per-cpu", Unit::Frequency),
+        PlotOpts::counter("Frequency (Per-CPU)", "frequency-per-cpu", Unit::Frequency),
         "sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m]))".to_string(),
     );
 
@@ -118,14 +117,14 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Branch Misprediction Rate %
     branch.plot_promql(
-        PlotOpts::line("Misprediction Rate %", "branch-miss-rate", Unit::Percentage)
+        PlotOpts::counter("Misprediction Rate %", "branch-miss-rate", Unit::Percentage)
             .range(0.0, 1.0),
         "sum(irate(cpu_branch_misses[5m])) / sum(irate(cpu_branch_instructions[5m]))".to_string(),
     );
 
     // Per-CPU Branch Misprediction Rate
     branch.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::counter(
             "Misprediction Rate % (Per-CPU)",
             "branch-miss-rate-per-cpu",
             Unit::Percentage,
@@ -137,13 +136,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Branch Instructions per Second
     branch.plot_promql(
-        PlotOpts::line("Instructions", "branch-instructions", Unit::Rate),
+        PlotOpts::counter("Instructions", "branch-instructions", Unit::Rate),
         "sum(irate(cpu_branch_instructions[5m]))".to_string(),
     );
 
     // Per-CPU Branch Instructions
     branch.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::counter(
             "Instructions (Per-CPU)",
             "branch-instructions-per-cpu",
             Unit::Rate,
@@ -153,13 +152,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Branch Misses per Second
     branch.plot_promql(
-        PlotOpts::line("Misses", "branch-misses", Unit::Rate),
+        PlotOpts::counter("Misses", "branch-misses", Unit::Rate),
         "sum(irate(cpu_branch_misses[5m]))".to_string(),
     );
 
     // Per-CPU Branch Misses
     branch.plot_promql(
-        PlotOpts::heatmap("Misses (Per-CPU)", "branch-misses-per-cpu", Unit::Rate),
+        PlotOpts::counter("Misses (Per-CPU)", "branch-misses-per-cpu", Unit::Rate),
         "sum by (id) (irate(cpu_branch_misses[5m]))".to_string(),
     );
 
@@ -177,25 +176,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total DTLB Misses (aggregates all op labels)
     dtlb.plot_promql(
-        PlotOpts::line("Misses", "dtlb-misses", Unit::Rate),
+        PlotOpts::counter("Misses", "dtlb-misses", Unit::Rate),
         "sum(irate(cpu_dtlb_miss[5m]))".to_string(),
     );
 
     // Per-CPU DTLB Misses
     dtlb.plot_promql(
-        PlotOpts::heatmap("Misses (Per-CPU)", "dtlb-misses-per-cpu", Unit::Rate),
+        PlotOpts::counter("Misses (Per-CPU)", "dtlb-misses-per-cpu", Unit::Rate),
         "sum by (id) (irate(cpu_dtlb_miss[5m]))".to_string(),
     );
 
     // DTLB MPKI (Misses Per Kilo Instructions) - system-wide
     dtlb.plot_promql(
-        PlotOpts::line("MPKI", "dtlb-mpki", Unit::Count),
+        PlotOpts::counter("MPKI", "dtlb-mpki", Unit::Count),
         "sum(irate(cpu_dtlb_miss[5m])) / sum(irate(cpu_instructions[5m])) * 1000".to_string(),
     );
 
     // DTLB MPKI - per-CPU
     dtlb.plot_promql(
-        PlotOpts::heatmap("MPKI (Per-CPU)", "dtlb-mpki-per-cpu", Unit::Count),
+        PlotOpts::counter("MPKI (Per-CPU)", "dtlb-mpki-per-cpu", Unit::Count),
         "sum by (id) (irate(cpu_dtlb_miss[5m])) / sum by (id) (irate(cpu_instructions[5m])) * 1000"
             .to_string(),
     );
@@ -210,25 +209,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Migrations To
     migrations.plot_promql(
-        PlotOpts::line("To", "cpu-migrations-to", Unit::Rate),
+        PlotOpts::counter("To", "cpu-migrations-to", Unit::Rate),
         "sum(irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
     );
 
     // Per-CPU Migrations To
     migrations.plot_promql(
-        PlotOpts::heatmap("To (Per-CPU)", "cpu-migrations-to-per-cpu", Unit::Rate),
+        PlotOpts::counter("To (Per-CPU)", "cpu-migrations-to-per-cpu", Unit::Rate),
         "sum by (id) (irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
     );
 
     // Migrations From
     migrations.plot_promql(
-        PlotOpts::line("From", "cpu-migrations-from", Unit::Rate),
+        PlotOpts::counter("From", "cpu-migrations-from", Unit::Rate),
         "sum(irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
     );
 
     // Per-CPU Migrations From
     migrations.plot_promql(
-        PlotOpts::heatmap("From (Per-CPU)", "cpu-migrations-from-per-cpu", Unit::Rate),
+        PlotOpts::counter("From (Per-CPU)", "cpu-migrations-from-per-cpu", Unit::Rate),
         "sum by (id) (irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
     );
 
@@ -242,13 +241,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total TLB Flushes
     tlb.plot_promql(
-        PlotOpts::line("Total", "tlb-total", Unit::Rate),
+        PlotOpts::counter("Total", "tlb-total", Unit::Rate),
         "sum(irate(cpu_tlb_flush[5m]))".to_string(),
     );
 
     // Per-CPU TLB Flushes
     tlb.plot_promql(
-        PlotOpts::heatmap("Total (Per-CPU)", "tlb-total-per-cpu", Unit::Rate),
+        PlotOpts::counter("Total (Per-CPU)", "tlb-total-per-cpu", Unit::Rate),
         "sum by (id) (irate(cpu_tlb_flush[5m]))".to_string(),
     );
 
@@ -263,12 +262,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         let id = format!("tlb-{}", reason_value.replace('_', "-"));
 
         tlb.plot_promql(
-            PlotOpts::line(*label, &id, Unit::Rate),
+            PlotOpts::counter(*label, &id, Unit::Rate),
             format!("sum(irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
         );
 
         tlb.plot_promql(
-            PlotOpts::heatmap(
+            PlotOpts::counter(
                 format!("{label} (Per-CPU)"),
                 format!("{id}-per-cpu"),
                 Unit::Rate,

--- a/src/viewer/dashboard/cpu.rs
+++ b/src/viewer/dashboard/cpu.rs
@@ -11,13 +11,14 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Average CPU busy percentage across all cores
     utilization.plot_promql(
-        PlotOpts::counter("Busy %", "busy-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy %", "busy-pct", Unit::Percentage).percentage_range(),
         "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU busy percentage heatmap
     utilization.plot_promql(
-        PlotOpts::counter("Busy % (Per-CPU)", "busy-pct-per-cpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy % (Per-CPU)", "busy-pct-per-cpu", Unit::Percentage)
+            .percentage_range(),
         "sum by (id) (irate(cpu_usage[5m])) / 1000000000".to_string(),
     );
 
@@ -32,7 +33,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
                 format!("{state}-pct"),
                 Unit::Percentage,
             )
-            .range(0.0, 1.0),
+            .percentage_range(),
             format!("sum(irate(cpu_usage{{state=\"{state}\"}}[5m])) / cpu_cores / 1000000000"),
         );
 
@@ -43,7 +44,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
                 format!("{state}-pct-per-cpu"),
                 Unit::Percentage,
             )
-            .range(0.0, 1.0),
+            .percentage_range(),
             format!("sum by (id) (irate(cpu_usage{{state=\"{state}\"}}[5m])) / 1000000000"),
         );
     }
@@ -84,13 +85,14 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // L3 Cache Hit Rate
     performance.plot_promql(
-        PlotOpts::counter("L3 Hit %", "l3-hit", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("L3 Hit %", "l3-hit", Unit::Percentage).percentage_range(),
         "1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))".to_string(),
     );
 
     // Per-CPU L3 Hit Rate
     performance.plot_promql(
-        PlotOpts::counter("L3 Hit % (Per-CPU)", "l3-hit-per-cpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("L3 Hit % (Per-CPU)", "l3-hit-per-cpu", Unit::Percentage)
+            .percentage_range(),
         "1 - sum by (id) (irate(cpu_l3_miss[5m])) / sum by (id) (irate(cpu_l3_access[5m]))"
             .to_string(),
     );
@@ -118,7 +120,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     // Branch Misprediction Rate %
     branch.plot_promql(
         PlotOpts::counter("Misprediction Rate %", "branch-miss-rate", Unit::Percentage)
-            .range(0.0, 1.0),
+            .percentage_range(),
         "sum(irate(cpu_branch_misses[5m])) / sum(irate(cpu_branch_instructions[5m]))".to_string(),
     );
 
@@ -129,7 +131,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             "branch-miss-rate-per-cpu",
             Unit::Percentage,
         )
-        .range(0.0, 1.0),
+        .percentage_range(),
         "sum by (id) (irate(cpu_branch_misses[5m])) / sum by (id) (irate(cpu_branch_instructions[5m]))"
             .to_string(),
     );

--- a/src/viewer/dashboard/gpu.rs
+++ b/src/viewer/dashboard/gpu.rs
@@ -12,19 +12,19 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     // GPU compute utilization (average across all GPUs)
     // NVML returns 0-100, divide by 100 for 0-1 ratio expected by Unit::Percentage
     utilization.plot_promql(
-        PlotOpts::gauge("GPU %", "gpu-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU %", "gpu-pct", Unit::Percentage).percentage_range(),
         "avg(gpu_utilization) / 100".to_string(),
     );
 
     // Per-GPU utilization heatmap
     utilization.plot_promql(
-        PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage).percentage_range(),
         "sum by (id) (gpu_utilization) / 100".to_string(),
     );
 
     // Memory controller utilization (average)
     utilization.plot_promql(
-        PlotOpts::gauge("Memory Controller %", "mem-ctrl-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("Memory Controller %", "mem-ctrl-pct", Unit::Percentage).percentage_range(),
         "avg(gpu_memory_utilization) / 100".to_string(),
     );
 
@@ -35,7 +35,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             "mem-ctrl-pct-per-gpu",
             Unit::Percentage,
         )
-        .range(0.0, 1.0),
+        .percentage_range(),
         "sum by (id) (gpu_memory_utilization) / 100".to_string(),
     );
 
@@ -46,7 +46,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     // GPU tensor activity
     activity.plot_promql(
         PlotOpts::gauge("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage)
-            .range(0.0, 1.0),
+            .percentage_range(),
         "avg(gpu_tensor_utilization) / 100".to_string(),
     );
 
@@ -57,13 +57,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             "gpu-tensor-act-per-gpu",
             Unit::Percentage,
         )
-        .range(0.0, 1.0),
+        .percentage_range(),
         "sum by (id) (gpu_tensor_utilization) / 100".to_string(),
     );
 
     // GPU DRAM activity
     activity.plot_promql(
-        PlotOpts::gauge("GPU DRAM Activity %", "gpu-dram-act", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU DRAM Activity %", "gpu-dram-act", Unit::Percentage).percentage_range(),
         "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
     );
 
@@ -74,13 +74,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             "gpu-dram-act-per-gpu",
             Unit::Percentage,
         )
-        .range(0.0, 1.0),
+        .percentage_range(),
         "sum by (id) (gpu_dram_bandwidth_utilization) / 100".to_string(),
     );
 
     // GPU SM activity
     activity.plot_promql(
-        PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).percentage_range(),
         "avg(gpu_sm_utilization) / 100".to_string(),
     );
 
@@ -91,13 +91,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             "gpu-sm-act-per-gpu",
             Unit::Percentage,
         )
-        .range(0.0, 1.0),
+        .percentage_range(),
         "sum by (id) (gpu_sm_utilization) / 100".to_string(),
     );
 
     // GPU SM occupancy (active warps / max warps, average across all GPUs)
     activity.plot_promql(
-        PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage).percentage_range(),
         "avg(gpu_sm_occupancy) / 100".to_string(),
     );
 
@@ -108,7 +108,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             "gpu-sm-ocp-per-gpu",
             Unit::Percentage,
         )
-        .range(0.0, 1.0),
+        .percentage_range(),
         "sum by (id) (gpu_sm_occupancy) / 100".to_string(),
     );
 
@@ -146,7 +146,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Memory utilization percentage (calculated)
     memory.plot_promql(
-        PlotOpts::gauge("Utilization %", "mem-util-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("Utilization %", "mem-util-pct", Unit::Percentage).percentage_range(),
         "sum(gpu_memory{state=\"used\"}) / (sum(gpu_memory{state=\"used\"}) + sum(gpu_memory{state=\"free\"}))".to_string(),
     );
 

--- a/src/viewer/dashboard/gpu.rs
+++ b/src/viewer/dashboard/gpu.rs
@@ -12,25 +12,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     // GPU compute utilization (average across all GPUs)
     // NVML returns 0-100, divide by 100 for 0-1 ratio expected by Unit::Percentage
     utilization.plot_promql(
-        PlotOpts::line("GPU %", "gpu-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU %", "gpu-pct", Unit::Percentage).range(0.0, 1.0),
         "avg(gpu_utilization) / 100".to_string(),
     );
 
     // Per-GPU utilization heatmap
     utilization.plot_promql(
-        PlotOpts::heatmap("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage).range(0.0, 1.0),
         "sum by (id) (gpu_utilization) / 100".to_string(),
     );
 
     // Memory controller utilization (average)
     utilization.plot_promql(
-        PlotOpts::line("Memory Controller %", "mem-ctrl-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("Memory Controller %", "mem-ctrl-pct", Unit::Percentage).range(0.0, 1.0),
         "avg(gpu_memory_utilization) / 100".to_string(),
     );
 
     // Per-GPU memory controller utilization
     utilization.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::gauge(
             "Memory Controller % (Per-GPU)",
             "mem-ctrl-pct-per-gpu",
             Unit::Percentage,
@@ -45,13 +45,14 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // GPU tensor activity
     activity.plot_promql(
-        PlotOpts::line("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage)
+            .range(0.0, 1.0),
         "avg(gpu_tensor_utilization) / 100".to_string(),
     );
 
     // Per-GPU GPU tensor activity
     activity.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::gauge(
             "GPU Tensor Activity % (Per-GPU)",
             "gpu-tensor-act-per-gpu",
             Unit::Percentage,
@@ -62,13 +63,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // GPU DRAM activity
     activity.plot_promql(
-        PlotOpts::line("GPU DRAM Activity %", "gpu-dram-act", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU DRAM Activity %", "gpu-dram-act", Unit::Percentage).range(0.0, 1.0),
         "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
     );
 
     // Per-GPU GPU DRAM activity
     activity.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::gauge(
             "GPU DRAM Activity % (Per-GPU)",
             "gpu-dram-act-per-gpu",
             Unit::Percentage,
@@ -79,13 +80,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // GPU SM activity
     activity.plot_promql(
-        PlotOpts::line("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).range(0.0, 1.0),
         "avg(gpu_sm_utilization) / 100".to_string(),
     );
 
     // Per-GPU GPU SM activity
     activity.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::gauge(
             "GPU SM Activity % (Per-GPU)",
             "gpu-sm-act-per-gpu",
             Unit::Percentage,
@@ -96,13 +97,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // GPU SM occupancy (active warps / max warps, average across all GPUs)
     activity.plot_promql(
-        PlotOpts::line("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage).range(0.0, 1.0),
         "avg(gpu_sm_occupancy) / 100".to_string(),
     );
 
     // Per-GPU GPU SM occupancy
     activity.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::gauge(
             "GPU SM Occupancy % (Per-GPU)",
             "gpu-sm-ocp-per-gpu",
             Unit::Percentage,
@@ -121,31 +122,31 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total memory used (sum across all GPUs)
     memory.plot_promql(
-        PlotOpts::line("Used", "mem-used", Unit::Bytes),
+        PlotOpts::gauge("Used", "mem-used", Unit::Bytes),
         "sum(gpu_memory{state=\"used\"})".to_string(),
     );
 
     // Per-GPU memory used
     memory.plot_promql(
-        PlotOpts::heatmap("Used (Per-GPU)", "mem-used-per-gpu", Unit::Bytes),
+        PlotOpts::gauge("Used (Per-GPU)", "mem-used-per-gpu", Unit::Bytes),
         "sum by (id) (gpu_memory{state=\"used\"})".to_string(),
     );
 
     // Total memory free (sum across all GPUs)
     memory.plot_promql(
-        PlotOpts::line("Free", "mem-free", Unit::Bytes),
+        PlotOpts::gauge("Free", "mem-free", Unit::Bytes),
         "sum(gpu_memory{state=\"free\"})".to_string(),
     );
 
     // Per-GPU memory free
     memory.plot_promql(
-        PlotOpts::heatmap("Free (Per-GPU)", "mem-free-per-gpu", Unit::Bytes),
+        PlotOpts::gauge("Free (Per-GPU)", "mem-free-per-gpu", Unit::Bytes),
         "sum by (id) (gpu_memory{state=\"free\"})".to_string(),
     );
 
     // Memory utilization percentage (calculated)
     memory.plot_promql(
-        PlotOpts::line("Utilization %", "mem-util-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("Utilization %", "mem-util-pct", Unit::Percentage).range(0.0, 1.0),
         "sum(gpu_memory{state=\"used\"}) / (sum(gpu_memory{state=\"used\"}) + sum(gpu_memory{state=\"free\"}))".to_string(),
     );
 
@@ -159,20 +160,20 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total power usage (sum across all GPUs, convert mW to W)
     power.plot_promql(
-        PlotOpts::line("Power (W)", "power-watts", Unit::Count).with_axis_label("Watts"),
+        PlotOpts::gauge("Power (W)", "power-watts", Unit::Count).with_axis_label("Watts"),
         "sum(gpu_power_usage) / 1000".to_string(),
     );
 
     // Per-GPU power usage (in Watts)
     power.plot_promql(
-        PlotOpts::heatmap("Power (Per-GPU)", "power-watts-per-gpu", Unit::Count)
+        PlotOpts::gauge("Power (Per-GPU)", "power-watts-per-gpu", Unit::Count)
             .with_axis_label("Watts"),
         "sum by (id) (gpu_power_usage) / 1000".to_string(),
     );
 
     // Energy consumption rate (convert mJ counter to Watts via rate)
     power.plot_promql(
-        PlotOpts::line("Energy Rate (W)", "energy-rate", Unit::Count).with_axis_label("Watts"),
+        PlotOpts::counter("Energy Rate (W)", "energy-rate", Unit::Count).with_axis_label("Watts"),
         "sum(rate(gpu_energy_consumption[5m])) / 1000".to_string(),
     );
 
@@ -186,20 +187,19 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Average temperature across all GPUs
     thermal.plot_promql(
-        PlotOpts::line("Average (°C)", "temp-avg", Unit::Count).with_axis_label("°C"),
+        PlotOpts::gauge("Average (°C)", "temp-avg", Unit::Count).with_axis_label("°C"),
         "avg(gpu_temperature)".to_string(),
     );
 
     // Max temperature across all GPUs
     thermal.plot_promql(
-        PlotOpts::line("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
+        PlotOpts::gauge("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
         "max(gpu_temperature)".to_string(),
     );
 
     // Per-GPU temperature
     thermal.plot_promql(
-        PlotOpts::heatmap("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count)
-            .with_axis_label("°C"),
+        PlotOpts::gauge("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count).with_axis_label("°C"),
         "sum by (id) (gpu_temperature)".to_string(),
     );
 
@@ -213,13 +213,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Graphics clock (average)
     clocks.plot_promql(
-        PlotOpts::line("Graphics", "clock-graphics", Unit::Frequency),
+        PlotOpts::gauge("Graphics", "clock-graphics", Unit::Frequency),
         "avg(gpu_clock{clock=\"graphics\"})".to_string(),
     );
 
     // Per-GPU graphics clock
     clocks.plot_promql(
-        PlotOpts::heatmap(
+        PlotOpts::gauge(
             "Graphics (Per-GPU)",
             "clock-graphics-per-gpu",
             Unit::Frequency,
@@ -229,25 +229,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Memory clock (average)
     clocks.plot_promql(
-        PlotOpts::line("Memory", "clock-memory", Unit::Frequency),
+        PlotOpts::gauge("Memory", "clock-memory", Unit::Frequency),
         "avg(gpu_clock{clock=\"memory\"})".to_string(),
     );
 
     // Per-GPU memory clock
     clocks.plot_promql(
-        PlotOpts::heatmap("Memory (Per-GPU)", "clock-memory-per-gpu", Unit::Frequency),
+        PlotOpts::gauge("Memory (Per-GPU)", "clock-memory-per-gpu", Unit::Frequency),
         "sum by (id) (gpu_clock{clock=\"memory\"})".to_string(),
     );
 
     // Compute clock (average)
     clocks.plot_promql(
-        PlotOpts::line("Compute", "clock-compute", Unit::Frequency),
+        PlotOpts::gauge("Compute", "clock-compute", Unit::Frequency),
         "avg(gpu_clock{clock=\"compute\"})".to_string(),
     );
 
     // Video clock (average)
     clocks.plot_promql(
-        PlotOpts::line("Video", "clock-video", Unit::Frequency),
+        PlotOpts::gauge("Video", "clock-video", Unit::Frequency),
         "avg(gpu_clock{clock=\"video\"})".to_string(),
     );
 
@@ -261,31 +261,31 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // PCIe bandwidth (max theoretical)
     pcie.plot_promql(
-        PlotOpts::line("Bandwidth", "pcie-bandwidth", Unit::Datarate),
+        PlotOpts::gauge("Bandwidth", "pcie-bandwidth", Unit::Datarate),
         "sum(gpu_pcie_bandwidth)".to_string(),
     );
 
     // PCIe receive throughput (total)
     pcie.plot_promql(
-        PlotOpts::line("Receive", "pcie-rx", Unit::Datarate),
+        PlotOpts::gauge("Receive", "pcie-rx", Unit::Datarate),
         "sum(gpu_pcie_throughput{direction=\"receive\"})".to_string(),
     );
 
     // Per-GPU receive throughput
     pcie.plot_promql(
-        PlotOpts::heatmap("Receive (Per-GPU)", "pcie-rx-per-gpu", Unit::Datarate),
+        PlotOpts::gauge("Receive (Per-GPU)", "pcie-rx-per-gpu", Unit::Datarate),
         "sum by (id) (gpu_pcie_throughput{direction=\"receive\"})".to_string(),
     );
 
     // PCIe transmit throughput (total)
     pcie.plot_promql(
-        PlotOpts::line("Transmit", "pcie-tx", Unit::Datarate),
+        PlotOpts::gauge("Transmit", "pcie-tx", Unit::Datarate),
         "sum(gpu_pcie_throughput{direction=\"transmit\"})".to_string(),
     );
 
     // Per-GPU transmit throughput
     pcie.plot_promql(
-        PlotOpts::heatmap("Transmit (Per-GPU)", "pcie-tx-per-gpu", Unit::Datarate),
+        PlotOpts::gauge("Transmit (Per-GPU)", "pcie-tx-per-gpu", Unit::Datarate),
         "sum by (id) (gpu_pcie_throughput{direction=\"transmit\"})".to_string(),
     );
 

--- a/src/viewer/dashboard/memory.rs
+++ b/src/viewer/dashboard/memory.rs
@@ -11,43 +11,43 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total memory
     usage.plot_promql(
-        PlotOpts::line("Total", "total", Unit::Bytes),
+        PlotOpts::gauge("Total", "total", Unit::Bytes),
         "memory_total".to_string(),
     );
 
     // Available memory - memory available for allocation
     usage.plot_promql(
-        PlotOpts::line("Available", "available", Unit::Bytes),
+        PlotOpts::gauge("Available", "available", Unit::Bytes),
         "memory_available".to_string(),
     );
 
     // Free memory - completely unused memory
     usage.plot_promql(
-        PlotOpts::line("Free", "free", Unit::Bytes),
+        PlotOpts::gauge("Free", "free", Unit::Bytes),
         "memory_free".to_string(),
     );
 
     // Buffers - memory used for file buffers
     usage.plot_promql(
-        PlotOpts::line("Buffers", "buffers", Unit::Bytes),
+        PlotOpts::gauge("Buffers", "buffers", Unit::Bytes),
         "memory_buffers".to_string(),
     );
 
     // Cached - memory used by page cache
     usage.plot_promql(
-        PlotOpts::line("Cached", "cached", Unit::Bytes),
+        PlotOpts::gauge("Cached", "cached", Unit::Bytes),
         "memory_cached".to_string(),
     );
 
     // Memory used (calculated)
     usage.plot_promql(
-        PlotOpts::line("Used", "used", Unit::Bytes),
+        PlotOpts::gauge("Used", "used", Unit::Bytes),
         "memory_total - memory_available".to_string(),
     );
 
     // Memory utilization percentage
     usage.plot_promql(
-        PlotOpts::line("Utilization %", "utilization-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("Utilization %", "utilization-pct", Unit::Percentage).range(0.0, 1.0),
         "(memory_total - memory_available) / memory_total".to_string(),
     );
 
@@ -61,13 +61,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Local allocations - fast (same NUMA node)
     numa.plot_promql(
-        PlotOpts::line("Local Rate", "numa-local-rate", Unit::Rate),
+        PlotOpts::counter("Local Rate", "numa-local-rate", Unit::Rate),
         "rate(memory_numa_local[5m])".to_string(),
     );
 
     // Remote allocations - slow (cross-node access)
     numa.plot_promql(
-        PlotOpts::line("Remote Rate", "numa-remote-rate", Unit::Rate),
+        PlotOpts::counter("Remote Rate", "numa-remote-rate", Unit::Rate),
         "rate(memory_numa_foreign[5m])".to_string(),
     );
 

--- a/src/viewer/dashboard/memory.rs
+++ b/src/viewer/dashboard/memory.rs
@@ -47,7 +47,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Memory utilization percentage
     usage.plot_promql(
-        PlotOpts::gauge("Utilization %", "utilization-pct", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::gauge("Utilization %", "utilization-pct", Unit::Percentage).percentage_range(),
         "(memory_total - memory_available) / memory_total".to_string(),
     );
 

--- a/src/viewer/dashboard/network.rs
+++ b/src/viewer/dashboard/network.rs
@@ -65,16 +65,9 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // TCP Packet Latency percentiles - p50, p90, p99, p99.9
     tcp.plot_promql(
-        PlotOpts::histogram(
-            "TCP Packet Latency",
-            "tcp-packet-latency",
-            Unit::Time,
-            "percentiles",
-        )
-        .with_axis_label("Latency")
-        .with_unit_system("time")
-        .with_log_scale(true)
-        .range(0.0, 100_000_000_000.0),
+        PlotOpts::histogram_latency("TCP Packet Latency", "tcp-packet-latency")
+            .with_axis_label("Latency")
+            .with_unit_system("time"),
         "tcp_packet_latency".to_string(),
     );
 

--- a/src/viewer/dashboard/network.rs
+++ b/src/viewer/dashboard/network.rs
@@ -11,27 +11,27 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Bandwidth Transmit (convert bytes/sec to bits/sec)
     traffic.plot_promql(
-        PlotOpts::line("Bandwidth Transmit", "bandwidth-tx", Unit::Bitrate)
+        PlotOpts::counter("Bandwidth Transmit", "bandwidth-tx", Unit::Bitrate)
             .with_unit_system("bitrate"),
         "sum(irate(network_bytes{direction=\"transmit\"}[5m])) * 8".to_string(),
     );
 
     // Bandwidth Receive (convert bytes/sec to bits/sec)
     traffic.plot_promql(
-        PlotOpts::line("Bandwidth Receive", "bandwidth-rx", Unit::Bitrate)
+        PlotOpts::counter("Bandwidth Receive", "bandwidth-rx", Unit::Bitrate)
             .with_unit_system("bitrate"),
         "sum(irate(network_bytes{direction=\"receive\"}[5m])) * 8".to_string(),
     );
 
     // Packets Transmit
     traffic.plot_promql(
-        PlotOpts::line("Packets Transmit", "packets-tx", Unit::Rate),
+        PlotOpts::counter("Packets Transmit", "packets-tx", Unit::Rate),
         "sum(irate(network_packets{direction=\"transmit\"}[5m]))".to_string(),
     );
 
     // Packets Receive
     traffic.plot_promql(
-        PlotOpts::line("Packets Receive", "packets-rx", Unit::Rate),
+        PlotOpts::counter("Packets Receive", "packets-rx", Unit::Rate),
         "sum(irate(network_packets{direction=\"receive\"}[5m]))".to_string(),
     );
 
@@ -45,13 +45,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Network packet drops - dropped packets at network layer
     errors.plot_promql(
-        PlotOpts::line("Packet Drops", "packet-drops", Unit::Rate),
+        PlotOpts::counter("Packet Drops", "packet-drops", Unit::Rate),
         "sum(irate(network_drop[5m]))".to_string(),
     );
 
     // TCP retransmits - retransmitted TCP packets (key health indicator)
     errors.plot_promql(
-        PlotOpts::line("TCP Retransmits", "tcp-retransmits", Unit::Rate),
+        PlotOpts::counter("TCP Retransmits", "tcp-retransmits", Unit::Rate),
         "sum(irate(tcp_retransmit[5m]))".to_string(),
     );
 
@@ -64,15 +64,18 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     let mut tcp = Group::new("TCP", "tcp");
 
     // TCP Packet Latency percentiles - p50, p90, p99, p99.9
-    // Use the efficient histogram_percentiles() function to compute all percentiles in one pass
-    // Note: histogram_percentiles works directly on histogram data, not on irate() results
     tcp.plot_promql(
-        PlotOpts::scatter("TCP Packet Latency", "tcp-packet-latency", Unit::Time)
-            .with_axis_label("Latency")
-            .with_unit_system("time")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999], tcp_packet_latency)".to_string(),
+        PlotOpts::histogram(
+            "TCP Packet Latency",
+            "tcp-packet-latency",
+            Unit::Time,
+            "percentiles",
+        )
+        .with_axis_label("Latency")
+        .with_unit_system("time")
+        .with_log_scale(true)
+        .range(0.0, 100_000_000_000.0),
+        "tcp_packet_latency".to_string(),
     );
 
     view.group(tcp);

--- a/src/viewer/dashboard/overview.rs
+++ b/src/viewer/dashboard/overview.rs
@@ -11,13 +11,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Average CPU busy percentage
     cpu.plot_promql(
-        PlotOpts::counter("Busy %", "cpu-busy", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy %", "cpu-busy", Unit::Percentage).percentage_range(),
         "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU busy percentage heatmap
     cpu.plot_promql(
-        PlotOpts::counter("Busy %", "cpu-busy-heatmap", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy %", "cpu-busy-heatmap", Unit::Percentage).percentage_range(),
         "sum by (id) (irate(cpu_usage[5m])) / 1000000000".to_string(),
     );
 
@@ -65,16 +65,9 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // TCP packet latency percentiles
     network.plot_promql(
-        PlotOpts::histogram(
-            "TCP Packet Latency",
-            "tcp-packet-latency",
-            Unit::Time,
-            "percentiles",
-        )
-        .with_axis_label("Latency")
-        .with_unit_system("time")
-        .with_log_scale(true)
-        .range(0.0, 100_000_000_000.0),
+        PlotOpts::histogram_latency("TCP Packet Latency", "tcp-packet-latency")
+            .with_axis_label("Latency")
+            .with_unit_system("time"),
         "tcp_packet_latency".to_string(),
     );
 
@@ -88,16 +81,9 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Runqueue latency percentiles
     scheduler.plot_promql(
-        PlotOpts::histogram(
-            "Runqueue Latency",
-            "scheduler-runqueue-latency",
-            Unit::Time,
-            "percentiles",
-        )
-        .with_axis_label("Latency")
-        .with_unit_system("time")
-        .with_log_scale(true)
-        .range(0.0, 100_000_000_000.0),
+        PlotOpts::histogram_latency("Runqueue Latency", "scheduler-runqueue-latency")
+            .with_axis_label("Latency")
+            .with_unit_system("time"),
         "scheduler_runqueue_latency".to_string(),
     );
 
@@ -117,9 +103,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Syscall latency percentiles
     syscall.plot_promql(
-        PlotOpts::histogram("Total", "syscall-total-latency", Unit::Time, "percentiles")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
+        PlotOpts::histogram_latency("Total", "syscall-total-latency"),
         "syscall_latency".to_string(),
     );
 
@@ -145,13 +129,14 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Average CPU % spent in softirq
     softirq.plot_promql(
-        PlotOpts::counter("CPU %", "softirq-total-time", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time", Unit::Percentage).percentage_range(),
         "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU % spent in softirq heatmap
     softirq.plot_promql(
-        PlotOpts::counter("CPU %", "softirq-total-time-heatmap", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time-heatmap", Unit::Percentage)
+            .percentage_range(),
         "sum by (id) (irate(softirq_time[5m])) / 1000000000".to_string(),
     );
 

--- a/src/viewer/dashboard/overview.rs
+++ b/src/viewer/dashboard/overview.rs
@@ -11,13 +11,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Average CPU busy percentage
     cpu.plot_promql(
-        PlotOpts::line("Busy %", "cpu-busy", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy %", "cpu-busy", Unit::Percentage).range(0.0, 1.0),
         "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU busy percentage heatmap
     cpu.plot_promql(
-        PlotOpts::heatmap("Busy %", "cpu-busy-heatmap", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("Busy %", "cpu-busy-heatmap", Unit::Percentage).range(0.0, 1.0),
         "sum by (id) (irate(cpu_usage[5m])) / 1000000000".to_string(),
     );
 
@@ -31,7 +31,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Transmit bandwidth
     network.plot_promql(
-        PlotOpts::line(
+        PlotOpts::counter(
             "Transmit Bandwidth",
             "network-transmit-bandwidth",
             Unit::Bitrate,
@@ -42,7 +42,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Receive bandwidth
     network.plot_promql(
-        PlotOpts::line(
+        PlotOpts::counter(
             "Receive Bandwidth",
             "network-receive-bandwidth",
             Unit::Bitrate,
@@ -53,24 +53,29 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Transmit packets
     network.plot_promql(
-        PlotOpts::line("Transmit Packets", "network-transmit-packets", Unit::Rate),
+        PlotOpts::counter("Transmit Packets", "network-transmit-packets", Unit::Rate),
         "sum(irate(network_packets{direction=\"transmit\"}[5m]))".to_string(),
     );
 
     // Receive packets
     network.plot_promql(
-        PlotOpts::line("Receive Packets", "network-receive-packets", Unit::Rate),
+        PlotOpts::counter("Receive Packets", "network-receive-packets", Unit::Rate),
         "sum(irate(network_packets{direction=\"receive\"}[5m]))".to_string(),
     );
 
     // TCP packet latency percentiles
     network.plot_promql(
-        PlotOpts::scatter("TCP Packet Latency", "tcp-packet-latency", Unit::Time)
-            .with_axis_label("Latency")
-            .with_unit_system("time")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], tcp_packet_latency)".to_string(),
+        PlotOpts::histogram(
+            "TCP Packet Latency",
+            "tcp-packet-latency",
+            Unit::Time,
+            "percentiles",
+        )
+        .with_axis_label("Latency")
+        .with_unit_system("time")
+        .with_log_scale(true)
+        .range(0.0, 100_000_000_000.0),
+        "tcp_packet_latency".to_string(),
     );
 
     view.group(network);
@@ -83,13 +88,17 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Runqueue latency percentiles
     scheduler.plot_promql(
-        PlotOpts::scatter("Runqueue Latency", "scheduler-runqueue-latency", Unit::Time)
-            .with_axis_label("Latency")
-            .with_unit_system("time")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_runqueue_latency)"
-            .to_string(),
+        PlotOpts::histogram(
+            "Runqueue Latency",
+            "scheduler-runqueue-latency",
+            Unit::Time,
+            "percentiles",
+        )
+        .with_axis_label("Latency")
+        .with_unit_system("time")
+        .with_log_scale(true)
+        .range(0.0, 100_000_000_000.0),
+        "scheduler_runqueue_latency".to_string(),
     );
 
     view.group(scheduler);
@@ -102,16 +111,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total syscall rate
     syscall.plot_promql(
-        PlotOpts::line("Total", "syscall-total", Unit::Rate),
+        PlotOpts::counter("Total", "syscall-total", Unit::Rate),
         "sum(irate(syscall[5m]))".to_string(),
     );
 
     // Syscall latency percentiles
     syscall.plot_promql(
-        PlotOpts::scatter("Total", "syscall-total-latency", Unit::Time)
+        PlotOpts::histogram("Total", "syscall-total-latency", Unit::Time, "percentiles")
             .with_log_scale(true)
             .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency)".to_string(),
+        "syscall_latency".to_string(),
     );
 
     view.group(syscall);
@@ -124,25 +133,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total softirq rate
     softirq.plot_promql(
-        PlotOpts::line("Rate", "softirq-total-rate", Unit::Rate),
+        PlotOpts::counter("Rate", "softirq-total-rate", Unit::Rate),
         "sum(irate(softirq[5m]))".to_string(),
     );
 
     // Per-CPU softirq rate heatmap
     softirq.plot_promql(
-        PlotOpts::heatmap("Rate", "softirq-total-rate-heatmap", Unit::Rate),
+        PlotOpts::counter("Rate", "softirq-total-rate-heatmap", Unit::Rate),
         "sum by (id) (irate(softirq[5m]))".to_string(),
     );
 
     // Average CPU % spent in softirq
     softirq.plot_promql(
-        PlotOpts::line("CPU %", "softirq-total-time", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time", Unit::Percentage).range(0.0, 1.0),
         "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU % spent in softirq heatmap
     softirq.plot_promql(
-        PlotOpts::heatmap("CPU %", "softirq-total-time-heatmap", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time-heatmap", Unit::Percentage).range(0.0, 1.0),
         "sum by (id) (irate(softirq_time[5m])) / 1000000000".to_string(),
     );
 
@@ -156,13 +165,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Read throughput
     blockio.plot_promql(
-        PlotOpts::line("Read Throughput", "blockio-throughput-read", Unit::Datarate),
+        PlotOpts::counter("Read Throughput", "blockio-throughput-read", Unit::Datarate),
         "sum(irate(blockio_bytes{op=\"read\"}[5m]))".to_string(),
     );
 
     // Write throughput
     blockio.plot_promql(
-        PlotOpts::line(
+        PlotOpts::counter(
             "Write Throughput",
             "blockio-throughput-write",
             Unit::Datarate,
@@ -172,13 +181,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Read IOPS
     blockio.plot_promql(
-        PlotOpts::line("Read IOPS", "blockio-iops-read", Unit::Count),
+        PlotOpts::counter("Read IOPS", "blockio-iops-read", Unit::Count),
         "sum(irate(blockio_operations{op=\"read\"}[5m]))".to_string(),
     );
 
     // Write IOPS
     blockio.plot_promql(
-        PlotOpts::line("Write IOPS", "blockio-iops-write", Unit::Count),
+        PlotOpts::counter("Write IOPS", "blockio-iops-write", Unit::Count),
         "sum(irate(blockio_operations{op=\"write\"}[5m]))".to_string(),
     );
 

--- a/src/viewer/dashboard/rezolus.rs
+++ b/src/viewer/dashboard/rezolus.rs
@@ -11,38 +11,38 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Rezolus CPU usage percentage
     rezolus.plot_promql(
-        PlotOpts::line("CPU %", "cpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "cpu", Unit::Percentage).range(0.0, 1.0),
         "sum(irate(rezolus_cpu_usage[5m])) / 1000000000".to_string(),
     );
 
     // Rezolus memory usage (RSS)
     rezolus.plot_promql(
-        PlotOpts::line("Memory (RSS)", "memory", Unit::Bytes),
+        PlotOpts::gauge("Memory (RSS)", "memory", Unit::Bytes),
         "sum(rezolus_memory_usage_resident_set_size)".to_string(),
     );
 
     // IPC for rezolus.service cgroup
     rezolus.plot_promql(
-        PlotOpts::line("IPC", "ipc", Unit::Count),
+        PlotOpts::counter("IPC", "ipc", Unit::Count),
         "sum(irate(cgroup_cpu_instructions{name=\"/system.slice/rezolus.service\"}[5m])) / sum(irate(cgroup_cpu_cycles{name=\"/system.slice/rezolus.service\"}[5m]))".to_string(),
     );
 
     // Syscalls for rezolus.service cgroup
     rezolus.plot_promql(
-        PlotOpts::line("Syscalls", "syscalls", Unit::Rate),
+        PlotOpts::counter("Syscalls", "syscalls", Unit::Rate),
         "sum(irate(cgroup_syscall{name=\"/system.slice/rezolus.service\"}[5m]))".to_string(),
     );
 
     // Total BPF overhead
     rezolus.plot_promql(
-        PlotOpts::line("Total BPF Overhead", "bpf-overhead", Unit::Count),
+        PlotOpts::counter("Total BPF Overhead", "bpf-overhead", Unit::Count),
         "sum(irate(rezolus_bpf_run_time[5m])) / 1000000000".to_string(),
     );
 
     // BPF Per-Sampler Overhead
     // Using sum by (sampler) to group by sampler, then we get multiple series
     rezolus.plot_promql(
-        PlotOpts::multi(
+        PlotOpts::counter(
             "BPF Per-Sampler Overhead",
             "bpf-sampler-overhead",
             Unit::Count,
@@ -52,7 +52,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // BPF Per-Sampler Execution Time (run_time / run_count per sampler)
     rezolus.plot_promql(
-        PlotOpts::multi(
+        PlotOpts::counter(
             "BPF Per-Sampler Execution Time",
             "bpf-execution-time",
             Unit::Time,

--- a/src/viewer/dashboard/rezolus.rs
+++ b/src/viewer/dashboard/rezolus.rs
@@ -11,7 +11,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Rezolus CPU usage percentage
     rezolus.plot_promql(
-        PlotOpts::counter("CPU %", "cpu", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "cpu", Unit::Percentage).percentage_range(),
         "sum(irate(rezolus_cpu_usage[5m])) / 1000000000".to_string(),
     );
 

--- a/src/viewer/dashboard/scheduler.rs
+++ b/src/viewer/dashboard/scheduler.rs
@@ -11,36 +11,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Runqueue Latency percentiles - p50, p90, p99, p99.9, p99.99
     scheduler.plot_promql(
-        PlotOpts::histogram(
-            "Runqueue Latency",
-            "scheduler-runqueue-latency",
-            Unit::Time,
-            "percentiles",
-        )
-        .with_axis_label("Latency")
-        .with_unit_system("time")
-        .with_log_scale(true)
-        .range(0.0, 100_000_000_000.0),
+        PlotOpts::histogram_latency("Runqueue Latency", "scheduler-runqueue-latency")
+            .with_axis_label("Latency")
+            .with_unit_system("time"),
         "scheduler_runqueue_latency".to_string(),
     );
 
     // Off CPU Time percentiles
     scheduler.plot_promql(
-        PlotOpts::histogram("Off CPU Time", "off-cpu-time", Unit::Time, "percentiles")
+        PlotOpts::histogram_latency("Off CPU Time", "off-cpu-time")
             .with_axis_label("Time")
-            .with_unit_system("time")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
+            .with_unit_system("time"),
         "scheduler_offcpu".to_string(),
     );
 
     // Running Time percentiles
     scheduler.plot_promql(
-        PlotOpts::histogram("Running Time", "running-time", Unit::Time, "percentiles")
+        PlotOpts::histogram_latency("Running Time", "running-time")
             .with_axis_label("Time")
-            .with_unit_system("time")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
+            .with_unit_system("time"),
         "scheduler_running".to_string(),
     );
 

--- a/src/viewer/dashboard/scheduler.rs
+++ b/src/viewer/dashboard/scheduler.rs
@@ -11,40 +11,42 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Runqueue Latency percentiles - p50, p90, p99, p99.9, p99.99
     scheduler.plot_promql(
-        PlotOpts::scatter("Runqueue Latency", "scheduler-runqueue-latency", Unit::Time)
-            .with_axis_label("Latency")
-            .with_unit_system("time")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_runqueue_latency)"
-            .to_string(),
+        PlotOpts::histogram(
+            "Runqueue Latency",
+            "scheduler-runqueue-latency",
+            Unit::Time,
+            "percentiles",
+        )
+        .with_axis_label("Latency")
+        .with_unit_system("time")
+        .with_log_scale(true)
+        .range(0.0, 100_000_000_000.0),
+        "scheduler_runqueue_latency".to_string(),
     );
 
     // Off CPU Time percentiles
     scheduler.plot_promql(
-        PlotOpts::scatter("Off CPU Time", "off-cpu-time", Unit::Time)
+        PlotOpts::histogram("Off CPU Time", "off-cpu-time", Unit::Time, "percentiles")
             .with_axis_label("Time")
             .with_unit_system("time")
             .with_log_scale(true)
             .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_offcpu)".to_string(),
+        "scheduler_offcpu".to_string(),
     );
 
     // Running Time percentiles
-    // Note: Original code seems to have a bug using scheduler_offcpu for running time,
-    // keeping it for compatibility
     scheduler.plot_promql(
-        PlotOpts::scatter("Running Time", "running-time", Unit::Time)
+        PlotOpts::histogram("Running Time", "running-time", Unit::Time, "percentiles")
             .with_axis_label("Time")
             .with_unit_system("time")
             .with_log_scale(true)
             .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], scheduler_running)".to_string(),
+        "scheduler_running".to_string(),
     );
 
     // Context Switch rate
     scheduler.plot_promql(
-        PlotOpts::line("Context Switch", "cswitch", Unit::Rate),
+        PlotOpts::counter("Context Switch", "cswitch", Unit::Rate),
         "sum(irate(scheduler_context_switch[5m]))".to_string(),
     );
 

--- a/src/viewer/dashboard/softirq.rs
+++ b/src/viewer/dashboard/softirq.rs
@@ -11,25 +11,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total softirq rate
     softirq.plot_promql(
-        PlotOpts::line("Rate", "softirq-total-rate", Unit::Rate),
+        PlotOpts::counter("Rate", "softirq-total-rate", Unit::Rate),
         "sum(irate(softirq[5m]))".to_string(),
     );
 
     // Per-CPU softirq rate heatmap
     softirq.plot_promql(
-        PlotOpts::heatmap("Rate", "softirq-total-rate-heatmap", Unit::Rate),
+        PlotOpts::counter("Rate", "softirq-total-rate-heatmap", Unit::Rate),
         "sum by (id) (irate(softirq[5m]))".to_string(),
     );
 
     // Average CPU % spent in softirq
     softirq.plot_promql(
-        PlotOpts::line("CPU %", "softirq-total-time", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time", Unit::Percentage).range(0.0, 1.0),
         "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
     // Per-CPU % spent in softirq heatmap
     softirq.plot_promql(
-        PlotOpts::heatmap("CPU %", "softirq-total-time-heatmap", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time-heatmap", Unit::Percentage).range(0.0, 1.0),
         "sum by (id) (irate(softirq_time[5m])) / 1000000000".to_string(),
     );
 
@@ -55,26 +55,26 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Rate for this softirq kind
         group.plot_promql(
-            PlotOpts::line("Rate", format!("softirq-{kind}-rate"), Unit::Rate),
+            PlotOpts::counter("Rate", format!("softirq-{kind}-rate"), Unit::Rate),
             format!("sum(irate(softirq{{kind=\"{kind}\"}}[5m]))"),
         );
 
         // Per-CPU rate heatmap for this softirq kind
         group.plot_promql(
-            PlotOpts::heatmap("Rate", format!("softirq-{kind}-rate-heatmap"), Unit::Rate),
+            PlotOpts::counter("Rate", format!("softirq-{kind}-rate-heatmap"), Unit::Rate),
             format!("sum by (id) (irate(softirq{{kind=\"{kind}\"}}[5m]))"),
         );
 
         // Average CPU % for this softirq kind
         group.plot_promql(
-            PlotOpts::line("CPU %", format!("softirq-{kind}-time"), Unit::Percentage)
+            PlotOpts::counter("CPU %", format!("softirq-{kind}-time"), Unit::Percentage)
                 .range(0.0, 1.0),
             format!("sum(irate(softirq_time{{kind=\"{kind}\"}}[5m])) / cpu_cores / 1000000000"),
         );
 
         // Per-CPU % heatmap for this softirq kind
         group.plot_promql(
-            PlotOpts::heatmap(
+            PlotOpts::counter(
                 "CPU %",
                 format!("softirq-{kind}-time-heatmap"),
                 Unit::Percentage,

--- a/src/viewer/dashboard/softirq.rs
+++ b/src/viewer/dashboard/softirq.rs
@@ -1,44 +1,69 @@
 use super::*;
 
+/// Adds the standard 4-plot pattern for a softirq kind: rate, rate heatmap,
+/// CPU %, and CPU % heatmap.
+fn add_softirq_group(view: &mut View, label: &str, kind: &str) {
+    let mut group = Group::new(label, format!("softirq-{kind}"));
+
+    group.plot_promql(
+        PlotOpts::counter("Rate", format!("softirq-{kind}-rate"), Unit::Rate),
+        format!("sum(irate(softirq{{kind=\"{kind}\"}}[5m]))"),
+    );
+
+    group.plot_promql(
+        PlotOpts::counter("Rate", format!("softirq-{kind}-rate-heatmap"), Unit::Rate),
+        format!("sum by (id) (irate(softirq{{kind=\"{kind}\"}}[5m]))"),
+    );
+
+    group.plot_promql(
+        PlotOpts::counter("CPU %", format!("softirq-{kind}-time"), Unit::Percentage)
+            .percentage_range(),
+        format!("sum(irate(softirq_time{{kind=\"{kind}\"}}[5m])) / cpu_cores / 1000000000"),
+    );
+
+    group.plot_promql(
+        PlotOpts::counter(
+            "CPU %",
+            format!("softirq-{kind}-time-heatmap"),
+            Unit::Percentage,
+        )
+        .percentage_range(),
+        format!("sum by (id) (irate(softirq_time{{kind=\"{kind}\"}}[5m])) / 1000000000"),
+    );
+
+    view.group(group);
+}
+
 pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
-    /*
-     * Softirq
-     */
-
+    // Total softirq (uses the same pattern but without a kind filter)
     let mut softirq = Group::new("Softirq", "softirq");
 
-    // Total softirq rate
     softirq.plot_promql(
         PlotOpts::counter("Rate", "softirq-total-rate", Unit::Rate),
         "sum(irate(softirq[5m]))".to_string(),
     );
 
-    // Per-CPU softirq rate heatmap
     softirq.plot_promql(
         PlotOpts::counter("Rate", "softirq-total-rate-heatmap", Unit::Rate),
         "sum by (id) (irate(softirq[5m]))".to_string(),
     );
 
-    // Average CPU % spent in softirq
     softirq.plot_promql(
-        PlotOpts::counter("CPU %", "softirq-total-time", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time", Unit::Percentage).percentage_range(),
         "sum(irate(softirq_time[5m])) / cpu_cores / 1000000000".to_string(),
     );
 
-    // Per-CPU % spent in softirq heatmap
     softirq.plot_promql(
-        PlotOpts::counter("CPU %", "softirq-total-time-heatmap", Unit::Percentage).range(0.0, 1.0),
+        PlotOpts::counter("CPU %", "softirq-total-time-heatmap", Unit::Percentage)
+            .percentage_range(),
         "sum by (id) (irate(softirq_time[5m])) / 1000000000".to_string(),
     );
 
     view.group(softirq);
 
-    /*
-     * Detailed
-     */
-
+    // Per-kind breakdowns
     for (label, kind) in [
         ("Hardware Interrupts", "hi"),
         ("IRQ Poll", "irq_poll"),
@@ -51,39 +76,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         ("HR Timer", "hrtimer"),
         ("Block", "block"),
     ] {
-        let mut group = Group::new(label, format!("softirq-{kind}"));
-
-        // Rate for this softirq kind
-        group.plot_promql(
-            PlotOpts::counter("Rate", format!("softirq-{kind}-rate"), Unit::Rate),
-            format!("sum(irate(softirq{{kind=\"{kind}\"}}[5m]))"),
-        );
-
-        // Per-CPU rate heatmap for this softirq kind
-        group.plot_promql(
-            PlotOpts::counter("Rate", format!("softirq-{kind}-rate-heatmap"), Unit::Rate),
-            format!("sum by (id) (irate(softirq{{kind=\"{kind}\"}}[5m]))"),
-        );
-
-        // Average CPU % for this softirq kind
-        group.plot_promql(
-            PlotOpts::counter("CPU %", format!("softirq-{kind}-time"), Unit::Percentage)
-                .range(0.0, 1.0),
-            format!("sum(irate(softirq_time{{kind=\"{kind}\"}}[5m])) / cpu_cores / 1000000000"),
-        );
-
-        // Per-CPU % heatmap for this softirq kind
-        group.plot_promql(
-            PlotOpts::counter(
-                "CPU %",
-                format!("softirq-{kind}-time-heatmap"),
-                Unit::Percentage,
-            )
-            .range(0.0, 1.0),
-            format!("sum by (id) (irate(softirq_time{{kind=\"{kind}\"}}[5m])) / 1000000000"),
-        );
-
-        view.group(group);
+        add_softirq_group(&mut view, label, kind);
     }
 
     view

--- a/src/viewer/dashboard/syscall.rs
+++ b/src/viewer/dashboard/syscall.rs
@@ -17,9 +17,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total syscall latency percentiles
     syscall.plot_promql(
-        PlotOpts::histogram("Total", "syscall-total-latency", Unit::Time, "percentiles")
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
+        PlotOpts::histogram_latency("Total", "syscall-total-latency"),
         "syscall_latency".to_string(),
     );
 
@@ -52,14 +50,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Latency percentiles for this operation
         syscall.plot_promql(
-            PlotOpts::histogram(
-                *op,
-                format!("syscall-{op}-latency"),
-                Unit::Time,
-                "percentiles",
-            )
-            .with_log_scale(true)
-            .range(0.0, 100_000_000_000.0),
+            PlotOpts::histogram_latency(*op, format!("syscall-{op}-latency")),
             format!("syscall_latency{{op=\"{op_lower}\"}}"),
         );
     }

--- a/src/viewer/dashboard/syscall.rs
+++ b/src/viewer/dashboard/syscall.rs
@@ -11,16 +11,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total syscall rate
     syscall.plot_promql(
-        PlotOpts::line("Total", "syscall-total", Unit::Rate),
+        PlotOpts::counter("Total", "syscall-total", Unit::Rate),
         "sum(irate(syscall[5m]))".to_string(),
     );
 
     // Total syscall latency percentiles
     syscall.plot_promql(
-        PlotOpts::scatter("Total", "syscall-total-latency", Unit::Time)
+        PlotOpts::histogram("Total", "syscall-total-latency", Unit::Time, "percentiles")
             .with_log_scale(true)
             .range(0.0, 100_000_000_000.0),
-        "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency)".to_string(),
+        "syscall_latency".to_string(),
     );
 
     // Per-operation syscall metrics
@@ -46,16 +46,21 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Rate for this operation
         syscall.plot_promql(
-            PlotOpts::line(*op, format!("syscall-{op}"), Unit::Rate),
+            PlotOpts::counter(*op, format!("syscall-{op}"), Unit::Rate),
             format!("sum(irate(syscall{{op=\"{op_lower}\"}}[5m]))"),
         );
 
         // Latency percentiles for this operation
         syscall.plot_promql(
-            PlotOpts::scatter(*op, format!("syscall-{op}-latency"), Unit::Time)
-                .with_log_scale(true)
-                .range(0.0, 100_000_000_000.0),
-            format!("histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], syscall_latency{{op=\"{op_lower}\"}})"),
+            PlotOpts::histogram(
+                *op,
+                format!("syscall-{op}-latency"),
+                Unit::Time,
+                "percentiles",
+            )
+            .with_log_scale(true)
+            .range(0.0, 100_000_000_000.0),
+            format!("syscall_latency{{op=\"{op_lower}\"}}"),
         );
     }
 

--- a/src/viewer/plot.rs
+++ b/src/viewer/plot.rs
@@ -276,10 +276,21 @@ pub struct Plot {
 impl Plot {}
 
 #[derive(Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricType {
+    Gauge,
+    DeltaCounter,
+    Histogram,
+}
+
+#[derive(Serialize, Clone)]
 pub struct PlotOpts {
     title: String,
     id: String,
-    style: String,
+    #[serde(rename = "type")]
+    metric_type: MetricType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subtype: Option<String>,
     // Unified configuration for value formatting, axis labels, etc.
     format: Option<FormatConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -316,42 +327,48 @@ pub struct FormatConfig {
 }
 
 impl PlotOpts {
-    // Basic constructors without formatting
-    pub fn line<T: Into<String>, U: Into<String>>(title: T, id: U, unit: Unit) -> Self {
+    // Constructors based on metric type
+
+    /// A gauge metric represents a point-in-time value (e.g., memory usage, temperature).
+    pub fn gauge<T: Into<String>, U: Into<String>>(title: T, id: U, unit: Unit) -> Self {
         Self {
             title: title.into(),
             id: id.into(),
-            style: "line".to_string(),
+            metric_type: MetricType::Gauge,
+            subtype: None,
             format: Some(FormatConfig::new(unit)),
             description: None,
         }
     }
 
-    pub fn multi<T: Into<String>, U: Into<String>>(title: T, id: U, unit: Unit) -> Self {
+    /// A delta counter metric represents the rate of change of a cumulative counter
+    /// (e.g., CPU usage rate, packet rate).
+    pub fn counter<T: Into<String>, U: Into<String>>(title: T, id: U, unit: Unit) -> Self {
         Self {
             title: title.into(),
             id: id.into(),
-            style: "multi".to_string(),
+            metric_type: MetricType::DeltaCounter,
+            subtype: None,
             format: Some(FormatConfig::new(unit)),
             description: None,
         }
     }
 
-    pub fn scatter<T: Into<String>, U: Into<String>>(title: T, id: U, unit: Unit) -> Self {
+    /// A histogram metric represents a distribution (e.g., latency, IO size).
+    /// The subtype determines the visualization and query wrapping:
+    /// - "percentiles": shows percentile scatter plot, wraps query with histogram_percentiles()
+    /// - "buckets": shows bucket heatmap, wraps query with histogram_heatmap()
+    pub fn histogram<T: Into<String>, U: Into<String>>(
+        title: T,
+        id: U,
+        unit: Unit,
+        subtype: &str,
+    ) -> Self {
         Self {
             title: title.into(),
             id: id.into(),
-            style: "scatter".to_string(),
-            format: Some(FormatConfig::new(unit)),
-            description: None,
-        }
-    }
-
-    pub fn heatmap<T: Into<String>, U: Into<String>>(title: T, id: U, unit: Unit) -> Self {
-        Self {
-            title: title.into(),
-            id: id.into(),
-            style: "heatmap".to_string(),
+            metric_type: MetricType::Histogram,
+            subtype: Some(subtype.to_string()),
             format: Some(FormatConfig::new(unit)),
             description: None,
         }

--- a/src/viewer/plot.rs
+++ b/src/viewer/plot.rs
@@ -101,116 +101,6 @@ impl Group {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn push(&mut self, plot: Option<Plot>) {
-        if let Some(plot) = plot {
-            self.plots.push(plot);
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn plot(&mut self, opts: PlotOpts, series: Option<UntypedSeries>) {
-        if let Some(data) = series.map(|v| v.as_data()) {
-            self.plots.push(Plot {
-                opts,
-                data,
-                min_value: None,
-                max_value: None,
-                time_data: None,
-                formatted_time_data: None,
-                series_names: None,
-                promql_query: None,
-            })
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn heatmap(&mut self, opts: PlotOpts, series: Option<Heatmap>) {
-        if let Some(heatmap) = series {
-            let echarts_data = heatmap.as_data();
-
-            if !echarts_data.data.is_empty() {
-                self.plots.push(Plot {
-                    opts,
-                    data: echarts_data.data,
-                    min_value: Some(echarts_data.min_value),
-                    max_value: Some(echarts_data.max_value),
-                    time_data: Some(echarts_data.time),
-                    formatted_time_data: Some(echarts_data.formatted_time),
-                    series_names: None,
-                    promql_query: None,
-                })
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn scatter(&mut self, opts: PlotOpts, data: Option<Vec<UntypedSeries>>) {
-        if data.is_none() {
-            return;
-        }
-
-        let d = data.unwrap();
-
-        let mut data = Vec::new();
-
-        for series in &d {
-            let d = series.as_data();
-
-            if data.is_empty() {
-                data.push(d[0].clone());
-            }
-
-            data.push(d[1].clone());
-        }
-
-        self.plots.push(Plot {
-            opts,
-            data,
-            min_value: None,
-            max_value: None,
-            time_data: None,
-            formatted_time_data: None,
-            series_names: None,
-            promql_query: None,
-        })
-    }
-
-    // New method to add a multi-series plot
-    #[allow(dead_code)]
-    pub fn multi(&mut self, opts: PlotOpts, cgroup_data: Option<Vec<(String, UntypedSeries)>>) {
-        if cgroup_data.is_none() {
-            return;
-        }
-
-        let mut cgroup_data = cgroup_data.unwrap();
-
-        let mut data = Vec::new();
-        let mut labels = Vec::new();
-
-        for (label, series) in cgroup_data.drain(..) {
-            labels.push(label);
-            let d = series.as_data();
-
-            if data.is_empty() {
-                data.push(d[0].clone());
-            }
-
-            data.push(d[1].clone());
-        }
-
-        self.plots.push(Plot {
-            opts,
-            data,
-            min_value: None,
-            max_value: None,
-            time_data: None,
-            formatted_time_data: None,
-            series_names: Some(labels),
-            promql_query: None,
-        });
-    }
-
     pub fn plot_promql(&mut self, mut opts: PlotOpts, promql_query: String) {
         // Auto-fill description from metric registry if not already set
         if opts.description.is_none() {
@@ -291,8 +181,7 @@ pub struct PlotOpts {
     metric_type: MetricType,
     #[serde(skip_serializing_if = "Option::is_none")]
     subtype: Option<String>,
-    // Unified configuration for value formatting, axis labels, etc.
-    format: Option<FormatConfig>,
+    format: FormatConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
 }
@@ -336,7 +225,7 @@ impl PlotOpts {
             id: id.into(),
             metric_type: MetricType::Gauge,
             subtype: None,
-            format: Some(FormatConfig::new(unit)),
+            format: FormatConfig::new(unit),
             description: None,
         }
     }
@@ -349,7 +238,7 @@ impl PlotOpts {
             id: id.into(),
             metric_type: MetricType::DeltaCounter,
             subtype: None,
-            format: Some(FormatConfig::new(unit)),
+            format: FormatConfig::new(unit),
             description: None,
         }
     }
@@ -369,43 +258,45 @@ impl PlotOpts {
             id: id.into(),
             metric_type: MetricType::Histogram,
             subtype: Some(subtype.to_string()),
-            format: Some(FormatConfig::new(unit)),
+            format: FormatConfig::new(unit),
             description: None,
         }
     }
 
-    // Convenience methods
-    pub fn with_unit_system<T: Into<String>>(mut self, unit_system: T) -> Self {
-        if let Some(ref mut format) = self.format {
-            format.unit_system = Some(unit_system.into());
-        }
+    /// Convenience: a histogram metric for latency distributions with standard
+    /// defaults (log scale, 100s range).
+    pub fn histogram_latency<T: Into<String>, U: Into<String>>(title: T, id: U) -> Self {
+        Self::histogram(title, id, Unit::Time, "percentiles")
+            .with_log_scale(true)
+            .range(0.0, 100_000_000_000.0)
+    }
 
+    /// Convenience: sets the standard 0..1 range used for percentage metrics.
+    pub fn percentage_range(self) -> Self {
+        self.range(0.0, 1.0)
+    }
+
+    // Builder methods
+    pub fn with_unit_system<T: Into<String>>(mut self, unit_system: T) -> Self {
+        self.format.unit_system = Some(unit_system.into());
         self
     }
 
     pub fn with_axis_label<T: Into<String>>(mut self, y_label: T) -> Self {
-        if let Some(ref mut format) = self.format {
-            format.y_axis_label = Some(y_label.into());
-        }
-
+        self.format.y_axis_label = Some(y_label.into());
         self
     }
 
     pub fn with_log_scale(mut self, log_scale: bool) -> Self {
-        if let Some(ref mut format) = self.format {
-            format.log_scale = Some(log_scale);
-        }
-
+        self.format.log_scale = Some(log_scale);
         self
     }
 
     pub fn range(mut self, min: f64, max: f64) -> Self {
-        if let Some(ref mut format) = self.format {
-            format.range = Some(Range {
-                min: Some(min),
-                max: Some(max),
-            });
-        }
+        self.format.range = Some(Range {
+            min: Some(min),
+            max: Some(max),
+        });
         self
     }
 }


### PR DESCRIPTION
## Problem

The dashboard visualization system was using a generic `style` field (e.g., "line", "heatmap", "scatter") to describe how metrics should be rendered. This approach conflates two concerns:
1. **What** the metric represents semantically (gauge, counter, histogram)
2. **How** it should be displayed (line chart, heatmap, scatter plot)

This made it difficult to:
- Automatically select appropriate visualizations based on metric semantics
- Handle histogram metrics that need special query wrapping
- Maintain consistency across dashboards when the same metric type appears in different contexts

## Solution

Introduced a semantic metric type system that separates concerns:

1. **Backend changes** (`src/viewer/plot.rs`):
   - Replaced `style: String` with `metric_type: MetricType` enum (`Gauge`, `DeltaCounter`, `Histogram`)
   - Added optional `subtype` field for histogram variants (e.g., "percentiles", "buckets")
   - Removed unused plotting methods (`push`, `plot`, `heatmap`, `scatter`, `multi`)
   - Updated `PlotOpts` constructors: `line()` → `counter()`, `heatmap()` → `counter()`, `scatter()` → `histogram_latency()`

2. **Dashboard refactoring** (`src/viewer/dashboard/*.rs`):
   - Updated all dashboard generators to use new `PlotOpts` constructors
   - Refactored cgroups dashboard to use `add_cgroup_metrics()` helper for DRY metric generation
   - Refactored softirq dashboard to use `add_softirq_group()` helper
   - Simplified GPU, CPU, memory, network, and other dashboards to use semantic types

3. **Frontend changes** (`src/viewer/assets/lib/charts/metric_types.js`):
   - New module that maps semantic types to compatible chart styles
   - `resolveStyle()` function infers concrete chart style from metric type and query result shape
   - `buildHistogramQuery()` wraps raw histogram metrics with appropriate PromQL functions
   - Handles histogram percentile/bucket variants automatically

4. **Data layer updates** (`src/viewer/assets/lib/data.js`):
   - Updated `applyResultToPlot()` to use `resolveStyle()` for dynamic style resolution
   - Maintains backward compatibility with explicit `style` field for query explorer

5. **Generated dashboards** (all `.json` files):
   - Replaced `"style": "line"` with `"type": "delta_counter"`
   - Replaced `"style": "heatmap"` with `"type": "delta_counter"`
   - Replaced `"style": "scatter"` with `"type": "histogram"` and `"subtype": "percentiles"`
   - Updated histogram queries to remove `histogram_percentiles()` wrapper (now handled by frontend)

## Result

- **Cleaner semantics**: Dashboards now declare *what* metrics are, not *how* to draw them
- **Automatic visualization**: Frontend intelligently selects chart type based on metric type and query results
- **Better maintainability**: Shared metric patterns (like cgroup metrics) use DRY helpers
- **Histogram support**: Proper handling of histogram metrics with percentile/bucket variants
- **Backward compatible**: Query explorer can still use explicit `style` field when needed

https://claude.ai/code/session_01M4Pr2fPYPbPjC9YGdHAHeU