### PR TITLE
feat(viewer): frontend service section, theme colors, and viewer improvements

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -3,6 +3,10 @@ pub use logging::{configure_logging, verbosity_to_level, Level, LogConfig, LogDr
 
 pub static HISTOGRAM_GROUPING_POWER: u8 = 3;
 
+/// Default percentile quantiles used for histogram summaries across the
+/// exporter, parquet annotation, and viewer.
+pub const DEFAULT_PERCENTILES: &[f64] = &[0.5, 0.9, 0.99, 0.999, 0.9999];
+
 // Static metric descriptions extracted from source by build.rs.
 // Platform-independent — includes all metrics regardless of target OS.
 include!(concat!(env!("OUT_DIR"), "/metric_descriptions.rs"));

--- a/src/exporter/snapshot.rs
+++ b/src/exporter/snapshot.rs
@@ -86,7 +86,7 @@ pub fn snapshot(
                 }
             }
 
-            if let Ok(Some(percentiles)) = delta.percentiles(&[0.5, 0.9, 0.99, 0.999, 0.9999]) {
+            if let Ok(Some(percentiles)) = delta.percentiles(crate::common::DEFAULT_PERCENTILES) {
                 for (percentile, value) in percentiles.into_iter().map(|(p, b)| (p, b.end())) {
                     if let Ok(value) = value.try_into() {
                         let mut metadata = metadata.clone();

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -11,10 +11,18 @@ use crate::viewer::ServiceExtension;
 
 static TEMPLATES: &[(&str, &str)] = &[("llm-perf", include_str!("templates/llm_perf.json"))];
 
+/// Source name aliases for renamed projects (old name → canonical name).
+static SOURCE_ALIASES: &[(&str, &str)] = &[("llm-bench", "llm-perf")];
+
 fn lookup_template(source: &str) -> Option<&'static str> {
+    let canonical = SOURCE_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == source)
+        .map(|(_, canon)| *canon)
+        .unwrap_or(source);
     TEMPLATES
         .iter()
-        .find(|(name, _)| *name == source)
+        .find(|(name, _)| *name == canonical)
         .map(|(_, json)| *json)
 }
 
@@ -70,10 +78,17 @@ fn effective_query(kpi: &crate::viewer::Kpi) -> String {
         if subtype == "buckets" {
             format!("histogram_heatmap({})", kpi.query)
         } else {
-            format!(
-                "histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], {})",
-                kpi.query
-            )
+            let quantiles = match &kpi.percentiles {
+                Some(p) => format!(
+                    "[{}]",
+                    p.iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                None => "[0.5, 0.9, 0.99, 0.999, 0.9999]".to_string(),
+            };
+            format!("histogram_percentiles({}, {})", quantiles, kpi.query)
         }
     } else {
         kpi.query.clone()

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -9,7 +9,10 @@ use crate::viewer::promql::QueryEngine;
 use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
 
-static TEMPLATES: &[(&str, &str)] = &[("llm-perf", include_str!("templates/llm_perf.json"))];
+static TEMPLATES: &[(&str, &str)] = &[
+    ("llm-perf", include_str!("templates/llm_perf.json")),
+    ("cachecannon", include_str!("templates/cachecannon.json")),
+];
 
 /// Source name aliases for renamed projects (old name → canonical name).
 static SOURCE_ALIASES: &[(&str, &str)] = &[("llm-bench", "llm-perf")];

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -86,7 +86,14 @@ fn effective_query(kpi: &crate::viewer::Kpi) -> String {
                         .collect::<Vec<_>>()
                         .join(", ")
                 ),
-                None => "[0.5, 0.9, 0.99, 0.999, 0.9999]".to_string(),
+                None => format!(
+                    "[{}]",
+                    crate::common::DEFAULT_PERCENTILES
+                        .iter()
+                        .map(|v| v.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
             };
             format!("histogram_percentiles({}, {})", quantiles, kpi.query)
         }

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -853,7 +853,7 @@ mod tests {
     #[test]
     fn test_combine_trims_to_overlap() {
         let (_t1, p1) = make_test_file(
-            &[1 * SEC, 2 * SEC, 3 * SEC],
+            &[SEC, 2 * SEC, 3 * SEC],
             "m1",
             &[Some(1), Some(2), Some(3)],
             "rezolus",
@@ -913,7 +913,7 @@ mod tests {
     #[test]
     fn test_combine_end_to_end() {
         let (_t1, p1) = make_test_file(
-            &[1 * SEC, 2 * SEC, 3 * SEC],
+            &[SEC, 2 * SEC, 3 * SEC],
             "cpu",
             &[Some(10), Some(20), Some(30)],
             "rezolus",
@@ -972,8 +972,8 @@ mod tests {
 
     #[test]
     fn test_combine_preserves_field_metadata() {
-        let (_t1, p1) = make_test_file(&[1 * SEC, 2 * SEC], "m1", &[Some(1), Some(2)], "rezolus", "1000");
-        let (_t2, p2) = make_test_file(&[1 * SEC, 2 * SEC], "m2", &[Some(3), Some(4)], "llm-perf", "1000");
+        let (_t1, p1) = make_test_file(&[SEC, 2 * SEC], "m1", &[Some(1), Some(2)], "rezolus", "1000");
+        let (_t2, p2) = make_test_file(&[SEC, 2 * SEC], "m2", &[Some(3), Some(4)], "llm-perf", "1000");
 
         let out_tmp = NamedTempFile::new().unwrap();
         let out_path = out_tmp.path().to_path_buf();
@@ -1002,7 +1002,7 @@ mod tests {
         // Overlapping time range but timestamps land in different buckets
         // (offset by a full interval so they never share a quantized bucket)
         let (_t1, p1) = make_test_file(
-            &[1 * SEC, 3 * SEC, 5 * SEC],
+            &[SEC, 3 * SEC, 5 * SEC],
             "m1",
             &[Some(1), Some(2), Some(3)],
             "rezolus",
@@ -1030,14 +1030,14 @@ mod tests {
         // Quantization should snap them to the same bucket.
         let offset = 5_000_000; // 5ms in ns
         let (_t1, p1) = make_test_file(
-            &[1 * SEC, 2 * SEC, 3 * SEC],
+            &[SEC, 2 * SEC, 3 * SEC],
             "m1",
             &[Some(10), Some(20), Some(30)],
             "rezolus",
             "1000",
         );
         let (_t2, p2) = make_test_file(
-            &[1 * SEC + offset, 2 * SEC + offset, 3 * SEC + offset],
+            &[SEC + offset, 2 * SEC + offset, 3 * SEC + offset],
             "m2",
             &[Some(40), Some(50), Some(60)],
             "llm-perf",
@@ -1075,14 +1075,14 @@ mod tests {
         // With a 1s interval, 150ms offset exceeds the 100ms (10%) tolerance.
         let bad_offset = 150_000_000; // 150ms in ns
         let (_t1, p1) = make_test_file(
-            &[1 * SEC, 2 * SEC, 3 * SEC],
+            &[SEC, 2 * SEC, 3 * SEC],
             "m1",
             &[Some(1), Some(2), Some(3)],
             "rezolus",
             "1000",
         );
         let (_t2, p2) = make_test_file(
-            &[1 * SEC + bad_offset, 2 * SEC + bad_offset, 3 * SEC + bad_offset],
+            &[SEC + bad_offset, 2 * SEC + bad_offset, 3 * SEC + bad_offset],
             "m2",
             &[Some(4), Some(5), Some(6)],
             "llm-perf",

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -219,17 +219,23 @@ fn combine_and_write(
     inputs: &[InputFile],
     output: &PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Step 1: Build timestamp → row-index maps
+    let interval_ns = resolve_interval_ns(inputs)?;
+
+    // Step 1: Build quantized-timestamp → row-index maps
     let ts_maps: Vec<HashMap<u64, usize>> = inputs
         .iter()
-        .map(build_timestamp_map)
+        .map(|input| build_timestamp_map(input, interval_ns))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Step 2: Compute intersection of all timestamp sets (sorted)
+    // Step 2: Compute intersection of all quantized timestamp sets (sorted)
     let common_timestamps = compute_common_timestamps(&ts_maps);
     if common_timestamps.is_empty() {
         return Err("no common timestamps across all input files".into());
     }
+
+    // Step 2b: Validate alignment quality — at least 95% of matched
+    // timestamps must have raw values within 10% of the interval.
+    validate_alignment_quality(inputs, &common_timestamps, interval_ns)?;
 
     // Step 3: Build merged schema
     let (primary_idx, merged_schema) = build_merged_schema(inputs);
@@ -250,15 +256,111 @@ fn combine_and_write(
     Ok(())
 }
 
+/// Parse the (already-validated-identical) sampling interval as nanoseconds.
+fn resolve_interval_ns(inputs: &[InputFile]) -> Result<u64, Box<dyn std::error::Error>> {
+    let ms_str = inputs
+        .iter()
+        .find_map(|i| i.sampling_interval_ms.as_deref())
+        .ok_or("no sampling_interval_ms metadata in any input file")?;
+    let ms: u64 = ms_str.parse().map_err(|_| {
+        format!("sampling_interval_ms {:?} is not a valid integer", ms_str)
+    })?;
+    Ok(ms * 1_000_000) // ms → ns
+}
+
+/// Round a nanosecond timestamp to the nearest interval boundary.
+fn quantize(ts: u64, interval_ns: u64) -> u64 {
+    let half = interval_ns / 2;
+    ((ts + half) / interval_ns) * interval_ns
+}
+
+/// Validate that aligned timestamps are close enough across files.
+///
+/// For each quantized bucket in the common set, collect the raw timestamps
+/// from every file that mapped to that bucket. At least 95% of these buckets
+/// must have all raw timestamps within 10% of the interval of each other.
+fn validate_alignment_quality(
+    inputs: &[InputFile],
+    common_quantized: &[u64],
+    interval_ns: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tolerance = interval_ns / 10; // 10% of interval
+    let threshold = 0.95;
+
+    // Build quantized → raw timestamp maps for each file
+    let raw_maps: Vec<HashMap<u64, u64>> = inputs
+        .iter()
+        .map(|input| {
+            let ts_idx = input.schema.index_of("timestamp").unwrap();
+            let mut map = HashMap::new();
+            for batch in &input.batches {
+                let ts_col = batch
+                    .column(ts_idx)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap();
+                for i in 0..ts_col.len() {
+                    let raw = ts_col.value(i);
+                    let q = quantize(raw, interval_ns);
+                    // Keep the value closest to the bucket center
+                    map.entry(q)
+                        .and_modify(|existing: &mut u64| {
+                            if raw.abs_diff(q) < existing.abs_diff(q) {
+                                *existing = raw;
+                            }
+                        })
+                        .or_insert(raw);
+                }
+            }
+            map
+        })
+        .collect();
+
+    let mut aligned = 0usize;
+    for &qts in common_quantized {
+        let raws: Vec<u64> = raw_maps.iter().filter_map(|m| m.get(&qts).copied()).collect();
+        if raws.len() < 2 {
+            aligned += 1;
+            continue;
+        }
+        let min_raw = *raws.iter().min().unwrap();
+        let max_raw = *raws.iter().max().unwrap();
+        if max_raw - min_raw <= tolerance {
+            aligned += 1;
+        }
+    }
+
+    let ratio = aligned as f64 / common_quantized.len() as f64;
+    if ratio < threshold {
+        return Err(format!(
+            "timestamp alignment too poor: only {:.1}% of matched timestamps are within \
+             10% of the sampling interval (need ≥95%)",
+            ratio * 100.0
+        )
+        .into());
+    }
+
+    if ratio < 1.0 {
+        let misaligned = common_quantized.len() - aligned;
+        eprintln!(
+            "warning: {misaligned}/{} timestamps have phase offset >10% of interval",
+            common_quantized.len()
+        );
+    }
+
+    Ok(())
+}
+
 fn build_timestamp_map(
     input: &InputFile,
+    interval_ns: u64,
 ) -> Result<HashMap<u64, usize>, Box<dyn std::error::Error>> {
     let ts_idx = input
         .schema
         .index_of("timestamp")
         .map_err(|_| format!("{:?}: missing 'timestamp' column", input.path))?;
 
-    let mut map = HashMap::new();
+    let mut map: HashMap<u64, (usize, u64)> = HashMap::new(); // quantized → (row_idx, raw_ts)
     let mut global_row = 0usize;
 
     for batch in &input.batches {
@@ -269,12 +371,23 @@ fn build_timestamp_map(
             .ok_or("timestamp column is not UInt64")?;
 
         for i in 0..ts_col.len() {
-            map.insert(ts_col.value(i), global_row + i);
+            let raw = ts_col.value(i);
+            let q = quantize(raw, interval_ns);
+            let row = global_row + i;
+            map.entry(q)
+                .and_modify(|(existing_row, existing_raw)| {
+                    // Keep the row whose raw timestamp is closest to the bucket center
+                    if raw.abs_diff(q) < existing_raw.abs_diff(q) {
+                        *existing_row = row;
+                        *existing_raw = raw;
+                    }
+                })
+                .or_insert((row, raw));
         }
         global_row += batch.num_rows();
     }
 
-    Ok(map)
+    Ok(map.into_iter().map(|(q, (row, _))| (q, row)).collect())
 }
 
 fn compute_common_timestamps(ts_maps: &[HashMap<u64, usize>]) -> Vec<u64> {
@@ -358,14 +471,12 @@ fn build_output_batch(
 
     let mut output_columns: Vec<ArrayRef> = Vec::new();
 
-    // timestamp and duration from primary file
-    let ts_idx = inputs[primary_idx].schema.index_of("timestamp").unwrap();
+    // Timestamp column: use quantized (bucket-center) values for a clean,
+    // uniform time grid regardless of per-file phase offsets.
+    output_columns.push(Arc::new(UInt64Array::from(common_timestamps.to_vec())));
+
+    // Duration from primary file
     let dur_idx = inputs[primary_idx].schema.index_of("duration").unwrap();
-    output_columns.push(compute::take(
-        concatenated[primary_idx][ts_idx].as_ref(),
-        &selection_indices[primary_idx],
-        None,
-    )?);
     output_columns.push(compute::take(
         concatenated[primary_idx][dur_idx].as_ref(),
         &selection_indices[primary_idx],
@@ -587,6 +698,10 @@ mod tests {
     use arrow::datatypes::DataType;
     use tempfile::NamedTempFile;
 
+    /// 1 second in nanoseconds — use as a multiplier so test timestamps
+    /// are at a realistic scale relative to the sampling interval.
+    const SEC: u64 = 1_000_000_000;
+
     /// Create a test parquet file with a timestamp column, duration column,
     /// and one gauge metric column.
     fn make_test_file(
@@ -738,14 +853,14 @@ mod tests {
     #[test]
     fn test_combine_trims_to_overlap() {
         let (_t1, p1) = make_test_file(
-            &[100, 200, 300],
+            &[1 * SEC, 2 * SEC, 3 * SEC],
             "m1",
             &[Some(1), Some(2), Some(3)],
             "rezolus",
             "1000",
         );
         let (_t2, p2) = make_test_file(
-            &[200, 300, 400],
+            &[2 * SEC, 3 * SEC, 4 * SEC],
             "m2",
             &[Some(4), Some(5), Some(6)],
             "llm-perf",
@@ -765,7 +880,7 @@ mod tests {
         let mut reader = builder.build().unwrap();
         let batch = reader.next().unwrap().unwrap();
 
-        // Only timestamps 200 and 300 should be present
+        // Only timestamps at 2s and 3s should be present
         assert_eq!(batch.num_rows(), 2);
 
         let ts_col = batch
@@ -773,10 +888,10 @@ mod tests {
             .as_any()
             .downcast_ref::<UInt64Array>()
             .unwrap();
-        assert_eq!(ts_col.value(0), 200);
-        assert_eq!(ts_col.value(1), 300);
+        assert_eq!(ts_col.value(0), 2 * SEC);
+        assert_eq!(ts_col.value(1), 3 * SEC);
 
-        // m1 values for timestamps 200, 300 are 2, 3
+        // m1 values for timestamps 2s, 3s are 2, 3
         let m1_col = batch
             .column(schema.index_of("m1").unwrap())
             .as_any()
@@ -785,7 +900,7 @@ mod tests {
         assert_eq!(m1_col.value(0), 2);
         assert_eq!(m1_col.value(1), 3);
 
-        // m2 values for timestamps 200, 300 are 4, 5
+        // m2 values for timestamps 2s, 3s are 4, 5
         let m2_col = batch
             .column(schema.index_of("m2").unwrap())
             .as_any()
@@ -798,14 +913,14 @@ mod tests {
     #[test]
     fn test_combine_end_to_end() {
         let (_t1, p1) = make_test_file(
-            &[100, 200, 300],
+            &[1 * SEC, 2 * SEC, 3 * SEC],
             "cpu",
             &[Some(10), Some(20), Some(30)],
             "rezolus",
             "1000",
         );
         let (_t2, p2) = make_test_file(
-            &[200, 300, 400],
+            &[2 * SEC, 3 * SEC, 4 * SEC],
             "tokens",
             &[Some(40), Some(50), Some(60)],
             "llm-perf",
@@ -857,8 +972,8 @@ mod tests {
 
     #[test]
     fn test_combine_preserves_field_metadata() {
-        let (_t1, p1) = make_test_file(&[100, 200], "m1", &[Some(1), Some(2)], "rezolus", "1000");
-        let (_t2, p2) = make_test_file(&[100, 200], "m2", &[Some(3), Some(4)], "llm-perf", "1000");
+        let (_t1, p1) = make_test_file(&[1 * SEC, 2 * SEC], "m1", &[Some(1), Some(2)], "rezolus", "1000");
+        let (_t2, p2) = make_test_file(&[1 * SEC, 2 * SEC], "m2", &[Some(3), Some(4)], "llm-perf", "1000");
 
         let out_tmp = NamedTempFile::new().unwrap();
         let out_path = out_tmp.path().to_path_buf();
@@ -884,16 +999,90 @@ mod tests {
 
     #[test]
     fn test_combine_empty_intersection() {
-        // Same time range but no matching timestamps
+        // Overlapping time range but timestamps land in different buckets
+        // (offset by a full interval so they never share a quantized bucket)
         let (_t1, p1) = make_test_file(
-            &[100, 300, 500],
+            &[1 * SEC, 3 * SEC, 5 * SEC],
+            "m1",
+            &[Some(1), Some(2), Some(3)],
+            "rezolus",
+            "2000", // 2s interval
+        );
+        let (_t2, p2) = make_test_file(
+            &[2 * SEC, 4 * SEC, 6 * SEC],
+            "m2",
+            &[Some(4), Some(5), Some(6)],
+            "llm-perf",
+            "2000",
+        );
+
+        let out_tmp = NamedTempFile::new().unwrap();
+        let out_path = out_tmp.path().to_path_buf();
+
+        let inputs = vec![load(&p1), load(&p2)];
+        let result = combine_and_write(&inputs, &out_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_combine_fuzzy_timestamp_matching() {
+        // Two files with a small phase offset (5ms) on a 1s interval.
+        // Quantization should snap them to the same bucket.
+        let offset = 5_000_000; // 5ms in ns
+        let (_t1, p1) = make_test_file(
+            &[1 * SEC, 2 * SEC, 3 * SEC],
+            "m1",
+            &[Some(10), Some(20), Some(30)],
+            "rezolus",
+            "1000",
+        );
+        let (_t2, p2) = make_test_file(
+            &[1 * SEC + offset, 2 * SEC + offset, 3 * SEC + offset],
+            "m2",
+            &[Some(40), Some(50), Some(60)],
+            "llm-perf",
+            "1000",
+        );
+
+        let out_tmp = NamedTempFile::new().unwrap();
+        let out_path = out_tmp.path().to_path_buf();
+
+        let inputs = vec![load(&p1), load(&p2)];
+        combine_and_write(&inputs, &out_path).unwrap();
+
+        let file = std::fs::File::open(&out_path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let schema = builder.schema().clone();
+        let mut reader = builder.build().unwrap();
+        let batch = reader.next().unwrap().unwrap();
+
+        // All 3 timestamps should match
+        assert_eq!(batch.num_rows(), 3);
+
+        let m2_col = batch
+            .column(schema.index_of("m2").unwrap())
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(m2_col.value(0), 40);
+        assert_eq!(m2_col.value(1), 50);
+        assert_eq!(m2_col.value(2), 60);
+    }
+
+    #[test]
+    fn test_combine_rejects_poor_alignment() {
+        // Two files where >5% of timestamps have phase offset >10% of interval.
+        // With a 1s interval, 150ms offset exceeds the 100ms (10%) tolerance.
+        let bad_offset = 150_000_000; // 150ms in ns
+        let (_t1, p1) = make_test_file(
+            &[1 * SEC, 2 * SEC, 3 * SEC],
             "m1",
             &[Some(1), Some(2), Some(3)],
             "rezolus",
             "1000",
         );
         let (_t2, p2) = make_test_file(
-            &[200, 400, 600],
+            &[1 * SEC + bad_offset, 2 * SEC + bad_offset, 3 * SEC + bad_offset],
             "m2",
             &[Some(4), Some(5), Some(6)],
             "llm-perf",
@@ -906,5 +1095,20 @@ mod tests {
         let inputs = vec![load(&p1), load(&p2)];
         let result = combine_and_write(&inputs, &out_path);
         assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("alignment too poor"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_quantize_rounds_to_nearest() {
+        let interval = 1_000_000_000; // 1s
+        // Exact boundary
+        assert_eq!(quantize(2 * interval, interval), 2 * interval);
+        // Slightly after boundary
+        assert_eq!(quantize(2 * interval + 1000, interval), 2 * interval);
+        // Just before next boundary (rounds up)
+        assert_eq!(quantize(3 * interval - 1000, interval), 3 * interval);
+        // Exactly at midpoint (rounds up)
+        assert_eq!(quantize(2 * interval + interval / 2, interval), 3 * interval);
     }
 }

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -262,9 +262,9 @@ fn resolve_interval_ns(inputs: &[InputFile]) -> Result<u64, Box<dyn std::error::
         .iter()
         .find_map(|i| i.sampling_interval_ms.as_deref())
         .ok_or("no sampling_interval_ms metadata in any input file")?;
-    let ms: u64 = ms_str.parse().map_err(|_| {
-        format!("sampling_interval_ms {:?} is not a valid integer", ms_str)
-    })?;
+    let ms: u64 = ms_str
+        .parse()
+        .map_err(|_| format!("sampling_interval_ms {:?} is not a valid integer", ms_str))?;
     Ok(ms * 1_000_000) // ms → ns
 }
 
@@ -318,7 +318,10 @@ fn validate_alignment_quality(
 
     let mut aligned = 0usize;
     for &qts in common_quantized {
-        let raws: Vec<u64> = raw_maps.iter().filter_map(|m| m.get(&qts).copied()).collect();
+        let raws: Vec<u64> = raw_maps
+            .iter()
+            .filter_map(|m| m.get(&qts).copied())
+            .collect();
         if raws.len() < 2 {
             aligned += 1;
             continue;
@@ -972,8 +975,20 @@ mod tests {
 
     #[test]
     fn test_combine_preserves_field_metadata() {
-        let (_t1, p1) = make_test_file(&[SEC, 2 * SEC], "m1", &[Some(1), Some(2)], "rezolus", "1000");
-        let (_t2, p2) = make_test_file(&[SEC, 2 * SEC], "m2", &[Some(3), Some(4)], "llm-perf", "1000");
+        let (_t1, p1) = make_test_file(
+            &[SEC, 2 * SEC],
+            "m1",
+            &[Some(1), Some(2)],
+            "rezolus",
+            "1000",
+        );
+        let (_t2, p2) = make_test_file(
+            &[SEC, 2 * SEC],
+            "m2",
+            &[Some(3), Some(4)],
+            "llm-perf",
+            "1000",
+        );
 
         let out_tmp = NamedTempFile::new().unwrap();
         let out_path = out_tmp.path().to_path_buf();
@@ -1096,19 +1111,25 @@ mod tests {
         let result = combine_and_write(&inputs, &out_path);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("alignment too poor"), "unexpected error: {err}");
+        assert!(
+            err.contains("alignment too poor"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn test_quantize_rounds_to_nearest() {
         let interval = 1_000_000_000; // 1s
-        // Exact boundary
+                                      // Exact boundary
         assert_eq!(quantize(2 * interval, interval), 2 * interval);
         // Slightly after boundary
         assert_eq!(quantize(2 * interval + 1000, interval), 2 * interval);
         // Just before next boundary (rounds up)
         assert_eq!(quantize(3 * interval - 1000, interval), 3 * interval);
         // Exactly at midpoint (rounds up)
-        assert_eq!(quantize(2 * interval + interval / 2, interval), 3 * interval);
+        assert_eq!(
+            quantize(2 * interval + interval / 2, interval),
+            3 * interval
+        );
     }
 }

--- a/src/parquet_tools/metadata.rs
+++ b/src/parquet_tools/metadata.rs
@@ -135,7 +135,7 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
 
         for field in schema.fields() {
             let name = field.name().clone();
-            let dtype = format!("{}", field.data_type());
+            let dtype = format_data_type(field.data_type());
             let meta = field.metadata();
 
             let metric_type = meta.get("metric_type").cloned().unwrap_or_default();
@@ -282,6 +282,17 @@ fn run_json(
 
     println!("{}", serde_json::to_string_pretty(&out)?);
     Ok(())
+}
+
+/// Human-friendly data type string. Simplifies `List(Field { name: "item",
+/// data_type: UInt64, ... })` to just `List<UInt64>`.
+fn format_data_type(dt: &arrow::datatypes::DataType) -> String {
+    use arrow::datatypes::DataType;
+    match dt {
+        DataType::List(f) => format!("List<{}>", format_data_type(f.data_type())),
+        DataType::LargeList(f) => format!("LargeList<{}>", format_data_type(f.data_type())),
+        other => format!("{other}"),
+    }
 }
 
 fn format_bytes(bytes: i64) -> String {

--- a/src/parquet_tools/metadata.rs
+++ b/src/parquet_tools/metadata.rs
@@ -47,6 +47,9 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(kv) = metadata.file_metadata().key_value_metadata() {
             println!("File Metadata:");
             for entry in kv {
+                if entry.key == "ARROW:schema" {
+                    continue;
+                }
                 let value = entry.value.as_deref().unwrap_or("");
                 if value.len() > 120 {
                     println!("  {}: {}...", entry.key, &value[..120]);
@@ -198,6 +201,9 @@ fn run_json(
         let mut file_meta = serde_json::Map::new();
         if let Some(kv) = metadata.file_metadata().key_value_metadata() {
             for entry in kv {
+                if entry.key == "ARROW:schema" {
+                    continue;
+                }
                 let value = entry.value.as_deref().unwrap_or("");
                 // Try to parse as JSON to nest it properly
                 if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(value) {

--- a/src/parquet_tools/templates/cachecannon.json
+++ b/src/parquet_tools/templates/cachecannon.json
@@ -1,0 +1,58 @@
+{
+  "service_name": "cachecannon",
+  "service_metadata": {},
+  "slo": null,
+  "kpis": [
+    {
+      "role": "load",
+      "title": "Request Rate",
+      "query": "sum(irate(requests_sent[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "load",
+      "title": "Target Rate",
+      "query": "target_rate",
+      "type": "gauge",
+      "unit_system": "count"
+    },
+    {
+      "role": "throughput",
+      "title": "Response Rate",
+      "query": "sum(irate(responses_received[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate",
+      "denominator": true
+    },
+    {
+      "role": "throughput",
+      "title": "Bytes Received Rate",
+      "query": "sum(irate(bytes_rx[5s]))",
+      "type": "delta_counter",
+      "unit_system": "data_rate"
+    },
+    {
+      "role": "latency",
+      "title": "Response Latency",
+      "query": "response_latency",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    },
+    {
+      "role": "error",
+      "title": "Error Rate",
+      "query": "sum(irate(request_errors[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "error",
+      "title": "Connection Failure Rate",
+      "query": "sum(irate(connections_failed[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    }
+  ]
+}

--- a/src/parquet_tools/templates/llm_perf.json
+++ b/src/parquet_tools/templates/llm_perf.json
@@ -11,49 +11,49 @@
       "unit_system": "rate"
     },
     {
-      "role": "custom",
+      "role": "load",
       "title": "Input Token Rate",
       "query": "sum(irate(tokens{direction=\"input\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
-      "role": "saturation",
+      "role": "load",
       "title": "Requests In-Flight",
       "query": "requests_inflight",
       "type": "gauge",
       "unit_system": "count"
     },
     {
-      "role": "custom",
+      "role": "throughput",
       "title": "Request Rate",
       "query": "sum(irate(requests{status=\"success\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
-      "role": "error_rate",
+      "role": "error",
       "title": "Error Rate",
       "query": "sum(irate(requests{status=\"error\"}[5s])) / sum(irate(requests{status=\"sent\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "percentage"
     },
     {
-      "role": "custom",
+      "role": "error",
       "title": "Error Request Rate",
       "query": "sum(irate(requests{status=\"error\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
-      "role": "custom",
+      "role": "error",
       "title": "Timeout Request Rate",
       "query": "sum(irate(requests{status=\"timeout\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
-      "role": "custom",
+      "role": "error",
       "title": "Canceled Request Rate",
       "query": "sum(irate(requests{status=\"canceled\"}[5s]))",
       "type": "delta_counter",

--- a/src/parquet_tools/templates/llm_perf.json
+++ b/src/parquet_tools/templates/llm_perf.json
@@ -8,7 +8,8 @@
       "title": "Output Token Rate",
       "query": "sum(irate(tokens{direction=\"output\"}[5s]))",
       "type": "delta_counter",
-      "unit_system": "rate"
+      "unit_system": "rate",
+      "denominator": true
     },
     {
       "role": "load",

--- a/src/parquet_tools/templates/llm_perf.json
+++ b/src/parquet_tools/templates/llm_perf.json
@@ -65,6 +65,7 @@
       "query": "ttft",
       "type": "histogram",
       "subtype": "percentiles",
+      "percentiles": [0.5, 0.95],
       "unit_system": "time"
     },
     {
@@ -73,6 +74,7 @@
       "query": "tpot",
       "type": "histogram",
       "subtype": "percentiles",
+      "percentiles": [0.5, 0.95],
       "unit_system": "time"
     },
     {
@@ -81,6 +83,7 @@
       "query": "itl",
       "type": "histogram",
       "subtype": "percentiles",
+      "percentiles": [0.5, 0.95],
       "unit_system": "time"
     },
     {
@@ -89,6 +92,7 @@
       "query": "request_latency",
       "type": "histogram",
       "subtype": "percentiles",
+      "percentiles": [0.5, 0.95],
       "unit_system": "time"
     },
     {
@@ -97,6 +101,7 @@
       "query": "think_duration",
       "type": "histogram",
       "subtype": "percentiles",
+      "percentiles": [0.5, 0.95],
       "unit_system": "time"
     }
   ]

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -16,6 +16,7 @@ import {
 } from './multi.js';
 import globalColorMapper, { COLORS } from './util/colormap.js';
 import { themeVersion } from '../theme.js';
+import { resolveStyle } from './metric_types.js';
 
 
 export class ChartsState {
@@ -147,6 +148,21 @@ export class Chart {
         if (this.echart && (oldSpec.data !== this.spec.data || themeChanged)) {
             this._themeVersion = themeVersion;
             this.configureChartByType();
+
+            // Restore zoom state after re-render (notMerge wipes dataZoom range)
+            if (themeChanged && this.chartsState.zoomLevel !== null) {
+                const z = this.chartsState.zoomLevel;
+                if (z.start !== 0 || z.end !== 100) {
+                    this.echart.dispatchAction({
+                        type: 'dataZoom',
+                        start: z.start,
+                        end: z.end,
+                        startValue: z.startValue,
+                        endValue: z.endValue,
+                    });
+                    this._rescaleYAxis();
+                }
+            }
         }
     }
 
@@ -370,7 +386,9 @@ export class Chart {
     _rescaleYAxis() {
         if (!this.echart) return;
 
-        const style = this.spec.opts.style || this.spec._resolvedStyle;
+        const style = this.spec.opts.style
+            || this.spec._resolvedStyle
+            || resolveStyle(this.spec.opts.type, this.spec.opts.subtype);
         // Only for chart types with a value/log Y-axis
         if (style === 'heatmap' || style === 'histogram_heatmap') return;
 
@@ -461,8 +479,11 @@ export class Chart {
     }
 
     configureChartByType() {
-        // Use explicit style (query explorer) or resolved style (from metric type)
-        const style = this.spec.opts.style || this.spec._resolvedStyle;
+        // Use explicit style (query explorer), resolved style (from query result),
+        // or infer from metric type/subtype before data arrives.
+        const style = this.spec.opts.style
+            || this.spec._resolvedStyle
+            || resolveStyle(this.spec.opts.type, this.spec.opts.subtype);
 
         // Clean up heatmap DOM legend bar when switching to a different chart type
         if (style !== 'histogram_heatmap' && style !== 'heatmap') {

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -1,3 +1,6 @@
+/** Default percentile quantiles used across the viewer. */
+export const DEFAULT_PERCENTILES = [0.5, 0.9, 0.99, 0.999, 0.9999];
+
 /**
  * Maps semantic metric types to compatible chart styles.
  *
@@ -63,14 +66,14 @@ export function resolveStyle(type_, subtype, result) {
  *
  * @param {string} baseQuery - The raw metric selector (e.g. 'tcp_packet_latency')
  * @param {string} [subtype]  - 'percentiles' or 'buckets'
- * @param {number[]} [percentiles] - Custom quantiles (default: [0.5, 0.9, 0.99, 0.999, 0.9999])
+ * @param {number[]} [percentiles] - Custom quantiles (default: DEFAULT_PERCENTILES)
  * @returns {string} The wrapped PromQL query
  */
 export function buildHistogramQuery(baseQuery, subtype, percentiles) {
     if (subtype === 'buckets') {
         return `histogram_heatmap(${baseQuery})`;
     }
-    const quantiles = percentiles || [0.5, 0.9, 0.99, 0.999, 0.9999];
+    const quantiles = percentiles || DEFAULT_PERCENTILES;
     return `histogram_percentiles([${quantiles.join(', ')}], ${baseQuery})`;
 }
 

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -63,14 +63,15 @@ export function resolveStyle(type_, subtype, result) {
  *
  * @param {string} baseQuery - The raw metric selector (e.g. 'tcp_packet_latency')
  * @param {string} [subtype]  - 'percentiles' or 'buckets'
+ * @param {number[]} [percentiles] - Custom quantiles (default: [0.5, 0.9, 0.99, 0.999, 0.9999])
  * @returns {string} The wrapped PromQL query
  */
-export function buildHistogramQuery(baseQuery, subtype) {
+export function buildHistogramQuery(baseQuery, subtype, percentiles) {
     if (subtype === 'buckets') {
         return `histogram_heatmap(${baseQuery})`;
     }
-    // Default to percentiles
-    return `histogram_percentiles([0.5, 0.9, 0.99, 0.999, 0.9999], ${baseQuery})`;
+    const quantiles = percentiles || [0.5, 0.9, 0.99, 0.999, 0.9999];
+    return `histogram_percentiles([${quantiles.join(', ')}], ${baseQuery})`;
 }
 
 /**

--- a/src/viewer/assets/lib/charts/multi.js
+++ b/src/viewer/assets/lib/charts/multi.js
@@ -58,6 +58,11 @@ export function configureMultiSeriesChart(chart) {
 
     const cgroupColors = seriesNames.map(name => globalColorMapper.getColorByName(name));
 
+    // For percentile charts, assign z-index so lower quantiles draw on top of higher ones.
+    // This ensures p50 is visible when its value equals p99.99.
+    const isPercentileChart = chart.spec.promql_query &&
+        chart.spec.promql_query.includes('histogram_percentiles');
+
     for (let i = 1; i < data.length; i++) {
         const name = seriesNames[i - 1];
         const isOtherCategory = name === "Other";
@@ -68,6 +73,16 @@ export function configureMultiSeriesChart(chart) {
             return [t * 1000, v, raw];
         });
         zippedData = insertGapNulls(zippedData, chart.interval);
+
+        // z controls draw order: higher z draws on top.
+        // Percentile charts: reverse so lower quantiles (earlier in array) draw on top.
+        // Other charts: "Other" category behind everything else.
+        let zLevel;
+        if (isPercentileChart) {
+            zLevel = data.length - i;
+        } else {
+            zLevel = isOtherCategory ? 1 : 2;
+        }
 
         series.push({
             name: name,
@@ -86,8 +101,7 @@ export function configureMultiSeriesChart(chart) {
             // Add symbol for "Other" category to make it more distinguishable
             showSymbol: isOtherCategory,
             symbolSize: isOtherCategory ? 3 : 0,
-            // Ensure "Other" appears behind other lines
-            z: isOtherCategory ? 1 : 2,
+            z: zLevel,
             emphasis: {
                 focus: 'series',
                 lineStyle: {

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -51,7 +51,11 @@ export function configureScatterChart(chart) {
     // Create series for each percentile
     const series = [];
 
-    const percentileLabels = format.percentile_labels || ['p50', 'p90', 'p99', 'p99.9', 'p99.99'];
+    // Derive labels from query result series names (set by the PromQL engine's
+    // percentile label), falling back to opts.percentiles for pre-data render.
+    const percentileLabels = (chart.spec.series_names && chart.spec.series_names.length > 0)
+        ? chart.spec.series_names.map(v => `p${parseFloat(v) * 100}`)
+        : (opts.percentiles || [0.5, 0.9, 0.99, 0.999, 0.9999]).map(v => `p${v * 100}`);
 
     const scatterColors = SCATTER_PALETTE;
 
@@ -85,6 +89,10 @@ export function configureScatterChart(chart) {
         // Line series underneath for visual continuity (with gap breaks)
         // Uses lineOnlyData which has nulls at clamped points so the line breaks there
         const lineData = insertGapNulls(lineOnlyData, chart.interval);
+        // Lower quantiles (earlier in array) get higher z so they draw on top
+        // when values overlap with higher quantiles.
+        const lineZ = (data.length - i) * 2;
+        const scatterZ = lineZ + 1;
         series.push({
             name: name,
             type: 'line',
@@ -97,11 +105,11 @@ export function configureScatterChart(chart) {
             },
             itemStyle: { color: color },
             tooltip: { show: false },
-            z: 1,
+            z: lineZ,
             animation: false,
         });
 
-        // Scatter series on top
+        // Scatter series on top of its own line
         series.push({
             name: name,
             type: 'scatter',
@@ -110,7 +118,7 @@ export function configureScatterChart(chart) {
             itemStyle: {
                 color: color,
             },
-            z: 2,
+            z: scatterZ,
             emphasis: {
                 focus: 'series',
                 scale: false,

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -19,6 +19,7 @@ import {
     FONTS,
 } from './base.js';
 import { SCATTER_PALETTE } from './util/colormap.js';
+import { DEFAULT_PERCENTILES } from './metric_types.js';
 
 /**
  * Configures the Chart based on Chart.spec
@@ -55,7 +56,7 @@ export function configureScatterChart(chart) {
     // percentile label), falling back to opts.percentiles for pre-data render.
     const percentileLabels = (chart.spec.series_names && chart.spec.series_names.length > 0)
         ? chart.spec.series_names.map(v => `p${parseFloat(v) * 100}`)
-        : (opts.percentiles || [0.5, 0.9, 0.99, 0.999, 0.9999]).map(v => `p${v * 100}`);
+        : (opts.percentiles || DEFAULT_PERCENTILES).map(v => `p${v * 100}`);
 
     const scatterColors = SCATTER_PALETTE;
 

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -179,7 +179,7 @@ const createDataApi = ({
 
                     // Wrap histogram queries with the appropriate function
                     if (plot.opts.type === 'histogram') {
-                        queryToRun = buildHistogramQuery(queryToRun, plot.opts.subtype);
+                        queryToRun = buildHistogramQuery(queryToRun, plot.opts.subtype, plot.opts.percentiles);
                     }
 
                     if (queryToRun.includes('__SELECTED_CGROUPS__')) {
@@ -280,6 +280,10 @@ const createDataApi = ({
         return heatmapData;
     };
 
+    const clearMetadataCache = () => {
+        cachedMetadata = null;
+    };
+
     return {
         executePromQLRangeQuery,
         applyResultToPlot,
@@ -287,6 +291,7 @@ const createDataApi = ({
         fetchHeatmapsForGroups,
         substituteCgroupPattern,
         processDashboardData,
+        clearMetadataCache,
     };
 };
 
@@ -297,6 +302,7 @@ const {
     fetchHeatmapForPlot,
     fetchHeatmapsForGroups,
     processDashboardData,
+    clearMetadataCache,
 } = defaultDataApi;
 
 export {
@@ -306,5 +312,6 @@ export {
     fetchHeatmapsForGroups,
     substituteCgroupPattern,
     processDashboardData,
+    clearMetadataCache,
     createDataApi,
 };

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -173,17 +173,15 @@ const Sidebar = {
     view({ attrs }) {
         const sectionResponseCache = attrs.sectionResponseCache;
 
-        // Separate Query Explorer from other sections
-        const regularSections = attrs.sections.filter(
-            (s) => s.name !== 'Query Explorer',
-        );
+        // Separate special sections from sampler sections
         const queryExplorer = attrs.sections.find(
             (s) => s.name === 'Query Explorer',
         );
-
-        // Find the first non-overview section to use as samplers header
-        const overviewSection = regularSections.find((s) => s.name === 'Overview');
-        const samplerSections = regularSections.filter((s) => s.name !== 'Overview');
+        const overviewSection = attrs.sections.find((s) => s.name === 'Overview');
+        const serviceSection = attrs.sections.find((s) => s.route === '/service');
+        const samplerSections = attrs.sections.filter(
+            (s) => s.name !== 'Query Explorer' && s.name !== 'Overview' && s.route !== '/service',
+        );
 
         return [
         // Backdrop overlay for mobile drawer
@@ -232,15 +230,18 @@ const Sidebar = {
                 overviewSection.name,
             ),
 
-            // Service section (shown only when service extension data is present)
-            attrs.hasServiceExtension && m(
-                m.route.Link,
-                {
-                    class: attrs.activeSection?.route === '/service' ? 'selected' : '',
-                    href: '/service',
-                },
-                'Service',
-            ),
+            // Service section (own labeled group, named after the source)
+            serviceSection && [
+                m('div.sidebar-label', serviceSection.name),
+                m(
+                    m.route.Link,
+                    {
+                        class: attrs.activeSection?.route === '/service' ? 'selected' : '',
+                        href: '/service',
+                    },
+                    'KPIs',
+                ),
+            ],
 
             // Samplers label
             samplerSections.length > 0 && m('div.sidebar-label', 'Samplers'),

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -232,6 +232,16 @@ const Sidebar = {
                 overviewSection.name,
             ),
 
+            // Service section (shown only when service extension data is present)
+            attrs.hasServiceExtension && m(
+                m.route.Link,
+                {
+                    class: attrs.activeSection?.route === '/service' ? 'selected' : '',
+                    href: '/service',
+                },
+                'Service',
+            ),
+
             // Samplers label
             samplerSections.length > 0 && m('div.sidebar-label', 'Samplers'),
 

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -231,17 +231,22 @@ const Sidebar = {
             ),
 
             // Service section (own labeled group, named after the source)
-            serviceSection && [
-                m('div.sidebar-label', serviceSection.name),
-                m(
-                    m.route.Link,
-                    {
-                        class: attrs.activeSection?.route === '/service' ? 'selected' : '',
-                        href: '/service',
-                    },
-                    'KPIs',
-                ),
-            ],
+            serviceSection && (() => {
+                const cached = sectionResponseCache['service'];
+                const count = cached ? countCharts(cached.groups) : null;
+                const label = count ? `KPIs (${count.withData})` : 'KPIs';
+                return [
+                    m('div.sidebar-label', serviceSection.name),
+                    m(
+                        m.route.Link,
+                        {
+                            class: attrs.activeSection?.route === '/service' ? 'selected' : '',
+                            href: '/service',
+                        },
+                        label,
+                    ),
+                ];
+            })(),
 
             // Samplers label
             samplerSections.length > 0 && m('div.sidebar-label', 'Samplers'),

--- a/src/viewer/assets/lib/navigation.js
+++ b/src/viewer/assets/lib/navigation.js
@@ -37,7 +37,6 @@ const createMainComponent = ({
     SectionContent,
     sectionResponseCache,
     getHasSystemInfo,
-    getHasServiceExtension,
     buildAttrs,
 }) => ({
     view({
@@ -56,7 +55,6 @@ const createMainComponent = ({
                     sections,
                     sectionResponseCache,
                     hasSystemInfo: !!getHasSystemInfo(),
-                    hasServiceExtension: !!getHasServiceExtension(),
                 }),
                 m(SectionContent, {
                     section: activeSection,

--- a/src/viewer/assets/lib/navigation.js
+++ b/src/viewer/assets/lib/navigation.js
@@ -37,10 +37,11 @@ const createMainComponent = ({
     SectionContent,
     sectionResponseCache,
     getHasSystemInfo,
+    getHasServiceExtension,
     buildAttrs,
 }) => ({
     view({
-        attrs: { activeSection, groups, sections, source, version, filename, interval, filesize, start_time, end_time, num_series },
+        attrs: { activeSection, groups, sections, source, version, filename, interval, filesize, start_time, end_time, num_series, metadata },
     }) {
         return m(
             'div',
@@ -55,11 +56,13 @@ const createMainComponent = ({
                     sections,
                     sectionResponseCache,
                     hasSystemInfo: !!getHasSystemInfo(),
+                    hasServiceExtension: !!getHasServiceExtension(),
                 }),
                 m(SectionContent, {
                     section: activeSection,
                     groups,
                     interval,
+                    metadata,
                 }),
             ]),
             m(SaveModal),

--- a/src/viewer/assets/lib/overlays.js
+++ b/src/viewer/assets/lib/overlays.js
@@ -46,14 +46,16 @@ const modalState = {
     prefix: '',
     suffix: '',
     onConfirm: null,
+    checkboxes: [],  // [{key, label, checked}]
 };
 
-const showSaveModal = (defaultPrefix, suffix) => {
+const showSaveModal = (defaultPrefix, suffix, checkboxes) => {
     return new Promise((resolve) => {
         modalState.visible = true;
         modalState.prefix = defaultPrefix;
         modalState.suffix = suffix;
-        modalState.onConfirm = (filename) => resolve(filename);
+        modalState.checkboxes = (checkboxes || []).map(cb => ({ ...cb }));
+        modalState.onConfirm = (result) => resolve(result);
         m.redraw();
     });
 };
@@ -63,9 +65,18 @@ const _closeModal = (result) => {
     modalState.visible = false;
     modalState.prefix = '';
     modalState.suffix = '';
+    modalState.checkboxes = [];
     modalState.onConfirm = null;
     m.redraw();
     if (cb) cb(result);
+};
+
+const _buildResult = () => {
+    const filename = modalState.prefix.trim() + modalState.suffix;
+    if (modalState.checkboxes.length === 0) return filename;
+    const opts = {};
+    for (const cb of modalState.checkboxes) opts[cb.key] = cb.checked;
+    return { filename, ...opts };
 };
 
 const SaveModal = {
@@ -94,7 +105,7 @@ const SaveModal = {
                         onkeydown: (e) => {
                             if (e.key === 'Enter' && modalState.prefix.trim()) {
                                 e.preventDefault();
-                                _closeModal(modalState.prefix.trim() + modalState.suffix);
+                                _closeModal(_buildResult());
                             }
                             if (e.key === 'Escape') {
                                 e.preventDefault();
@@ -104,6 +115,18 @@ const SaveModal = {
                     }),
                     m('span.save-modal-suffix', modalState.suffix),
                 ]),
+                modalState.checkboxes.length > 0 && m('div.save-modal-options',
+                    modalState.checkboxes.map(cb =>
+                        m('label.save-modal-checkbox', [
+                            m('input', {
+                                type: 'checkbox',
+                                checked: cb.checked,
+                                onchange: (e) => { cb.checked = e.target.checked; },
+                            }),
+                            ' ', cb.label,
+                        ]),
+                    ),
+                ),
                 m('div.save-modal-actions', [
                     m('button.save-modal-btn.save-modal-cancel', {
                         onclick: () => _closeModal(null),
@@ -111,7 +134,7 @@ const SaveModal = {
                     m('button.save-modal-btn.save-modal-confirm', {
                         onclick: () => {
                             if (modalState.prefix.trim()) {
-                                _closeModal(modalState.prefix.trim() + modalState.suffix);
+                                _closeModal(_buildResult());
                             }
                         },
                         disabled: !modalState.prefix.trim(),

--- a/src/viewer/assets/lib/overlays.js
+++ b/src/viewer/assets/lib/overlays.js
@@ -73,7 +73,6 @@ const _closeModal = (result) => {
 
 const _buildResult = () => {
     const filename = modalState.prefix.trim() + modalState.suffix;
-    if (modalState.checkboxes.length === 0) return filename;
     const opts = {};
     for (const cb of modalState.checkboxes) opts[cb.key] = cb.checked;
     return { filename, ...opts };

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -4,7 +4,7 @@ import { CgroupSelector } from './cgroup_selector.js';
 import globalColorMapper from './charts/util/colormap.js';
 import { TopNav, Sidebar, countCharts, formatSize } from './layout.js';
 import { CpuTopology } from './topology.js';
-import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData } from './data.js';
+import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache } from './data.js';
 import { reportStore, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
 import { expandLink, selectButton } from './chart_controls.js';
 import { notify, showSaveModal, SaveModal } from './overlays.js';
@@ -99,6 +99,7 @@ const uploadParquet = async (file) => {
     try {
         await ViewerApi.uploadParquet(file);
         clearViewerCaches();
+        clearMetadataCache();
         chartsState.resetAll();
         await fetchBackendState();
         // Re-fetch overview so the view has data to render immediately.
@@ -212,6 +213,28 @@ const SectionContent = {
             });
         }
 
+        // Special handling for Service extension
+        if (sectionName === 'Service') {
+            const meta = attrs.metadata || {};
+            const serviceName = meta.service_name || 'Service';
+            const serviceMeta = meta.service_metadata || {};
+            return m('div#section-content', [
+                m('h1', serviceName),
+                Object.keys(serviceMeta).length > 0
+                    ? m('table.sysinfo-table', [
+                        m('tbody', Object.entries(serviceMeta).map(([k, v]) =>
+                            m('tr', [m('td.sysinfo-key', k), m('td', v)])
+                        )),
+                    ])
+                    : null,
+                m('div#groups',
+                    (attrs.groups || []).map((group) =>
+                        m(Group, { ...group, sectionRoute, sectionName, interval })
+                    )
+                ),
+            ]);
+        }
+
         const { withData } = countCharts(attrs.groups);
         const titleText = `${sectionName} (${withData})`;
 
@@ -279,6 +302,10 @@ Main = createMainComponent({
     SectionContent,
     sectionResponseCache,
     getHasSystemInfo: () => systemInfoData,
+    getHasServiceExtension: () => {
+        const anyCached = Object.values(sectionResponseCache)[0];
+        return anyCached?.sections?.some(s => s.route === '/service');
+    },
     buildAttrs: topNavAttrs,
 });
 const SystemInfoView = createSystemInfoView({
@@ -614,6 +641,8 @@ const bootstrap = async () => {
                     bootstrapCacheIfNeeded();
                     return buildClientOnlySectionView(reportSection);
                 }
+
+                // Service section is fetched from backend like any other section
 
                 // In live mode, always read from cache dynamically so
                 // refreshes flow through to the rendered view.

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -215,7 +215,7 @@ const SectionContent = {
         }
 
         // Special handling for Service extension
-        if (sectionName === 'Service') {
+        if (sectionRoute === '/service') {
             const meta = attrs.metadata || {};
             const serviceName = meta.service_name || 'Service';
             const serviceMeta = meta.service_metadata || {};
@@ -303,10 +303,6 @@ Main = createMainComponent({
     SectionContent,
     sectionResponseCache,
     getHasSystemInfo: () => systemInfoData,
-    getHasServiceExtension: () => {
-        const anyCached = Object.values(sectionResponseCache)[0];
-        return anyCached?.sections?.some(s => s.route === '/service');
-    },
     buildAttrs: topNavAttrs,
 });
 const SystemInfoView = createSystemInfoView({

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -78,8 +78,9 @@ const stopRecording = () => {
 };
 
 const saveCapture = async () => {
-    const filename = await showSaveModal('rezolus-capture', '.parquet');
-    if (!filename) return;
+    const result = await showSaveModal('rezolus-capture', '.parquet');
+    if (!result) return;
+    const filename = result.filename;
     const a = document.createElement('a');
     a.href = ViewerApi.saveUrl();
     a.download = filename;

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -219,6 +219,7 @@ const SectionContent = {
             const meta = attrs.metadata || {};
             const serviceName = meta.service_name || 'Service';
             const serviceMeta = meta.service_metadata || {};
+            const unavailable = meta.unavailable_kpis || [];
             return m('div#section-content', [
                 m('h1', serviceName),
                 Object.keys(serviceMeta).length > 0
@@ -233,6 +234,16 @@ const SectionContent = {
                         m(Group, { ...group, sectionRoute, sectionName, interval })
                     )
                 ),
+                unavailable.length > 0 && m('div.service-notes', [
+                    m('h3', 'Unavailable KPIs'),
+                    m('p', 'The following KPIs have no matching data in this recording:'),
+                    m('ul', unavailable.map((kpi) =>
+                        m('li', [
+                            m('strong', kpi.title),
+                            ` (${kpi.role})`,
+                        ])
+                    )),
+                ]),
             ]);
         }
 

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -277,9 +277,29 @@ const importJSON = (currentChecksum) => {
 
 const saveToParquet = async (store, attrs) => {
     const defaultPrefix = (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-annotated';
-    const filename = await showSaveModal(defaultPrefix, '.parquet');
-    if (!filename) return;
+    const cs = attrs.chartsState;
+    const hasZoom = cs && !cs.isDefaultZoom();
+    const checkboxes = hasZoom
+        ? [{ key: 'trim', label: 'Trim to selected time range', checked: false }]
+        : [];
+    const result = await showSaveModal(defaultPrefix, '.parquet', checkboxes);
+    if (!result) return;
+    const filename = typeof result === 'string' ? result : result.filename;
+    const trimToSelection = typeof result === 'object' && result.trim;
     const payload = buildPayload(store, attrs);
+
+    // When trimming, compute the absolute time range (ms) from the zoom percentage
+    if (trimToSelection) {
+        const zoom = cs?.globalZoom || cs?.zoomLevel;
+        if (zoom && attrs.start_time != null && attrs.end_time != null) {
+            const total = attrs.end_time - attrs.start_time;
+            payload.trim_range_ms = {
+                start: attrs.start_time + (zoom.start / 100) * total,
+                end: attrs.start_time + (zoom.end / 100) * total,
+            };
+        }
+    }
+
     try {
         const xhr = new XMLHttpRequest();
         xhr.open('POST', '/api/v1/save_with_selection', true);
@@ -419,7 +439,9 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                     'Export JSON ',
                     m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 10V2m0 8l-3-3m3 3l3-3"/></svg>'),
                 ]),
-                m('button.selection-btn', { onclick: () => saveToParquet(selectionStore, attrs) }, [
+                m('button.selection-btn', {
+                    onclick: () => saveToParquet(selectionStore, attrs),
+                }, [
                     'Annotate Parquet ',
                     m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 10V2m0 8l-3-3m3 3l3-3"/></svg>'),
                 ]),

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -191,8 +191,9 @@ const buildPayload = (store, attrs) => ({
 
 const exportJSON = async (store, attrs) => {
     const defaultPrefix = `report-${Date.now()}`;
-    const filename = await showSaveModal(defaultPrefix, '.json');
-    if (!filename) return;
+    const result = await showSaveModal(defaultPrefix, '.json');
+    if (!result) return;
+    const filename = result.filename;
     const payload = buildPayload(store, attrs);
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -284,8 +285,8 @@ const saveToParquet = async (store, attrs) => {
         : [];
     const result = await showSaveModal(defaultPrefix, '.parquet', checkboxes);
     if (!result) return;
-    const filename = typeof result === 'string' ? result : result.filename;
-    const trimToSelection = typeof result === 'object' && result.trim;
+    const filename = result.filename;
+    const trimToSelection = result.trim;
     const payload = buildPayload(store, attrs);
 
     // When trimming, compute the absolute time range (ms) from the zoom percentage

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -45,7 +45,39 @@
     --success: #3fb950;
     --warning: #d29922;
     --danger: #f85149;
+    --danger-fg: #ffa198;
     --info: #58a6ff;
+
+    /* Transport / recording controls */
+    --record: #f56565;
+    --record-bg: rgba(229, 62, 62, 0.2);
+    --record-bg-hover: rgba(229, 62, 62, 0.35);
+    --record-hover: #fc8181;
+    --record-glow: rgba(229, 62, 62, 0.25);
+    --stop: #ecc94b;
+    --stop-bg: rgba(236, 201, 75, 0.15);
+    --stop-bg-hover: rgba(236, 201, 75, 0.3);
+    --stop-hover: #f6e05e;
+    --stop-glow: rgba(236, 201, 75, 0.2);
+    --recording-badge: #e53e3e;
+
+    /* Overlays */
+    --overlay: rgba(0, 0, 0, 0.5);
+    --overlay-heavy: rgba(0, 0, 0, 0.6);
+    --selection-highlight: rgba(255, 255, 255, 0.06);
+
+    /* Topology diagram */
+    --topo-threads: rgba(63, 185, 80, 0.6);
+    --topo-threads-emphasis: rgba(63, 185, 80, 0.9);
+    --topo-cache: rgba(249, 115, 22, 0.6);
+    --topo-numa: rgba(88, 166, 255, 0.6);
+    --topo-numa-emphasis: rgba(88, 166, 255, 0.9);
+    --topo-inset: rgba(22, 27, 34, 0.4);
+    --topo-inset-deep: rgba(28, 33, 40, 0.6);
+    --topo-inset-deeper: rgba(13, 17, 23, 0.5);
+
+    /* On-accent foreground (text on filled accent/primary buttons) */
+    --fg-on-accent: #fff;
 
     /* Gradients */
     --bg-card-gradient: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-void) 100%);
@@ -122,7 +154,39 @@
     --success: #1a7f37;
     --warning: #9a6700;
     --danger: #cf222e;
+    --danger-fg: #cf222e;
     --info: #0969da;
+
+    /* Transport / recording controls */
+    --record: #cf222e;
+    --record-bg: rgba(207, 34, 46, 0.1);
+    --record-bg-hover: rgba(207, 34, 46, 0.18);
+    --record-hover: #a40e26;
+    --record-glow: rgba(207, 34, 46, 0.15);
+    --stop: #9a6700;
+    --stop-bg: rgba(154, 103, 0, 0.1);
+    --stop-bg-hover: rgba(154, 103, 0, 0.18);
+    --stop-hover: #7c5200;
+    --stop-glow: rgba(154, 103, 0, 0.12);
+    --recording-badge: #cf222e;
+
+    /* Overlays */
+    --overlay: rgba(0, 0, 0, 0.3);
+    --overlay-heavy: rgba(0, 0, 0, 0.45);
+    --selection-highlight: rgba(0, 0, 0, 0.06);
+
+    /* Topology diagram */
+    --topo-threads: rgba(26, 127, 55, 0.6);
+    --topo-threads-emphasis: rgba(26, 127, 55, 0.9);
+    --topo-cache: rgba(188, 82, 0, 0.6);
+    --topo-numa: rgba(9, 105, 218, 0.6);
+    --topo-numa-emphasis: rgba(9, 105, 218, 0.85);
+    --topo-inset: rgba(208, 215, 222, 0.5);
+    --topo-inset-deep: rgba(208, 215, 222, 0.7);
+    --topo-inset-deeper: rgba(208, 215, 222, 0.4);
+
+    /* On-accent foreground */
+    --fg-on-accent: #fff;
 
     /* Shadows */
     --shadow-sm: 0 1px 2px rgba(31, 35, 40, 0.08);
@@ -139,11 +203,11 @@
     --chart-shadow-strong: rgba(31, 35, 40, 0.25);
 }
 
-/* In light theme, replace the subtle grid overlay with a lighter tint */
+/* In light theme, use a slightly stronger grid tint for visibility */
 [data-theme="light"] body::before {
     background-image:
-        linear-gradient(rgba(9, 105, 218, 0.025) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(9, 105, 218, 0.025) 1px, transparent 1px);
+        linear-gradient(color-mix(in srgb, var(--accent) 2.5%, transparent) 1px, transparent 1px),
+        linear-gradient(90deg, color-mix(in srgb, var(--accent) 2.5%, transparent) 1px, transparent 1px);
 }
 
 [data-theme="light"] body::after {
@@ -175,8 +239,8 @@ body::before {
     position: fixed;
     inset: 0;
     background-image:
-        linear-gradient(rgba(88, 166, 255, 0.015) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(88, 166, 255, 0.015) 1px, transparent 1px);
+        linear-gradient(color-mix(in srgb, var(--accent) 1.5%, transparent) 1px, transparent 1px),
+        linear-gradient(90deg, color-mix(in srgb, var(--accent) 1.5%, transparent) 1px, transparent 1px);
     background-size: 48px 48px;
     pointer-events: none;
     z-index: -1;
@@ -240,13 +304,13 @@ body::after {
     font-size: var(--font-size-xs);
     font-weight: 700;
     letter-spacing: 0.08em;
-    color: #fff;
+    color: var(--fg-on-accent);
     padding: 0.15rem 0.5rem;
     border-radius: 4px;
 }
 
 #topnav .logo .live-indicator.recording {
-    background: #e53e3e;
+    background: var(--recording-badge);
     animation: live-pulse 2s ease-in-out infinite;
 }
 
@@ -313,7 +377,7 @@ body::after {
     position: absolute;
     top: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--overlay);
     pointer-events: none;
 }
 
@@ -321,7 +385,7 @@ body::after {
     position: absolute;
     top: 0;
     bottom: 0;
-    background: rgba(255, 255, 255, 0.06);
+    background: var(--selection-highlight);
     cursor: grab;
     min-width: 2px;
 }
@@ -455,7 +519,7 @@ body::after {
     border-radius: 6px;
     z-index: 200;
     white-space: nowrap;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--shadow-md);
     overflow: hidden;
     border-spacing: 0;
 }
@@ -513,38 +577,38 @@ body::after {
 
 /* Record button — red */
 #topnav .topnav-actions .transport-btn.record-btn {
-    background: rgba(229, 62, 62, 0.2);
-    color: #f56565;
+    background: var(--record-bg);
+    color: var(--record);
 }
 
 #topnav .topnav-actions .transport-btn.record-btn:hover:not(:disabled) {
-    background: rgba(229, 62, 62, 0.35);
-    color: #fc8181;
-    box-shadow: 0 0 12px rgba(229, 62, 62, 0.25);
+    background: var(--record-bg-hover);
+    color: var(--record-hover);
+    box-shadow: 0 0 12px var(--record-glow);
 }
 
 /* Stop button — amber */
 #topnav .topnav-actions .transport-btn.stop-btn {
-    background: rgba(236, 201, 75, 0.15);
-    color: #ecc94b;
+    background: var(--stop-bg);
+    color: var(--stop);
 }
 
 #topnav .topnav-actions .transport-btn.stop-btn:hover:not(:disabled) {
-    background: rgba(236, 201, 75, 0.3);
-    color: #f6e05e;
-    box-shadow: 0 0 12px rgba(236, 201, 75, 0.2);
+    background: var(--stop-bg-hover);
+    color: var(--stop-hover);
+    box-shadow: 0 0 12px var(--stop-glow);
 }
 
 /* Save button — blue */
 #topnav .topnav-actions .transport-btn.save-btn {
-    background: rgba(88, 166, 255, 0.15);
+    background: var(--accent-subtle);
     color: var(--accent);
 }
 
 #topnav .topnav-actions .transport-btn.save-btn:hover {
-    background: rgba(88, 166, 255, 0.3);
+    background: var(--accent-muted);
     color: var(--accent-emphasis);
-    box-shadow: 0 0 12px rgba(88, 166, 255, 0.2);
+    box-shadow: 0 0 12px var(--accent-glow);
 }
 
 #topnav .topnav-actions .transport-btn.import-btn {
@@ -555,7 +619,7 @@ body::after {
     font-size: 0.75rem;
     font-weight: 500;
     letter-spacing: 0.03em;
-    background: rgba(88, 166, 255, 0.15);
+    background: var(--accent-subtle);
     color: var(--accent);
 }
 
@@ -571,20 +635,20 @@ body::after {
 }
 
 #topnav .topnav-actions .transport-btn.import-btn:hover {
-    background: rgba(88, 166, 255, 0.3);
+    background: var(--accent-muted);
     color: var(--accent-emphasis);
-    box-shadow: 0 0 12px rgba(88, 166, 255, 0.2);
+    box-shadow: 0 0 12px var(--accent-glow);
 }
 
 #topnav .topnav-actions .transport-btn.import-btn.parquet-loaded {
-    color: #3fb950;
-    border-color: rgba(63, 185, 80, 0.4);
+    color: var(--success);
+    border-color: color-mix(in srgb, var(--success) 40%, transparent);
 }
 
 #topnav .topnav-actions .transport-btn.import-btn.parquet-loaded:hover {
-    background: rgba(63, 185, 80, 0.15);
-    color: #56d364;
-    box-shadow: 0 0 12px rgba(63, 185, 80, 0.2);
+    background: color-mix(in srgb, var(--success) 15%, transparent);
+    color: var(--success);
+    box-shadow: 0 0 12px color-mix(in srgb, var(--success) 20%, transparent);
 }
 
 #topnav .theme-toggle-btn {
@@ -931,7 +995,7 @@ main {
     content: '';
     position: absolute;
     inset: 0;
-    background: linear-gradient(180deg, rgba(88, 166, 255, 0.03) 0%, transparent 30%);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 3%, transparent) 0%, transparent 30%);
     pointer-events: none;
     opacity: 0;
     transition: opacity var(--transition-base);
@@ -942,7 +1006,7 @@ main {
     box-shadow:
         var(--shadow-lg),
         0 0 0 1px var(--accent-subtle),
-        inset 0 1px 0 rgba(255, 255, 255, 0.02);
+        inset 0 1px 0 color-mix(in srgb, var(--fg-on-accent) 2%, transparent);
 }
 
 .chart-wrapper:hover::before {
@@ -1157,7 +1221,7 @@ main {
 
 .execute-btn {
     padding: 0.75rem 1.5rem;
-    background: linear-gradient(180deg, var(--accent) 0%, #4393eb 100%);
+    background: linear-gradient(180deg, var(--accent) 0%, var(--accent-emphasis) 100%);
     color: var(--bg-void);
     border: none;
     border-radius: 6px;
@@ -1168,14 +1232,14 @@ main {
     letter-spacing: 0.02em;
     align-self: flex-start;
     transition: all var(--transition-base);
-    box-shadow: 0 2px 8px rgba(88, 166, 255, 0.3);
+    box-shadow: 0 2px 8px var(--accent-muted);
 }
 
 .execute-btn:hover:not(:disabled) {
     transform: translateY(-1px);
     box-shadow:
-        0 4px 16px rgba(88, 166, 255, 0.4),
-        0 0 24px rgba(88, 166, 255, 0.2);
+        0 4px 16px var(--accent-muted),
+        0 0 24px var(--accent-glow);
 }
 
 .execute-btn:active:not(:disabled) {
@@ -1218,9 +1282,9 @@ main {
 }
 
 .error-message {
-    background: linear-gradient(180deg, rgba(248, 81, 73, 0.15) 0%, rgba(248, 81, 73, 0.05) 100%);
-    border: 1px solid rgba(248, 81, 73, 0.3);
-    color: #ffa198;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--danger) 15%, transparent) 0%, color-mix(in srgb, var(--danger) 5%, transparent) 100%);
+    border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+    color: var(--danger-fg);
     padding: 1rem;
     border-radius: var(--card-radius);
     margin: 1rem 0;
@@ -1384,9 +1448,9 @@ main {
 }
 
 .cgroup-selector .error-message {
-    background: rgba(248, 81, 73, 0.1);
-    border: 1px solid rgba(248, 81, 73, 0.3);
-    color: #ffa198;
+    background: color-mix(in srgb, var(--danger) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+    color: var(--danger-fg);
     padding: 0.5rem 1rem;
     border-radius: 4px;
     margin-bottom: 1rem;
@@ -1660,9 +1724,9 @@ main {
 .topo-toggle:hover { color: var(--fg-secondary); }
 .topo-toggle.active { color: var(--fg); }
 
-.topo-toggle-threads.active { border-color: rgba(63, 185, 80, 0.6); }
-.topo-toggle-caches.active  { border-color: rgba(249, 115, 22, 0.6); }
-.topo-toggle-numa.active    { border-color: rgba(88, 166, 255, 0.6); }
+.topo-toggle-threads.active { border-color: var(--topo-threads); }
+.topo-toggle-caches.active  { border-color: var(--topo-cache); }
+.topo-toggle-numa.active    { border-color: var(--topo-numa); }
 
 /* Packages container */
 .topo-packages {
@@ -1702,14 +1766,14 @@ main {
 }
 
 .topo-numa-box.numa-highlighted {
-    border-color: rgba(88, 166, 255, 0.6);
+    border-color: var(--topo-numa);
 }
 
 .topo-numa-header {
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
     font-weight: 400;
-    color: rgba(88, 166, 255, 0.9);
+    color: var(--topo-numa-emphasis);
     margin-bottom: 0.35rem;
 }
 
@@ -1729,7 +1793,7 @@ main {
 /* Core cell */
 .topo-core {
     background: var(--bg-tertiary);
-    border: var(--topo-border, 2px) solid rgba(63, 185, 80, 0.6);
+    border: var(--topo-border, 2px) solid var(--topo-threads);
     border-radius: 3px;
     display: flex;
     flex-direction: column;
@@ -1742,7 +1806,7 @@ main {
 }
 
 .topo-core:hover {
-    border-color: rgba(63, 185, 80, 0.9);
+    border-color: var(--topo-threads-emphasis);
 }
 
 .core-id {
@@ -1776,8 +1840,8 @@ main {
     gap: 2px;
     justify-content: center;
     align-items: center;
-    background: rgba(22, 27, 34, 0.4);
-    border: var(--topo-border, 2px) solid rgba(249, 115, 22, 0.6);
+    background: var(--topo-inset);
+    border: var(--topo-border, 2px) solid var(--topo-cache);
     border-radius: 3px;
     padding: 3px 4px;
     min-width: 0;
@@ -1797,7 +1861,7 @@ main {
     font-family: var(--font-mono);
     font-size: 9px;
     color: var(--fg);
-    background: rgba(28, 33, 40, 0.6);
+    background: var(--topo-inset-deep);
     border-radius: 2px;
     padding: 2px 4px;
     line-height: 1.4;
@@ -1805,7 +1869,7 @@ main {
 
 /* Cache bars — span their cores (orange outline) */
 .topo-cache-bar {
-    border: var(--topo-border, 2px) solid rgba(249, 115, 22, 0.6);
+    border: var(--topo-border, 2px) solid var(--topo-cache);
     text-align: center;
     display: flex;
     flex-direction: column;
@@ -1833,12 +1897,12 @@ main {
 }
 
 .topo-mid-cache {
-    background: rgba(22, 27, 34, 0.4);
+    background: var(--topo-inset);
     border-radius: 3px;
 }
 
 .topo-llc {
-    background: rgba(13, 17, 23, 0.5);
+    background: var(--topo-inset-deeper);
     border-radius: 4px;
 }
 
@@ -2005,9 +2069,39 @@ main {
 }
 
 .selection-btn-danger:hover {
-    background: rgba(248, 81, 73, 0.15);
-    color: #f85149;
-    border-color: #f85149;
+    background: color-mix(in srgb, var(--danger) 15%, transparent);
+    color: var(--danger);
+    border-color: var(--danger);
+}
+
+.save-modal-input-row + .save-modal-options {
+    margin-top: -11px;
+}
+
+.save-modal-options {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 1rem;
+    padding-left: 2px;
+}
+
+.save-modal-checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--fg-secondary);
+    cursor: pointer;
+    user-select: none;
+}
+
+.save-modal-checkbox input[type="checkbox"] {
+    margin: 0;
+    cursor: pointer;
+    accent-color: var(--accent-muted);
+    background: var(--bg-tertiary);
 }
 
 .selection-card {
@@ -2068,7 +2162,7 @@ main {
 }
 
 .selection-card-remove:hover {
-    color: #f85149;
+    color: var(--danger);
 }
 
 .selection-card-body {
@@ -2197,7 +2291,7 @@ main {
     color: var(--fg);
     border: 1px solid var(--border-default);
     background: var(--bg-elevated);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--shadow-md);
     opacity: 0;
     transform: translateX(20px);
     transition: opacity 0.25s ease, transform 0.25s ease;
@@ -2235,7 +2329,7 @@ main {
 .save-modal-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.6);
+    background: var(--overlay-heavy);
     z-index: 9999;
     display: flex;
     align-items: center;
@@ -2249,7 +2343,7 @@ main {
     padding: 1.5rem;
     min-width: 380px;
     max-width: 500px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    box-shadow: var(--shadow-lg);
 }
 
 .save-modal-title {
@@ -2483,7 +2577,7 @@ main {
     .sidebar-backdrop {
         position: fixed;
         inset: 0;
-        background: rgba(0, 0, 0, 0.5);
+        background: var(--overlay);
         z-index: 199;
     }
 
@@ -2626,7 +2720,7 @@ main {
 
 .upload-dropzone.dragover {
     border-color: var(--accent);
-    background: rgba(91, 155, 213, 0.05);
+    background: var(--accent-subtle);
 }
 
 .upload-icon {
@@ -2651,7 +2745,7 @@ main {
     margin-top: 0.75rem;
     padding: 0.5rem 1.5rem;
     background: var(--accent);
-    color: #fff;
+    color: var(--fg-on-accent);
     border: none;
     border-radius: 6px;
     font-size: 0.9rem;
@@ -2665,7 +2759,7 @@ main {
 }
 
 .upload-error {
-    color: #e05252;
+    color: var(--danger);
     margin-top: 1rem;
     font-size: 0.85rem;
 }

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -1659,6 +1659,41 @@ main {
     user-select: text;
 }
 
+/* Service section heading */
+#section-content > h1 {
+    margin-bottom: 1.5rem;
+}
+
+/* Service notes — unavailable KPIs */
+.service-notes {
+    margin-top: 2rem;
+    padding: 1rem 1.25rem;
+    background: var(--bg-void);
+    border: 1px solid var(--border-default);
+    border-radius: var(--card-radius);
+    color: var(--fg-muted);
+    font-size: var(--font-size-sm);
+}
+
+.service-notes h3 {
+    margin: 0 0 0.5rem;
+    font-size: var(--font-size-sm);
+    color: var(--fg-secondary);
+}
+
+.service-notes p {
+    margin: 0 0 0.5rem;
+}
+
+.service-notes ul {
+    margin: 0;
+    padding-left: 1.25rem;
+}
+
+.service-notes li {
+    margin-bottom: 0.25rem;
+}
+
 /* Sidebar systeminfo link — same style as query explorer link */
 #sidebar .systeminfo-link {
     color: var(--fg-secondary);

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -1,6 +1,10 @@
 // Backend API adapter for src/viewer frontend.
 // Defines a transport abstraction that mirrors the site/viewer WASM adapter.
 
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB — must match server DefaultBodyLimit
+
+const formatMB = (bytes) => (bytes / (1024 * 1024)).toFixed(1);
+
 const backendRequest = (opts) => m.request({
     withCredentials: true,
     ...opts,
@@ -30,17 +34,31 @@ const ViewerApi = {
     },
 
     async uploadParquet(file) {
+        if (file.size > MAX_UPLOAD_BYTES) {
+            throw new Error(
+                `File is too large (${formatMB(file.size)} MB). Maximum upload size is ${formatMB(MAX_UPLOAD_BYTES)} MB.`,
+            );
+        }
         const data = await file.arrayBuffer();
-        return backendRequest({
-            method: 'POST',
-            url: '/api/v1/upload',
-            body: data,
-            serialize: (v) => v,
-            headers: {
-                'Content-Type': 'application/octet-stream',
-                'x-rezolus-filename': file.name || 'upload.parquet',
-            },
-        });
+        try {
+            return await backendRequest({
+                method: 'POST',
+                url: '/api/v1/upload',
+                body: data,
+                serialize: (v) => v,
+                headers: {
+                    'Content-Type': 'application/octet-stream',
+                    'x-rezolus-filename': file.name || 'upload.parquet',
+                },
+            });
+        } catch (e) {
+            if (e.code === 413) {
+                throw new Error(
+                    `File is too large (${formatMB(file.size)} MB). Maximum upload size is ${formatMB(MAX_UPLOAD_BYTES)} MB.`,
+                );
+            }
+            throw e;
+        }
     },
 
     async connectAgent(url) {

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -75,6 +75,7 @@ const ViewerApi = {
             background: true,
         });
     },
+
 };
 
 export { ViewerApi };

--- a/src/viewer/dashboard/mod.rs
+++ b/src/viewer/dashboard/mod.rs
@@ -35,7 +35,7 @@ static SECTION_META: &[(&str, &str, Generator)] = &[
 pub fn generate(
     data: Tsdb,
     filesize: Option<u64>,
-    service_ext: Option<&crate::viewer::ServiceExtension>,
+    service_ext: Option<(&str, &crate::viewer::ServiceExtension)>,
 ) -> AppState {
     let state = AppState::new(data);
 
@@ -49,12 +49,14 @@ pub fn generate(
     }))
     .collect();
 
-    if service_ext.is_some() {
-        // Insert Service section after Overview (position 1)
+    if let Some((source_name, _)) = service_ext {
+        // Insert service section after Overview (position 1).
+        // Use the parquet source name (e.g. "llm-perf") so the sidebar
+        // labels the section after the service rather than a generic "Service".
         all_sections.insert(
             1,
             Section {
-                name: "Service".to_string(),
+                name: source_name.to_string(),
                 route: "/service".to_string(),
             },
         );
@@ -65,7 +67,7 @@ pub fn generate(
 
     // Generate overview separately (needs throughput_query from service extension)
     let throughput_query = service_ext
-        .and_then(|e| e.throughput_query())
+        .and_then(|(_, e)| e.throughput_query())
         .map(str::to_string);
     {
         let mut view = overview::generate(&tsdb, all_sections.clone(), throughput_query.as_deref());
@@ -88,7 +90,7 @@ pub fn generate(
     }
 
     // Generate service section if extension is present
-    if let Some(ext) = service_ext {
+    if let Some((_, ext)) = service_ext {
         let view = service::generate(&tsdb, all_sections.clone(), ext);
         rendered_sections.insert(
             "service.json".to_string(),

--- a/src/viewer/dashboard/service.rs
+++ b/src/viewer/dashboard/service.rs
@@ -17,19 +17,33 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtens
         );
     }
 
+    // Group KPIs by role so that charts sharing a role render side-by-side
+    // via the 2-column CSS grid on `.group .charts`.
+    let mut groups: Vec<(String, Group)> = Vec::new();
+
     for kpi in &service_ext.kpis {
-        let id = format!("kpi-{}", kpi.role);
-        let mut group = Group::new(&kpi.title, &id);
+        let plot_id = format!("kpi-{}-{}", kpi.role, slug(&kpi.title));
+
+        let group = match groups.iter_mut().find(|(r, _)| *r == kpi.role) {
+            Some((_, g)) => g,
+            None => {
+                groups.push((
+                    kpi.role.clone(),
+                    Group::new(&capitalize(&kpi.role), &format!("kpi-{}", kpi.role)),
+                ));
+                &mut groups.last_mut().unwrap().1
+            }
+        };
 
         let opts = match kpi.metric_type.as_str() {
-            "gauge" => PlotOpts::gauge(&kpi.title, &id, Unit::Count),
+            "gauge" => PlotOpts::gauge(&kpi.title, &plot_id, Unit::Count),
             "histogram" => PlotOpts::histogram(
                 &kpi.title,
-                &id,
+                &plot_id,
                 Unit::Count,
                 kpi.subtype.as_deref().unwrap_or("percentiles"),
             ),
-            _ => PlotOpts::counter(&kpi.title, &id, Unit::Count),
+            _ => PlotOpts::counter(&kpi.title, &plot_id, Unit::Count),
         };
         let opts = opts.maybe_unit_system(kpi.unit_system.as_deref());
         let opts = match &kpi.percentiles {
@@ -38,8 +52,32 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtens
         };
 
         group.plot_promql(opts, kpi.query.clone());
+    }
+
+    for (_, group) in groups {
         view.group(group);
     }
 
     view
+}
+
+/// Convert a title into a kebab-case slug for use as a DOM id.
+fn slug(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// Capitalize the first letter of a string (for group titles).
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+    }
 }

--- a/src/viewer/dashboard/service.rs
+++ b/src/viewer/dashboard/service.rs
@@ -20,8 +20,18 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtens
     // Group KPIs by role so that charts sharing a role render side-by-side
     // via the 2-column CSS grid on `.group .charts`.
     let mut groups: Vec<(String, Group)> = Vec::new();
+    let mut unavailable: Vec<serde_json::Value> = Vec::new();
 
     for kpi in &service_ext.kpis {
+        if !kpi.available {
+            unavailable.push(serde_json::json!({
+                "title": kpi.title,
+                "role": kpi.role,
+                "query": kpi.query,
+            }));
+            continue;
+        }
+
         let plot_id = format!("kpi-{}-{}", kpi.role, slug(&kpi.title));
 
         let group = match groups.iter_mut().find(|(r, _)| *r == kpi.role) {
@@ -52,6 +62,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtens
         };
 
         group.plot_promql(opts, kpi.query.clone());
+    }
+
+    if !unavailable.is_empty() {
+        view.metadata.insert(
+            "unavailable_kpis".to_string(),
+            serde_json::Value::Array(unavailable),
+        );
     }
 
     for (_, group) in groups {

--- a/src/viewer/dashboard/service.rs
+++ b/src/viewer/dashboard/service.rs
@@ -4,6 +4,19 @@ use crate::viewer::ServiceExtension;
 pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtension) -> View {
     let mut view = View::new(data, sections);
 
+    // Embed service metadata in the view so the frontend can display it
+    // without a separate API call.
+    view.metadata.insert(
+        "service_name".to_string(),
+        serde_json::Value::String(service_ext.service_name.clone()),
+    );
+    if !service_ext.service_metadata.is_empty() {
+        view.metadata.insert(
+            "service_metadata".to_string(),
+            serde_json::to_value(&service_ext.service_metadata).unwrap_or_default(),
+        );
+    }
+
     for kpi in &service_ext.kpis {
         let id = format!("kpi-{}", kpi.role);
         let mut group = Group::new(&kpi.title, &id);
@@ -19,6 +32,10 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtens
             _ => PlotOpts::counter(&kpi.title, &id, Unit::Count),
         };
         let opts = opts.maybe_unit_system(kpi.unit_system.as_deref());
+        let opts = match &kpi.percentiles {
+            Some(p) => opts.with_percentiles(p.clone()),
+            None => opts,
+        };
 
         group.plot_promql(opts, kpi.query.clone());
         view.group(group);

--- a/src/viewer/dashboard/service.rs
+++ b/src/viewer/dashboard/service.rs
@@ -39,7 +39,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtens
             None => {
                 groups.push((
                     kpi.role.clone(),
-                    Group::new(&capitalize(&kpi.role), &format!("kpi-{}", kpi.role)),
+                    Group::new(capitalize(&kpi.role), format!("kpi-{}", kpi.role)),
                 ));
                 &mut groups.last_mut().unwrap().1
             }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -533,7 +533,11 @@ fn app(livereload: LiveReloadLayer, state: AppState) -> Router {
         .route("/save", get(save_parquet))
         .route("/systeminfo", get(systeminfo_handler))
         .route("/selection", get(selection_handler))
-        .route("/upload", axum::routing::post(upload_parquet))
+        .route(
+            "/upload",
+            axum::routing::post(upload_parquet)
+                .layer(axum::extract::DefaultBodyLimit::max(50 * 1024 * 1024)),
+        )
         .route("/connect", axum::routing::post(connect_agent))
         .route(
             "/save_with_selection",

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -159,16 +159,21 @@ pub fn run(config: Config) {
             info!("Computing file checksum...");
             let file_checksum = compute_file_checksum(path);
 
-            if let Some(ref ext) = service_ext {
+            if let Some((ref source, ref ext)) = service_ext {
                 info!(
-                    "Found service extension for {:?} ({} KPIs)",
+                    "Found service extension for {:?} from source {:?} ({} KPIs)",
                     ext.service_name,
+                    source,
                     ext.kpis.len()
                 );
             }
 
             info!("Generating dashboards...");
-            let state = dashboard::generate(data, filesize, service_ext.as_ref());
+            let state = dashboard::generate(
+                data,
+                filesize,
+                service_ext.as_ref().map(|(s, e)| (s.as_str(), e)),
+            );
             *state.parquet_path.write() = Some(path.clone());
             *state.systeminfo.write() = systeminfo;
             *state.selection.write() = selection;
@@ -448,7 +453,7 @@ fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>) {
 
 /// Search for service_queries inside the nested `metadata` map.
 /// Scans all sources and returns the first ServiceExtension found.
-fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
+fn extract_service_extension_metadata(path: &Path) -> Option<(String, ServiceExtension)> {
     use crate::parquet_metadata::{KEY_PER_SOURCE_METADATA, NESTED_SERVICE_QUERIES};
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
@@ -465,10 +470,10 @@ fn extract_service_extension_metadata(path: &Path) -> Option<ServiceExtension> {
     let metadata_map: serde_json::Map<String, serde_json::Value> =
         serde_json::from_str(metadata_json).ok()?;
 
-    for (_source, value) in &metadata_map {
+    for (source, value) in &metadata_map {
         if let Some(sq) = value.get(NESTED_SERVICE_QUERIES) {
             if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone()) {
-                return Some(ext);
+                return Some((source.clone(), ext));
             }
         }
     }
@@ -841,7 +846,11 @@ async fn upload_parquet(
     data.set_filename(filename.clone());
 
     let service_ext = extract_service_extension_metadata(&temp_path);
-    let new_state = dashboard::generate(data, filesize, service_ext.as_ref());
+    let new_state = dashboard::generate(
+        data,
+        filesize,
+        service_ext.as_ref().map(|(s, e)| (s.as_str(), e)),
+    );
     let (systeminfo, selection) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 

--- a/src/viewer/plot.rs
+++ b/src/viewer/plot.rs
@@ -181,6 +181,8 @@ pub struct PlotOpts {
     metric_type: MetricType,
     #[serde(skip_serializing_if = "Option::is_none")]
     subtype: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    percentiles: Option<Vec<f64>>,
     format: FormatConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
@@ -225,6 +227,7 @@ impl PlotOpts {
             id: id.into(),
             metric_type: MetricType::Gauge,
             subtype: None,
+            percentiles: None,
             format: FormatConfig::new(unit),
             description: None,
         }
@@ -238,6 +241,7 @@ impl PlotOpts {
             id: id.into(),
             metric_type: MetricType::DeltaCounter,
             subtype: None,
+            percentiles: None,
             format: FormatConfig::new(unit),
             description: None,
         }
@@ -258,6 +262,7 @@ impl PlotOpts {
             id: id.into(),
             metric_type: MetricType::Histogram,
             subtype: Some(subtype.to_string()),
+            percentiles: None,
             format: FormatConfig::new(unit),
             description: None,
         }
@@ -287,6 +292,11 @@ impl PlotOpts {
             Some(u) => self.with_unit_system(u),
             None => self,
         }
+    }
+
+    pub fn with_percentiles(mut self, percentiles: Vec<f64>) -> Self {
+        self.percentiles = Some(percentiles);
+        self
     }
 
     pub fn with_axis_label<T: Into<String>>(mut self, y_label: T) -> Self {

--- a/src/viewer/service_extension.rs
+++ b/src/viewer/service_extension.rs
@@ -32,6 +32,10 @@ pub struct Kpi {
     /// Set by `rezolus parquet annotate` during validation.
     #[serde(default = "default_available")]
     pub available: bool,
+    /// When true, this KPI's query is used as the denominator for
+    /// normalized overview charts (e.g. "CPU / Throughput").
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub denominator: bool,
 }
 
 fn default_available() -> bool {
@@ -42,7 +46,7 @@ impl ServiceExtension {
     pub fn throughput_query(&self) -> Option<&str> {
         self.kpis
             .iter()
-            .find(|k| k.role == "throughput")
+            .find(|k| k.denominator)
             .map(|k| k.query.as_str())
     }
 }

--- a/src/viewer/service_extension.rs
+++ b/src/viewer/service_extension.rs
@@ -25,7 +25,7 @@ pub struct Kpi {
     #[serde(default)]
     pub unit_system: Option<String>,
     /// Custom percentile quantiles for histogram KPIs (e.g. [0.5, 0.95]).
-    /// When absent, the default set [0.5, 0.9, 0.99, 0.999, 0.9999] is used.
+    /// When absent, `common::DEFAULT_PERCENTILES` is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub percentiles: Option<Vec<f64>>,
     /// Whether the parquet file contains data for this KPI's query.

--- a/src/viewer/service_extension.rs
+++ b/src/viewer/service_extension.rs
@@ -24,6 +24,10 @@ pub struct Kpi {
     pub subtype: Option<String>,
     #[serde(default)]
     pub unit_system: Option<String>,
+    /// Custom percentile quantiles for histogram KPIs (e.g. [0.5, 0.95]).
+    /// When absent, the default set [0.5, 0.9, 0.99, 0.999, 0.9999] is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub percentiles: Option<Vec<f64>>,
     /// Whether the parquet file contains data for this KPI's query.
     /// Set by `rezolus parquet annotate` during validation.
     #[serde(default = "default_available")]


### PR DESCRIPTION
## Summary

Frontend companion to #767 (parquet annotation and service extension support):

- **Service section**: sidebar link (conditional on service data), metadata table header with service name/metadata, KPI chart rendering from dashboard JSON
- **Service metadata embedding**: `service.rs` injects `service_name` and `service_metadata` into the `View.metadata` map so the frontend reads it from the section JSON — no separate API endpoint needed
- **Theme-aware colors**: chart colors via CSS custom properties for consistent light/dark theme support
- **Save modal**: trim-to-selection checkbox for parquet export
- **Zoom persistence**: zoom state preserved across section navigation
- **Chart improvements**: responsive scatter/multi chart color handling

## Test plan

- [x] Load an annotated parquet file (with `rezolus parquet annotate`) and verify the Service section appears in the sidebar
- [x] Verify Service section shows service name header and metadata table
- [x] Verify KPI charts render with correct types (gauge → line, histogram → scatter)
- [x] Toggle light/dark theme and verify chart colors adapt
- [x] Use save modal with trim-to-selection checkbox
- [ ] Zoom into a chart, navigate to another section and back, verify zoom is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)