### PR TITLE
chore: default to draft PRs and skip release builds for drafts

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -60,6 +60,7 @@ The skill accepts an optional branch name argument:
    gh pr create \
      --repo iopsystems/rezolus \
      --head <fork-owner>:<branch-name> \
+     --draft \
      --title "<conventional commit style title>" \
      --body "$(cat <<'EOF'
    ## Summary
@@ -94,3 +95,4 @@ Non-release PRs must **never** bump the major, minor, or patch version. Instead,
 - If `cargo clippy`, `cargo test`, or `cargo fmt --check` haven't been run yet during this session, run them before committing
 - Never force push or amend existing commits
 - The fork owner can be determined from the origin remote URL (e.g., `git@github.com:brayniac/rezolus` → `brayniac`)
+- PRs are created as drafts by default. Mark ready via GitHub UI or `gh pr ready`

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - 'site/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'site/**'
 
@@ -118,15 +119,31 @@ jobs:
           rustup component add rustfmt
           cargo fmt --all -- --check
 
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    outputs:
+      profiles: ${{ steps.set-profiles.outputs.profiles }}
+    steps:
+      - name: determine build profiles
+        id: set-profiles
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            echo 'profiles=["debug"]' >> $GITHUB_OUTPUT
+          else
+            echo 'profiles=["release", "debug"]' >> $GITHUB_OUTPUT
+          fi
+
   # Second group of checks: These are more expensive than the first set so we
   # gate them on the check action succeeding.
   build:
     name: build-${{ matrix.os }}-${{ matrix.profile }}-${{ matrix.features }}
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04, macos-latest ]
-        profile: [ release, debug ]
+        profile: ${{ fromJson(needs.setup.outputs.profiles) }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
@@ -185,6 +202,7 @@ jobs:
     name: verify all tests pass
     runs-on: ubuntu-latest
     needs:
+      - setup
       - build
       - check
       - dashboard-drift


### PR DESCRIPTION
## Summary

- Update `/pr` skill to create PRs as drafts by default (`--draft` flag)
- Skip release-profile CI builds for draft PRs (only run debug builds), restoring the full matrix when marked ready for review

## Details

**PR skill** (`.claude/skills/pr/SKILL.md`):
- Added `--draft` flag to the `gh pr create` command template
- Added note that PRs are drafts by default and can be marked ready via GitHub UI or `gh pr ready`

**CI** (`.github/workflows/cargo.yml`):
- Added `ready_for_review` to the `pull_request` event types so the full build matrix triggers when a draft is marked ready
- Added a `setup` job that outputs `["debug"]` for draft PRs and `["release", "debug"]` otherwise
- Build matrix now uses the dynamic profiles from `setup`

## Test plan

- [ ] Verify draft PRs only run debug builds in CI
- [ ] Verify marking a PR as "ready for review" triggers the full build matrix (release + debug)
- [ ] Verify `/pr` skill creates draft PRs by default