### PR TITLE
feat(gpu): improve dashboard layout and PCIe bandwidth util

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 !.claude/scripts/
 target
 **/*.rs.bk
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "metriken"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9090645d701c7399dd77e598b6e2d6ad627c56b4793aedc829b8c05e07dec2"
+checksum = "d34d88b3f3ec8c532945831eeea8170f9410a37f444feb1322b8e124f3a4a3b9"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -2084,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dff9d78bf1e1d1a6528c33fb2bfc7d673cf57104718fbe8540df5cac5782a5b"
+checksum = "d02889c2e600a8a8c748deb141629f0208604c473245f61fcd3d678eac304579"
 dependencies = [
  "arrow",
  "axum",
@@ -2334,9 +2334,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3650,9 +3650,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.9.2-alpha.3"
+version = "5.9.2-alpha.4"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.172"
 log = "0.4.21"
 metriken = "0.9.1"
 metriken-exposition = "0.16.0"
-metriken-query = { version = "0.9.3", default-features = false }
+metriken-query = { version = "0.9.4", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.9.2-alpha.3"
+version = "5.9.2-alpha.4"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -173,7 +173,8 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             Unit::Percentage,
         )
         .percentage_range(),
-        "gpu_pcie_throughput{direction=\"receive\"} / ignoring(direction) gpu_pcie_bandwidth".to_string(),
+        "gpu_pcie_throughput{direction=\"receive\"} / ignoring(direction) gpu_pcie_bandwidth"
+            .to_string(),
     );
 
     // Per-GPU transmit throughput
@@ -190,7 +191,8 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             Unit::Percentage,
         )
         .percentage_range(),
-        "gpu_pcie_throughput{direction=\"transmit\"} / ignoring(direction) gpu_pcie_bandwidth".to_string(),
+        "gpu_pcie_throughput{direction=\"transmit\"} / ignoring(direction) gpu_pcie_bandwidth"
+            .to_string(),
     );
 
     // PCIe bandwidth (max theoretical)

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -42,7 +42,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     view.group(utilization);
 
-    let mut activity = Group::new("Activity", "activity");
+    let mut activity = Group::new("Parallel Compute Activity", "activity");
 
     // GPU tensor activity
     activity.plot_promql(
@@ -60,23 +60,6 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         )
         .percentage_range(),
         "sum by (id) (gpu_tensor_utilization) / 100".to_string(),
-    );
-
-    // GPU DRAM activity
-    activity.plot_promql(
-        PlotOpts::gauge("GPU DRAM Activity %", "gpu-dram-act", Unit::Percentage).percentage_range(),
-        "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
-    );
-
-    // Per-GPU GPU DRAM activity
-    activity.plot_promql(
-        PlotOpts::gauge(
-            "GPU DRAM Activity % (Per-GPU)",
-            "gpu-dram-act-per-gpu",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum by (id) (gpu_dram_bandwidth_utilization) / 100".to_string(),
     );
 
     // GPU SM activity
@@ -151,7 +134,72 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         "sum(gpu_memory{state=\"used\"}) / (sum(gpu_memory{state=\"used\"}) + sum(gpu_memory{state=\"free\"}))".to_string(),
     );
 
+    // DRAM bandwidth utilization (average)
+    memory.plot_promql(
+        PlotOpts::gauge("DRAM Bandwidth %", "gpu-dram-act", Unit::Percentage).percentage_range(),
+        "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
+    );
+
+    // Per-GPU DRAM bandwidth utilization
+    memory.plot_promql(
+        PlotOpts::gauge(
+            "DRAM Bandwidth % (Per-GPU)",
+            "gpu-dram-act-per-gpu",
+            Unit::Percentage,
+        )
+        .percentage_range(),
+        "sum by (id) (gpu_dram_bandwidth_utilization) / 100".to_string(),
+    );
+
     view.group(memory);
+
+    /*
+     * PCIe
+     */
+
+    let mut pcie = Group::new("PCIe", "pcie");
+
+    // GPU receive throughput
+    pcie.plot_promql(
+        PlotOpts::gauge("Total Receive Rate", "pcie-rx-per-gpu", Unit::Datarate),
+        "sum(gpu_pcie_throughput{direction=\"receive\"})".to_string(),
+    );
+
+    // receive bandwidth util %
+    pcie.plot_promql(
+        PlotOpts::gauge(
+            "Receive Bandwidth Utilization %",
+            "pcie-rx-util",
+            Unit::Percentage,
+        )
+        .percentage_range(),
+        "gpu_pcie_throughput{direction=\"receive\"} / ignoring(direction) gpu_pcie_bandwidth".to_string(),
+    );
+
+    // Per-GPU transmit throughput
+    pcie.plot_promql(
+        PlotOpts::gauge("Total Transmit Rate", "pcie-tx-per-gpu", Unit::Datarate),
+        "sum(gpu_pcie_throughput{direction=\"transmit\"})".to_string(),
+    );
+
+    // transmit bandwidth util %
+    pcie.plot_promql(
+        PlotOpts::gauge(
+            "Transmit Bandwidth Utilization %",
+            "pcie-tx-util",
+            Unit::Percentage,
+        )
+        .percentage_range(),
+        "gpu_pcie_throughput{direction=\"transmit\"} / ignoring(direction) gpu_pcie_bandwidth".to_string(),
+    );
+
+    // PCIe bandwidth (max theoretical)
+    pcie.plot_promql(
+        PlotOpts::gauge("Bandwidth", "pcie-bandwidth", Unit::Datarate),
+        "sum(gpu_pcie_bandwidth)".to_string(),
+    );
+
+    view.group(pcie);
 
     /*
      * Power
@@ -186,22 +234,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let mut thermal = Group::new("Temperature", "temperature");
 
-    // Average temperature across all GPUs
+    // Per-GPU temperature
     thermal.plot_promql(
-        PlotOpts::gauge("Average (°C)", "temp-avg", Unit::Count).with_axis_label("°C"),
-        "avg(gpu_temperature)".to_string(),
+        PlotOpts::gauge("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count).with_axis_label("°C"),
+        "sum by (id) (gpu_temperature)".to_string(),
     );
 
     // Max temperature across all GPUs
     thermal.plot_promql(
         PlotOpts::gauge("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
         "max(gpu_temperature)".to_string(),
-    );
-
-    // Per-GPU temperature
-    thermal.plot_promql(
-        PlotOpts::gauge("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count).with_axis_label("°C"),
-        "sum by (id) (gpu_temperature)".to_string(),
     );
 
     view.group(thermal);
@@ -212,85 +254,31 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let mut clocks = Group::new("Clocks", "clocks");
 
-    // Graphics clock (average)
-    clocks.plot_promql(
-        PlotOpts::gauge("Graphics", "clock-graphics", Unit::Frequency),
-        "avg(gpu_clock{clock=\"graphics\"})".to_string(),
-    );
-
     // Per-GPU graphics clock
     clocks.plot_promql(
-        PlotOpts::gauge(
-            "Graphics (Per-GPU)",
-            "clock-graphics-per-gpu",
-            Unit::Frequency,
-        ),
+        PlotOpts::gauge("Graphics", "clock-graphics", Unit::Frequency),
         "sum by (id) (gpu_clock{clock=\"graphics\"})".to_string(),
-    );
-
-    // Memory clock (average)
-    clocks.plot_promql(
-        PlotOpts::gauge("Memory", "clock-memory", Unit::Frequency),
-        "avg(gpu_clock{clock=\"memory\"})".to_string(),
     );
 
     // Per-GPU memory clock
     clocks.plot_promql(
-        PlotOpts::gauge("Memory (Per-GPU)", "clock-memory-per-gpu", Unit::Frequency),
+        PlotOpts::gauge("Memory", "clock-memory", Unit::Frequency),
         "sum by (id) (gpu_clock{clock=\"memory\"})".to_string(),
     );
 
-    // Compute clock (average)
+    // Per-GPU compute clock
     clocks.plot_promql(
         PlotOpts::gauge("Compute", "clock-compute", Unit::Frequency),
-        "avg(gpu_clock{clock=\"compute\"})".to_string(),
+        "sum by (id) (gpu_clock{clock=\"compute\"})".to_string(),
     );
 
-    // Video clock (average)
+    // Per-GPU video clock
     clocks.plot_promql(
         PlotOpts::gauge("Video", "clock-video", Unit::Frequency),
-        "avg(gpu_clock{clock=\"video\"})".to_string(),
+        "sum by (id) (gpu_clock{clock=\"video\"})".to_string(),
     );
 
     view.group(clocks);
-
-    /*
-     * PCIe
-     */
-
-    let mut pcie = Group::new("PCIe", "pcie");
-
-    // PCIe bandwidth (max theoretical)
-    pcie.plot_promql(
-        PlotOpts::gauge("Bandwidth", "pcie-bandwidth", Unit::Datarate),
-        "sum(gpu_pcie_bandwidth)".to_string(),
-    );
-
-    // PCIe receive throughput (total)
-    pcie.plot_promql(
-        PlotOpts::gauge("Receive", "pcie-rx", Unit::Datarate),
-        "sum(gpu_pcie_throughput{direction=\"receive\"})".to_string(),
-    );
-
-    // Per-GPU receive throughput
-    pcie.plot_promql(
-        PlotOpts::gauge("Receive (Per-GPU)", "pcie-rx-per-gpu", Unit::Datarate),
-        "sum by (id) (gpu_pcie_throughput{direction=\"receive\"})".to_string(),
-    );
-
-    // PCIe transmit throughput (total)
-    pcie.plot_promql(
-        PlotOpts::gauge("Transmit", "pcie-tx", Unit::Datarate),
-        "sum(gpu_pcie_throughput{direction=\"transmit\"})".to_string(),
-    );
-
-    // Per-GPU transmit throughput
-    pcie.plot_promql(
-        PlotOpts::gauge("Transmit (Per-GPU)", "pcie-tx-per-gpu", Unit::Datarate),
-        "sum by (id) (gpu_pcie_throughput{direction=\"transmit\"})".to_string(),
-    );
-
-    view.group(pcie);
 
     view
 }

