### PR TITLE
Viewer UX: splash screen, dashboard labels, and nav cleanup

### DIFF
--- a/crates/dashboard/src/dashboard/softirq.rs
+++ b/crates/dashboard/src/dashboard/softirq.rs
@@ -12,7 +12,11 @@ fn add_softirq_group(view: &mut View, label: &str, kind: &str) {
     );
 
     group.plot_promql(
-        PlotOpts::counter("Rate", format!("softirq-{kind}-rate-heatmap"), Unit::Rate),
+        PlotOpts::counter(
+            "Rate (per-CPU)",
+            format!("softirq-{kind}-rate-heatmap"),
+            Unit::Rate,
+        ),
         format!("sum by (id) (irate(softirq{{kind=\"{kind}\"}}[5m]))"),
     );
 
@@ -24,7 +28,7 @@ fn add_softirq_group(view: &mut View, label: &str, kind: &str) {
 
     group.plot_promql(
         PlotOpts::counter(
-            "CPU %",
+            "CPU % (per-CPU)",
             format!("softirq-{kind}-time-heatmap"),
             Unit::Percentage,
         )
@@ -47,7 +51,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     );
 
     softirq.plot_promql(
-        PlotOpts::counter("Rate", "softirq-total-rate-heatmap", Unit::Rate),
+        PlotOpts::counter("Rate (per-CPU)", "softirq-total-rate-heatmap", Unit::Rate),
         "sum by (id) (irate(softirq[5m]))".to_string(),
     );
 
@@ -57,8 +61,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     );
 
     softirq.plot_promql(
-        PlotOpts::counter("CPU %", "softirq-total-time-heatmap", Unit::Percentage)
-            .percentage_range(),
+        PlotOpts::counter(
+            "CPU % (per-CPU)",
+            "softirq-total-time-heatmap",
+            Unit::Percentage,
+        )
+        .percentage_range(),
         "sum by (id) (irate(softirq_time[5m])) / 1000000000".to_string(),
     );
 

--- a/crates/dashboard/src/dashboard/syscall.rs
+++ b/crates/dashboard/src/dashboard/syscall.rs
@@ -48,13 +48,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Rate for this operation
         syscall.plot_promql(
-            PlotOpts::counter(&format!("{op} Rate"), format!("syscall-{op}"), Unit::Rate),
+            PlotOpts::counter(format!("{op} Rate"), format!("syscall-{op}"), Unit::Rate),
             format!("sum(irate(syscall{{op=\"{op_lower}\"}}[5m]))"),
         );
 
         // Latency percentiles for this operation
         syscall.plot_promql(
-            PlotOpts::histogram_latency(&format!("{op} Latency"), format!("syscall-{op}-latency")),
+            PlotOpts::histogram_latency(format!("{op} Latency"), format!("syscall-{op}-latency")),
             format!("syscall_latency{{op=\"{op_lower}\"}}"),
         );
     }

--- a/crates/dashboard/src/dashboard/syscall.rs
+++ b/crates/dashboard/src/dashboard/syscall.rs
@@ -9,6 +9,9 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
      */
 
     let mut syscall = Group::new("Syscall", "syscall");
+    syscall
+        .metadata
+        .insert("no_collapse".to_string(), serde_json::json!(true));
 
     // Total syscall rate
     syscall.plot_promql(

--- a/crates/dashboard/src/dashboard/syscall.rs
+++ b/crates/dashboard/src/dashboard/syscall.rs
@@ -12,13 +12,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     // Total syscall rate
     syscall.plot_promql(
-        PlotOpts::counter("Total", "syscall-total", Unit::Rate),
+        PlotOpts::counter("Overall Rate", "syscall-total", Unit::Rate),
         "sum(irate(syscall[5m]))".to_string(),
     );
 
     // Total syscall latency percentiles
     syscall.plot_promql(
-        PlotOpts::histogram_latency("Total", "syscall-total-latency"),
+        PlotOpts::histogram_latency("Overall Latency", "syscall-total-latency"),
         "syscall_latency".to_string(),
     );
 
@@ -45,13 +45,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
         // Rate for this operation
         syscall.plot_promql(
-            PlotOpts::counter(*op, format!("syscall-{op}"), Unit::Rate),
+            PlotOpts::counter(&format!("{op} Rate"), format!("syscall-{op}"), Unit::Rate),
             format!("sum(irate(syscall{{op=\"{op_lower}\"}}[5m]))"),
         );
 
         // Latency percentiles for this operation
         syscall.plot_promql(
-            PlotOpts::histogram_latency(*op, format!("syscall-{op}-latency")),
+            PlotOpts::histogram_latency(&format!("{op} Latency"), format!("syscall-{op}-latency")),
             format!("syscall_latency{{op=\"{op_lower}\"}}"),
         );
     }

