### PR TITLE
Fix expand button URLs in site viewer

### DIFF
--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -220,7 +220,7 @@ const Group = {
 
         const expandLink = (spec) => {
             if (!spec.promql_query) return null;
-            const href = `${sectionRoute}/chart/${encodeURIComponent(spec.opts.id)}`;
+            const href = `#${sectionRoute}/chart/${encodeURIComponent(spec.opts.id)}`;
             return m('a.chart-expand', {
                 href, target: '_blank', title: 'Open in new tab',
                 onclick: (e) => e.stopPropagation(),


### PR DESCRIPTION
## Summary
- Fix expand button generating bare paths instead of hash-prefixed paths in the static site viewer
- The site viewer uses `m.route.prefix = '#'` (hash-based routing), so expand links need `#/path` not `/path`

## Test plan
- [x] Load a service section on the static site viewer (e.g. `?demo=vllm.parquet`)
- [x] Click expand button on a chart — should open `#/service/vllm/chart/...` in new tab
- [x] Verify the expanded chart view loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)