### PR TITLE
Add Docker support with agent and capture tooling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,123 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    if: github.repository == 'iopsystems/rezolus'
+    name: "Build and push Docker image (${{ matrix.arch }})"
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    strategy:
+      matrix:
+        arch: [x86_64, arm64]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Determine platform
+        id: platform
+        run: |
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+          else
+            echo "platform=linux/amd64" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: ${{ steps.platform.outputs.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: github.repository == 'iopsystems/rezolus'
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+*.parquet
+debian/cargo_home/
+debian/cargo_target/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,55 @@
+# Stage 1: Build Rezolus from source
+FROM debian:bookworm AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    libelf-dev \
+    clang \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /build
+
+# Copy source tree
+COPY . .
+
+# Build release binary
+RUN cargo build --release
+
+# Stage 2: Runtime image
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    libelf1 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the rezolus binary
+COPY --from=builder /build/target/release/rezolus /usr/local/bin/rezolus
+
+# Copy default agent config
+COPY config/agent.toml /etc/rezolus/agent.toml
+
+# Copy entrypoint and capture scripts
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY docker/rezolus-capture /usr/local/bin/rezolus-capture
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/rezolus-capture
+
+# Create default output directory
+RUN mkdir -p /data
+
+# Agent port
+EXPOSE 4241
+# Viewer port
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,157 @@
+# Rezolus Docker Image
+
+A Docker image for trying out Rezolus -- capture high-resolution system and
+service metrics, then view them in an interactive dashboard.
+
+The container runs the Rezolus agent automatically for system metrics collection
+(CPU, memory, network, disk, scheduler, syscalls, TCP) via eBPF. It also
+includes a `rezolus-capture` script that records metrics for a given duration,
+optionally combines system metrics with service metrics from a
+Prometheus-compatible endpoint, and launches the Rezolus viewer.
+
+## Quick Start
+
+Build the image:
+
+```bash
+docker build -f docker/Dockerfile -t rezolus .
+```
+
+Or pull a pre-built image:
+
+```bash
+docker pull ghcr.io/iopsystems/rezolus:latest
+```
+
+## Usage
+
+### System metrics only
+
+Capture system metrics for 60 seconds and view the results:
+
+```bash
+docker run --rm -it --privileged \
+  -p 8080:8080 \
+  -v $(pwd)/data:/data \
+  rezolus \
+  rezolus-capture --duration 60s
+```
+
+Then open http://localhost:8080 in your browser.
+
+### System + service metrics (e.g., Redis)
+
+Start Redis and a Prometheus exporter for it:
+
+```bash
+docker run -d --name redis -p 6379:6379 redis:latest
+docker run -d --name redis-exporter -p 9121:9121 \
+  --link redis oliver006/redis_exporter
+```
+
+Capture both system and Redis metrics for 2 minutes:
+
+```bash
+docker run --rm -it --privileged \
+  --network=host \
+  -v $(pwd)/data:/data \
+  rezolus \
+  rezolus-capture --duration 2m \
+    --endpoint http://localhost:9121/metrics \
+    --source redis
+```
+
+The combined dashboard at http://localhost:8080 shows system-level and
+Redis metrics side by side.
+
+### System + service metrics (e.g., Valkey)
+
+```bash
+docker run -d --name valkey -p 6379:6379 valkey/valkey:latest
+docker run -d --name valkey-exporter -p 9121:9121 \
+  --link valkey oliver006/redis_exporter --redis.addr redis://valkey:6379
+
+docker run --rm -it --privileged \
+  --network=host \
+  -v $(pwd)/data:/data \
+  rezolus \
+  rezolus-capture --duration 2m \
+    --endpoint http://localhost:9121/metrics \
+    --source valkey
+```
+
+### Just run the agent
+
+Run the Rezolus agent indefinitely (no capture, no viewer):
+
+```bash
+docker run --rm -d --privileged \
+  -p 4241:4241 \
+  rezolus
+```
+
+The agent's metrics endpoint is available at http://localhost:4241.
+
+## rezolus-capture Reference
+
+```
+rezolus-capture [OPTIONS]
+
+REQUIRED:
+  --duration <DURATION>       How long to capture (e.g., 60s, 5m, 1h)
+
+OPTIONS:
+  --endpoint <URL>            Service metrics endpoint (Prometheus-compatible)
+  --source <NAME>             Source name for service metrics (required with --endpoint)
+  --interval <INTERVAL>       Sampling interval (default: 1s)
+  --output-dir <DIR>          Output directory for parquet files (default: /data)
+  --viewer-listen <ADDR>      Viewer listen address (default: 0.0.0.0:8080)
+  --no-viewer                 Skip launching the viewer after capture
+  -h, --help                  Show help text
+```
+
+## Ports
+
+| Port | Service |
+|------|---------|
+| 4241 | Rezolus agent (always running) |
+| 8080 | Rezolus viewer (after capture completes) |
+
+## Volumes
+
+Mount `/data` to persist capture output on the host:
+
+```bash
+-v $(pwd)/data:/data
+```
+
+The capture script writes `capture.parquet` to this directory.
+
+## Privileged Mode
+
+The Rezolus agent uses eBPF for low-overhead kernel instrumentation. This
+requires elevated privileges. Run the container with one of:
+
+```bash
+# Full privileged mode (simplest)
+docker run --privileged ...
+
+# Or with specific capabilities
+docker run --cap-add SYS_ADMIN --cap-add BPF --cap-add PERFMON ...
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REZOLUS_AGENT_CONFIG` | `/etc/rezolus/agent.toml` | Path to the agent config file |
+
+## Building from Source
+
+```bash
+docker build -f docker/Dockerfile -t rezolus .
+```
+
+The Dockerfile uses a multi-stage build:
+1. **Build stage**: Compiles Rezolus from source (Debian bookworm with Rust toolchain)
+2. **Runtime stage**: Minimal image with just the binary and runtime dependencies

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+AGENT_CONFIG="${REZOLUS_AGENT_CONFIG:-/etc/rezolus/agent.toml}"
+AGENT_URL="http://127.0.0.1:4241/"
+
+# Start the Rezolus agent in the background
+echo "Starting Rezolus agent..."
+rezolus "$AGENT_CONFIG" &
+AGENT_PID=$!
+
+# Wait for the agent to become ready
+echo "Waiting for agent to be ready..."
+for i in $(seq 1 30); do
+    if curl -sf "$AGENT_URL" > /dev/null 2>&1; then
+        echo "Agent is ready (pid $AGENT_PID)"
+        break
+    fi
+    if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+        echo "Error: Agent process exited unexpectedly"
+        exit 1
+    fi
+    sleep 1
+done
+
+if ! curl -sf "$AGENT_URL" > /dev/null 2>&1; then
+    echo "Error: Agent failed to start within 30 seconds"
+    exit 1
+fi
+
+# Execute the user's command, or default to keeping the container alive
+if [ $# -eq 0 ]; then
+    echo "Agent running on port 4241. Use 'rezolus-capture' to start a recording."
+    wait "$AGENT_PID"
+else
+    exec "$@"
+fi

--- a/docker/rezolus-capture
+++ b/docker/rezolus-capture
@@ -1,0 +1,183 @@
+#!/bin/bash
+set -e
+
+PROGRAM="$(basename "$0")"
+
+# Defaults
+DURATION=""
+ENDPOINT=""
+SOURCE=""
+INTERVAL="1s"
+OUTPUT_DIR="/data"
+VIEWER_LISTEN="0.0.0.0:8080"
+NO_VIEWER=false
+
+help() {
+    cat <<EOF
+$PROGRAM - Capture system and service metrics, then view the results.
+
+The Rezolus agent must already be running (started by the container entrypoint).
+This script records system metrics from the local agent and optionally records
+service metrics from a Prometheus-compatible endpoint, combines them into a
+single parquet file, and launches the Rezolus viewer.
+
+USAGE:
+    $PROGRAM --duration <DURATION> [OPTIONS]
+
+REQUIRED:
+    --duration <DURATION>       How long to capture (e.g., 60s, 5m, 1h)
+
+OPTIONS:
+    --endpoint <URL>            Service metrics endpoint (Prometheus-compatible)
+    --source <NAME>             Source name for service metrics (required with --endpoint)
+    --interval <INTERVAL>       Sampling interval (default: 1s)
+    --output-dir <DIR>          Output directory for parquet files (default: /data)
+    --viewer-listen <ADDR>      Viewer listen address (default: 0.0.0.0:8080)
+    --no-viewer                 Skip launching the viewer after capture
+    -h, --help                  Show this help text
+
+EXAMPLES:
+    # System metrics only for 60 seconds
+    $PROGRAM --duration 60s
+
+    # System + Redis metrics for 2 minutes
+    $PROGRAM --duration 2m \\
+        --endpoint http://localhost:9121/metrics \\
+        --source redis
+
+    # Capture without launching the viewer
+    $PROGRAM --duration 60s --no-viewer
+EOF
+}
+
+error() {
+    echo "Error: $1" >&2
+    echo "Try '$PROGRAM --help' for more information." >&2
+    exit 1
+}
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            help
+            exit 0
+            ;;
+        --duration)
+            [ -n "${2:-}" ] || error "--duration requires a value"
+            DURATION="$2"; shift 2
+            ;;
+        --endpoint)
+            [ -n "${2:-}" ] || error "--endpoint requires a value"
+            ENDPOINT="$2"; shift 2
+            ;;
+        --source)
+            [ -n "${2:-}" ] || error "--source requires a value"
+            SOURCE="$2"; shift 2
+            ;;
+        --interval)
+            [ -n "${2:-}" ] || error "--interval requires a value"
+            INTERVAL="$2"; shift 2
+            ;;
+        --output-dir)
+            [ -n "${2:-}" ] || error "--output-dir requires a value"
+            OUTPUT_DIR="$2"; shift 2
+            ;;
+        --viewer-listen)
+            [ -n "${2:-}" ] || error "--viewer-listen requires a value"
+            VIEWER_LISTEN="$2"; shift 2
+            ;;
+        --no-viewer)
+            NO_VIEWER=true; shift
+            ;;
+        *)
+            error "unexpected argument '$1'"
+            ;;
+    esac
+done
+
+# Validate required arguments
+[ -n "$DURATION" ] || error "--duration is required"
+
+# If endpoint is given, source is required
+if [ -n "$ENDPOINT" ] && [ -z "$SOURCE" ]; then
+    error "--source is required when --endpoint is specified"
+fi
+
+# Verify the agent is running
+if ! curl -sf http://127.0.0.1:4241/ > /dev/null 2>&1; then
+    error "Rezolus agent is not running on 127.0.0.1:4241"
+fi
+
+# Set up temp files and output
+SYSTEM_PARQUET="$(mktemp /tmp/system-XXXXXX.parquet)"
+SERVICE_PARQUET="$(mktemp /tmp/service-XXXXXX.parquet)"
+OUTPUT_FILE="${OUTPUT_DIR}/capture.parquet"
+
+mkdir -p "$OUTPUT_DIR"
+
+cleanup() {
+    rm -f "$SYSTEM_PARQUET" "$SERVICE_PARQUET"
+}
+trap cleanup EXIT
+
+# Start system metrics recording
+echo "Recording system metrics for $DURATION (interval: $INTERVAL)..."
+rezolus record http://127.0.0.1:4241 "$SYSTEM_PARQUET" \
+    -d "$DURATION" -i "$INTERVAL" -m source=rezolus &
+SYSTEM_PID=$!
+
+# Start service metrics recording if endpoint is specified
+SERVICE_PID=""
+if [ -n "$ENDPOINT" ]; then
+    echo "Recording service metrics from $ENDPOINT (source: $SOURCE)..."
+    rezolus record "$ENDPOINT" "$SERVICE_PARQUET" \
+        -d "$DURATION" -i "$INTERVAL" -m "source=$SOURCE" &
+    SERVICE_PID=$!
+fi
+
+# Wait for recordings to complete
+FAILED=false
+
+if ! wait "$SYSTEM_PID"; then
+    echo "Error: System metrics recording failed" >&2
+    FAILED=true
+fi
+
+if [ -n "$SERVICE_PID" ]; then
+    if ! wait "$SERVICE_PID"; then
+        echo "Error: Service metrics recording failed" >&2
+        FAILED=true
+    fi
+fi
+
+if $FAILED; then
+    exit 1
+fi
+
+echo "Recording complete."
+
+# Combine or move the output
+if [ -n "$ENDPOINT" ] && [ -f "$SERVICE_PARQUET" ] && [ -s "$SERVICE_PARQUET" ]; then
+    echo "Combining system and service recordings..."
+    rezolus parquet combine "$SYSTEM_PARQUET" "$SERVICE_PARQUET" -o "$OUTPUT_FILE"
+    echo "Combined parquet saved to $OUTPUT_FILE"
+else
+    cp "$SYSTEM_PARQUET" "$OUTPUT_FILE"
+    echo "System parquet saved to $OUTPUT_FILE"
+fi
+
+# Show metadata summary
+echo ""
+echo "Recording metadata:"
+rezolus parquet metadata -i "$OUTPUT_FILE" 2>/dev/null || true
+echo ""
+
+# Launch viewer
+if ! $NO_VIEWER; then
+    echo "Launching viewer at http://$VIEWER_LISTEN ..."
+    exec rezolus view "$OUTPUT_FILE" "$VIEWER_LISTEN"
+else
+    echo "Done. View the recording with:"
+    echo "  rezolus view $OUTPUT_FILE"
+fi


