### PR TITLE
Scope selection/report localStorage by file fingerprint

### DIFF
--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -5,7 +5,7 @@ import globalColorMapper from './charts/util/colormap.js';
 import { TopNav, Sidebar, countCharts } from './layout.js';
 import { CpuTopology } from './topology.js';
 import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData } from './data.js';
-import { selectionStore, reportStore, toggleSelection, isSelected, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
+import { selectionStore, reportStore, setStorageScope, toggleSelection, isSelected, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
 import { SaveModal } from './overlays.js';
 import { ViewerApi } from './viewer_api.js';
 import { createSystemInfoView, renderCgroupSection } from './section_views.js';
@@ -371,6 +371,14 @@ async function loadDemo(filename = 'demo.parquet') {
 
         viewerInfo = JSON.parse(window.viewer.info());
         ViewerApi.setViewerInfo(viewerInfo);
+        setStorageScope({
+            filename: viewerInfo.filename,
+            minTime: viewerInfo.minTime,
+            maxTime: viewerInfo.maxTime,
+            numSeries: (viewerInfo.counter_names?.length || 0) +
+                       (viewerInfo.gauge_names?.length || 0) +
+                       (viewerInfo.histogram_names?.length || 0),
+        });
 
         try { systemInfoData = await ViewerApi.getSystemInfo(); } catch { /* ignore */ }
 
@@ -416,6 +424,14 @@ async function loadFile(file) {
 
         viewerInfo = JSON.parse(window.viewer.info());
         ViewerApi.setViewerInfo(viewerInfo);
+        setStorageScope({
+            filename: viewerInfo.filename,
+            minTime: viewerInfo.minTime,
+            maxTime: viewerInfo.maxTime,
+            numSeries: (viewerInfo.counter_names?.length || 0) +
+                       (viewerInfo.gauge_names?.length || 0) +
+                       (viewerInfo.histogram_names?.length || 0),
+        });
 
         try { systemInfoData = await ViewerApi.getSystemInfo(); } catch { /* ignore */ }
 

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -5,7 +5,7 @@ import globalColorMapper from './charts/util/colormap.js';
 import { TopNav, Sidebar, countCharts, formatSize } from './layout.js';
 import { CpuTopology } from './topology.js';
 import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache } from './data.js';
-import { reportStore, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
+import { reportStore, setStorageScope, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
 import { expandLink, selectButton } from './chart_controls.js';
 import { notify, showSaveModal, SaveModal } from './overlays.js';
 import { ViewerApi } from './viewer_api.js';
@@ -104,6 +104,9 @@ const uploadParquet = async (file) => {
         clearMetadataCache();
         chartsState.resetAll();
         await fetchBackendState();
+        if (fileChecksum) {
+            setStorageScope({ filename: fileChecksum });
+        }
         // Re-fetch overview so the view has data to render immediately.
         // m.route.set('/overview') is a no-op when already on /overview
         // (the route guard returns a never-resolving promise), so we must
@@ -550,6 +553,9 @@ const bootstrap = async () => {
 
     // Fetch metadata, system info, and selection in parallel
     await fetchBackendState();
+    if (fileChecksum) {
+        setStorageScope({ filename: fileChecksum });
+    }
 
     // Set up the router now that data is loaded
     m.route.prefix = ''; // use regular paths for navigation, eg. /overview

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -48,8 +48,33 @@ const reportStore = {
 
 // ── LocalStorage persistence ─────────────────────────────────────
 
-const REPORT_STORAGE_KEY = 'rezolus_report';
-const SELECTION_STORAGE_KEY = 'rezolus_selection';
+let REPORT_STORAGE_KEY = 'rezolus_report';
+let SELECTION_STORAGE_KEY = 'rezolus_selection';
+
+/**
+ * Scope localStorage keys by a file fingerprint so each parquet file
+ * gets its own selection/report state. Call after loading a new file.
+ *
+ * @param {{ filename?: string, minTime?: number, maxTime?: number, numSeries?: number }} info
+ */
+const setStorageScope = (info) => {
+    const parts = [
+        info.filename || '',
+        info.minTime || 0,
+        info.maxTime || 0,
+        info.numSeries || 0,
+    ].join('|');
+    const suffix = Array.from(new TextEncoder().encode(parts))
+        .reduce((h, b) => ((h << 5) - h + b) | 0, 0)
+        .toString(36);
+    REPORT_STORAGE_KEY = `rezolus_report_${suffix}`;
+    SELECTION_STORAGE_KEY = `rezolus_selection_${suffix}`;
+    // Restore from the scoped keys
+    clearStore(selectionStore);
+    clearStore(reportStore);
+    restoreStore(REPORT_STORAGE_KEY, reportStore);
+    restoreStore(SELECTION_STORAGE_KEY, selectionStore);
+};
 
 const persistStore = (key, store) => {
     try {
@@ -110,6 +135,8 @@ const restoreStore = (key, store) => {
 const persistReport = () => persistStore(REPORT_STORAGE_KEY, reportStore);
 const persistSelection = () => persistStore(SELECTION_STORAGE_KEY, selectionStore);
 
+// Stores are restored when setStorageScope() is called with a file fingerprint,
+// or eagerly here for the default (unscoped) keys as a fallback.
 restoreStore(REPORT_STORAGE_KEY, reportStore);
 restoreStore(SELECTION_STORAGE_KEY, selectionStore);
 
@@ -575,6 +602,7 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
 export {
     selectionStore,
     reportStore,
+    setStorageScope,
     toggleSelection,
     isSelected,
     clearStore,


### PR DESCRIPTION
## Summary
- Selection and report stores were persisted with fixed localStorage keys (`rezolus_selection`, `rezolus_report`), causing stale data to appear when switching between parquet files
- Add `setStorageScope()` to `selection.js` that re-keys localStorage by a content fingerprint (hash of filename + time range + metric count for site viewer, file checksum for binary viewer)
- Called after every file load (demo, file upload, binary bootstrap, binary upload)
- Each unique parquet file gets its own isolated selection/report state

## Test plan
- [x] Load demo.parquet, select a chart, reload — selection persists
- [x] Switch to vllm.parquet — selection is clean (no stale charts)
- [x] Switch back to demo.parquet — previous selection is restored
- [x] Replace a demo file with different content but same name — old selection does not leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)