### PR TITLE
chore(deps): bump metriken to 0.9.2 for GaugeGroup sentinel fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "metriken"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9090645d701c7399dd77e598b6e2d6ad627c56b4793aedc829b8c05e07dec2"
+checksum = "d34d88b3f3ec8c532945831eeea8170f9410a37f444feb1322b8e124f3a4a3b9"
 dependencies = [
  "histogram",
  "metriken-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ console_error_panic_hook = "0.1"
 histogram = "1.1.0"
 libc = "0.2.172"
 log = "0.4.21"
-metriken = "0.9.1"
+metriken = "0.9.2"
 metriken-exposition = "0.16.0"
 metriken-query = { version = "0.9.3", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
## Summary

Bumps `metriken` from 0.9.1 → 0.9.2 to pull in the `GaugeGroup` sentinel fix.

## The bug

`GaugeGroup` slots in metriken 0.9.1 defaulted to `0`, but the snapshot builder at `src/agent/exposition/http/snapshot.rs:159` uses `i64::MIN` as the "never set" sentinel:

```rust
Some(Value::GaugeGroup(g)) => {
    if let Some(values) = g.load_gauges() {
        for (gauge_id, value) in values.iter().enumerate() {
            if *value == i64::MIN {
                continue;
            }
```

Result: on a single-GPU host, the NVIDIA sampler called `GPU_UTILIZATION.set(0, ...)` only for slot 0, leaving slots 1..`MAX_GPUS` (31 of them) at their default `0`. Since `0 != i64::MIN`, those slots were emitted as phantom series — `gpu_utilization{id="1"}` through `gpu_utilization{id="31"}` — all reading `0`. Same pattern for every other `GaugeGroup` metric (`gpu_memory`, `gpu_power_usage`, `gpu_temperature`, `gpu_clock`, etc.).

## The fix

metriken 0.9.2 initializes slots to `AtomicI64::new(i64::MIN)` and teaches `add`/`sub`/`value` to honor that sentinel (treating `i64::MIN` as "unset"). The snapshot-builder check at `snapshot.rs:159` then works as originally intended — phantom slots are skipped.

## Test plan

- [ ] Run agent on a single-GPU host and confirm only `id="0"` appears for `gpu_utilization` and other GPU GaugeGroup metrics
- [ ] Verify no regression on multi-GPU hosts
- [ ] Confirm non-GPU GaugeGroup metrics (e.g. `cpu_frequency` per-core) still report correctly for populated slots