### PR TITLE
fix(viewer): cgroup charts survive granularity change

### DIFF
--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -32,15 +32,28 @@ const clearViewerCaches = () => {
 const changeGranularity = async (step) => {
     currentGranularity = step;
     setStepOverride(step);
-    clearViewerCaches();
-    m.redraw();
 
     const currentRoute = m.route.get();
-    if (!currentRoute) return;
-    const section = currentRoute.replace(/^\//, '').replace(/#.*/, '');
+    const section = currentRoute
+        ? currentRoute.replace(/^\//, '').replace(/#.*/, '')
+        : '';
+
+    // Invalidate all section caches EXCEPT the current one so the component
+    // tree stays mounted (avoids unmounting CgroupSelector which would lose
+    // its selected-cgroup state and leave charts empty).
+    for (const key of Object.keys(sectionResponseCache)) {
+        if (key !== section) delete sectionResponseCache[key];
+    }
+    heatmapDataCache.clear();
+    chartsState.zoomLevel = null;
+    chartsState.zoomSource = null;
+    chartsState.globalZoom = null;
+
     if (!section) return;
 
     try {
+        // Force re-fetch by clearing just this section's cache before loadSection
+        delete sectionResponseCache[section];
         const data = await loadSection(section);
         if (data?.sections) preloadSections(data.sections);
         m.redraw();
@@ -531,7 +544,9 @@ function initDashboardRouter() {
 
                 if (requestedPath !== m.route.get()) {
                     chartsState.charts.clear();
-                    activeCgroupPattern = null;
+                    if (params.section !== 'cgroups') {
+                        activeCgroupPattern = null;
+                    }
                     window.scrollTo(0, 0);
                 }
 

--- a/src/viewer/assets/lib/cgroup_selector.js
+++ b/src/viewer/assets/lib/cgroup_selector.js
@@ -27,8 +27,9 @@ const extractCgroupNames = (result) => {
     return names;
 };
 
-/** Render a custom multi-select list with a color swatch per item. */
-const selectList = (title, items, selectionSet, onToggle, emptyLabel) =>
+/** Render a custom multi-select list with a color swatch per item.
+ *  Supports shift+click range selection via lastClicked / setLastClicked. */
+const selectList = (title, items, selectionSet, onToggle, emptyLabel, lastClicked, setLastClicked) =>
     m('div.selector-column', [
         m('h4', title),
         m('ul.cgroup-select', {
@@ -41,7 +42,22 @@ const selectList = (title, items, selectionSet, onToggle, emptyLabel) =>
                     role: 'option',
                     'aria-selected': selectionSet.has(item) ? 'true' : 'false',
                     class: selectionSet.has(item) ? 'selected' : '',
-                    onclick: () => onToggle(item),
+                    onclick: (e) => {
+                        if (e.shiftKey && lastClicked != null) {
+                            const from = items.indexOf(lastClicked);
+                            const to = items.indexOf(item);
+                            if (from !== -1 && to !== -1) {
+                                const lo = Math.min(from, to);
+                                const hi = Math.max(from, to);
+                                for (let i = lo; i <= hi; i++) {
+                                    selectionSet.add(items[i]);
+                                }
+                            }
+                        } else {
+                            onToggle(item);
+                        }
+                        setLastClicked(item);
+                    },
                 }, [
                     m('span.cgroup-select-swatch', {
                         style: { background: globalColorMapper.getColorByName(item) },
@@ -74,6 +90,8 @@ export const CgroupSelector = {
         vnode.state.error = null;
         vnode.state.leftSelected = new Set();
         vnode.state.rightSelected = new Set();
+        vnode.state.lastClickedLeft = null;
+        vnode.state.lastClickedRight = null;
         vnode.state.originalQueries = persistedOriginalQueries;
 
         // Force multi-series style on right-side (individual) cgroup plots so that
@@ -90,6 +108,13 @@ export const CgroupSelector = {
         }
 
         this.fetchAvailableCgroups(vnode);
+
+        // When re-initialized with persisted selections (e.g. after granularity
+        // or node change unmounts/remounts the component tree), re-run queries
+        // so the individual cgroup charts get populated.
+        if (persistedSelectedCgroups.size > 0 && persistedOriginalQueries) {
+            this.debouncedUpdateQueries(vnode);
+        }
     },
 
     async fetchAvailableCgroups(vnode) {
@@ -252,6 +277,8 @@ export const CgroupSelector = {
                     st.leftSelected,
                     (item) => toggleMark(st.leftSelected, item),
                     st.loading ? 'Loading cgroups...' : 'No cgroups available',
+                    st.lastClickedLeft,
+                    (item) => { st.lastClickedLeft = item; },
                 ),
 
                 // Transfer buttons
@@ -277,6 +304,8 @@ export const CgroupSelector = {
                     st.rightSelected,
                     (item) => toggleMark(st.rightSelected, item),
                     'No cgroups selected',
+                    st.lastClickedRight,
+                    (item) => { st.lastClickedRight = item; },
                 ),
             ]),
             m('div.selector-info', [

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -87,8 +87,14 @@ const injectLabel = (query, labelName, labelValue) => {
         const after = query.substring(offset + match.length);
         if (/^\s*\(/.test(after)) return match;
 
-        // Check if inside braces (label name/value) or square brackets (duration)
+        // Check context before the identifier
         const before = query.substring(0, offset);
+
+        // Skip identifiers inside by(...) / without(...) grouping clauses —
+        // these are label names, not metric names.
+        if (/\b(?:by|without)\s*\([^)]*$/.test(before)) return match;
+
+        // Check if inside braces (label name/value) or square brackets (duration)
         const lastOpenBrace = before.lastIndexOf('{');
         const lastCloseBrace = before.lastIndexOf('}');
         if (lastOpenBrace > lastCloseBrace) return match;

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -520,12 +520,23 @@ let currentGranularity = null;
 const changeGranularity = async (step) => {
     currentGranularity = step;
     setStepOverride(step);
-    clearViewerCaches();
-    m.redraw();
 
     const currentRoute = m.route.get();
-    if (!currentRoute) return;
-    const section = currentRoute.replace(/^\//, '');
+    const section = currentRoute ? currentRoute.replace(/^\//, '') : '';
+
+    // Invalidate all section caches EXCEPT the current one so the component
+    // tree stays mounted (avoids unmounting CgroupSelector which would lose
+    // its selected-cgroup state and leave charts empty).
+    for (const key of Object.keys(sectionResponseCache)) {
+        if (key !== section) delete sectionResponseCache[key];
+    }
+    heatmapDataCache.clear();
+    // Reset zoom state but keep chart registrations — the chart instances
+    // stay alive because we preserved the current section's cache.
+    chartsState.zoomLevel = null;
+    chartsState.zoomSource = null;
+    chartsState.globalZoom = null;
+
     if (!section) return;
 
     try {


### PR DESCRIPTION
## Summary
- **Fix `injectLabel()` corrupting cgroup queries** — identifiers inside `by(...)` / `without(...)` grouping clauses (e.g. `name` in `sum by (name)`) were incorrectly treated as metric names and injected with label selectors, producing invalid PromQL that returned no data
- **Preserve component tree during granularity change** — keep the current section's cache alive so CgroupSelector isn't unmounted/remounted, avoiding loss of selected-cgroup state
- **Re-run cgroup queries on CgroupSelector re-init** — safety net for paths that do remount (e.g. node change)
- **Add shift+click range selection** to both Available and Individual cgroup selector lists

## Test plan
- [x] Select cgroups, change step selector (1s/5s/15s/1m/Auto) — charts should persist
- [x] Change node with cgroups selected — charts should repopulate
- [x] Shift+click range selection in both Available and Individual lists
- [x] Verify non-cgroup sections still work correctly with granularity change

🤖 Generated with [Claude Code](https://claude.com/claude-code)