### PR TITLE
Suppress claude.ai session links from commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,7 @@ TOML configs in `config/`:
 - **Linux**: Full support including eBPF (kernel 5.8+)
 - **macOS**: Limited (CPU usage only, no eBPF)
 - **Architectures**: x86_64 and ARM64
+
+## Git Conventions
+
+Do not append claude.ai session links to commit messages.


### PR DESCRIPTION
## Summary
- Add a "Git Conventions" section to CLAUDE.md instructing Claude Code not to append `claude.ai/code/session_...` URLs to commit messages
