### PR TITLE
Add filter subcommand to reduce parquet files to needed columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ target/release/rezolus parquet metadata -i file.parquet             # show file/
 target/release/rezolus parquet metadata -i file.parquet --json      # JSON output
 target/release/rezolus parquet metadata -i file.parquet --field source
 target/release/rezolus parquet annotate file.parquet                # add service extension KPIs
-target/release/rezolus parquet annotate file.parquet --file ext.json
+target/release/rezolus parquet annotate file.parquet --queries ext.json
 target/release/rezolus parquet combine a.parquet b.parquet -o combined.parquet
 
 # MCP - AI analysis server or CLI commands

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -60,6 +60,13 @@ pub(super) fn run(args: &ArgMatches) {
         ext.service_name,
         ext.kpis.len()
     );
+
+    if args.get_flag("filter") {
+        if let Err(e) = super::filter::filter_parquet_file(path, &ext, None) {
+            eprintln!("error: failed to filter columns: {e}");
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Remove service_queries from all sources in per_source_metadata.
@@ -158,7 +165,7 @@ fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
 ///
 /// Matches `metric_name` or `metric_name{labels...}`, skipping anything
 /// followed by `(` (i.e. function calls like `sum(`, `irate(`).
-fn extract_metric_selectors(query: &str) -> BTreeSet<String> {
+pub(super) fn extract_metric_selectors(query: &str) -> BTreeSet<String> {
     use regex::Regex;
     use std::sync::LazyLock;
 
@@ -188,7 +195,7 @@ fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {
     }
 }
 
-fn read_source_metadata(path: &Path) -> Option<String> {
+pub(super) fn read_source_metadata(path: &Path) -> Option<String> {
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
 

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -18,11 +18,11 @@ pub(super) fn run(args: &ArgMatches) {
         return;
     }
 
-    let custom_file = args.get_one::<PathBuf>("service-extension");
+    let custom_file = args.get_one::<PathBuf>("queries");
 
     let source = read_source_metadata(path).unwrap_or_else(|| {
         eprintln!(
-            "error: parquet file has no 'source' metadata. Use --file to provide a template."
+            "error: parquet file has no 'source' metadata. Use --queries to provide a template."
         );
         std::process::exit(1);
     });
@@ -36,7 +36,7 @@ pub(super) fn run(args: &ArgMatches) {
     } else {
         let template = lookup_template(&source).unwrap_or_else(|| {
             eprintln!(
-                "error: no built-in template for source {:?}. Use --file to provide one.",
+                "error: no built-in template for source {:?}. Use --queries to provide one.",
                 source
             );
             std::process::exit(1);

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -1,6 +1,5 @@
 use clap::ArgMatches;
 use std::collections::BTreeSet;
-use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -212,70 +211,24 @@ fn annotate_parquet(
     path: &Path,
     service_queries_json: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-    use parquet::arrow::ArrowWriter;
-    use parquet::file::properties::WriterProperties;
-    use parquet::file::reader::FileReader;
-    use parquet::file::serialized_reader::SerializedFileReader;
     use parquet::format::KeyValue;
 
-    // Read existing metadata
-    let meta_reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
-    let mut kv_meta: Vec<KeyValue> = meta_reader
-        .metadata()
-        .file_metadata()
-        .key_value_metadata()
-        .cloned()
-        .unwrap_or_default();
+    let mut kv_meta = super::read_file_metadata(path)?;
 
-    // Write service_queries as a top-level key
     kv_meta.retain(|kv| kv.key != KEY_SERVICE_QUERIES);
     kv_meta.push(KeyValue {
         key: KEY_SERVICE_QUERIES.to_string(),
         value: Some(service_queries_json.to_string()),
     });
 
-    let props = WriterProperties::builder()
-        .set_key_value_metadata(Some(kv_meta))
-        .build();
-
-    // Read all record batches
-    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path)?)?;
-    let schema = builder.schema().clone();
-    let reader = builder.build()?;
-
-    // Write to memory buffer with updated metadata
-    let mut output = Vec::new();
-    {
-        let mut writer = ArrowWriter::try_new(Cursor::new(&mut output), schema, Some(props))?;
-        for batch in reader {
-            writer.write(&batch?)?;
-        }
-        writer.close()?;
-    }
-
-    // Write back to the same file (in-place)
-    std::fs::write(path, &output)?;
-
+    let buf = super::rewrite_parquet(path, kv_meta, None)?;
+    std::fs::write(path, &buf)?;
     Ok(())
 }
 
 /// Remove the top-level `service_queries` key from parquet metadata.
 fn unannotate_parquet(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-    use parquet::arrow::ArrowWriter;
-    use parquet::file::properties::WriterProperties;
-    use parquet::file::reader::FileReader;
-    use parquet::file::serialized_reader::SerializedFileReader;
-    use parquet::format::KeyValue;
-
-    let meta_reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
-    let mut kv_meta: Vec<KeyValue> = meta_reader
-        .metadata()
-        .file_metadata()
-        .key_value_metadata()
-        .cloned()
-        .unwrap_or_default();
+    let mut kv_meta = super::read_file_metadata(path)?;
 
     let before = kv_meta.len();
     kv_meta.retain(|kv| kv.key != KEY_SERVICE_QUERIES);
@@ -285,25 +238,8 @@ fn unannotate_parquet(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let props = WriterProperties::builder()
-        .set_key_value_metadata(Some(kv_meta))
-        .build();
-
-    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path)?)?;
-    let schema = builder.schema().clone();
-    let reader = builder.build()?;
-
-    let mut output = Vec::new();
-    {
-        let mut writer = ArrowWriter::try_new(Cursor::new(&mut output), schema, Some(props))?;
-        for batch in reader {
-            writer.write(&batch?)?;
-        }
-        writer.close()?;
-    }
-
-    std::fs::write(path, &output)?;
-
+    let buf = super::rewrite_parquet(path, kv_meta, None)?;
+    std::fs::write(path, &buf)?;
     Ok(())
 }
 

--- a/src/parquet_tools/filter.rs
+++ b/src/parquet_tools/filter.rs
@@ -1,10 +1,9 @@
 use clap::ArgMatches;
 use std::collections::BTreeSet;
-use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use crate::parquet_metadata::{
-    KEY_DESCRIPTIONS, KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, MAX_ROW_GROUP_SIZE,
+    KEY_DESCRIPTIONS, KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE,
     NESTED_SERVICE_QUERIES,
 };
 use crate::viewer::ServiceExtension;
@@ -39,33 +38,18 @@ pub(super) fn filter_parquet_file(
     output: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-    use parquet::arrow::ArrowWriter;
-    use parquet::file::properties::WriterProperties;
-    use parquet::file::reader::FileReader;
-    use parquet::file::serialized_reader::SerializedFileReader;
-    use parquet::format::KeyValue;
 
     let mut keep = extract_column_names(ext);
     keep.insert("timestamp".to_string());
     keep.insert("duration".to_string());
 
-    // Read existing metadata
-    let meta_reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
-    let mut kv_meta: Vec<KeyValue> = meta_reader
-        .metadata()
-        .file_metadata()
-        .key_value_metadata()
-        .cloned()
-        .unwrap_or_default();
+    let mut kv_meta = super::read_file_metadata(path)?;
 
-    // Read all record batches
+    // Read schema to compute column indices
     let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path)?)?;
     let schema = builder.schema().clone();
-    let reader = builder.build()?;
-
     let total_columns = schema.fields().len();
 
-    // Compute column indices to keep
     let indices: Vec<usize> = schema
         .fields()
         .iter()
@@ -79,30 +63,9 @@ pub(super) fn filter_parquet_file(
         .map(|&i| schema.field(i).name().as_str())
         .collect();
 
-    // Project schema
-    let projected_schema = std::sync::Arc::new(schema.project(&indices)?);
-
-    // Filter descriptions metadata to only retained columns
     filter_descriptions_metadata(&mut kv_meta, &kept_names);
 
-    let props = WriterProperties::builder()
-        .set_key_value_metadata(Some(kv_meta))
-        .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
-        .build();
-
-    // Write projected batches to memory buffer
-    let mut buf = Vec::new();
-    {
-        let mut writer =
-            ArrowWriter::try_new(Cursor::new(&mut buf), projected_schema.clone(), Some(props))?;
-        for batch in reader {
-            let batch = batch?;
-            let projected = batch.project(&indices)?;
-            writer.write(&projected)?;
-        }
-        writer.close()?;
-    }
-
+    let buf = super::rewrite_parquet(path, kv_meta, Some(&indices))?;
     let dest = output.unwrap_or(path);
     std::fs::write(dest, &buf)?;
 

--- a/src/parquet_tools/filter.rs
+++ b/src/parquet_tools/filter.rs
@@ -13,7 +13,7 @@ use super::lookup_template;
 
 pub(super) fn run(args: &ArgMatches) {
     let path = args.get_one::<PathBuf>("FILE").unwrap();
-    let custom_file = args.get_one::<PathBuf>("service-extension");
+    let custom_file = args.get_one::<PathBuf>("queries");
     let output = args.get_one::<PathBuf>("output");
 
     let ext =
@@ -191,7 +191,7 @@ fn resolve_service_extension(
         }
     }
 
-    Err("no service extension found: use --file to provide one".into())
+    Err("no service extension found: use --queries to provide one".into())
 }
 
 #[cfg(test)]

--- a/src/parquet_tools/filter.rs
+++ b/src/parquet_tools/filter.rs
@@ -1,0 +1,288 @@
+use clap::ArgMatches;
+use std::collections::BTreeSet;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use crate::parquet_metadata::{
+    KEY_DESCRIPTIONS, KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, MAX_ROW_GROUP_SIZE,
+    NESTED_SERVICE_QUERIES,
+};
+use crate::viewer::ServiceExtension;
+
+use super::annotate::extract_metric_selectors;
+use super::lookup_template;
+
+pub(super) fn run(args: &ArgMatches) {
+    let path = args.get_one::<PathBuf>("FILE").unwrap();
+    let custom_file = args.get_one::<PathBuf>("service-extension");
+    let output = args.get_one::<PathBuf>("output");
+
+    let ext =
+        resolve_service_extension(path, custom_file.map(|p| p.as_path())).unwrap_or_else(|e| {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        });
+
+    if let Err(e) = filter_parquet_file(path, &ext, output.map(|p| p.as_path())) {
+        eprintln!("error: failed to filter parquet file: {e}");
+        std::process::exit(1);
+    }
+}
+
+/// Filter a parquet file to retain only columns needed by the service extension
+/// KPI queries, plus `timestamp` and `duration`.
+///
+/// If `output` is `None`, the file is overwritten in-place.
+pub(super) fn filter_parquet_file(
+    path: &Path,
+    ext: &ServiceExtension,
+    output: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+    use parquet::format::KeyValue;
+
+    let mut keep = extract_column_names(ext);
+    keep.insert("timestamp".to_string());
+    keep.insert("duration".to_string());
+
+    // Read existing metadata
+    let meta_reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
+    let mut kv_meta: Vec<KeyValue> = meta_reader
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .cloned()
+        .unwrap_or_default();
+
+    // Read all record batches
+    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path)?)?;
+    let schema = builder.schema().clone();
+    let reader = builder.build()?;
+
+    let total_columns = schema.fields().len();
+
+    // Compute column indices to keep
+    let indices: Vec<usize> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| keep.contains(f.name()))
+        .map(|(i, _)| i)
+        .collect();
+
+    let kept_names: BTreeSet<&str> = indices
+        .iter()
+        .map(|&i| schema.field(i).name().as_str())
+        .collect();
+
+    // Project schema
+    let projected_schema = std::sync::Arc::new(schema.project(&indices)?);
+
+    // Filter descriptions metadata to only retained columns
+    filter_descriptions_metadata(&mut kv_meta, &kept_names);
+
+    let props = WriterProperties::builder()
+        .set_key_value_metadata(Some(kv_meta))
+        .set_max_row_group_size(MAX_ROW_GROUP_SIZE)
+        .build();
+
+    // Write projected batches to memory buffer
+    let mut buf = Vec::new();
+    {
+        let mut writer =
+            ArrowWriter::try_new(Cursor::new(&mut buf), projected_schema.clone(), Some(props))?;
+        for batch in reader {
+            let batch = batch?;
+            let projected = batch.project(&indices)?;
+            writer.write(&projected)?;
+        }
+        writer.close()?;
+    }
+
+    let dest = output.unwrap_or(path);
+    std::fs::write(dest, &buf)?;
+
+    println!(
+        "Filtered {:?}: kept {} of {} columns",
+        dest,
+        indices.len(),
+        total_columns,
+    );
+
+    Ok(())
+}
+
+/// Extract base metric column names from all KPI queries in a service extension.
+fn extract_column_names(ext: &ServiceExtension) -> BTreeSet<String> {
+    ext.kpis
+        .iter()
+        .flat_map(|kpi| extract_metric_selectors(&kpi.query))
+        .map(|selector| {
+            // Strip label selectors: "tokens{direction=\"output\"}" -> "tokens"
+            selector.split('{').next().unwrap_or(&selector).to_string()
+        })
+        .collect()
+}
+
+/// Filter the `descriptions` metadata key to only include entries for retained columns.
+fn filter_descriptions_metadata(kv_meta: &mut [parquet::format::KeyValue], kept: &BTreeSet<&str>) {
+    if let Some(entry) = kv_meta.iter_mut().find(|kv| kv.key == KEY_DESCRIPTIONS) {
+        if let Some(value) = &entry.value {
+            if let Ok(mut map) =
+                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(value)
+            {
+                map.retain(|k, _| kept.contains(k.as_str()));
+                if let Ok(filtered) = serde_json::to_string(&map) {
+                    entry.value = Some(filtered);
+                }
+            }
+        }
+    }
+}
+
+/// Resolve a ServiceExtension from the available sources.
+///
+/// Resolution order:
+/// 1. Custom file (if provided via `--file`)
+/// 2. Top-level `service_queries` key in parquet metadata
+/// 3. `per_source_metadata.<source>.service_queries` (combined files)
+/// 4. Built-in template looked up by source name
+fn resolve_service_extension(
+    path: &Path,
+    custom_file: Option<&Path>,
+) -> Result<ServiceExtension, Box<dyn std::error::Error>> {
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+
+    // 1. Custom file
+    if let Some(custom_path) = custom_file {
+        let content = std::fs::read_to_string(custom_path)?;
+        let ext: ServiceExtension = serde_json::from_str(&content)?;
+        return Ok(ext);
+    }
+
+    // Read parquet metadata
+    let file = std::fs::File::open(path)?;
+    let reader = SerializedFileReader::new(file)?;
+    let kv = reader
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .cloned()
+        .unwrap_or_default();
+
+    // 2. Top-level service_queries
+    if let Some(sq) = kv
+        .iter()
+        .find(|kv| kv.key == KEY_SERVICE_QUERIES)
+        .and_then(|kv| kv.value.as_deref())
+    {
+        if let Ok(ext) = serde_json::from_str::<ServiceExtension>(sq) {
+            return Ok(ext);
+        }
+    }
+
+    // 3. per_source_metadata.<source>.service_queries
+    let source = kv
+        .iter()
+        .find(|kv| kv.key == KEY_SOURCE)
+        .and_then(|kv| kv.value.as_deref());
+
+    if let Some(psm_str) = kv
+        .iter()
+        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
+        .and_then(|kv| kv.value.as_deref())
+    {
+        if let Ok(psm) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(psm_str)
+        {
+            for (_source_name, source_meta) in &psm {
+                if let Some(sq) = source_meta.get(NESTED_SERVICE_QUERIES) {
+                    if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone()) {
+                        return Ok(ext);
+                    }
+                }
+            }
+        }
+    }
+
+    // 4. Built-in template by source name
+    if let Some(source_str) = source {
+        // Source may be a plain string or a JSON array; try plain string first
+        let canonical = source_str.trim_matches('"');
+        if let Some(template) = lookup_template(canonical) {
+            let ext: ServiceExtension = serde_json::from_str(template)?;
+            return Ok(ext);
+        }
+        // Try as JSON array
+        if let Ok(sources) = serde_json::from_str::<Vec<String>>(source_str) {
+            for s in &sources {
+                if let Some(template) = lookup_template(s) {
+                    let ext: ServiceExtension = serde_json::from_str(template)?;
+                    return Ok(ext);
+                }
+            }
+        }
+    }
+
+    Err("no service extension found: use --file to provide one".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_ext(queries: &[&str]) -> ServiceExtension {
+        ServiceExtension {
+            service_name: "test".to_string(),
+            service_metadata: Default::default(),
+            slo: None,
+            kpis: queries
+                .iter()
+                .map(|q| crate::viewer::Kpi {
+                    role: "test".to_string(),
+                    title: "test".to_string(),
+                    description: None,
+                    query: q.to_string(),
+                    metric_type: "gauge".to_string(),
+                    subtype: None,
+                    unit_system: None,
+                    percentiles: None,
+                    available: false,
+                    denominator: false,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn extract_column_names_basic() {
+        let ext = make_test_ext(&["requests_inflight", "ttft"]);
+        let names = extract_column_names(&ext);
+        assert!(names.contains("requests_inflight"));
+        assert!(names.contains("ttft"));
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    fn extract_column_names_strips_labels() {
+        let ext = make_test_ext(&[r#"sum(irate(tokens{direction="output"}[5s]))"#]);
+        let names = extract_column_names(&ext);
+        assert!(names.contains("tokens"));
+        assert!(!names.iter().any(|n| n.contains('{')));
+    }
+
+    #[test]
+    fn extract_column_names_deduplicates() {
+        let ext = make_test_ext(&[
+            r#"sum(irate(requests{status="error"}[5s])) / sum(irate(requests{status="sent"}[5s]))"#,
+        ]);
+        let names = extract_column_names(&ext);
+        // "requests" appears twice in query but should be deduplicated
+        assert!(names.contains("requests"));
+        assert_eq!(names.len(), 1);
+    }
+}

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -49,8 +49,8 @@ pub fn command() -> Command {
                         .index(1),
                 )
                 .arg(
-                    clap::Arg::new("service-extension")
-                        .long("file")
+                    clap::Arg::new("queries")
+                        .long("queries")
                         .value_name("PATH")
                         .help("Custom service extension JSON file (overrides built-in template)")
                         .value_parser(value_parser!(PathBuf))
@@ -61,7 +61,7 @@ pub fn command() -> Command {
                         .long("undo")
                         .help("Remove service extension annotation from the parquet file")
                         .action(clap::ArgAction::SetTrue)
-                        .conflicts_with("service-extension"),
+                        .conflicts_with("queries"),
                 )
                 .arg(
                     clap::Arg::new("filter")
@@ -145,8 +145,8 @@ pub fn command() -> Command {
                         .index(1),
                 )
                 .arg(
-                    clap::Arg::new("service-extension")
-                        .long("file")
+                    clap::Arg::new("queries")
+                        .long("queries")
                         .value_name("PATH")
                         .help("Custom service extension JSON file (overrides metadata/template)")
                         .value_parser(value_parser!(PathBuf))

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -1,5 +1,6 @@
 mod annotate;
 mod combine;
+mod filter;
 mod metadata;
 
 use arrow::datatypes::SchemaRef;
@@ -60,6 +61,13 @@ pub fn command() -> Command {
                         .help("Remove service extension annotation from the parquet file")
                         .action(clap::ArgAction::SetTrue)
                         .conflicts_with("service-extension"),
+                )
+                .arg(
+                    clap::Arg::new("filter")
+                        .long("filter")
+                        .help("Also filter columns to only those needed by the service extension KPIs")
+                        .action(clap::ArgAction::SetTrue)
+                        .conflicts_with("undo"),
                 ),
         )
         .subcommand(
@@ -125,6 +133,34 @@ pub fn command() -> Command {
                         .action(clap::ArgAction::SetTrue),
                 ),
         )
+        .subcommand(
+            Command::new("filter")
+                .about("Filter parquet columns to only those needed by service extension KPIs")
+                .arg(
+                    clap::Arg::new("FILE")
+                        .help("Parquet file to filter")
+                        .value_parser(value_parser!(PathBuf))
+                        .required(true)
+                        .index(1),
+                )
+                .arg(
+                    clap::Arg::new("service-extension")
+                        .long("file")
+                        .value_name("PATH")
+                        .help("Custom service extension JSON file (overrides metadata/template)")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(clap::ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("output")
+                        .short('o')
+                        .long("output")
+                        .value_name("PATH")
+                        .help("Output file path (default: overwrite input file in-place)")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(clap::ArgAction::Set),
+                ),
+        )
 }
 
 pub fn run(args: ArgMatches) {
@@ -134,6 +170,10 @@ pub fn run(args: ArgMatches) {
             return;
         }
         Some(("combine", sub_args)) => combine::run(sub_args),
+        Some(("filter", sub_args)) => {
+            filter::run(sub_args);
+            return;
+        }
         Some(("metadata", sub_args)) => metadata::run(sub_args),
         _ => unreachable!(),
     };

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -7,6 +7,7 @@ use arrow::datatypes::SchemaRef;
 use clap::{value_parser, ArgMatches, Command};
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
 use parquet::file::metadata::ParquetMetaData;
+use parquet::format::KeyValue;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -182,6 +183,68 @@ pub fn run(args: ArgMatches) {
         eprintln!("Error: {e}");
         std::process::exit(1);
     }
+}
+
+/// Read file-level key-value metadata from a parquet file footer.
+pub(crate) fn read_file_metadata(
+    path: impl AsRef<Path>,
+) -> Result<Vec<KeyValue>, Box<dyn std::error::Error>> {
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+
+    let reader = SerializedFileReader::new(std::fs::File::open(path)?)?;
+    Ok(reader
+        .metadata()
+        .file_metadata()
+        .key_value_metadata()
+        .cloned()
+        .unwrap_or_default())
+}
+
+/// Rewrite a parquet file with updated metadata, optionally projecting columns.
+/// Returns the serialized parquet bytes.
+///
+/// If `projection` is `Some`, only the columns at those indices are kept and
+/// the output schema is projected accordingly.  If `None`, all columns are
+/// passed through unchanged.
+pub(crate) fn rewrite_parquet(
+    path: impl AsRef<Path>,
+    kv_meta: Vec<KeyValue>,
+    projection: Option<&[usize]>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::properties::WriterProperties;
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(path)?)?;
+    let schema = builder.schema().clone();
+    let reader = builder.build()?;
+
+    let output_schema = match projection {
+        Some(indices) => Arc::new(schema.project(indices)?),
+        None => schema,
+    };
+
+    let props = WriterProperties::builder()
+        .set_key_value_metadata(Some(kv_meta))
+        .set_max_row_group_size(crate::parquet_metadata::MAX_ROW_GROUP_SIZE)
+        .build();
+
+    let mut buf = Vec::new();
+    {
+        let mut writer =
+            ArrowWriter::try_new(std::io::Cursor::new(&mut buf), output_schema, Some(props))?;
+        for batch in reader {
+            let batch = batch?;
+            let batch = match projection {
+                Some(indices) => batch.project(indices)?,
+                None => batch,
+            };
+            writer.write(&batch)?;
+        }
+        writer.close()?;
+    }
+
+    Ok(buf)
 }
 
 fn read_parquet_footer(

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1169,48 +1169,18 @@ async fn save_with_selection(
     // File mode: copy original parquet with selection metadata added
     if let Some(path) = parquet_path {
         let result = tokio::task::spawn_blocking(move || {
-            use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-            use parquet::arrow::ArrowWriter;
-            use parquet::file::properties::WriterProperties;
-            use parquet::file::reader::FileReader;
-            use parquet::file::serialized_reader::SerializedFileReader;
             use parquet::format::KeyValue;
 
-            let file = std::fs::File::open(&path)?;
-
-            // Read existing metadata to preserve and augment
-            let meta_reader = SerializedFileReader::new(std::fs::File::open(&path)?)?;
-            let mut kv_meta: Vec<KeyValue> = meta_reader
-                .metadata()
-                .file_metadata()
-                .key_value_metadata()
-                .cloned()
-                .unwrap_or_default();
+            let mut kv_meta =
+                crate::parquet_tools::read_file_metadata(&path).map_err(|e| e.to_string())?;
             kv_meta.retain(|kv| kv.key != "selection");
             kv_meta.push(KeyValue {
                 key: "selection".to_string(),
                 value: Some(selection_json),
             });
 
-            let props = WriterProperties::builder()
-                .set_key_value_metadata(Some(kv_meta))
-                .build();
-
-            let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
-            let schema = builder.schema().clone();
-            let reader = builder.build()?;
-
-            let mut output = Vec::new();
-            {
-                let mut writer =
-                    ArrowWriter::try_new(Cursor::new(&mut output), schema, Some(props))?;
-                for batch in reader {
-                    let batch = batch?;
-                    writer.write(&batch)?;
-                }
-                writer.close()?;
-            }
-
+            let output = crate::parquet_tools::rewrite_parquet(&path, kv_meta, None)
+                .map_err(|e| e.to_string())?;
             info!("saved annotated parquet ({} bytes)", output.len());
             Ok::<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>(output)
         })


### PR DESCRIPTION
## Problem

Parquet files can contain many columns that are not needed for a particular service's KPI queries. This results in unnecessarily large files and slower processing. Users need a way to filter parquet files to retain only the columns required by their service extension's KPI queries, plus essential metadata columns like `timestamp` and `duration`.

## Solution

Added a new `filter` subcommand that:

1. **Resolves service extensions** using a priority-based lookup:
   - Custom file provided via `--file` flag
   - Top-level `service_queries` metadata in the parquet file
   - Per-source metadata for combined files
   - Built-in templates matched by source name

2. **Extracts required columns** by parsing KPI queries to identify metric selectors and stripping label matchers (e.g., `tokens{direction="output"}` → `tokens`)

3. **Filters the parquet file** by:
   - Projecting the arrow schema to only retained columns
   - Filtering the `descriptions` metadata to match retained columns
   - Writing the filtered data to output (in-place or to specified path)

4. **Integrates with annotate** by adding a `--filter` flag to the `annotate` subcommand, allowing users to filter columns immediately after annotating a file

The implementation includes unit tests for column name extraction, label stripping, and deduplication logic.

## Result

Users can now:
- Run `parquet-tools filter <file>` to reduce file size by keeping only necessary columns
- Use `parquet-tools annotate --filter <file>` to annotate and filter in one operation
- Specify custom service extensions or output paths as needed
- Automatically preserve essential metadata while removing unused columns

https://claude.ai/code/session_01QB2kNL2E23pnvkWT1PErEd