--- a/site/viewer/index.html
+++ b/site/viewer/index.html
@@ -20,6 +20,13 @@
 </head>
 
 <body>
+<div id="splash">
+    <div class="card">
+        <h1>Rezolus</h1>
+        <p class="subtitle">Loading…</p>
+        <div class="progress-bar"><div class="progress-fill indeterminate"></div></div>
+    </div>
+</div>
 </body>
 
 </html>

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -1,5 +1,5 @@
 // script.js — WASM viewer bootstrap stub.
-// Handles parquet loading (demo or upload), WASM init, and template loading.
+// Handles demo parquet loading, WASM init, and template loading.
 // Delegates all UI/routing to app.js via initDashboard().
 
 import { ViewerApi } from './viewer_api.js';
@@ -7,10 +7,17 @@ import { FileUpload } from './landing.js';
 import { setStorageScope } from './selection.js';
 import { initDashboard } from './app.js';
 
-// ── Module-level state ──────────────────────────────────────────────
+// ── UI state ────────────────────────────────────────────────────────
 
-let loading = false;
-let loadError = null;
+let splashLabel = null;   // non-null = show splash, null = show landing
+let splashProgress = -1;  // -1 = indeterminate, 0–1 = determinate
+let landingError = null;
+
+const demos = [
+    { label: 'vLLM + System', file: 'vllm.parquet' },
+    { label: 'Cachecannon + System', file: 'cachecannon.parquet' },
+    { label: 'System Metrics', file: 'demo.parquet' },
+];
 
 // ── WASM + template initialization ─────────────────────────────────
 
@@ -70,20 +77,52 @@ async function loadParquet(data, filename) {
     });
 }
 
-// ── Load demo parquet ──────────────────────────────────────────────
+// ── Load demo parquet (with download progress) ──────────────────────
 
 async function loadDemo(filename = 'demo.parquet') {
-    loading = true;
-    loadError = null;
+    splashLabel = filename;
+    splashProgress = -1;
+    landingError = null;
     m.redraw();
 
     try {
         const resp = await fetch('data/' + filename);
         if (!resp.ok) throw new Error(`Failed to fetch ${filename}: ${resp.status}`);
-        const data = new Uint8Array(await resp.arrayBuffer());
+
+        let data;
+        const contentLength = resp.headers.get('Content-Length');
+
+        if (contentLength && resp.body) {
+            const total = parseInt(contentLength, 10);
+            const reader = resp.body.getReader();
+            const chunks = [];
+            let received = 0;
+
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                chunks.push(value);
+                received += value.length;
+                splashProgress = received / total;
+                m.redraw();
+            }
+
+            data = new Uint8Array(received);
+            let pos = 0;
+            for (const chunk of chunks) {
+                data.set(chunk, pos);
+                pos += chunk.length;
+            }
+        } else {
+            data = new Uint8Array(await resp.arrayBuffer());
+        }
+
+        // WASM init phase — indeterminate
+        splashLabel = 'Initializing';
+        splashProgress = -1;
+        m.redraw();
 
         await loadParquet(data, filename);
-        loading = false;
 
         // Ensure ?demo is in the URL so bookmarks/refreshes auto-load the demo
         const url = new URL(window.location);
@@ -93,47 +132,44 @@ async function loadDemo(filename = 'demo.parquet') {
             window.history.replaceState(null, '', url);
         }
     } catch (e) {
-        loading = false;
-        loadError = `Failed to load demo: ${e.message || e}`;
+        splashLabel = null;
+        landingError = `Failed to load demo: ${e?.message ?? e ?? 'unknown error'}`;
         m.redraw();
     }
 }
 
-// ── Load uploaded file ─────────────────────────────────────────────
+// ── Root component — switches between splash and landing ────────────
 
-async function loadFile(file) {
-    loading = true;
-    loadError = null;
-    m.redraw();
-
-    try {
-        const data = new Uint8Array(await file.arrayBuffer());
-        await loadParquet(data, file.name);
-        loading = false;
-    } catch (e) {
-        loading = false;
-        loadError = `Failed to load file: ${e.message || e}`;
-        m.redraw();
-    }
-}
+const Root = {
+    view: () => {
+        if (splashLabel) {
+            return m('div#splash', m('div.card', [
+                m('h1', 'Rezolus'),
+                m('p.subtitle', `Loading ${splashLabel}…`),
+                m('div.progress-bar',
+                    m('div.progress-fill', splashProgress < 0
+                        ? { class: 'indeterminate' }
+                        : { style: { width: `${Math.round(splashProgress * 100)}%` } }
+                    ),
+                ),
+            ]));
+        }
+        return m('div', m(FileUpload, {
+            onDemo: loadDemo,
+            demos,
+            loading: false,
+            error: landingError,
+        }));
+    },
+};
 
 // ── Initial mount ──────────────────────────────────────────────────
 
 const _demoParam = new URLSearchParams(window.location.search).get('demo');
 if (_demoParam !== null) {
+    splashLabel = _demoParam || 'demo.parquet';
+    m.mount(document.body, Root);
     loadDemo(_demoParam || 'demo.parquet');
 } else {
-    m.mount(document.body, {
-        view: () => m(FileUpload, {
-            onFile: loadFile,
-            onDemo: loadDemo,
-            demos: [
-                { label: 'vLLM + System', file: 'vllm.parquet' },
-                { label: 'Cachecannon + System', file: 'cachecannon.parquet' },
-                { label: 'System Metrics', file: 'demo.parquet' },
-            ],
-            loading,
-            error: loadError,
-        }),
-    });
+    m.mount(document.body, Root);
 }