--- a/src/agent/samplers/gpu/linux/nvidia/stats.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/stats.rs
@@ -23,7 +23,7 @@ pub static GPU_MEMORY_USED: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 #[metric(
     name = "gpu_pcie_bandwidth",
     description = "The PCIe bandwidth in Bytes/s.",
-    metadata = { direction = "receive", unit = "bytes/second" }
+    metadata = { unit = "bytes/second" }
 )]
 pub static GPU_PCIE_BANDWIDTH: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 


### PR DESCRIPTION
## Summary
- Reorganize GPU dashboard: rename Activity → Parallel Compute Activity, move DRAM bandwidth to Memory section, add PCIe section with bandwidth utilization % charts
- Convert clock charts from averaged values to per-GPU heatmaps, reorder temperature charts
- Remove spurious `direction` metadata from `gpu_pcie_bandwidth` metric and bump metriken-query to 0.9.4 for `ignoring()` support

## Test plan
- [ ] Verify GPU dashboard renders correctly with a recording from an agent running updated metriken (all GPUs reporting PCIe bandwidth)
- [ ] Confirm PCIe bandwidth utilization % charts show per-GPU ratios via `ignoring(direction)`
- [ ] Verify clock heatmaps display per-GPU frequencies
- [ ] Check DRAM bandwidth charts appear under Memory section

🤖 Generated with [Claude Code](https://claude.com/claude-code)