### PR TITLE
chore: begin next development iteration (5.10.1-alpha.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.10.0"
+version = "5.10.1-alpha.0"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.10.0"
+version = "5.10.1-alpha.0"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/release.toml
+++ b/release.toml
@@ -25,7 +25,7 @@ tag-name = "{{prefix}}{{version}}"
 push = false
 
 # Commit message format
-pre-release-commit-message = "release: {{version}}"
+pre-release-commit-message = "release: prepare v{{version}}"
 
 # Allow releasing from main branch only
 allow-branch = ["main", "release/*"]


### PR DESCRIPTION
Manually bump dev version after the v5.10.0 release, since `tag-release.yml` skipped the v5.10.0 merge commit.

## Why tag-release.yml skipped

The workflow filters on commit message prefix `release: prepare v` ([tag-release.yml:21](../blob/main/.github/workflows/tag-release.yml#L21)), but `release.toml` was configured with `pre-release-commit-message = "release: {{version}}"` — so the release PR landed as `release: 5.10.0`, which doesn't match. Prior releases (#770, #754) used the `release: prepare v...` form.

## What this PR does

1. Bumps `Cargo.toml` / `Cargo.lock` to `5.10.1-alpha.0`
2. Fixes `release.toml` so `pre-release-commit-message = "release: prepare v{{version}}"` — future releases will now match the workflow filter and tag-release.yml will fire automatically

## v5.10.0 status

The tag `v5.10.0` has been pushed manually to `1ebe0c2`, which should trigger `release.yml` to build/publish artifacts and create the GitHub release.