### PR DESCRIPTION
## Problem

Rezolus currently lacks containerized deployment support, making it difficult for users to run the agent and capture metrics in Docker environments. There's no standardized way to package Rezolus, start the agent, and provide convenient metric capture tooling within a container.

## Solution

Added comprehensive Docker support including:

1. **Dockerfile** - Multi-stage build that:
   - Builds Rezolus from source in a builder stage
   - Creates a minimal runtime image based on Debian bookworm-slim
   - Includes necessary runtime dependencies (libelf1, curl)
   - Exposes ports 4241 (agent) and 8080 (viewer)

2. **entrypoint.sh** - Container entrypoint script that:
   - Starts the Rezolus agent in the background
   - Waits for the agent to be ready (with 30-second timeout)
   - Allows users to run custom commands or keep the container alive
   - Supports custom agent config via `REZOLUS_AGENT_CONFIG` environment variable

3. **rezolus-capture** - Utility script for recording metrics that:
   - Captures system metrics from the local agent
   - Optionally captures service metrics from Prometheus-compatible endpoints
   - Combines multiple metric sources into a single parquet file
   - Launches the Rezolus viewer for interactive analysis
   - Provides comprehensive CLI with help text and validation
   - Supports customizable sampling intervals and output directories

4. **.dockerignore** - Excludes unnecessary files from the build context

## Result

Users can now:
- Build a Docker image containing Rezolus with `docker build`
- Run the agent in a container with automatic startup and health checking
- Use the `rezolus-capture` command to record system and service metrics
- View captured metrics using the built-in viewer
- Integrate Rezolus into containerized monitoring and profiling workflows

The Docker image provides a complete, self-contained solution for metric collection and analysis in container environments.

https://claude.ai/code/session_012nFNtySN5Hbm9XHXz72qLU