### PR TITLE
Install GPG dependencies in release workflow container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,9 @@ jobs:
             echo "No GPG signing key configured, skipping."
             exit 0
           fi
+          # Install GPG agent and pinentry (not present in minimal container images)
+          yum install -y gnupg2 pinentry
+
           # Import the GPG signing key
           echo "$GPG_SIGNING_KEY" | base64 -d | gpg --batch --import
 


### PR DESCRIPTION
## Problem

The release workflow runs GPG signing operations in a minimal container image that lacks the necessary GPG tools and dependencies. This causes the GPG signing step to fail because `gnupg2` and `pinentry` are not available in the container environment.

## Solution

Added installation of `gnupg2` and `pinentry` packages via `yum install` before the GPG key import step in the release workflow. This ensures all required GPG dependencies are present in the container before attempting to sign releases.

## Result

The release workflow will now successfully install the necessary GPG tools, allowing the GPG signing step to complete without errors when running in minimal container images.

https://claude.ai/code/session_01B2G9WDmXQpBKRc2g2sMxpA