### PR TITLE
Service template fallback, annotation improvements, and CI fixes

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -147,10 +147,10 @@ jobs:
         if: ${{ matrix.os != 'macos-latest' }}
         shell: bash
         run: |
-          sudo fallocate -l 4G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          sudo fallocate -l 4G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
 
       - name: Install dependencies
         if: ${{ matrix.os != 'macos-latest' }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -136,7 +136,9 @@ jobs:
 
       - name: Update cargo flags
         if: ${{ matrix.profile == 'release' }}
-        run: echo 'FLAGS=--release' >> $GITHUB_ENV
+        run: |
+          echo 'FLAGS=--release' >> $GITHUB_ENV
+          echo 'CARGO_BUILD_JOBS=2' >> $GITHUB_ENV
         shell: bash
       - name: Update cargo flags
         if: ${{ matrix.profile == 'debug' }}

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -143,6 +143,15 @@ jobs:
         run: echo 'FLAGS=' >> $GITHUB_ENV
         shell: bash
 
+      - name: Add swap
+        if: ${{ matrix.os != 'macos-latest' }}
+        shell: bash
+        run: |
+          sudo fallocate -l 4G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+
       - name: Install dependencies
         if: ${{ matrix.os != 'macos-latest' }}
         shell: bash

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -36,7 +36,14 @@ pub const KEY_DESCRIPTIONS: &str = "descriptions";
 /// JSON-serialised user selection/filter state saved by the viewer.
 pub const KEY_SELECTION: &str = "selection";
 
-/// Per-source metadata map. Value is a JSON object keyed by source name:
+/// Service KPI query definitions (ServiceExtension JSON). Top-level key
+/// used in single-source parquet files written by `parquet annotate`.
+/// When files are combined, this is moved under
+/// `per_source_metadata.<source>.service_queries`.
+pub const KEY_SERVICE_QUERIES: &str = "service_queries";
+
+/// Per-source metadata map (used in combined files). Value is a JSON
+/// object keyed by source name:
 ///
 /// ```json
 /// {

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -4,7 +4,7 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::parquet_metadata::{KEY_PER_SOURCE_METADATA, KEY_SOURCE, NESTED_SERVICE_QUERIES};
+use crate::parquet_metadata::{KEY_SERVICE_QUERIES, KEY_SOURCE};
 use crate::viewer::promql::QueryEngine;
 use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
@@ -52,7 +52,7 @@ pub(super) fn run(args: &ArgMatches) {
 
     let annotated_json =
         serde_json::to_string(&ext).expect("failed to serialize service extension");
-    annotate_parquet(path, &source, &annotated_json).expect("failed to annotate parquet file");
+    annotate_parquet(path, &annotated_json).expect("failed to annotate parquet file");
 
     println!(
         "Annotated {:?} with {:?} service queries ({} KPIs)",
@@ -203,7 +203,6 @@ fn read_source_metadata(path: &Path) -> Option<String> {
 
 fn annotate_parquet(
     path: &Path,
-    source: &str,
     service_queries_json: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -222,27 +221,11 @@ fn annotate_parquet(
         .cloned()
         .unwrap_or_default();
 
-    // Build or update the nested metadata map
-    let mut metadata_map: serde_json::Map<String, serde_json::Value> = kv_meta
-        .iter()
-        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
-        .and_then(|kv| kv.value.as_deref())
-        .and_then(|v| serde_json::from_str(v).ok())
-        .unwrap_or_default();
-
-    // Nest service_queries under this source
-    let service_queries: serde_json::Value = serde_json::from_str(service_queries_json)?;
-    let source_entry = metadata_map
-        .entry(source.to_string())
-        .or_insert_with(|| serde_json::json!({}));
-    if let serde_json::Value::Object(map) = source_entry {
-        map.insert(NESTED_SERVICE_QUERIES.to_string(), service_queries);
-    }
-
-    kv_meta.retain(|kv| kv.key != KEY_PER_SOURCE_METADATA);
+    // Write service_queries as a top-level key
+    kv_meta.retain(|kv| kv.key != KEY_SERVICE_QUERIES);
     kv_meta.push(KeyValue {
-        key: KEY_PER_SOURCE_METADATA.to_string(),
-        value: Some(serde_json::to_string(&metadata_map)?),
+        key: KEY_SERVICE_QUERIES.to_string(),
+        value: Some(service_queries_json.to_string()),
     });
 
     let props = WriterProperties::builder()
@@ -270,7 +253,7 @@ fn annotate_parquet(
     Ok(())
 }
 
-/// Remove `service_queries` from all sources in `per_source_metadata`.
+/// Remove the top-level `service_queries` key from parquet metadata.
 fn unannotate_parquet(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use parquet::arrow::ArrowWriter;
@@ -287,34 +270,12 @@ fn unannotate_parquet(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         .cloned()
         .unwrap_or_default();
 
-    let mut metadata_map: serde_json::Map<String, serde_json::Value> = kv_meta
-        .iter()
-        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
-        .and_then(|kv| kv.value.as_deref())
-        .and_then(|v| serde_json::from_str(v).ok())
-        .unwrap_or_default();
+    let before = kv_meta.len();
+    kv_meta.retain(|kv| kv.key != KEY_SERVICE_QUERIES);
 
-    // Remove service_queries from every source entry.
-    let mut removed = false;
-    for (_source, value) in &mut metadata_map {
-        if let serde_json::Value::Object(map) = value {
-            if map.remove(NESTED_SERVICE_QUERIES).is_some() {
-                removed = true;
-            }
-        }
-    }
-
-    if !removed {
+    if kv_meta.len() == before {
         eprintln!("warning: no service_queries annotation found");
         return Ok(());
-    }
-
-    kv_meta.retain(|kv| kv.key != KEY_PER_SOURCE_METADATA);
-    if !metadata_map.is_empty() {
-        kv_meta.push(KeyValue {
-            key: KEY_PER_SOURCE_METADATA.to_string(),
-            value: Some(serde_json::to_string(&metadata_map)?),
-        });
     }
 
     let props = WriterProperties::builder()

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -13,6 +13,12 @@ use super::lookup_template;
 
 pub(super) fn run(args: &ArgMatches) {
     let path = args.get_one::<PathBuf>("FILE").unwrap();
+
+    if args.get_flag("undo") {
+        run_undo(path);
+        return;
+    }
+
     let custom_file = args.get_one::<PathBuf>("service-extension");
 
     let source = read_source_metadata(path).unwrap_or_else(|| {
@@ -54,6 +60,15 @@ pub(super) fn run(args: &ArgMatches) {
         ext.service_name,
         ext.kpis.len()
     );
+}
+
+/// Remove service_queries from all sources in per_source_metadata.
+fn run_undo(path: &Path) {
+    unannotate_parquet(path).unwrap_or_else(|e| {
+        eprintln!("error: failed to remove annotation: {e}");
+        std::process::exit(1);
+    });
+    println!("Removed service extension annotation from {:?}", path);
 }
 
 /// Build the effective PromQL query for a KPI, accounting for histogram wrapping.
@@ -250,6 +265,75 @@ fn annotate_parquet(
     }
 
     // Write back to the same file (in-place)
+    std::fs::write(path, &output)?;
+
+    Ok(())
+}
+
+/// Remove `service_queries` from all sources in `per_source_metadata`.
+fn unannotate_parquet(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+    use parquet::format::KeyValue;
+
+    let meta_reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
+    let mut kv_meta: Vec<KeyValue> = meta_reader
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .cloned()
+        .unwrap_or_default();
+
+    let mut metadata_map: serde_json::Map<String, serde_json::Value> = kv_meta
+        .iter()
+        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
+        .and_then(|kv| kv.value.as_deref())
+        .and_then(|v| serde_json::from_str(v).ok())
+        .unwrap_or_default();
+
+    // Remove service_queries from every source entry.
+    let mut removed = false;
+    for (_source, value) in &mut metadata_map {
+        if let serde_json::Value::Object(map) = value {
+            if map.remove(NESTED_SERVICE_QUERIES).is_some() {
+                removed = true;
+            }
+        }
+    }
+
+    if !removed {
+        eprintln!("warning: no service_queries annotation found");
+        return Ok(());
+    }
+
+    kv_meta.retain(|kv| kv.key != KEY_PER_SOURCE_METADATA);
+    if !metadata_map.is_empty() {
+        kv_meta.push(KeyValue {
+            key: KEY_PER_SOURCE_METADATA.to_string(),
+            value: Some(serde_json::to_string(&metadata_map)?),
+        });
+    }
+
+    let props = WriterProperties::builder()
+        .set_key_value_metadata(Some(kv_meta))
+        .build();
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path)?)?;
+    let schema = builder.schema().clone();
+    let reader = builder.build()?;
+
+    let mut output = Vec::new();
+    {
+        let mut writer = ArrowWriter::try_new(Cursor::new(&mut output), schema, Some(props))?;
+        for batch in reader {
+            writer.write(&batch?)?;
+        }
+        writer.close()?;
+    }
+
     std::fs::write(path, &output)?;
 
     Ok(())

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -9,25 +9,7 @@ use crate::viewer::promql::QueryEngine;
 use crate::viewer::tsdb::Tsdb;
 use crate::viewer::ServiceExtension;
 
-static TEMPLATES: &[(&str, &str)] = &[
-    ("llm-perf", include_str!("templates/llm_perf.json")),
-    ("cachecannon", include_str!("templates/cachecannon.json")),
-];
-
-/// Source name aliases for renamed projects (old name → canonical name).
-static SOURCE_ALIASES: &[(&str, &str)] = &[("llm-bench", "llm-perf")];
-
-fn lookup_template(source: &str) -> Option<&'static str> {
-    let canonical = SOURCE_ALIASES
-        .iter()
-        .find(|(alias, _)| *alias == source)
-        .map(|(_, canon)| *canon)
-        .unwrap_or(source);
-    TEMPLATES
-        .iter()
-        .find(|(name, _)| *name == canonical)
-        .map(|(_, json)| *json)
-}
+use super::lookup_template;
 
 pub(super) fn run(args: &ArgMatches) {
     let path = args.get_one::<PathBuf>("FILE").unwrap();

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -624,8 +624,7 @@ fn merge_metadata(inputs: &[InputFile]) -> Result<Vec<KeyValue>, Box<dyn std::er
                 .and_then(|kv| kv.value.as_deref())
                 .and_then(|v| serde_json::from_str::<serde_json::Value>(v).ok())
             {
-                map.entry(NESTED_SERVICE_QUERIES.to_string())
-                    .or_insert(sq);
+                map.entry(NESTED_SERVICE_QUERIES.to_string()).or_insert(sq);
             }
         }
     }

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -603,7 +603,7 @@ fn merge_metadata(inputs: &[InputFile]) -> Result<Vec<KeyValue>, Box<dyn std::er
             }
         }
 
-        // Move top-level version into per_source_metadata.<source>.version
+        // Move top-level version and service_queries into per_source_metadata.<source>
         let source_entry = per_source
             .entry(input.source.clone())
             .or_insert_with(|| serde_json::json!({}));
@@ -616,6 +616,16 @@ fn merge_metadata(inputs: &[InputFile]) -> Result<Vec<KeyValue>, Box<dyn std::er
             {
                 map.entry(NESTED_VERSION.to_string())
                     .or_insert(serde_json::Value::String(version));
+            }
+            if let Some(sq) = input
+                .kv_metadata
+                .iter()
+                .find(|kv| kv.key == KEY_SERVICE_QUERIES)
+                .and_then(|kv| kv.value.as_deref())
+                .and_then(|v| serde_json::from_str::<serde_json::Value>(v).ok())
+            {
+                map.entry(NESTED_SERVICE_QUERIES.to_string())
+                    .or_insert(sq);
             }
         }
     }

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -10,6 +10,28 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Built-in service extension templates keyed by canonical source name.
+pub(crate) static TEMPLATES: &[(&str, &str)] = &[
+    ("llm-perf", include_str!("templates/llm_perf.json")),
+    ("cachecannon", include_str!("templates/cachecannon.json")),
+];
+
+/// Source name aliases for renamed projects (old name → canonical name).
+pub(crate) static SOURCE_ALIASES: &[(&str, &str)] = &[("llm-bench", "llm-perf")];
+
+/// Look up a built-in service template by source name, resolving aliases.
+pub(crate) fn lookup_template(source: &str) -> Option<&'static str> {
+    let canonical = SOURCE_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == source)
+        .map(|(_, canon)| *canon)
+        .unwrap_or(source);
+    TEMPLATES
+        .iter()
+        .find(|(name, _)| *name == canonical)
+        .map(|(_, json)| *json)
+}
+
 pub fn command() -> Command {
     Command::new("parquet")
         .about("Parquet file operations")

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -53,6 +53,13 @@ pub fn command() -> Command {
                         .help("Custom service extension JSON file (overrides built-in template)")
                         .value_parser(value_parser!(PathBuf))
                         .action(clap::ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("undo")
+                        .long("undo")
+                        .help("Remove service extension annotation from the parquet file")
+                        .action(clap::ArgAction::SetTrue)
+                        .conflicts_with("service-extension"),
                 ),
         )
         .subcommand(

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -451,12 +451,16 @@ fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>) {
         .unwrap_or((None, None))
 }
 
-/// Search for service_queries inside the nested `metadata` map.
-/// Scans all sources and returns the first ServiceExtension found.
-/// If no service_queries exist but the source matches a known service
-/// template (e.g. llm-perf, cachecannon), falls back to the built-in template.
+/// Extract service extension metadata from a parquet file.
+///
+/// Checks in order:
+/// 1. Top-level `service_queries` key (single-source annotated files)
+/// 2. `per_source_metadata.<source>.service_queries` (combined files)
+/// 3. Built-in template for known sources (fallback)
 fn extract_service_extension_metadata(path: &Path) -> Option<(String, ServiceExtension)> {
-    use crate::parquet_metadata::{KEY_PER_SOURCE_METADATA, KEY_SOURCE, NESTED_SERVICE_QUERIES};
+    use crate::parquet_metadata::{
+        KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, NESTED_SERVICE_QUERIES,
+    };
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
 
@@ -464,7 +468,24 @@ fn extract_service_extension_metadata(path: &Path) -> Option<(String, ServiceExt
     let reader = SerializedFileReader::new(f).ok()?;
     let kv = reader.metadata().file_metadata().key_value_metadata()?;
 
-    // Try to find service_queries in per_source_metadata first.
+    // 1. Top-level service_queries (written by `parquet annotate`).
+    if let Some(sq_json) = kv
+        .iter()
+        .find(|kv| kv.key == KEY_SERVICE_QUERIES)
+        .and_then(|kv| kv.value.as_deref())
+    {
+        if let Ok(ext) = serde_json::from_str::<ServiceExtension>(sq_json) {
+            // Use the top-level source key as the source name.
+            let source = kv
+                .iter()
+                .find(|kv| kv.key == KEY_SOURCE)
+                .and_then(|kv| kv.value.as_deref())
+                .unwrap_or(&ext.service_name);
+            return Some((source.to_string(), ext));
+        }
+    }
+
+    // 2. Nested under per_source_metadata (combined files).
     if let Some(metadata_json) = kv
         .iter()
         .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
@@ -481,7 +502,7 @@ fn extract_service_extension_metadata(path: &Path) -> Option<(String, ServiceExt
                 }
             }
 
-            // No service_queries found — check if any source has a built-in template.
+            // 3a. No service_queries found — check if any source has a built-in template.
             for source in metadata_map.keys() {
                 if let Some(template_json) = crate::parquet_tools::lookup_template(source) {
                     if let Ok(ext) = serde_json::from_str::<ServiceExtension>(template_json) {
@@ -492,7 +513,7 @@ fn extract_service_extension_metadata(path: &Path) -> Option<(String, ServiceExt
         }
     }
 
-    // No per_source_metadata at all — check the top-level source key.
+    // 3b. No per_source_metadata — check the top-level source key for a template.
     let source = kv
         .iter()
         .find(|kv| kv.key == KEY_SOURCE)

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -453,8 +453,10 @@ fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>) {
 
 /// Search for service_queries inside the nested `metadata` map.
 /// Scans all sources and returns the first ServiceExtension found.
+/// If no service_queries exist but the source matches a known service
+/// template (e.g. llm-perf, cachecannon), falls back to the built-in template.
 fn extract_service_extension_metadata(path: &Path) -> Option<(String, ServiceExtension)> {
-    use crate::parquet_metadata::{KEY_PER_SOURCE_METADATA, NESTED_SERVICE_QUERIES};
+    use crate::parquet_metadata::{KEY_PER_SOURCE_METADATA, KEY_SOURCE, NESTED_SERVICE_QUERIES};
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
 
@@ -462,19 +464,43 @@ fn extract_service_extension_metadata(path: &Path) -> Option<(String, ServiceExt
     let reader = SerializedFileReader::new(f).ok()?;
     let kv = reader.metadata().file_metadata().key_value_metadata()?;
 
-    let metadata_json = kv
+    // Try to find service_queries in per_source_metadata first.
+    if let Some(metadata_json) = kv
         .iter()
         .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
+        .and_then(|kv| kv.value.as_deref())
+    {
+        if let Ok(metadata_map) =
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(metadata_json)
+        {
+            for (source, value) in &metadata_map {
+                if let Some(sq) = value.get(NESTED_SERVICE_QUERIES) {
+                    if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone()) {
+                        return Some((source.clone(), ext));
+                    }
+                }
+            }
+
+            // No service_queries found — check if any source has a built-in template.
+            for source in metadata_map.keys() {
+                if let Some(template_json) = crate::parquet_tools::lookup_template(source) {
+                    if let Ok(ext) = serde_json::from_str::<ServiceExtension>(template_json) {
+                        return Some((source.clone(), ext));
+                    }
+                }
+            }
+        }
+    }
+
+    // No per_source_metadata at all — check the top-level source key.
+    let source = kv
+        .iter()
+        .find(|kv| kv.key == KEY_SOURCE)
         .and_then(|kv| kv.value.as_deref())?;
 
-    let metadata_map: serde_json::Map<String, serde_json::Value> =
-        serde_json::from_str(metadata_json).ok()?;
-
-    for (source, value) in &metadata_map {
-        if let Some(sq) = value.get(NESTED_SERVICE_QUERIES) {
-            if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone()) {
-                return Some((source.clone(), ext));
-            }
+    if let Some(template_json) = crate::parquet_tools::lookup_template(source) {
+        if let Ok(ext) = serde_json::from_str::<ServiceExtension>(template_json) {
+            return Some((source.to_string(), ext));
         }
     }
 


### PR DESCRIPTION
## Summary

- **Service template fallback**: When the viewer loads a parquet file for a known service source (llm-perf, cachecannon) without `service_queries` metadata, it falls back to the built-in template instead of skipping the service dashboard. Removes the requirement to run `parquet annotate` before viewing known service recordings.

- **Top-level `service_queries` key**: `parquet annotate` now writes `service_queries` as a top-level parquet metadata key instead of nesting inside `per_source_metadata`. The `combine` command moves it into `per_source_metadata.<source>.service_queries` when merging files. The viewer checks both locations.

- **`--undo` flag**: `rezolus parquet annotate file.parquet --undo` strips the `service_queries` annotation from a parquet file.

- **Shared template lookup**: `TEMPLATES`, `SOURCE_ALIASES`, and `lookup_template()` moved from `annotate.rs` to `parquet_tools/mod.rs` as `pub(crate)` so both the annotation command and the viewer can share them.

- **CI**: Add 4GB swap and limit release builds to 2 parallel jobs to fix OOM kills (exit code 143) on GitHub Actions runners.

## Files changed

| File | Change |
|------|--------|
| `src/parquet_metadata.rs` | Add `KEY_SERVICE_QUERIES` top-level constant |
| `src/parquet_tools/mod.rs` | Shared template lookup; `--undo` CLI arg |
| `src/parquet_tools/annotate.rs` | Write top-level key; `--undo` support; use shared templates |
| `src/parquet_tools/combine.rs` | Lift top-level `service_queries` into `per_source_metadata` on combine |
| `src/viewer/mod.rs` | Check top-level key, then per_source_metadata, then built-in templates |
| `.github/workflows/cargo.yml` | Add swap + limit release build parallelism |

## Test plan

- [x] `rezolus parquet annotate file.parquet` writes top-level `service_queries` key
- [x] `rezolus parquet annotate file.parquet --undo` removes it
- [ ] `rezolus parquet combine` nests `service_queries` under `per_source_metadata`
- [x] Viewer shows service dashboard for known sources without prior annotation
- [x] `cargo test` passes
- [x] Release builds no longer OOM on CI