### PR TITLE
Viewer UX improvements, cachecannon template, and combine bypass flag

### DIFF
--- a/config/templates/cachecannon.json
+++ b/config/templates/cachecannon.json
@@ -5,17 +5,17 @@
   "kpis": [
     {
       "role": "load",
-      "title": "Request Rate",
-      "query": "sum(irate(requests_sent[5s]))",
-      "type": "delta_counter",
-      "unit_system": "rate"
-    },
-    {
-      "role": "load",
       "title": "Target Rate",
       "query": "target_rate",
       "type": "gauge",
       "unit_system": "count"
+    },
+    {
+      "role": "throughput",
+      "title": "Request Rate",
+      "query": "sum(irate(requests_sent[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
     },
     {
       "role": "throughput",
@@ -33,6 +33,13 @@
       "unit_system": "datarate"
     },
     {
+      "role": "throughput",
+      "title": "Bytes Sent Rate",
+      "query": "sum(irate(bytes_tx[5s]))",
+      "type": "delta_counter",
+      "unit_system": "datarate"
+    },
+    {
       "role": "latency",
       "title": "Response Latency",
       "query": "response_latency",
@@ -41,8 +48,24 @@
       "unit_system": "time"
     },
     {
+      "role": "latency",
+      "title": "GET Latency",
+      "query": "get_latency",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    },
+    {
+      "role": "latency",
+      "title": "SET Latency",
+      "query": "set_latency",
+      "type": "histogram",
+      "subtype": "percentiles",
+      "unit_system": "time"
+    },
+    {
       "role": "error",
-      "title": "Error Rate",
+      "title": "Request Error Rate",
       "query": "sum(irate(request_errors[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
@@ -51,6 +74,34 @@
       "role": "error",
       "title": "Connection Failure Rate",
       "query": "sum(irate(connections_failed[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "custom",
+      "title": "Cache Hit Rate",
+      "query": "sum(irate(cache_hits[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "custom",
+      "title": "Cache Miss Rate",
+      "query": "sum(irate(cache_misses[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "custom",
+      "title": "GET Rate",
+      "query": "sum(irate(get_count[5s]))",
+      "type": "delta_counter",
+      "unit_system": "rate"
+    },
+    {
+      "role": "custom",
+      "title": "SET Rate",
+      "query": "sum(irate(set_count[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     }

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -32,6 +32,7 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
         .cloned()
         .collect();
     let output = args.get_one::<PathBuf>("output").unwrap();
+    let bypass_time_check = args.get_flag("bypass-time-check");
 
     // Phase 1: Load all input files
     let inputs = load_inputs(&files)?;
@@ -43,7 +44,7 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
     validate_time_overlap(&inputs)?;
 
     // Phase 3: Combine and write
-    combine_and_write(&inputs, output)?;
+    combine_and_write(&inputs, output, bypass_time_check)?;
 
     let source_names: Vec<&str> = inputs.iter().map(|i| i.source.as_str()).collect();
     println!(
@@ -218,6 +219,7 @@ fn timestamp_range(input: &InputFile) -> Result<(u64, u64), Box<dyn std::error::
 fn combine_and_write(
     inputs: &[InputFile],
     output: &PathBuf,
+    bypass_time_check: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let interval_ns = resolve_interval_ns(inputs)?;
 
@@ -235,7 +237,11 @@ fn combine_and_write(
 
     // Step 2b: Validate alignment quality — at least 95% of matched
     // timestamps must have raw values within 10% of the interval.
-    validate_alignment_quality(inputs, &common_timestamps, interval_ns)?;
+    if bypass_time_check {
+        eprintln!("warning: skipping timestamp alignment quality check (--bypass-time-check)");
+    } else {
+        validate_alignment_quality(inputs, &common_timestamps, interval_ns)?;
+    }
 
     // Step 3: Build merged schema
     let (primary_idx, merged_schema) = build_merged_schema(inputs);
@@ -877,7 +883,7 @@ mod tests {
         let out_path = out_tmp.path().to_path_buf();
 
         let inputs = vec![load(&p1), load(&p2)];
-        combine_and_write(&inputs, &out_path).unwrap();
+        combine_and_write(&inputs, &out_path, false).unwrap();
 
         // Read back
         let file = std::fs::File::open(&out_path).unwrap();
@@ -941,7 +947,7 @@ mod tests {
         validate_sampling_interval(&inputs).unwrap();
         validate_no_column_conflicts(&inputs).unwrap();
         validate_time_overlap(&inputs).unwrap();
-        combine_and_write(&inputs, &out_path).unwrap();
+        combine_and_write(&inputs, &out_path, false).unwrap();
 
         // Read back and verify schema
         let file = std::fs::File::open(&out_path).unwrap();
@@ -997,7 +1003,7 @@ mod tests {
         let out_path = out_tmp.path().to_path_buf();
 
         let inputs = vec![load(&p1), load(&p2)];
-        combine_and_write(&inputs, &out_path).unwrap();
+        combine_and_write(&inputs, &out_path, false).unwrap();
 
         let file = std::fs::File::open(&out_path).unwrap();
         let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
@@ -1038,7 +1044,7 @@ mod tests {
         let out_path = out_tmp.path().to_path_buf();
 
         let inputs = vec![load(&p1), load(&p2)];
-        let result = combine_and_write(&inputs, &out_path);
+        let result = combine_and_write(&inputs, &out_path, false);
         assert!(result.is_err());
     }
 
@@ -1066,7 +1072,7 @@ mod tests {
         let out_path = out_tmp.path().to_path_buf();
 
         let inputs = vec![load(&p1), load(&p2)];
-        combine_and_write(&inputs, &out_path).unwrap();
+        combine_and_write(&inputs, &out_path, false).unwrap();
 
         let file = std::fs::File::open(&out_path).unwrap();
         let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
@@ -1111,7 +1117,7 @@ mod tests {
         let out_path = out_tmp.path().to_path_buf();
 
         let inputs = vec![load(&p1), load(&p2)];
-        let result = combine_and_write(&inputs, &out_path);
+        let result = combine_and_write(&inputs, &out_path, false);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -75,6 +75,12 @@ pub fn command() -> Command {
                         .help("Output parquet file path")
                         .value_parser(value_parser!(PathBuf))
                         .required(true),
+                )
+                .arg(
+                    clap::Arg::new("bypass-time-check")
+                        .long("bypass-time-check")
+                        .help("Skip the timestamp alignment quality check")
+                        .action(clap::ArgAction::SetTrue),
                 ),
         )
         .subcommand(

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -399,8 +399,12 @@ export class Chart {
         const option = this.echart.getOption();
         const isLog = option?.yAxis?.[0]?.type === 'log';
 
-        // If at default zoom, restore original bounds
-        if (this.chartsState.isDefaultZoom()) {
+        // When percentile series are pinned, rescale Y to pinned subset only.
+        const hasPins = this.pinnedSet && this.pinnedSet.size > 0;
+        const labels = this._seriesLabels; // set by scatter chart config
+
+        // If at default zoom and no pins active, restore original bounds
+        if (this.chartsState.isDefaultZoom() && !(hasPins && labels)) {
             this.echart.setOption({
                 yAxis: { min: null, max: this._oobAxisMax ?? null }
             });
@@ -412,7 +416,11 @@ export class Chart {
         const zoom = this.chartsState.zoomLevel;
 
         let visibleMinMs, visibleMaxMs;
-        if (zoom.startValue !== undefined && zoom.endValue !== undefined) {
+        if (!zoom) {
+            // No zoom state (default view) — scan full time range
+            visibleMinMs = timeData[0] * 1000;
+            visibleMaxMs = timeData[timeData.length - 1] * 1000;
+        } else if (zoom.startValue !== undefined && zoom.endValue !== undefined) {
             visibleMinMs = zoom.startValue;
             visibleMaxMs = zoom.endValue;
         } else {
@@ -423,11 +431,17 @@ export class Chart {
             visibleMaxMs = totalMinMs + (zoom.end / 100) * totalRange;
         }
 
-        // Scan raw data for min/max Y in visible range
+        // Scan raw data for min/max Y in visible range.
+        // When percentile series are pinned, only consider pinned series.
         let yMin = Infinity;
         let yMax = -Infinity;
 
         for (let seriesIdx = 1; seriesIdx < data.length; seriesIdx++) {
+            // Skip faded (non-pinned) series so Y-axis rescales to selection
+            if (hasPins && labels) {
+                const name = labels[seriesIdx - 1];
+                if (name && !this.pinnedSet.has(name)) continue;
+            }
             const values = data[seriesIdx];
             for (let i = 0; i < timeData.length; i++) {
                 const tMs = timeData[i] * 1000;

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -164,6 +164,9 @@ export function configureScatterChart(chart) {
         chart.pinnedSet = new Set();
     }
 
+    // Store labels so _rescaleYAxis can map data indices to pinned names
+    chart._seriesLabels = percentileLabels;
+
     const minZoomSpan = calculateMinZoomSpan(timeData);
 
     const uniqueNamesForLayout = [...new Set(series.map(s => s.name))];
@@ -376,6 +379,7 @@ export function configureScatterChart(chart) {
             }
         }
         applyPinState();
+        chart._rescaleYAxis();
     });
 
     // Restore pin state if chart was reconfigured (e.g., data update)

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -131,6 +131,7 @@
     --bg-card: #ffffff;
     --bg-card-hover: #f3f5f8;
     --bg-elevated: #ffffff;
+    --bg-card-gradient: var(--bg-card);
 
     /* Border hierarchy */
     --border-subtle: rgba(31, 35, 40, 0.12);
@@ -475,6 +476,7 @@ body::after {
     display: flex;
     align-items: center;
     gap: 4px;
+    margin-left: 12px;
     margin-right: 4px;
     flex-shrink: 0;
 }
@@ -1862,9 +1864,26 @@ main {
     flex: 1 1 0;
 }
 
+/* Wrapped LLC group: explicit row packing (no CSS flex-wrap) */
+.topo-llc-group-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.topo-llc-row {
+    display: flex;
+    gap: 8px;
+}
+
+.topo-subgroup-grid {
+    display: grid;
+    gap: var(--topo-border, 2px);
+}
+
 /* Core cell */
 .topo-core {
-    background: var(--bg-tertiary);
+    background: var(--bg);
     border: var(--topo-border, 2px) solid var(--topo-threads);
     border-radius: 3px;
     display: flex;

--- a/src/viewer/assets/lib/topology.js
+++ b/src/viewer/assets/lib/topology.js
@@ -45,6 +45,22 @@ const DESCRIPTIONS = {
     numa: 'NUMA Topology: Memory locality domains. Each node has local memory and a set of CPUs.',
 };
 
+// ── Layout helpers ───────────────────────────────────────────────────
+
+/**
+ * Pick the best columns-per-row so cores divide evenly (no dangling last row).
+ * Searches [maxCols .. maxCols/2] for the largest exact divisor of totalCores.
+ * Falls back to maxCols if no clean split exists.
+ */
+const bestCols = (totalCores, maxCols) => {
+    if (totalCores <= maxCols) return totalCores;
+    const minCols = Math.max(1, Math.ceil(maxCols / 2));
+    for (let c = maxCols; c >= minCols; c--) {
+        if (totalCores % c === 0) return c;
+    }
+    return maxCols;
+};
+
 // ── Cache level helpers ──────────────────────────────────────────────
 
 const getCacheLevels = (levels) => {
@@ -95,25 +111,34 @@ const computeLayout = (numaGroups, numaPerRow, containerWidth) => {
         if (cores.size > maxCoresPerNuma) maxCoresPerNuma = cores.size;
     }
 
-    const effectiveCores = maxCoresPerNuma * numaPerRow;
-
-    let labeled, cellWidth;
-    if (containerWidth) {
-        // Subtract padding/borders/gaps: package ~14px, NUMA box ~16px + gap ~12px per column
-        const overhead = 48 + numaPerRow * 40;
-        cellWidth = (containerWidth - overhead) / effectiveCores;
-        labeled = cellWidth >= 48;
-    } else {
-        labeled = effectiveCores <= 24;
-        cellWidth = null;
+    if (!containerWidth) {
+        const total = maxCoresPerNuma * numaPerRow;
+        const labeled = total <= 24;
+        return { labeled, borderW: labeled ? 2 : 1, numaPerRow, maxCoresPerNuma, cellSize: null, maxCols: labeled ? 16 : 32 };
     }
 
-    const borderW = effectiveCores > 32 ? 1 : labeled ? 2 : 1;
+    // Subtract padding/borders/gaps: package ~14px, NUMA box ~16px + gap ~12px per column
+    const overhead = 48 + numaPerRow * 40;
+    const widthPerNuma = (containerWidth - overhead) / numaPerRow;
 
-    // In compact mode, cap cell size for comfortable proportions
-    const cellSize = !labeled && cellWidth ? Math.min(cellWidth, 32) : null;
+    // Try labeled mode: need >= 48px per cell.  Wrapping caps columns to maxCols.
+    const labeledMaxCols = Math.max(8, Math.floor(widthPerNuma / 48));
+    const labeledCols = Math.min(maxCoresPerNuma, labeledMaxCols);
+    const labeledCellW = widthPerNuma / labeledCols;
 
-    return { labeled, borderW, numaPerRow, maxCoresPerNuma, cellSize };
+    if (labeledCellW >= 48) {
+        const total = labeledCols * numaPerRow;
+        return { labeled: true, borderW: total > 32 ? 1 : 2, numaPerRow, maxCoresPerNuma, cellSize: null, maxCols: labeledMaxCols };
+    }
+
+    // Compact mode: smaller cells, more columns per row
+    const compactMaxCols = Math.max(8, Math.floor(widthPerNuma / 20));
+    const compactCols = Math.min(maxCoresPerNuma, compactMaxCols);
+    const compactCellW = widthPerNuma / compactCols;
+    const cellSize = Math.min(compactCellW, 32);
+    const total = compactCols * numaPerRow;
+
+    return { labeled: false, borderW: total > 32 ? 1 : 1, numaPerRow, maxCoresPerNuma, cellSize, maxCols: compactMaxCols };
 };
 
 // ── Rendering ────────────────────────────────────────────────────────
@@ -191,86 +216,162 @@ const renderNumaGroup = ({ numaNode, cores }, opts) => {
         }];
     }
 
+    const colSize = cellSize ? `${Math.round(cellSize)}px` : '1fr';
+    const coreH = cellSize ? `height:${Math.round(cellSize)}px` : '';
+    const barH = cellSize ? `height:${Math.max(8, Math.round(cellSize / 2))}px` : '';
+
+    /** Render core cells + L1 row for a slice of cores. */
+    const renderCoreCells = (cores) => {
+        const cells = [];
+        for (const { coreId, cpus } of cores) {
+            cells.push(m('div.topo-core', {
+                key: `c${coreId}`,
+                title: buildTooltip(coreId, cpus, l1dSize, l1iSize),
+                style: labeled ? '' : coreH,
+            }, labeled ? [
+                m('span.core-id', `C${coreId}`),
+                opts.hasSMT && toggles.threads && m('div.topo-threads',
+                    cpus.map(e => m('span.topo-thread', `T${e.cpu}`)),
+                ),
+            ] : []));
+        }
+        if (showCaches && (l1dSize || l1iSize)) {
+            for (const { coreId } of cores) {
+                cells.push(
+                    labeled
+                        ? m('div.topo-l1-pair', { key: `l1-${coreId}` }, [
+                            l1dSize && m('span.topo-l1', [
+                                m('span.topo-cache-name', 'L1d'),
+                                m('span.topo-cache-size', l1dSize),
+                            ]),
+                            l1iSize && m('span.topo-l1', [
+                                m('span.topo-cache-name', 'L1i'),
+                                m('span.topo-cache-size', l1iSize),
+                            ]),
+                        ])
+                        : m('div.topo-l1-pair.compact', { key: `l1-${coreId}`, style: barH }),
+                );
+            }
+        }
+        return cells;
+    };
+
+    /** Render a cache bar (mid-level or LLC). cls is dot-separated. */
+    const renderBar = (cls, label, size, key, style) =>
+        m(`div.topo-cache-bar.${cls}`, { key, style: style || '' },
+            labeled ? [
+                m('span.topo-cache-name', label),
+                m('span.topo-cache-size', size),
+            ] : []);
+
     /**
-     * Render an LLC group as a CSS grid:
-     *   Row 1: core cells (one per column)
-     *   Row 2: L1 cells (one per column)
-     *   Row 3: mid-level cache bars (each spanning its shared cores)
-     *   Row 4: LLC bar (spanning all columns)
+     * Render an LLC group.
+     *
+     * Flat mode (fits in maxCols): single CSS grid with spanning bars.
+     * Wrapped mode: each sub-group (L2/CCX) as its own grid, flex-wrapped,
+     * with the LLC bar full-width below.
      */
     const renderLLCGroup = ({ llcIdx, allCores: llcCores, subGroups: sgs }) => {
         const numCols = llcCores.length;
+        const { maxCols } = layout;
+
+        // ── Wrapped layout: explicit row packing ──────────────────
+        if (numCols > maxCols) {
+            const rowCols = bestCols(numCols, maxCols);
+
+            // Build renderable elements with their column widths
+            const elems = []; // { el, cols } or { el, cols: Infinity } for full-width bars
+            for (const { groupIdx, cores: sgCores, size } of sgs) {
+                if (sgCores.length <= rowCols) {
+                    // Sub-group fits in one row: render as one grid
+                    const children = renderCoreCells(sgCores);
+                    if (showCaches && size && groupLevel) {
+                        children.push(renderBar('topo-mid-cache',
+                            groupLevel.toUpperCase(), size,
+                            `mid-${groupIdx}`,
+                            `grid-column:1/-1` + (barH ? `;${barH}` : '')));
+                    }
+                    elems.push({ cols: sgCores.length, el: m('div.topo-subgroup-grid', {
+                        key: `sg-${groupIdx}`,
+                        style: `grid-template-columns:repeat(${sgCores.length},${colSize});flex:${sgCores.length} 1 0`,
+                    }, children) });
+                } else {
+                    // Large sub-group: chunk cores into even rows
+                    const chunkCols = bestCols(sgCores.length, rowCols);
+                    for (let i = 0; i < sgCores.length; i += chunkCols) {
+                        const slice = sgCores.slice(i, i + chunkCols);
+                        elems.push({ cols: slice.length, el: m('div.topo-subgroup-grid', {
+                            key: `sg-${groupIdx}-${i}`,
+                            style: `grid-template-columns:repeat(${slice.length},${colSize});flex:${slice.length} 1 0`,
+                        }, renderCoreCells(slice)) });
+                    }
+                    // Full-width bar for the chunked sub-group's cache level
+                    if (showCaches && size && groupLevel) {
+                        elems.push({ cols: Infinity, el: renderBar('topo-mid-cache.topo-full-width',
+                            groupLevel.toUpperCase(), size,
+                            `mid-full-${groupIdx}`, barH || '') });
+                    }
+                }
+            }
+
+            // Pack elements into rows of <= rowCols cores
+            const rows = [];
+            let curRow = [], curCols = 0;
+            for (const e of elems) {
+                if (e.cols === Infinity) {
+                    if (curRow.length) { rows.push(curRow); curRow = []; curCols = 0; }
+                    rows.push([e]);
+                } else if (curCols + e.cols > rowCols && curRow.length) {
+                    rows.push(curRow);
+                    curRow = [e]; curCols = e.cols;
+                } else {
+                    curRow.push(e); curCols += e.cols;
+                }
+            }
+            if (curRow.length) rows.push(curRow);
+
+            const rowDivs = rows.map((row, ri) =>
+                row.length === 1 && row[0].cols === Infinity
+                    ? row[0].el
+                    : m('div.topo-llc-row', { key: `row-${ri}` },
+                        row.map(e => e.el))
+            );
+
+            // LLC bar (when separate from group level)
+            if (showCaches && llc && llc !== groupLevel && llcData) {
+                rowDivs.push(renderBar('topo-llc.topo-full-width',
+                    llc.toUpperCase(), llcData.size,
+                    `llc-${llcIdx}`, barH || ''));
+            }
+
+            return m('div.topo-llc-group-wrap', { key: llcIdx }, rowDivs);
+        }
+
+        // ── Flat layout: single grid with spanning cache bars ─────
         const coreColIdx = new Map();
         llcCores.forEach((c, i) => coreColIdx.set(c.coreId, i));
 
-        // Compact mode heights
-        const coreH = cellSize ? `height:${Math.round(cellSize)}px` : '';
-        const barH = cellSize ? `height:${Math.max(8, Math.round(cellSize / 2))}px` : '';
+        const children = renderCoreCells(llcCores);
 
-        const children = [
-            // Row: cores
-            ...llcCores.map(({ coreId, cpus }) =>
-                m('div.topo-core', {
-                    key: `c${coreId}`,
-                    title: buildTooltip(coreId, cpus, l1dSize, l1iSize),
-                    style: labeled ? '' : coreH,
-                }, labeled ? [
-                    m('span.core-id', `C${coreId}`),
-                    opts.hasSMT && toggles.threads && m('div.topo-threads',
-                        cpus.map(e => m('span.topo-thread', `T${e.cpu}`)),
-                    ),
-                ] : []),
-            ),
-        ];
-
-        // Row: L1
-        if (showCaches && (l1dSize || l1iSize)) {
-            children.push(...llcCores.map(({ coreId }) =>
-                labeled
-                    ? m('div.topo-l1-pair', { key: `l1-${coreId}` }, [
-                        l1dSize && m('span.topo-l1', [
-                            m('span.topo-cache-name', 'L1d'),
-                            m('span.topo-cache-size', l1dSize),
-                        ]),
-                        l1iSize && m('span.topo-l1', [
-                            m('span.topo-cache-name', 'L1i'),
-                            m('span.topo-cache-size', l1iSize),
-                        ]),
-                    ])
-                    : m('div.topo-l1-pair.compact', { key: `l1-${coreId}`, style: barH }),
-            ));
-        }
-
-        // Row: mid-level cache bars (each spanning its shared cores)
         if (showCaches && groupLevel) {
             for (const { groupIdx, cores: sgCores, size } of sgs) {
                 if (!size) continue;
                 const startCol = coreColIdx.get(sgCores[0].coreId) + 1;
                 const span = sgCores.length;
-                const style = `grid-column:${startCol}/span ${span}` + (barH ? `;${barH}` : '');
-                children.push(m('div.topo-cache-bar.topo-mid-cache', {
-                    key: `mid-${groupIdx}`,
-                    style,
-                }, labeled ? [
-                    m('span.topo-cache-name', groupLevel.toUpperCase()),
-                    m('span.topo-cache-size', size),
-                ] : []));
+                children.push(renderBar('topo-mid-cache',
+                    groupLevel.toUpperCase(), size,
+                    `mid-${groupIdx}`,
+                    `grid-column:${startCol}/span ${span}` + (barH ? `;${barH}` : '')));
             }
         }
 
-        // Row: LLC bar spanning all columns
         if (showCaches && llc && llc !== groupLevel && llcData) {
-            const style = `grid-column:1/-1` + (barH ? `;${barH}` : '');
-            children.push(m('div.topo-cache-bar.topo-llc', {
-                key: `llc-${llcIdx}`,
-                style,
-            }, labeled ? [
-                m('span.topo-cache-name', llc.toUpperCase()),
-                m('span.topo-cache-size', llcData.size),
-            ] : []));
+            children.push(renderBar('topo-llc',
+                llc.toUpperCase(), llcData.size,
+                `llc-${llcIdx}`,
+                `grid-column:1/-1` + (barH ? `;${barH}` : '')));
         }
 
-        const colSize = cellSize ? `${Math.round(cellSize)}px` : '1fr';
         return m('div.topo-llc-group', {
             key: llcIdx,
             style: `grid-template-columns:repeat(${numCols},${colSize})`,


### PR DESCRIPTION
## Summary
- **Topology rendering**: rewrite LLC group layout with explicit row packing and `bestCols()` for even core distribution across rows; fix wrapping for large LLC groups (e.g. 32 cores → 4×8 instead of 15,15,2)
- **Percentile chart Y-axis**: rescale Y when selecting a subset of quantiles via legend pin; fix null `zoomLevel` crash when pins are active at default zoom
- **Light theme**: eliminate gradients on main containers, fix card backgrounds to match chart brightness, fix Reset button spacing from granularity selector, fix uneven core cell widths when caches toggled off
- **Cachecannon template**: expand KPIs with GET/SET latency histograms, cache hit/miss rates, byte TX rate, and operation counts using correct metric names (`cache_hits`, `cache_misses`, `get_count`, `set_count`)
- **Parquet combine**: add `--bypass-time-check` flag to skip timestamp alignment quality validation

## Test plan
- [x] Load a parquet file with histogram percentile charts, click legend items to pin individual quantiles — verify Y-axis rescales to fit selected series
- [x] View topology diagram with 32+ cores — verify even row distribution with no dangling cores
- [x] Toggle light theme — verify no gradients on cards/containers, consistent backgrounds
- [x] View cachecannon parquet — verify all KPI charts render with correct data
- [x] Run `rezolus parquet combine --bypass-time-check` — verify alignment check is skipped with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)