### PR TITLE
Disable scroll zoom on charts

### DIFF
--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -264,11 +264,6 @@ export function calculateMinZoomSpan(timeData) {
  */
 export function getDataZoomConfig(minZoomSpan) {
     return [{
-        type: 'inside',
-        xAxisIndex: 0,
-        minSpan: minZoomSpan,
-        filterMode: 'none',
-    }, {
         type: 'slider',
         show: false,
         xAxisIndex: 0,


### PR DESCRIPTION
## Summary
- Remove the `inside` type dataZoom from ECharts config to stop charts from hijacking mouse wheel events
- Page scrolling now works normally when hovering over charts
- Drag-to-zoom (toolbox) and programmatic zoom (time range bar) are unaffected

## Test plan
- [x] Scroll over charts — page scrolls normally, no zoom
- [x] Drag-to-zoom still works on charts
- [x] Time range bar zoom still syncs to all charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)