### PR TITLE
release: prepare v5.9.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
             exit 0
           fi
           # Install GPG agent and pinentry (not present in minimal container images)
-          yum install -y gnupg2 pinentry
+          yum install -y --allowerasing gnupg2 pinentry
 
           # Import the GPG signing key
           echo "$GPG_SIGNING_KEY" | base64 -d | gpg --batch --import
@@ -210,6 +210,10 @@ jobs:
             echo "Signing $(basename $rpm)..."
             rpm --addsign "$rpm"
           done
+
+          # Import public key into RPM's keyring for verification
+          gpg --export -a "$GPG_KEY_ID" > /tmp/rpm-signing-key.pub
+          rpm --import /tmp/rpm-signing-key.pub
 
           # Verify signatures
           echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [5.9.1] - 2026-04-12
+
+### Fixed
+
+- CI: install gnupg2 and pinentry for RPM signing in containers.
+
 ## [5.9.0] - 2026-04-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.9.1-alpha.0"
+version = "5.9.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rezolus"
-version = "5.9.1-alpha.0"
+version = "5.9.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "High resolution systems performance telemetry agent"


### PR DESCRIPTION
## Summary

- Fix RPM signing in release workflow: use `--allowerasing` for gnupg2 install (resolves Amazon Linux 2023 `gnupg2-minimal` conflict)
- Import GPG public key into RPM's keyring before `rpm --checksig` verification
- Bump version to 5.9.1 and update CHANGELOG

## Test plan

- [ ] Merge triggers `tag-release.yml` via `release: prepare v` commit message
- [ ] `tag-release.yml` creates `v5.9.1` tag and bumps to `5.9.2-alpha.0`
- [ ] `release.yml` builds and signs RPMs successfully on Rocky Linux and Amazon Linux
- [ ] RPM signature verification passes

https://claude.ai/code/session_01B2G9WDmXQpBKRc2g2sMxpA