### PR TITLE
Add parquet annotation tool and service extension support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,6 +3121,7 @@ dependencies = [
  "plist",
  "prometheus-parse",
  "rayon",
+ "regex",
  "reqwest",
  "rmp-serde",
  "rustfft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ parquet = "54.3.1"
 prometheus-parse = "0.2.5"
 plain = "0.2.3"
 rayon = "1.10"
+regex = "1"
 reqwest = { version = "0.12.20", default-features = false, features = ["blocking"] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod agent;
 mod exporter;
 mod hindsight;
 mod mcp;
+mod parquet_tools;
 mod recorder;
 mod viewer;
 
@@ -64,6 +65,7 @@ fn main() {
         .subcommand(exporter::command())
         .subcommand(hindsight::command())
         .subcommand(mcp::command())
+        .subcommand(parquet_tools::command())
         .subcommand(recorder::command())
         .subcommand(viewer::command())
         .subcommand(
@@ -101,6 +103,9 @@ fn main() {
             let config = mcp::Config::try_from(args.clone()).expect("failed to configure");
 
             mcp::run(config)
+        }
+        Some(("parquet", args)) => {
+            parquet_tools::run(args.clone());
         }
         Some(("record", args)) => {
             let config = recorder::Config::try_from(args.clone()).expect("failed to configure");

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod agent;
 mod exporter;
 mod hindsight;
 mod mcp;
+mod parquet_metadata;
 mod parquet_tools;
 mod recorder;
 mod viewer;

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+
+/// Top-level parquet footer keys. These are read by `Tsdb::load` or shared
+/// infrastructure and must remain flat strings in both single-source and
+/// combined files.
+/// Identifies the recording source(s).
+/// Single file: `"llm-perf"`.  Combined: `["rezolus", "llm-perf"]`.
+pub const KEY_SOURCE: &str = "source";
+
+/// Agent/tool version string (single-source files only; for combined files
+/// the per-source version lives under `metadata.<source>.version`).
+pub const KEY_VERSION: &str = "version";
+
+/// Sampling interval in milliseconds, e.g. `"1000"`. Must be identical
+/// across files before they can be combined.
+pub const KEY_SAMPLING_INTERVAL_MS: &str = "sampling_interval_ms";
+
+/// JSON-serialised hardware summary (from the Rezolus agent `/systeminfo`
+/// endpoint). Display-only — used by the viewer and MCP.
+pub const KEY_SYSTEMINFO: &str = "systeminfo";
+
+/// JSON map of metric name → help text. Used by MCP `describe-metrics`.
+pub const KEY_DESCRIPTIONS: &str = "descriptions";
+
+/// JSON-serialised user selection/filter state saved by the viewer.
+pub const KEY_SELECTION: &str = "selection";
+
+/// Per-source metadata map. Value is a JSON object keyed by source name:
+///
+/// ```json
+/// {
+///   "llm-perf": { "version": "0.1.0", "service_queries": { ... } },
+///   "rezolus":  { "version": "5.8.3" }
+/// }
+/// ```
+pub const KEY_METADATA: &str = "metadata";
+
+// ── Keys nested under `metadata.<source>` ────────────────────────────
+
+/// Per-source version string.
+pub const NESTED_VERSION: &str = "version";
+
+/// Service KPI query definitions (ServiceExtension JSON).
+pub const NESTED_SERVICE_QUERIES: &str = "service_queries";

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -8,7 +8,7 @@
 pub const KEY_SOURCE: &str = "source";
 
 /// Agent/tool version string (single-source files only; for combined files
-/// the per-source version lives under `metadata.<source>.version`).
+/// the per-source version lives under `per_source_metadata.<source>.version`).
 pub const KEY_VERSION: &str = "version";
 
 /// Sampling interval in milliseconds, e.g. `"1000"`. Must be identical
@@ -33,9 +33,9 @@ pub const KEY_SELECTION: &str = "selection";
 ///   "rezolus":  { "version": "5.8.3", "role": "service" }
 /// }
 /// ```
-pub const KEY_METADATA: &str = "metadata";
+pub const KEY_PER_SOURCE_METADATA: &str = "per_source_metadata";
 
-// ── Keys nested under `metadata.<source>` ────────────────────────────
+// ── Keys nested under `per_source_metadata.<source>` ─────────────────
 
 /// Per-source version string.
 pub const NESTED_VERSION: &str = "version";

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -29,8 +29,8 @@ pub const KEY_SELECTION: &str = "selection";
 ///
 /// ```json
 /// {
-///   "llm-perf": { "version": "0.1.0", "service_queries": { ... } },
-///   "rezolus":  { "version": "5.8.3" }
+///   "llm-perf": { "version": "0.1.0", "role": "loadgen", "service_queries": { ... } },
+///   "rezolus":  { "version": "5.8.3", "role": "service" }
 /// }
 /// ```
 pub const KEY_METADATA: &str = "metadata";
@@ -42,3 +42,8 @@ pub const NESTED_VERSION: &str = "version";
 
 /// Service KPI query definitions (ServiceExtension JSON).
 pub const NESTED_SERVICE_QUERIES: &str = "service_queries";
+
+/// The role this source plays in the recording. Known values:
+/// - `"service"` — the system under test (e.g. an LLM inference server)
+/// - `"loadgen"` — the load generator / benchmark tool (e.g. llm-perf)
+pub const NESTED_ROLE: &str = "role";

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -4,7 +4,7 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::parquet_metadata::{KEY_METADATA, KEY_SOURCE, NESTED_SERVICE_QUERIES};
+use crate::parquet_metadata::{KEY_PER_SOURCE_METADATA, KEY_SOURCE, NESTED_SERVICE_QUERIES};
 use crate::viewer::promql::QueryEngine;
 use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
@@ -235,7 +235,7 @@ fn annotate_parquet(
     // Build or update the nested metadata map
     let mut metadata_map: serde_json::Map<String, serde_json::Value> = kv_meta
         .iter()
-        .find(|kv| kv.key == KEY_METADATA)
+        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
         .and_then(|kv| kv.value.as_deref())
         .and_then(|v| serde_json::from_str(v).ok())
         .unwrap_or_default();
@@ -249,9 +249,9 @@ fn annotate_parquet(
         map.insert(NESTED_SERVICE_QUERIES.to_string(), service_queries);
     }
 
-    kv_meta.retain(|kv| kv.key != KEY_METADATA);
+    kv_meta.retain(|kv| kv.key != KEY_PER_SOURCE_METADATA);
     kv_meta.push(KeyValue {
-        key: KEY_METADATA.to_string(),
+        key: KEY_PER_SOURCE_METADATA.to_string(),
         value: Some(serde_json::to_string(&metadata_map)?),
     });
 

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -53,26 +53,24 @@ fn run_annotate(args: &ArgMatches) {
     let path = args.get_one::<PathBuf>("FILE").unwrap();
     let custom_file = args.get_one::<PathBuf>("service-extension");
 
+    let source = read_source_metadata(path).unwrap_or_else(|| {
+        eprintln!(
+            "error: parquet file has no 'source' metadata. Use --file to provide a template."
+        );
+        std::process::exit(1);
+    });
+
     let json = if let Some(custom_path) = custom_file {
         let content =
             std::fs::read_to_string(custom_path).expect("failed to read service extension file");
-        // Validate the JSON parses correctly
         let _: ServiceExtension =
             serde_json::from_str(&content).expect("invalid service extension JSON");
         content
     } else {
-        // Look up built-in template from parquet source metadata
-        let source = read_source_metadata(path);
-        let name = source.as_deref().unwrap_or_else(|| {
-            eprintln!(
-                "error: parquet file has no 'source' metadata. Use --file to provide a template."
-            );
-            std::process::exit(1);
-        });
-        let template = lookup_template(name).unwrap_or_else(|| {
+        let template = lookup_template(&source).unwrap_or_else(|| {
             eprintln!(
                 "error: no built-in template for source {:?}. Use --file to provide one.",
-                name
+                source
             );
             std::process::exit(1);
         });
@@ -86,10 +84,10 @@ fn run_annotate(args: &ArgMatches) {
 
     let annotated_json =
         serde_json::to_string(&ext).expect("failed to serialize service extension");
-    annotate_parquet(path, &annotated_json).expect("failed to annotate parquet file");
+    annotate_parquet(path, &source, &annotated_json).expect("failed to annotate parquet file");
 
     println!(
-        "Annotated {:?} with {:?} service extension ({} KPIs)",
+        "Annotated {:?} with {:?} service queries ({} KPIs)",
         path,
         ext.service_name,
         ext.kpis.len()
@@ -214,7 +212,8 @@ fn read_source_metadata(path: &Path) -> Option<String> {
 
 fn annotate_parquet(
     path: &Path,
-    service_extension_json: &str,
+    source: &str,
+    service_queries_json: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use parquet::arrow::ArrowWriter;
@@ -232,12 +231,27 @@ fn annotate_parquet(
         .cloned()
         .unwrap_or_default();
 
-    // Remove any existing service queries key
-    kv_meta.retain(|kv| kv.key != "service_queries");
+    // Build or update the nested metadata map
+    let mut metadata_map: serde_json::Map<String, serde_json::Value> = kv_meta
+        .iter()
+        .find(|kv| kv.key == "metadata")
+        .and_then(|kv| kv.value.as_deref())
+        .and_then(|v| serde_json::from_str(v).ok())
+        .unwrap_or_default();
 
+    // Nest service_queries under this source
+    let service_queries: serde_json::Value = serde_json::from_str(service_queries_json)?;
+    let source_entry = metadata_map
+        .entry(source.to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    if let serde_json::Value::Object(map) = source_entry {
+        map.insert("service_queries".to_string(), service_queries);
+    }
+
+    kv_meta.retain(|kv| kv.key != "metadata");
     kv_meta.push(KeyValue {
-        key: "service_queries".to_string(),
-        value: Some(service_extension_json.to_string()),
+        key: "metadata".to_string(),
+        value: Some(serde_json::to_string(&metadata_map)?),
     });
 
     let props = WriterProperties::builder()

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -1,0 +1,171 @@
+use clap::{value_parser, ArgMatches, Command};
+use std::io::Cursor;
+use std::path::PathBuf;
+use tracing::info;
+
+use crate::viewer::ServiceExtension;
+
+static TEMPLATES: &[(&str, &str)] = &[("llm-perf", include_str!("templates/llm_perf.json"))];
+
+fn lookup_template(source: &str) -> Option<&'static str> {
+    TEMPLATES
+        .iter()
+        .find(|(name, _)| *name == source)
+        .map(|(_, json)| *json)
+}
+
+pub fn command() -> Command {
+    Command::new("parquet")
+        .about("Parquet file operations")
+        .subcommand_required(true)
+        .subcommand(
+            Command::new("annotate")
+                .about("Add service extension metadata to a parquet file")
+                .arg(
+                    clap::Arg::new("FILE")
+                        .help("Parquet file to annotate")
+                        .value_parser(value_parser!(PathBuf))
+                        .required(true)
+                        .index(1),
+                )
+                .arg(
+                    clap::Arg::new("service-extension")
+                        .long("file")
+                        .value_name("PATH")
+                        .help("Custom service extension JSON file (overrides built-in template)")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(clap::ArgAction::Set),
+                ),
+        )
+}
+
+pub fn run(args: ArgMatches) {
+    match args.subcommand() {
+        Some(("annotate", sub_args)) => run_annotate(sub_args),
+        _ => unreachable!(),
+    }
+}
+
+fn run_annotate(args: &ArgMatches) {
+    let path = args.get_one::<PathBuf>("FILE").unwrap();
+    let custom_file = args.get_one::<PathBuf>("service-extension");
+
+    let json = if let Some(custom_path) = custom_file {
+        let content =
+            std::fs::read_to_string(custom_path).expect("failed to read service extension file");
+        // Validate the JSON parses correctly
+        let _: ServiceExtension =
+            serde_json::from_str(&content).expect("invalid service extension JSON");
+        content
+    } else {
+        // Look up built-in template from parquet source metadata
+        let source = read_source_metadata(path);
+        match source.as_deref() {
+            Some(name) => match lookup_template(name) {
+                Some(template) => template.to_string(),
+                None => {
+                    eprintln!(
+                        "error: no built-in template for source {:?}. Use --file to provide one.",
+                        name
+                    );
+                    std::process::exit(1);
+                }
+            },
+            None => {
+                eprintln!(
+                    "error: parquet file has no 'source' metadata. Use --file to provide a template."
+                );
+                std::process::exit(1);
+            }
+        }
+    };
+
+    annotate_parquet(path, &json).expect("failed to annotate parquet file");
+
+    let ext: ServiceExtension = serde_json::from_str(&json).unwrap();
+    info!(
+        "annotated {:?} with service extension for {:?} ({} KPIs)",
+        path,
+        ext.service_name,
+        ext.kpis.len()
+    );
+    println!(
+        "Annotated {:?} with {:?} service extension ({} KPIs)",
+        path,
+        ext.service_name,
+        ext.kpis.len()
+    );
+}
+
+fn read_source_metadata(path: &PathBuf) -> Option<String> {
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+
+    let file = std::fs::File::open(path).ok()?;
+    let reader = SerializedFileReader::new(file).ok()?;
+    let kv = reader.metadata().file_metadata().key_value_metadata()?;
+
+    kv.iter()
+        .find(|kv| kv.key == "source")
+        .and_then(|kv| kv.value.clone())
+}
+
+fn annotate_parquet(
+    path: &PathBuf,
+    service_extension_json: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+    use parquet::format::KeyValue;
+
+    let file = std::fs::File::open(path)?;
+
+    // Read existing metadata
+    let meta_reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
+    let mut kv_meta: Vec<KeyValue> = meta_reader
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .cloned()
+        .unwrap_or_default();
+
+    // Remove any existing service extension keys
+    kv_meta.retain(|kv| kv.key != "metric_type" && kv.key != "service_extension");
+
+    // Add new keys
+    kv_meta.push(KeyValue {
+        key: "metric_type".to_string(),
+        value: Some("rezolus:service-extension".to_string()),
+    });
+    kv_meta.push(KeyValue {
+        key: "service_extension".to_string(),
+        value: Some(service_extension_json.to_string()),
+    });
+
+    let props = WriterProperties::builder()
+        .set_key_value_metadata(Some(kv_meta))
+        .build();
+
+    // Read all record batches
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let schema = builder.schema().clone();
+    let reader = builder.build()?;
+
+    // Write to memory buffer with updated metadata
+    let mut output = Vec::new();
+    {
+        let mut writer = ArrowWriter::try_new(Cursor::new(&mut output), schema, Some(props))?;
+        for batch in reader {
+            writer.write(&batch?)?;
+        }
+        writer.close()?;
+    }
+
+    // Write back to the same file (in-place)
+    std::fs::write(path, &output)?;
+
+    Ok(())
+}

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -1,8 +1,11 @@
 use clap::{value_parser, ArgMatches, Command};
 use std::io::Cursor;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::info;
 
+use crate::viewer::promql::QueryEngine;
+use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
 
 static TEMPLATES: &[(&str, &str)] = &[("llm-perf", include_str!("templates/llm_perf.json"))];
@@ -80,9 +83,13 @@ fn run_annotate(args: &ArgMatches) {
         }
     };
 
+    let ext: ServiceExtension = serde_json::from_str(&json).unwrap();
+
+    // Validate KPI queries against the parquet data
+    validate_kpis(path, &ext);
+
     annotate_parquet(path, &json).expect("failed to annotate parquet file");
 
-    let ext: ServiceExtension = serde_json::from_str(&json).unwrap();
     info!(
         "annotated {:?} with service extension for {:?} ({} KPIs)",
         path,
@@ -95,6 +102,89 @@ fn run_annotate(args: &ArgMatches) {
         ext.service_name,
         ext.kpis.len()
     );
+}
+
+/// Build the effective PromQL query for a KPI, accounting for histogram wrapping.
+fn effective_query(kpi: &crate::viewer::Kpi) -> String {
+    if kpi.metric_type == "histogram" {
+        let subtype = kpi.subtype.as_deref().unwrap_or("percentiles");
+        if subtype == "buckets" {
+            format!("histogram_heatmap({})", kpi.query)
+        } else {
+            format!(
+                "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], {})",
+                kpi.query
+            )
+        }
+    } else {
+        kpi.query.clone()
+    }
+}
+
+/// Validate that each KPI query returns data from the parquet file.
+/// Prints warnings for KPIs with no matching data and exits with an error
+/// if none of the queries match.
+fn validate_kpis(path: &PathBuf, ext: &ServiceExtension) {
+    let tsdb = match Tsdb::load(path) {
+        Ok(tsdb) => Arc::new(tsdb),
+        Err(e) => {
+            eprintln!("warning: could not load parquet for validation: {e}");
+            return;
+        }
+    };
+
+    let engine = QueryEngine::new(tsdb);
+    let (start, end) = engine.get_time_range();
+    let step = 1.0;
+
+    let mut matched = 0;
+    let mut missing = Vec::new();
+
+    for kpi in &ext.kpis {
+        let query = effective_query(kpi);
+        match engine.query_range(&query, start, end, step) {
+            Ok(result) => {
+                if query_result_is_empty(&result) {
+                    missing.push(&kpi.title);
+                } else {
+                    matched += 1;
+                }
+            }
+            Err(_) => {
+                missing.push(&kpi.title);
+            }
+        }
+    }
+
+    if !missing.is_empty() {
+        eprintln!(
+            "warning: {} KPI(s) returned no data from this parquet file:",
+            missing.len()
+        );
+        for title in &missing {
+            eprintln!("  - {title}");
+        }
+    }
+
+    if matched == 0 {
+        eprintln!("error: no KPI queries matched any data in the parquet file");
+        std::process::exit(1);
+    }
+
+    println!(
+        "Validated: {matched}/{} KPIs have matching data",
+        ext.kpis.len()
+    );
+}
+
+fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {
+    use crate::viewer::promql::QueryResult;
+    match result {
+        QueryResult::Vector { result } => result.is_empty(),
+        QueryResult::Matrix { result } => result.is_empty(),
+        QueryResult::Scalar { .. } => false,
+        QueryResult::HistogramHeatmap { result } => result.data.is_empty(),
+    }
 }
 
 fn read_source_metadata(path: &PathBuf) -> Option<String> {

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -1,7 +1,7 @@
 use clap::{value_parser, ArgMatches, Command};
 use std::collections::BTreeSet;
 use std::io::Cursor;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::info;
 
@@ -127,7 +127,7 @@ fn effective_query(kpi: &crate::viewer::Kpi) -> String {
 /// Validate that each KPI query returns data from the parquet file.
 /// Sets `available` on each KPI based on whether its query returns data.
 /// Prints warnings for unavailable KPIs and exits if none match.
-fn validate_kpis(path: &PathBuf, ext: &mut ServiceExtension) {
+fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
     let tsdb = match Tsdb::load(path) {
         Ok(tsdb) => Arc::new(tsdb),
         Err(e) => {
@@ -243,7 +243,6 @@ fn extract_metric_selectors(query: &str) -> Vec<String> {
 
             // If followed by '{', include the label matchers
             if j < len && chars[j] == '{' {
-                let brace_start = j;
                 let mut depth = 1;
                 j += 1;
                 while j < len && depth > 0 {
@@ -280,7 +279,7 @@ fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {
     }
 }
 
-fn read_source_metadata(path: &PathBuf) -> Option<String> {
+fn read_source_metadata(path: &Path) -> Option<String> {
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
 
@@ -294,7 +293,7 @@ fn read_source_metadata(path: &PathBuf) -> Option<String> {
 }
 
 fn annotate_parquet(
-    path: &PathBuf,
+    path: &Path,
     service_extension_json: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -165,87 +165,28 @@ fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
     );
 }
 
-/// Extract metric selectors (name + labels) from a PromQL query string.
+/// Extract metric selectors (name + optional labels) from a PromQL query.
 ///
-/// Returns selectors like `tokens{direction="output"}` or `requests_inflight`,
-/// excluding known PromQL function names.
+/// Matches `metric_name` or `metric_name{labels...}`, skipping anything
+/// followed by `(` (i.e. function calls like `sum(`, `irate(`).
 fn extract_metric_selectors(query: &str) -> BTreeSet<String> {
-    let bytes = query.as_bytes();
-    let len = bytes.len();
-    let mut selectors = BTreeSet::new();
-    let mut i = 0;
+    use regex::Regex;
+    use std::sync::LazyLock;
 
-    while i < len {
-        if bytes[i].is_ascii_alphabetic() || bytes[i] == b'_' {
-            let start = i;
-            while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-                i += 1;
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[a-zA-Z_][a-zA-Z0-9_]*(\{[^}]*\})?").unwrap());
+
+    RE.find_iter(query)
+        .filter(|m| {
+            // Skip duration suffixes like 5s, 1m, 1h (preceded by a digit)
+            if m.start() > 0 && query.as_bytes()[m.start() - 1].is_ascii_digit() {
+                return false;
             }
-            let ident = &query[start..i];
-
-            // Skip whitespace, then check what follows
-            let rest = query[i..].trim_start();
-            let next = rest.as_bytes().first().copied();
-
-            // function call — skip
-            if next == Some(b'(') && is_promql_function(ident) {
-                i = query.len() - rest.len();
-                continue;
-            }
-
-            // metric{labels} — include the braces
-            if next == Some(b'{') {
-                if let Some(close) = rest.find('}') {
-                    let sel_end = query.len() - rest.len() + close + 1;
-                    selectors.insert(query[start..sel_end].to_string());
-                    i = sel_end;
-                    continue;
-                }
-            }
-
-            selectors.insert(ident.to_string());
-        } else {
-            i += 1;
-        }
-    }
-
-    selectors
-}
-
-fn is_promql_function(name: &str) -> bool {
-    matches!(
-        name,
-        "sum"
-            | "avg"
-            | "min"
-            | "max"
-            | "count"
-            | "rate"
-            | "irate"
-            | "increase"
-            | "delta"
-            | "idelta"
-            | "abs"
-            | "ceil"
-            | "floor"
-            | "round"
-            | "clamp"
-            | "clamp_min"
-            | "clamp_max"
-            | "ln"
-            | "log2"
-            | "log10"
-            | "exp"
-            | "sqrt"
-            | "sgn"
-            | "sort"
-            | "sort_desc"
-            | "label_replace"
-            | "label_join"
-            | "histogram_quantile"
-            | "histogram_percentiles"
-            | "histogram_heatmap"
-    )
+            // Skip function calls: next non-whitespace char after match is '('
+            query[m.end()..].trim_start().as_bytes().first() != Some(&b'(')
+        })
+        .map(|m| m.as_str().to_string())
+        .collect()
 }
 
 fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {
@@ -327,4 +268,41 @@ fn annotate_parquet(
     std::fs::write(path, &output)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_selectors_from_counter_query() {
+        let q = r#"sum(irate(tokens{direction="output"}[5s]))"#;
+        let sel: Vec<_> = extract_metric_selectors(q).into_iter().collect();
+        assert_eq!(sel, vec![r#"tokens{direction="output"}"#]);
+    }
+
+    #[test]
+    fn extract_selectors_from_ratio_query() {
+        let q =
+            r#"sum(irate(requests{status="error"}[5s])) / sum(irate(requests{status="sent"}[5s]))"#;
+        let sel: Vec<_> = extract_metric_selectors(q).into_iter().collect();
+        assert_eq!(
+            sel,
+            vec![r#"requests{status="error"}"#, r#"requests{status="sent"}"#]
+        );
+    }
+
+    #[test]
+    fn extract_selectors_from_bare_metric() {
+        let sel: Vec<_> = extract_metric_selectors("requests_inflight")
+            .into_iter()
+            .collect();
+        assert_eq!(sel, vec!["requests_inflight"]);
+    }
+
+    #[test]
+    fn extract_selectors_from_histogram() {
+        let sel: Vec<_> = extract_metric_selectors("ttft").into_iter().collect();
+        assert_eq!(sel, vec!["ttft"]);
+    }
 }

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeSet;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tracing::info;
 
 use crate::viewer::promql::QueryEngine;
 use crate::viewer::tsdb::Tsdb;
@@ -64,24 +63,20 @@ fn run_annotate(args: &ArgMatches) {
     } else {
         // Look up built-in template from parquet source metadata
         let source = read_source_metadata(path);
-        match source.as_deref() {
-            Some(name) => match lookup_template(name) {
-                Some(template) => template.to_string(),
-                None => {
-                    eprintln!(
-                        "error: no built-in template for source {:?}. Use --file to provide one.",
-                        name
-                    );
-                    std::process::exit(1);
-                }
-            },
-            None => {
-                eprintln!(
-                    "error: parquet file has no 'source' metadata. Use --file to provide a template."
-                );
-                std::process::exit(1);
-            }
-        }
+        let name = source.as_deref().unwrap_or_else(|| {
+            eprintln!(
+                "error: parquet file has no 'source' metadata. Use --file to provide a template."
+            );
+            std::process::exit(1);
+        });
+        let template = lookup_template(name).unwrap_or_else(|| {
+            eprintln!(
+                "error: no built-in template for source {:?}. Use --file to provide one.",
+                name
+            );
+            std::process::exit(1);
+        });
+        template.to_string()
     };
 
     let mut ext: ServiceExtension = serde_json::from_str(&json).unwrap();
@@ -93,12 +88,6 @@ fn run_annotate(args: &ArgMatches) {
         serde_json::to_string(&ext).expect("failed to serialize service extension");
     annotate_parquet(path, &annotated_json).expect("failed to annotate parquet file");
 
-    info!(
-        "annotated {:?} with service extension for {:?} ({} KPIs)",
-        path,
-        ext.service_name,
-        ext.kpis.len()
-    );
     println!(
         "Annotated {:?} with {:?} service extension ({} KPIs)",
         path,
@@ -150,9 +139,7 @@ fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
             Err(_) => false,
         };
         if !has_data {
-            for sel in extract_metric_selectors(&kpi.query) {
-                missing_metrics.insert(sel);
-            }
+            missing_metrics.extend(extract_metric_selectors(&kpi.query));
         }
         kpi.available = has_data;
         if has_data {
@@ -182,91 +169,83 @@ fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
 ///
 /// Returns selectors like `tokens{direction="output"}` or `requests_inflight`,
 /// excluding known PromQL function names.
-fn extract_metric_selectors(query: &str) -> Vec<String> {
-    static PROMQL_FUNCTIONS: &[&str] = &[
-        "sum",
-        "avg",
-        "min",
-        "max",
-        "count",
-        "rate",
-        "irate",
-        "increase",
-        "delta",
-        "idelta",
-        "abs",
-        "ceil",
-        "floor",
-        "round",
-        "clamp",
-        "clamp_min",
-        "clamp_max",
-        "ln",
-        "log2",
-        "log10",
-        "exp",
-        "sqrt",
-        "sgn",
-        "sort",
-        "sort_desc",
-        "label_replace",
-        "label_join",
-        "histogram_quantile",
-        "histogram_percentiles",
-        "histogram_heatmap",
-    ];
-
-    let mut selectors = Vec::new();
-    let chars: Vec<char> = query.chars().collect();
-    let len = chars.len();
+fn extract_metric_selectors(query: &str) -> BTreeSet<String> {
+    let bytes = query.as_bytes();
+    let len = bytes.len();
+    let mut selectors = BTreeSet::new();
     let mut i = 0;
 
     while i < len {
-        if chars[i].is_ascii_alphabetic() || chars[i] == '_' {
+        if bytes[i].is_ascii_alphabetic() || bytes[i] == b'_' {
             let start = i;
-            while i < len && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+            while i < len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
                 i += 1;
             }
-            let ident: String = chars[start..i].iter().collect();
+            let ident = &query[start..i];
 
-            // Skip whitespace
-            let mut j = i;
-            while j < len && chars[j].is_ascii_whitespace() {
-                j += 1;
-            }
+            // Skip whitespace, then check what follows
+            let rest = query[i..].trim_start();
+            let next = rest.as_bytes().first().copied();
 
-            // If followed by '(', it's a function call — skip
-            if j < len && chars[j] == '(' && PROMQL_FUNCTIONS.contains(&ident.as_str()) {
-                i = j;
+            // function call — skip
+            if next == Some(b'(') && is_promql_function(ident) {
+                i = query.len() - rest.len();
                 continue;
             }
 
-            // If followed by '{', include the label matchers
-            if j < len && chars[j] == '{' {
-                let mut depth = 1;
-                j += 1;
-                while j < len && depth > 0 {
-                    if chars[j] == '{' {
-                        depth += 1;
-                    } else if chars[j] == '}' {
-                        depth -= 1;
-                    }
-                    j += 1;
+            // metric{labels} — include the braces
+            if next == Some(b'{') {
+                if let Some(close) = rest.find('}') {
+                    let sel_end = query.len() - rest.len() + close + 1;
+                    selectors.insert(query[start..sel_end].to_string());
+                    i = sel_end;
+                    continue;
                 }
-                let selector: String = chars[start..j].iter().collect();
-                selectors.push(selector);
-                i = j;
-            } else {
-                selectors.push(ident);
             }
+
+            selectors.insert(ident.to_string());
         } else {
             i += 1;
         }
     }
 
-    selectors.sort();
-    selectors.dedup();
     selectors
+}
+
+fn is_promql_function(name: &str) -> bool {
+    matches!(
+        name,
+        "sum"
+            | "avg"
+            | "min"
+            | "max"
+            | "count"
+            | "rate"
+            | "irate"
+            | "increase"
+            | "delta"
+            | "idelta"
+            | "abs"
+            | "ceil"
+            | "floor"
+            | "round"
+            | "clamp"
+            | "clamp_min"
+            | "clamp_max"
+            | "ln"
+            | "log2"
+            | "log10"
+            | "exp"
+            | "sqrt"
+            | "sgn"
+            | "sort"
+            | "sort_desc"
+            | "label_replace"
+            | "label_join"
+            | "histogram_quantile"
+            | "histogram_percentiles"
+            | "histogram_heatmap"
+    )
 }
 
 fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {
@@ -303,8 +282,6 @@ fn annotate_parquet(
     use parquet::file::serialized_reader::SerializedFileReader;
     use parquet::format::KeyValue;
 
-    let file = std::fs::File::open(path)?;
-
     // Read existing metadata
     let meta_reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
     let mut kv_meta: Vec<KeyValue> = meta_reader
@@ -332,7 +309,7 @@ fn annotate_parquet(
         .build();
 
     // Read all record batches
-    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path)?)?;
     let schema = builder.schema().clone();
     let reader = builder.build()?;
 

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -1,10 +1,11 @@
 use clap::{value_parser, ArgMatches, Command};
+use std::collections::BTreeSet;
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 
-use crate::viewer::promql::QueryEngine;
+use crate::viewer::promql::{QueryEngine, QueryError};
 use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
 
@@ -140,29 +141,47 @@ fn validate_kpis(path: &PathBuf, ext: &mut ServiceExtension) {
     let step = 1.0;
 
     let mut matched = 0;
-    let mut missing = Vec::new();
+    let mut missing_kpis = Vec::new();
+    let mut missing_metrics = BTreeSet::new();
 
     for kpi in &mut ext.kpis {
         let query = effective_query(kpi);
         let has_data = match engine.query_range(&query, start, end, step) {
             Ok(result) => !query_result_is_empty(&result),
-            Err(_) => false,
+            Err(QueryError::MetricNotFound(name)) => {
+                missing_metrics.insert(name);
+                false
+            }
+            Err(_) => {
+                // Parse error or other failure — extract metric names from query
+                for name in extract_metric_names(&kpi.query) {
+                    missing_metrics.insert(name);
+                }
+                false
+            }
         };
         kpi.available = has_data;
         if has_data {
             matched += 1;
         } else {
-            missing.push(kpi.title.clone());
+            missing_kpis.push(kpi.title.clone());
         }
     }
 
-    if !missing.is_empty() {
+    if !missing_kpis.is_empty() {
         eprintln!(
             "warning: {} KPI(s) returned no data from this parquet file:",
-            missing.len()
+            missing_kpis.len()
         );
-        for title in &missing {
+        for title in &missing_kpis {
             eprintln!("  - {title}");
+        }
+    }
+
+    if !missing_metrics.is_empty() {
+        eprintln!("missing metrics:");
+        for name in &missing_metrics {
+            eprintln!("  - {name}");
         }
     }
 
@@ -175,6 +194,83 @@ fn validate_kpis(path: &PathBuf, ext: &mut ServiceExtension) {
         "Validated: {matched}/{} KPIs have matching data",
         ext.kpis.len()
     );
+}
+
+/// Extract metric selector names from a PromQL query string.
+/// Finds identifiers that are followed by `{`, `[`, `)`, or end-of-string,
+/// excluding known PromQL functions.
+fn extract_metric_names(query: &str) -> Vec<String> {
+    static PROMQL_FUNCTIONS: &[&str] = &[
+        "sum",
+        "avg",
+        "min",
+        "max",
+        "count",
+        "rate",
+        "irate",
+        "increase",
+        "delta",
+        "idelta",
+        "abs",
+        "ceil",
+        "floor",
+        "round",
+        "clamp",
+        "clamp_min",
+        "clamp_max",
+        "ln",
+        "log2",
+        "log10",
+        "exp",
+        "sqrt",
+        "sgn",
+        "sort",
+        "sort_desc",
+        "label_replace",
+        "label_join",
+        "histogram_quantile",
+        "histogram_percentiles",
+        "histogram_heatmap",
+    ];
+
+    let mut names = Vec::new();
+    let chars: Vec<char> = query.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Find start of an identifier
+        if chars[i].is_ascii_alphabetic() || chars[i] == '_' {
+            let start = i;
+            while i < len && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                i += 1;
+            }
+            let ident: String = chars[start..i].iter().collect();
+
+            // Skip whitespace after identifier
+            let mut j = i;
+            while j < len && chars[j].is_ascii_whitespace() {
+                j += 1;
+            }
+
+            // If followed by '(', it's a function call — skip it
+            if j < len && chars[j] == '(' {
+                if PROMQL_FUNCTIONS.contains(&ident.as_str()) {
+                    i = j;
+                    continue;
+                }
+            }
+
+            // Otherwise it's a metric name
+            names.push(ident);
+        } else {
+            i += 1;
+        }
+    }
+
+    names.sort();
+    names.dedup();
+    names
 }
 
 fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -232,16 +232,11 @@ fn annotate_parquet(
         .cloned()
         .unwrap_or_default();
 
-    // Remove any existing service extension keys
-    kv_meta.retain(|kv| kv.key != "metric_type" && kv.key != "service_extension");
+    // Remove any existing service queries key
+    kv_meta.retain(|kv| kv.key != "service_queries");
 
-    // Add new keys
     kv_meta.push(KeyValue {
-        key: "metric_type".to_string(),
-        value: Some("rezolus:service-extension".to_string()),
-    });
-    kv_meta.push(KeyValue {
-        key: "service_extension".to_string(),
+        key: "service_queries".to_string(),
         value: Some(service_extension_json.to_string()),
     });
 

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 
-use crate::viewer::promql::{QueryEngine, QueryError};
+use crate::viewer::promql::QueryEngine;
 use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
 
@@ -141,40 +141,22 @@ fn validate_kpis(path: &PathBuf, ext: &mut ServiceExtension) {
     let step = 1.0;
 
     let mut matched = 0;
-    let mut missing_kpis = Vec::new();
     let mut missing_metrics = BTreeSet::new();
 
     for kpi in &mut ext.kpis {
         let query = effective_query(kpi);
         let has_data = match engine.query_range(&query, start, end, step) {
             Ok(result) => !query_result_is_empty(&result),
-            Err(QueryError::MetricNotFound(name)) => {
-                missing_metrics.insert(name);
-                false
-            }
-            Err(_) => {
-                // Parse error or other failure — extract metric names from query
-                for name in extract_metric_names(&kpi.query) {
-                    missing_metrics.insert(name);
-                }
-                false
-            }
+            Err(_) => false,
         };
+        if !has_data {
+            for sel in extract_metric_selectors(&kpi.query) {
+                missing_metrics.insert(sel);
+            }
+        }
         kpi.available = has_data;
         if has_data {
             matched += 1;
-        } else {
-            missing_kpis.push(kpi.title.clone());
-        }
-    }
-
-    if !missing_kpis.is_empty() {
-        eprintln!(
-            "warning: {} KPI(s) returned no data from this parquet file:",
-            missing_kpis.len()
-        );
-        for title in &missing_kpis {
-            eprintln!("  - {title}");
         }
     }
 
@@ -196,10 +178,11 @@ fn validate_kpis(path: &PathBuf, ext: &mut ServiceExtension) {
     );
 }
 
-/// Extract metric selector names from a PromQL query string.
-/// Finds identifiers that are followed by `{`, `[`, `)`, or end-of-string,
-/// excluding known PromQL functions.
-fn extract_metric_names(query: &str) -> Vec<String> {
+/// Extract metric selectors (name + labels) from a PromQL query string.
+///
+/// Returns selectors like `tokens{direction="output"}` or `requests_inflight`,
+/// excluding known PromQL function names.
+fn extract_metric_selectors(query: &str) -> Vec<String> {
     static PROMQL_FUNCTIONS: &[&str] = &[
         "sum",
         "avg",
@@ -233,13 +216,12 @@ fn extract_metric_names(query: &str) -> Vec<String> {
         "histogram_heatmap",
     ];
 
-    let mut names = Vec::new();
+    let mut selectors = Vec::new();
     let chars: Vec<char> = query.chars().collect();
     let len = chars.len();
     let mut i = 0;
 
     while i < len {
-        // Find start of an identifier
         if chars[i].is_ascii_alphabetic() || chars[i] == '_' {
             let start = i;
             while i < len && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
@@ -247,30 +229,45 @@ fn extract_metric_names(query: &str) -> Vec<String> {
             }
             let ident: String = chars[start..i].iter().collect();
 
-            // Skip whitespace after identifier
+            // Skip whitespace
             let mut j = i;
             while j < len && chars[j].is_ascii_whitespace() {
                 j += 1;
             }
 
-            // If followed by '(', it's a function call — skip it
-            if j < len && chars[j] == '(' {
-                if PROMQL_FUNCTIONS.contains(&ident.as_str()) {
-                    i = j;
-                    continue;
-                }
+            // If followed by '(', it's a function call — skip
+            if j < len && chars[j] == '(' && PROMQL_FUNCTIONS.contains(&ident.as_str()) {
+                i = j;
+                continue;
             }
 
-            // Otherwise it's a metric name
-            names.push(ident);
+            // If followed by '{', include the label matchers
+            if j < len && chars[j] == '{' {
+                let brace_start = j;
+                let mut depth = 1;
+                j += 1;
+                while j < len && depth > 0 {
+                    if chars[j] == '{' {
+                        depth += 1;
+                    } else if chars[j] == '}' {
+                        depth -= 1;
+                    }
+                    j += 1;
+                }
+                let selector: String = chars[start..j].iter().collect();
+                selectors.push(selector);
+                i = j;
+            } else {
+                selectors.push(ident);
+            }
         } else {
             i += 1;
         }
     }
 
-    names.sort();
-    names.dedup();
-    names
+    selectors.sort();
+    selectors.dedup();
+    selectors
 }
 
 fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -4,6 +4,7 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::parquet_metadata::{KEY_METADATA, KEY_SOURCE, NESTED_SERVICE_QUERIES};
 use crate::viewer::promql::QueryEngine;
 use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
@@ -206,7 +207,7 @@ fn read_source_metadata(path: &Path) -> Option<String> {
     let kv = reader.metadata().file_metadata().key_value_metadata()?;
 
     kv.iter()
-        .find(|kv| kv.key == "source")
+        .find(|kv| kv.key == KEY_SOURCE)
         .and_then(|kv| kv.value.clone())
 }
 
@@ -234,7 +235,7 @@ fn annotate_parquet(
     // Build or update the nested metadata map
     let mut metadata_map: serde_json::Map<String, serde_json::Value> = kv_meta
         .iter()
-        .find(|kv| kv.key == "metadata")
+        .find(|kv| kv.key == KEY_METADATA)
         .and_then(|kv| kv.value.as_deref())
         .and_then(|v| serde_json::from_str(v).ok())
         .unwrap_or_default();
@@ -245,12 +246,12 @@ fn annotate_parquet(
         .entry(source.to_string())
         .or_insert_with(|| serde_json::json!({}));
     if let serde_json::Value::Object(map) = source_entry {
-        map.insert("service_queries".to_string(), service_queries);
+        map.insert(NESTED_SERVICE_QUERIES.to_string(), service_queries);
     }
 
-    kv_meta.retain(|kv| kv.key != "metadata");
+    kv_meta.retain(|kv| kv.key != KEY_METADATA);
     kv_meta.push(KeyValue {
-        key: "metadata".to_string(),
+        key: KEY_METADATA.to_string(),
         value: Some(serde_json::to_string(&metadata_map)?),
     });
 

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -83,12 +83,14 @@ fn run_annotate(args: &ArgMatches) {
         }
     };
 
-    let ext: ServiceExtension = serde_json::from_str(&json).unwrap();
+    let mut ext: ServiceExtension = serde_json::from_str(&json).unwrap();
 
-    // Validate KPI queries against the parquet data
-    validate_kpis(path, &ext);
+    // Validate KPI queries against the parquet data and set available flags
+    validate_kpis(path, &mut ext);
 
-    annotate_parquet(path, &json).expect("failed to annotate parquet file");
+    let annotated_json =
+        serde_json::to_string(&ext).expect("failed to serialize service extension");
+    annotate_parquet(path, &annotated_json).expect("failed to annotate parquet file");
 
     info!(
         "annotated {:?} with service extension for {:?} ({} KPIs)",
@@ -122,9 +124,9 @@ fn effective_query(kpi: &crate::viewer::Kpi) -> String {
 }
 
 /// Validate that each KPI query returns data from the parquet file.
-/// Prints warnings for KPIs with no matching data and exits with an error
-/// if none of the queries match.
-fn validate_kpis(path: &PathBuf, ext: &ServiceExtension) {
+/// Sets `available` on each KPI based on whether its query returns data.
+/// Prints warnings for unavailable KPIs and exits if none match.
+fn validate_kpis(path: &PathBuf, ext: &mut ServiceExtension) {
     let tsdb = match Tsdb::load(path) {
         Ok(tsdb) => Arc::new(tsdb),
         Err(e) => {
@@ -140,19 +142,17 @@ fn validate_kpis(path: &PathBuf, ext: &ServiceExtension) {
     let mut matched = 0;
     let mut missing = Vec::new();
 
-    for kpi in &ext.kpis {
+    for kpi in &mut ext.kpis {
         let query = effective_query(kpi);
-        match engine.query_range(&query, start, end, step) {
-            Ok(result) => {
-                if query_result_is_empty(&result) {
-                    missing.push(&kpi.title);
-                } else {
-                    matched += 1;
-                }
-            }
-            Err(_) => {
-                missing.push(&kpi.title);
-            }
+        let has_data = match engine.query_range(&query, start, end, step) {
+            Ok(result) => !query_result_is_empty(&result),
+            Err(_) => false,
+        };
+        kpi.available = has_data;
+        if has_data {
+            matched += 1;
+        } else {
+            missing.push(kpi.title.clone());
         }
     }
 

--- a/src/parquet_tools/templates/llm_perf.json
+++ b/src/parquet_tools/templates/llm_perf.json
@@ -1,0 +1,103 @@
+{
+  "service_name": "llm-perf",
+  "service_metadata": {},
+  "slo": null,
+  "kpis": [
+    {
+      "role": "throughput",
+      "title": "Output Token Rate",
+      "query": "sum(irate(tokens{direction=\"output\"}[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "custom",
+      "title": "Input Token Rate",
+      "query": "sum(irate(tokens{direction=\"input\"}[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "saturation",
+      "title": "Requests In-Flight",
+      "query": "requests_inflight",
+      "type": "gauge",
+      "unit_system": "count"
+    },
+    {
+      "role": "custom",
+      "title": "Request Rate",
+      "query": "sum(irate(requests{status=\"success\"}[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "error_rate",
+      "title": "Error Rate",
+      "query": "sum(irate(requests{status=\"error\"}[5s])) / sum(irate(requests{status=\"sent\"}[5s]))",
+      "type": "delta_counter",
+      "unit_system": "percentage"
+    },
+    {
+      "role": "custom",
+      "title": "Error Request Rate",
+      "query": "sum(irate(requests{status=\"error\"}[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "custom",
+      "title": "Timeout Request Rate",
+      "query": "sum(irate(requests{status=\"timeout\"}[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "custom",
+      "title": "Canceled Request Rate",
+      "query": "sum(irate(requests{status=\"canceled\"}[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "latency",
+      "title": "Time to First Token (TTFT)",
+      "query": "ttft",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    },
+    {
+      "role": "latency",
+      "title": "Time per Output Token (TPOT)",
+      "query": "tpot",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    },
+    {
+      "role": "latency",
+      "title": "Inter-Token Latency (ITL)",
+      "query": "itl",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    },
+    {
+      "role": "latency",
+      "title": "Request Latency",
+      "query": "request_latency",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    },
+    {
+      "role": "latency",
+      "title": "Think Duration",
+      "query": "think_duration",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    }
+  ]
+}

--- a/src/viewer/dashboard/mod.rs
+++ b/src/viewer/dashboard/mod.rs
@@ -10,13 +10,15 @@ mod overview;
 mod query_explorer;
 mod rezolus;
 mod scheduler;
+mod service;
 mod softirq;
 mod syscall;
 
 type Generator = fn(&Tsdb, Vec<Section>) -> View;
 
+// Overview is excluded here because it needs an extra throughput_query parameter
+// when a service extension is present. It is generated separately in generate().
 static SECTION_META: &[(&str, &str, Generator)] = &[
-    ("Overview", "/overview", overview::generate),
     ("Query Explorer", "/query", query_explorer::generate),
     ("CPU", "/cpu", cpu::generate),
     ("GPU", "/gpu", gpu::generate),
@@ -30,19 +32,53 @@ static SECTION_META: &[(&str, &str, Generator)] = &[
     ("Rezolus", "/rezolus", rezolus::generate),
 ];
 
-pub fn generate(data: Tsdb, filesize: Option<u64>) -> AppState {
+pub fn generate(
+    data: Tsdb,
+    filesize: Option<u64>,
+    service_ext: Option<&crate::viewer::ServiceExtension>,
+) -> AppState {
     let state = AppState::new(data);
 
-    let all_sections: Vec<Section> = SECTION_META
-        .iter()
-        .map(|(name, route, _)| Section {
-            name: (*name).to_string(),
-            route: (*route).to_string(),
-        })
-        .collect();
+    let mut all_sections: Vec<Section> = std::iter::once(Section {
+        name: "Overview".to_string(),
+        route: "/overview".to_string(),
+    })
+    .chain(SECTION_META.iter().map(|(name, route, _)| Section {
+        name: (*name).to_string(),
+        route: (*route).to_string(),
+    }))
+    .collect();
+
+    if service_ext.is_some() {
+        // Insert Service section after Overview (position 1)
+        all_sections.insert(
+            1,
+            Section {
+                name: "Service".to_string(),
+                route: "/service".to_string(),
+            },
+        );
+    }
 
     let tsdb = state.tsdb.read();
     let mut rendered_sections = state.sections.write();
+
+    // Generate overview separately (needs throughput_query from service extension)
+    let throughput_query = service_ext
+        .and_then(|e| e.throughput_query())
+        .map(str::to_string);
+    {
+        let mut view =
+            overview::generate(&tsdb, all_sections.clone(), throughput_query.as_deref());
+        if let Some(size) = filesize {
+            view.set_filesize(size);
+        }
+        rendered_sections.insert(
+            "overview.json".to_string(),
+            serde_json::to_string(&view).unwrap(),
+        );
+    }
+
     for (_, route, generator) in SECTION_META {
         let key = format!("{}.json", &route[1..]);
         let mut view = generator(&tsdb, all_sections.clone());
@@ -51,6 +87,16 @@ pub fn generate(data: Tsdb, filesize: Option<u64>) -> AppState {
         }
         rendered_sections.insert(key, serde_json::to_string(&view).unwrap());
     }
+
+    // Generate service section if extension is present
+    if let Some(ext) = service_ext {
+        let view = service::generate(&tsdb, all_sections.clone(), ext);
+        rendered_sections.insert(
+            "service.json".to_string(),
+            serde_json::to_string(&view).unwrap(),
+        );
+    }
+
     drop(rendered_sections);
     drop(tsdb);
 
@@ -64,7 +110,7 @@ mod tests {
     #[test]
     fn generate_produces_expected_keys() {
         let data = Tsdb::default();
-        let state = generate(data, None);
+        let state = generate(data, None, None);
 
         let mut keys: Vec<_> = state.sections.read().keys().cloned().collect();
         keys.sort();

--- a/src/viewer/dashboard/mod.rs
+++ b/src/viewer/dashboard/mod.rs
@@ -68,8 +68,7 @@ pub fn generate(
         .and_then(|e| e.throughput_query())
         .map(str::to_string);
     {
-        let mut view =
-            overview::generate(&tsdb, all_sections.clone(), throughput_query.as_deref());
+        let mut view = overview::generate(&tsdb, all_sections.clone(), throughput_query.as_deref());
         if let Some(size) = filesize {
             view.set_filesize(size);
         }

--- a/src/viewer/dashboard/overview.rs
+++ b/src/viewer/dashboard/overview.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &Tsdb, sections: Vec<Section>, throughput_query: Option<&str>) -> View {
     let mut view = View::new(data, sections);
 
     /*
@@ -177,6 +177,42 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     );
 
     view.group(blockio);
+
+    /*
+     * Normalized by Throughput (only when service extension provides throughput KPI)
+     */
+    if let Some(tq) = throughput_query {
+        let mut normalized = Group::new("Normalized by Throughput", "normalized-throughput");
+
+        normalized.plot_promql(
+            PlotOpts::counter(
+                "CPU Busy % / Throughput",
+                "normalized-cpu-busy",
+                Unit::Count,
+            ),
+            format!("(sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000) / ({tq})"),
+        );
+
+        normalized.plot_promql(
+            PlotOpts::counter(
+                "Network TX / Throughput",
+                "normalized-network-tx",
+                Unit::Count,
+            ),
+            format!("(sum(irate(network_bytes{{direction=\"transmit\"}}[5m])) * 8) / ({tq})"),
+        );
+
+        normalized.plot_promql(
+            PlotOpts::counter(
+                "Network RX / Throughput",
+                "normalized-network-rx",
+                Unit::Count,
+            ),
+            format!("(sum(irate(network_bytes{{direction=\"receive\"}}[5m])) * 8) / ({tq})"),
+        );
+
+        view.group(normalized);
+    }
 
     view
 }

--- a/src/viewer/dashboard/service.rs
+++ b/src/viewer/dashboard/service.rs
@@ -1,0 +1,28 @@
+use super::*;
+use crate::viewer::ServiceExtension;
+
+pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtension) -> View {
+    let mut view = View::new(data, sections);
+
+    for kpi in &service_ext.kpis {
+        let id = format!("kpi-{}", kpi.role);
+        let mut group = Group::new(&kpi.title, &id);
+
+        let opts = match kpi.metric_type.as_str() {
+            "gauge" => PlotOpts::gauge(&kpi.title, &id, Unit::Count),
+            "histogram" => PlotOpts::histogram(
+                &kpi.title,
+                &id,
+                Unit::Count,
+                kpi.subtype.as_deref().unwrap_or("percentiles"),
+            ),
+            _ => PlotOpts::counter(&kpi.title, &id, Unit::Count),
+        };
+        let opts = opts.maybe_unit_system(kpi.unit_system.as_deref());
+
+        group.plot_promql(opts, kpi.query.clone());
+        view.group(group);
+    }
+
+    view
+}

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -446,6 +446,8 @@ fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>) {
         .unwrap_or((None, None))
 }
 
+/// Search for service_queries inside the nested `metadata` map.
+/// Scans all sources and returns the first ServiceExtension found.
 fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
@@ -454,11 +456,23 @@ fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
     let reader = SerializedFileReader::new(f).ok()?;
     let kv = reader.metadata().file_metadata().key_value_metadata()?;
 
-    let json = kv
+    let metadata_json = kv
         .iter()
-        .find(|kv| kv.key == "service_queries")
+        .find(|kv| kv.key == "metadata")
         .and_then(|kv| kv.value.as_deref())?;
-    ServiceExtension::from_json(json)
+
+    let metadata_map: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_str(metadata_json).ok()?;
+
+    for (_source, value) in &metadata_map {
+        if let Some(sq) = value.get("service_queries") {
+            if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone()) {
+                return Some(ext);
+            }
+        }
+    }
+
+    None
 }
 
 fn compute_file_checksum(path: &Path) -> Option<String> {

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -454,17 +454,9 @@ fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
     let reader = SerializedFileReader::new(f).ok()?;
     let kv = reader.metadata().file_metadata().key_value_metadata()?;
 
-    let metric_type = kv
-        .iter()
-        .find(|kv| kv.key == "metric_type")
-        .and_then(|kv| kv.value.as_deref())?;
-    if metric_type != "rezolus:service-extension" {
-        return None;
-    }
-
     let json = kv
         .iter()
-        .find(|kv| kv.key == "service_extension")
+        .find(|kv| kv.key == "service_queries")
         .and_then(|kv| kv.value.as_deref())?;
     ServiceExtension::from_json(json)
 }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -35,7 +35,7 @@ static ASSETS: Dir<'_> = include_dir!("src/viewer/assets");
 mod dashboard;
 mod plot;
 mod service_extension;
-pub use service_extension::ServiceExtension;
+pub use service_extension::{Kpi, ServiceExtension};
 
 // Re-export from metriken-query crate
 pub use metriken_query::promql;

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -449,6 +449,7 @@ fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>) {
 /// Search for service_queries inside the nested `metadata` map.
 /// Scans all sources and returns the first ServiceExtension found.
 fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
+    use crate::parquet_metadata::{KEY_METADATA, NESTED_SERVICE_QUERIES};
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
 
@@ -458,14 +459,14 @@ fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
 
     let metadata_json = kv
         .iter()
-        .find(|kv| kv.key == "metadata")
+        .find(|kv| kv.key == KEY_METADATA)
         .and_then(|kv| kv.value.as_deref())?;
 
     let metadata_map: serde_json::Map<String, serde_json::Value> =
         serde_json::from_str(metadata_json).ok()?;
 
     for (_source, value) in &metadata_map {
-        if let Some(sq) = value.get("service_queries") {
+        if let Some(sq) = value.get(NESTED_SERVICE_QUERIES) {
             if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone()) {
                 return Some(ext);
             }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -34,6 +34,8 @@ static ASSETS: Dir<'_> = include_dir!("src/viewer/assets");
 
 mod dashboard;
 mod plot;
+mod service_extension;
+pub use service_extension::ServiceExtension;
 
 // Re-export from metriken-query crate
 pub use metriken_query::promql;
@@ -148,6 +150,7 @@ pub fn run(config: Config) {
             let filesize = std::fs::metadata(path).map(|m| m.len()).ok();
 
             let (systeminfo, selection) = extract_parquet_metadata(path);
+            let service_ext = extract_service_extension_metadata(path);
 
             // Compute SHA-256 checksum of the parquet data (excluding footer metadata).
             // Parquet layout: [magic 4B] [row groups...] [footer] [footer_len 4B] [magic 4B]
@@ -156,8 +159,16 @@ pub fn run(config: Config) {
             info!("Computing file checksum...");
             let file_checksum = compute_file_checksum(path);
 
+            if let Some(ref ext) = service_ext {
+                info!(
+                    "Found service extension for {:?} ({} KPIs)",
+                    ext.service_name,
+                    ext.kpis.len()
+                );
+            }
+
             info!("Generating dashboards...");
-            let state = dashboard::generate(data, filesize);
+            let state = dashboard::generate(data, filesize, service_ext.as_ref());
             *state.parquet_path.write() = Some(path.clone());
             *state.systeminfo.write() = systeminfo;
             *state.selection.write() = selection;
@@ -218,7 +229,7 @@ pub fn run(config: Config) {
             tsdb.set_source(source.clone());
             tsdb.set_version(version.clone());
             tsdb.set_filename(url.to_string());
-            let state = dashboard::generate(tsdb, None);
+            let state = dashboard::generate(tsdb, None, None);
             state.live.store(true, Ordering::Relaxed);
 
             *state.systeminfo.write() = agent_systeminfo;
@@ -433,6 +444,29 @@ fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>) {
             Some((sysinfo, sel))
         })
         .unwrap_or((None, None))
+}
+
+fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+
+    let f = std::fs::File::open(path).ok()?;
+    let reader = SerializedFileReader::new(f).ok()?;
+    let kv = reader.metadata().file_metadata().key_value_metadata()?;
+
+    let metric_type = kv
+        .iter()
+        .find(|kv| kv.key == "metric_type")
+        .and_then(|kv| kv.value.as_deref())?;
+    if metric_type != "rezolus:service-extension" {
+        return None;
+    }
+
+    let json = kv
+        .iter()
+        .find(|kv| kv.key == "service_extension")
+        .and_then(|kv| kv.value.as_deref())?;
+    ServiceExtension::from_json(json)
 }
 
 fn compute_file_checksum(path: &Path) -> Option<String> {
@@ -799,7 +833,8 @@ async fn upload_parquet(
     // embeds the original name instead of the temp path.
     data.set_filename(filename.clone());
 
-    let new_state = dashboard::generate(data, filesize);
+    let service_ext = extract_service_extension_metadata(&temp_path);
+    let new_state = dashboard::generate(data, filesize, service_ext.as_ref());
     let (systeminfo, selection) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 
@@ -903,7 +938,7 @@ async fn connect_agent(
     tsdb.set_source(source.clone());
     tsdb.set_version(version.clone());
     tsdb.set_filename(url.to_string());
-    let new_state = dashboard::generate(tsdb, None);
+    let new_state = dashboard::generate(tsdb, None, None);
 
     // Update shared state
     {
@@ -1269,7 +1304,7 @@ async fn lib(uri: Uri) -> impl IntoResponse {
 pub fn dump_dashboards(output_dir: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(output_dir)?;
 
-    let state = dashboard::generate(Tsdb::default(), None);
+    let state = dashboard::generate(Tsdb::default(), None, None);
 
     // Extract the shared sections list from the first entry and write it once.
     let mut sections_written = false;

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -449,7 +449,7 @@ fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>) {
 /// Search for service_queries inside the nested `metadata` map.
 /// Scans all sources and returns the first ServiceExtension found.
 fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
-    use crate::parquet_metadata::{KEY_METADATA, NESTED_SERVICE_QUERIES};
+    use crate::parquet_metadata::{KEY_PER_SOURCE_METADATA, NESTED_SERVICE_QUERIES};
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
 
@@ -459,7 +459,7 @@ fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
 
     let metadata_json = kv
         .iter()
-        .find(|kv| kv.key == KEY_METADATA)
+        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
         .and_then(|kv| kv.value.as_deref())?;
 
     let metadata_map: serde_json::Map<String, serde_json::Value> =

--- a/src/viewer/plot.rs
+++ b/src/viewer/plot.rs
@@ -282,6 +282,13 @@ impl PlotOpts {
         self
     }
 
+    pub fn maybe_unit_system(self, unit: Option<&str>) -> Self {
+        match unit {
+            Some(u) => self.with_unit_system(u),
+            None => self,
+        }
+    }
+
     pub fn with_axis_label<T: Into<String>>(mut self, y_label: T) -> Self {
         self.format.y_axis_label = Some(y_label.into());
         self

--- a/src/viewer/service_extension.rs
+++ b/src/viewer/service_extension.rs
@@ -35,10 +35,6 @@ fn default_available() -> bool {
 }
 
 impl ServiceExtension {
-    pub fn from_json(json: &str) -> Option<Self> {
-        serde_json::from_str(json).ok()
-    }
-
     pub fn throughput_query(&self) -> Option<&str> {
         self.kpis
             .iter()

--- a/src/viewer/service_extension.rs
+++ b/src/viewer/service_extension.rs
@@ -24,6 +24,14 @@ pub struct Kpi {
     pub subtype: Option<String>,
     #[serde(default)]
     pub unit_system: Option<String>,
+    /// Whether the parquet file contains data for this KPI's query.
+    /// Set by `rezolus parquet annotate` during validation.
+    #[serde(default = "default_available")]
+    pub available: bool,
+}
+
+fn default_available() -> bool {
+    true
 }
 
 impl ServiceExtension {

--- a/src/viewer/service_extension.rs
+++ b/src/viewer/service_extension.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceExtension {
+    pub service_name: String,
+    #[serde(default)]
+    pub service_metadata: HashMap<String, String>,
+    #[serde(default)]
+    pub slo: Option<serde_json::Value>,
+    pub kpis: Vec<Kpi>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Kpi {
+    pub role: String,
+    pub title: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub query: String,
+    #[serde(rename = "type")]
+    pub metric_type: String,
+    #[serde(default)]
+    pub subtype: Option<String>,
+    #[serde(default)]
+    pub unit_system: Option<String>,
+}
+
+impl ServiceExtension {
+    pub fn from_json(json: &str) -> Option<Self> {
+        serde_json::from_str(json).ok()
+    }
+
+    pub fn throughput_query(&self) -> Option<&str> {
+        self.kpis
+            .iter()
+            .find(|k| k.role == "throughput")
+            .map(|k| k.query.as_str())
+    }
+}


### PR DESCRIPTION
## Problem

Currently, there's no way to add service extension metadata to parquet files, and the dashboard doesn't support rendering service-specific KPIs. This limits the ability to annotate performance data with service-level metrics and SLOs.

## Solution

This PR adds comprehensive service extension support:

1. **New `parquet_tools` module** with an `annotate` subcommand that:
   - Adds service extension metadata to parquet files
   - Supports built-in templates (starting with `llm-perf`)
   - Allows custom service extension JSON files via `--file` flag
   - Reads the `source` metadata from parquet files to auto-select templates
   - Validates JSON before writing and preserves existing metadata

2. **Service extension infrastructure**:
   - New `ServiceExtension` struct with KPI definitions
   - Support for extracting service extension metadata from parquet files
   - Helper methods for querying throughput KPIs

3. **Dashboard enhancements**:
   - New "Service" dashboard section that dynamically renders KPIs from service extensions
   - Overview section now includes "Normalized by Throughput" plots when a throughput KPI is available
   - Dashboard generation updated to accept optional service extension data

4. **Built-in LLM performance template** (`llm_perf.json`) with 13 KPIs covering:
   - Throughput metrics (token rates, request rates)
   - Latency metrics (TTFT, TPOT, ITL, request latency)
   - Error tracking and saturation metrics

## Result

Users can now:
- Annotate parquet files with service metadata using `rezolus parquet annotate <file>`
- Automatically select templates based on parquet source metadata
- View service-specific KPIs in a dedicated dashboard section
- See throughput-normalized resource utilization metrics in the overview
- Extend with custom service definitions via JSON files

The changes are backward compatible—dashboards work normally without service extensions, and the new service section only appears when extension metadata is present.

https://claude.ai/code/session_01LXQArZeWdKABfeZnHHRrEP