--- a/src/viewer/assets/index.html
+++ b/src/viewer/assets/index.html
@@ -29,6 +29,13 @@
 </head>
 
 <body>
+<div id="splash">
+    <div class="card">
+        <h1>Rezolus</h1>
+        <p class="subtitle">Loading…</p>
+        <div class="progress-bar"><div class="progress-fill indeterminate"></div></div>
+    </div>
+</div>
 </body>
 
 </html>

--- a/src/viewer/assets/lib/landing.js
+++ b/src/viewer/assets/lib/landing.js
@@ -16,8 +16,10 @@ const FileUpload = {
         return m('div.upload-container', [
             m('div.upload-card', [
                 m('h1.upload-title', 'Rezolus Viewer'),
-                m('p.upload-subtitle', 'Drop a parquet file to explore system performance metrics.'),
-                m('div.upload-dropzone', {
+                m('p.upload-subtitle', onFile
+                    ? 'Drop a parquet file to explore system performance metrics.'
+                    : 'Explore system performance metrics.'),
+                onFile && m('div.upload-dropzone', {
                     ondragover: (e) => {
                         e.preventDefault();
                         e.currentTarget.classList.add('dragover');
@@ -29,7 +31,7 @@ const FileUpload = {
                         e.preventDefault();
                         e.currentTarget.classList.remove('dragover');
                         const file = e.dataTransfer.files[0];
-                        if (file && onFile) onFile(file);
+                        if (file) onFile(file);
                     },
                 }, [
                     m('svg.upload-icon', {
@@ -49,7 +51,7 @@ const FileUpload = {
                             style: 'display:none',
                             onchange: (e) => {
                                 const file = e.target.files[0];
-                                if (file && onFile) onFile(file);
+                                if (file) onFile(file);
                             },
                         }),
                     ]),
@@ -75,7 +77,7 @@ const FileUpload = {
                 ]),
                 (attrs.demos || (onDemo ? [{ label: 'Try Demo' }] : [])).length > 0 &&
                     m('div', { style: 'margin-top: 1.5rem' }, [
-                        m('p.upload-or', 'or'),
+                        onFile && m('p.upload-or', 'or'),
                         m('div', { style: 'display: flex; gap: 0.5rem; justify-content: center; margin-top: 0.75rem; flex-wrap: wrap' },
                             (attrs.demos || [{ label: 'Try Demo' }]).map(demo =>
                                 m('button.upload-btn', {

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -56,8 +56,8 @@ const TopNav = {
                 ]);
             })(),
             m('div.topnav-actions', [
-                // Upload parquet (file mode only)
-                !liveMode && m('button.transport-btn.import-btn', {
+                // Upload parquet (file mode only, when handler provided)
+                attrs.onUploadParquet && !liveMode && m('button.transport-btn.import-btn', {
                     onclick: () => {
                         const input = document.createElement('input');
                         input.type = 'file';
@@ -75,8 +75,8 @@ const TopNav = {
                     m('span', 'Load Parquet'),
                     m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 2v8m0-8l-3 3m3-3l3 3"/></svg>'),
                 ]),
-                // Import report JSON
-                m('button.transport-btn.import-btn', {
+                // Import report JSON (server viewer only)
+                attrs.onUploadParquet && m('button.transport-btn.import-btn', {
                     class: attrs.filename ? 'parquet-loaded' : '',
                     disabled: !attrs.filename,
                     onclick: () => importJSON(attrs.fileChecksum),

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -91,7 +91,7 @@ const uploadParquet = async (file) => {
         }
         m.redraw();
     } catch (e) {
-        notify('error', `Failed to upload parquet: ${e.message || e}`);
+        notify('error', `Failed to upload parquet: ${e?.message ?? e ?? 'unknown error'}`);
     }
 };
 
@@ -144,7 +144,7 @@ const showLanding = () => {
                     window.location.reload();
                 } catch (e) {
                     landingState.loading = false;
-                    landingState.error = `Failed to load file: ${e.message || e}`;
+                    landingState.error = `Failed to load file: ${e?.message ?? e ?? 'unknown error'}`;
                     m.redraw();
                 }
             },
@@ -157,7 +157,7 @@ const showLanding = () => {
                     window.location.reload();
                 } catch (e) {
                     landingState.loading = false;
-                    landingState.error = `Failed to connect: ${e.message || e}`;
+                    landingState.error = `Failed to connect: ${e?.message ?? e ?? 'unknown error'}`;
                     m.redraw();
                 }
             },

--- a/src/viewer/assets/lib/service.js
+++ b/src/viewer/assets/lib/service.js
@@ -50,7 +50,7 @@ const renderServiceSection = (attrs, Group, sectionRoute, sectionName, interval,
                 m(Group, { ...group, sectionRoute, sectionName, interval })
             )
         ),
-        unavailable.length > 0 && m('div.service-notes', [
+        unavailable.length > 0 && m('div.section-notes', [
             m('h3', 'Unavailable KPIs'),
             m('p', 'The following KPIs have no matching data in this recording:'),
             m('ul', unavailable.map((kpi) =>

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -279,6 +279,41 @@ body::after {
 .card .link-row a { font-size: 0.9rem; padding: 0.4rem 0.8rem; border: 1px solid var(--border-subtle); border-radius: 6px; color: var(--accent); text-decoration: none; }
 .card .link-row a:hover { border-color: var(--accent); }
 
+/* Splash / loading screen */
+#splash {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.progress-bar {
+    width: 200px;
+    height: 3px;
+    background: var(--bg-tertiary);
+    border-radius: 2px;
+    overflow: hidden;
+    margin: 1rem auto 0;
+}
+
+.progress-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 2px;
+    transition: width 0.3s ease;
+}
+
+.progress-fill.indeterminate {
+    width: 30%;
+    animation: splash-slide 1.5s ease-in-out infinite;
+}
+
+@keyframes splash-slide {
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(400%); }
+}
+
 /* ==========================================================================
    Top Navigation Bar
    ========================================================================== */

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -1748,7 +1748,7 @@ main {
 }
 
 /* Service notes — unavailable KPIs */
-.service-notes {
+.section-notes {
     margin-top: 2rem;
     padding: 1rem 1.25rem;
     background: var(--bg-void);
@@ -1758,22 +1758,22 @@ main {
     font-size: var(--font-size-sm);
 }
 
-.service-notes h3 {
+.section-notes h3 {
     margin: 0 0 0.5rem;
     font-size: var(--font-size-sm);
     color: var(--fg-secondary);
 }
 
-.service-notes p {
+.section-notes p {
     margin: 0 0 0.5rem;
 }
 
-.service-notes ul {
+.section-notes ul {
     margin: 0;
     padding-left: 1.25rem;
 }
 
-.service-notes li {
+.section-notes li {
     margin-bottom: 0.25rem;
 }
 

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -31,6 +31,8 @@ export function createGroupComponent(getState) {
                 opts.description && m('span.chart-subtitle', opts.description),
             ]);
 
+            const noCollapse = attrs.noCollapse || attrs.metadata?.no_collapse;
+
             return m(
                 'div.group',
                 { id: attrs.id },
@@ -52,7 +54,7 @@ export function createGroupComponent(getState) {
                                 ]);
                             }
 
-                            const prefixedSpec = { ...spec, opts: prefixTitle(spec.opts), noCollapse: attrs.noCollapse };
+                            const prefixedSpec = { ...spec, opts: prefixTitle(spec.opts), noCollapse };
                             return m('div.chart-wrapper', [
                                 chartHeader(prefixedSpec.opts),
                                 m(Chart, { spec: prefixedSpec, chartsState, interval }),
@@ -107,4 +109,3 @@ export function buildClientOnlySectionView(Main, sectionResponseCache, activeSec
         },
     };
 }
-


### PR DESCRIPTION
## Summary
- Add splash screen with download progress bar for WASM viewer demo loading
- Remove file upload from WASM viewer (demos loaded via URL params)
- Hide Load Parquet / Load Report buttons from WASM viewer nav bar
- Add Rate/Latency suffixes to per-operation syscall chart titles
- Add `(per-CPU)` label to softirq heatmap chart titles
- Preserve grid layout for empty syscall latency charts (no-collapse)
- Rename `.service-notes` → `.section-notes` CSS class for reuse

## Test plan
- [x] Load WASM viewer — verify splash screen with progress bar during demo download
- [x] Verify no upload buttons in WASM viewer nav bar
- [x] Load server viewer — verify upload buttons still present
- [x] Check syscall section: charts titled "Read Rate" / "Read Latency" etc.
- [x] Check syscall section: empty latency charts hold grid space
- [x] Check softirq section: heatmap charts labeled "(per-CPU)"
- [ ] Verify service extension unavailable KPIs note still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)