### PR TITLE
fix(viewer): stable cgroup colors, selector swatches, no ghost legends

### DIFF
--- a/src/viewer/assets/lib/cgroup_selector.js
+++ b/src/viewer/assets/lib/cgroup_selector.js
@@ -7,6 +7,8 @@
 //   substitutePattern: (query, pattern) => string — substitutes cgroup placeholder
 //   setActiveCgroupPattern: (pattern) => void — sets the global active cgroup pattern
 
+import globalColorMapper from './charts/util/colormap.js';
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /** Extract cgroup names from a PromQL query result's metric labels. */
@@ -25,25 +27,27 @@ const extractCgroupNames = (result) => {
     return names;
 };
 
-/** Collect the selected options from a <select> change event into a Set. */
-const syncSelection = (set, event) => {
-    set.clear();
-    for (const opt of event.target.selectedOptions) {
-        set.add(opt.value);
-    }
-};
-
-/** Render a multi-select list with a header. */
-const selectList = (title, items, selectionSet, onchange, emptyLabel) =>
+/** Render a custom multi-select list with a color swatch per item. */
+const selectList = (title, items, selectionSet, onToggle, emptyLabel) =>
     m('div.selector-column', [
         m('h4', title),
-        m('select.cgroup-select[multiple]', {
-            size: Math.max(2, Math.min(10, items.length || 1)),
-            onchange,
+        m('ul.cgroup-select', {
+            role: 'listbox',
+            'aria-multiselectable': 'true',
         }, items.length === 0
-            ? [m('option[disabled]', emptyLabel)]
+            ? m('li.cgroup-select-empty', emptyLabel)
             : items.map((item) =>
-                m('option', { value: item, selected: selectionSet.has(item) }, item),
+                m('li.cgroup-select-item', {
+                    role: 'option',
+                    'aria-selected': selectionSet.has(item) ? 'true' : 'false',
+                    class: selectionSet.has(item) ? 'selected' : '',
+                    onclick: () => onToggle(item),
+                }, [
+                    m('span.cgroup-select-swatch', {
+                        style: { background: globalColorMapper.getColorByName(item) },
+                    }),
+                    m('span.cgroup-select-name', item),
+                ]),
             ),
         ),
     ]);
@@ -71,6 +75,19 @@ export const CgroupSelector = {
         vnode.state.leftSelected = new Set();
         vnode.state.rightSelected = new Set();
         vnode.state.originalQueries = persistedOriginalQueries;
+
+        // Force multi-series style on right-side (individual) cgroup plots so that
+        // color assignment is always by cgroup name (hash-based) — even when only
+        // one cgroup is selected, which would otherwise resolve to a single-series
+        // line chart with the accent color.
+        for (const group of vnode.attrs.groups || []) {
+            if (group.metadata?.side !== 'right') continue;
+            for (const plot of group.plots || []) {
+                if (plot.opts && plot.opts.style !== 'multi') {
+                    plot.opts.style = 'multi';
+                }
+            }
+        }
 
         this.fetchAvailableCgroups(vnode);
     },
@@ -219,6 +236,11 @@ export const CgroupSelector = {
             ? [] // selectList will show emptyLabel
             : unselected;
 
+        const toggleMark = (set, item) => {
+            if (set.has(item)) set.delete(item);
+            else set.add(item);
+        };
+
         return m('div.cgroup-selector', [
             m('h3', 'Cgroup Selection'),
             st.error && m('div.error-message', st.error),
@@ -228,7 +250,7 @@ export const CgroupSelector = {
                     'Available Cgroups (Aggregate)',
                     leftItems,
                     st.leftSelected,
-                    (e) => syncSelection(st.leftSelected, e),
+                    (item) => toggleMark(st.leftSelected, item),
                     st.loading ? 'Loading cgroups...' : 'No cgroups available',
                 ),
 
@@ -253,7 +275,7 @@ export const CgroupSelector = {
                     'Individual Cgroups',
                     selected,
                     st.rightSelected,
-                    (e) => syncSelection(st.rightSelected, e),
+                    (item) => toggleMark(st.rightSelected, item),
                     'No cgroups selected',
                 ),
             ]),

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -153,6 +153,9 @@ const applyResultToPlot = (plot, result) => {
             } else {
                 plot.data = [];
             }
+            // Line-style plots have no series legend; clear any stale entries
+            // from a prior multi-series render so legends don't "ghost".
+            plot.series_names = [];
         }
     } else {
         plot.data = [];

--- a/src/viewer/assets/lib/section_views.js
+++ b/src/viewer/assets/lib/section_views.js
@@ -154,7 +154,12 @@ const renderCgroupSection = ({
             pairs.map((pair) => {
                 const title = pair.left?.opts?.title || pair.right?.opts?.title || '';
                 const description = pair.left?.opts?.description || pair.right?.opts?.description;
-                const seriesNames = pair.right?.series_names || [];
+                // Only show a legend when the right-side chart has actual series data;
+                // otherwise stale series_names can linger as "ghost" entries.
+                const rightData = pair.right?.data;
+                const hasData = Array.isArray(rightData) && rightData.length > 1
+                    && Array.isArray(rightData[0]) && rightData[0].length > 0;
+                const seriesNames = hasData ? (pair.right?.series_names || []) : [];
                 const legend = seriesNames.length > 0 && m('div.cgroup-pair-legend',
                     seriesNames.map((name) =>
                         m('span.cgroup-legend-item', [

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -1521,27 +1521,57 @@ main {
 .cgroup-select {
     width: 100%;
     min-height: 8.5rem;
+    max-height: 16rem;
+    overflow-y: auto;
     background: var(--bg-card);
     color: var(--fg);
     border: 1px solid var(--border-default);
     border-radius: 6px;
-    padding: 0.5rem;
+    padding: 0.25rem;
+    margin: 0;
+    list-style: none;
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
 }
 
-.cgroup-select option {
-    padding: 0.375rem 0.5rem;
+.cgroup-select-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 3px;
+    cursor: pointer;
+    user-select: none;
 }
 
-.cgroup-select option:checked {
+.cgroup-select-item:hover {
+    background: var(--bg-tertiary);
+}
+
+.cgroup-select-item.selected {
     background: var(--accent);
     color: var(--bg-void);
 }
 
-.cgroup-select option[disabled] {
+.cgroup-select-swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+
+.cgroup-select-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.cgroup-select-empty {
+    padding: 0.375rem 0.5rem;
     color: var(--fg-muted);
     font-style: italic;
+    list-style: none;
 }
 
 .selector-controls {


### PR DESCRIPTION
## Summary

Three related fixes to the cgroup section of the viewer:

- **Consistent cgroup colors regardless of selection.** Force
  `style: 'multi'` on right-side (individual) cgroup plots so the color
  of a given cgroup is always the hash-based color from `ColorMapper`.
  Previously, selecting exactly one cgroup resolved the chart style to
  `line`, which uses the accent color — so a cgroup's color changed
  when it was the only one selected vs. displayed alongside others.
  Now the chart line and the legend swatch always agree.
- **Color swatch at the start of each selector entry.** The cgroup
  selector now shows a small square swatch before each cgroup name in
  both the Available and Individual lists. The native `<select multiple>`
  has been replaced with a custom `<ul>`/`<li>` listbox so the swatch
  can be rendered inline; hover/selected states are styled in CSS.
- **No more "ghost" legend entries.** Clear `plot.series_names` when
  `applyResultToPlot` falls into the single-series line branch, so a
  transition from multi-series → single-series no longer leaves stale
  names in the legend. Also guard the cgroup legend renderer so it
  only displays entries when the underlying chart actually has data.

## Test plan

- [x] Open the cgroup section with a parquet file, select one cgroup,
      verify its line color matches the legend swatch.
- [x] Add and remove cgroups; colors stay stable per cgroup name.
- [x] Verify the swatch is visible beside each cgroup name in both the
      Available and Individual lists.
- [x] Deselect all cgroups: legend disappears, no ghost entries linger.