### PR TITLE
fix(viewer): hide subgroup header when all charts are empty

### DIFF
--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -1000,6 +1000,13 @@ main {
     display: none;
 }
 
+/* Hide a subgroup entirely — header, description, and grid — when
+   every chart it contains is a no-data placeholder. Also covers the
+   (rare) degenerate case of a subgroup with zero plots. */
+.group .subgroup:not(:has(.chart-wrapper:not(:has(.no-data)))) {
+    display: none;
+}
+
 .chart-header {
     position: absolute;
     top: 0;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -1000,13 +1000,6 @@ main {
     display: none;
 }
 
-/* Hide a subgroup entirely — header, description, and grid — when
-   every chart it contains is a no-data placeholder. Also covers the
-   (rare) degenerate case of a subgroup with zero plots. */
-.group .subgroup:not(:has(.chart-wrapper:not(:has(.no-data)))) {
-    display: none;
-}
-
 .chart-header {
     position: absolute;
     top: 0;

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -40,6 +40,16 @@ export function createGroupComponent(getState) {
                 ? attrs.subgroups
                 : [{ name: null, description: null, plots: attrs.plots || [] }];
 
+            // Whether a plot has any series data to show. Used to suppress
+            // subgroup headers + descriptions when the whole cluster is
+            // empty (e.g. a section querying metrics that don't exist on
+            // the host, like GPU on a CPU-only box).
+            const plotHasData = (plot) =>
+                Array.isArray(plot.data) && plot.data.some((series) =>
+                    Array.isArray(series) && series.length > 0
+                );
+            const subgroupHasData = (sg) => (sg.plots || []).some(plotHasData);
+
             const renderChart = (spec) => {
                 const isHistogramChart = isHistogramPlot(spec);
                 const wrapperClass = spec.width === 'full'
@@ -71,13 +81,14 @@ export function createGroupComponent(getState) {
                 { id: attrs.id },
                 [
                     m('h2', `${attrs.name}`),
-                    subgroups.map((sg) =>
-                        m('div.subgroup', [
-                            sg.name && m('h3.subgroup-title', sg.name),
-                            sg.description && m('p.subgroup-description', sg.description),
+                    subgroups.map((sg) => {
+                        const hasData = subgroupHasData(sg);
+                        return m('div.subgroup', [
+                            hasData && sg.name && m('h3.subgroup-title', sg.name),
+                            hasData && sg.description && m('p.subgroup-description', sg.description),
                             m('div.charts', (sg.plots || []).map(renderChart)),
-                        ])
-                    ),
+                        ]);
+                    }),
                 ],
             );
         },

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -41,7 +41,7 @@ export function createGroupComponent(getState) {
                 : [{ name: null, description: null, plots: attrs.plots || [] }];
 
             // Whether a plot has any series data to show. Used to suppress
-            // subgroup headers + descriptions when the whole cluster is
+            // the group title + subgroup headers when the whole cluster is
             // empty (e.g. a section querying metrics that don't exist on
             // the host, like GPU on a CPU-only box).
             const plotHasData = (plot) =>
@@ -49,6 +49,9 @@ export function createGroupComponent(getState) {
                     Array.isArray(series) && series.length > 0
                 );
             const subgroupHasData = (sg) => (sg.plots || []).some(plotHasData);
+            const groupHasData = subgroups.some(subgroupHasData);
+
+            if (!groupHasData) return null;
 
             const renderChart = (spec) => {
                 const isHistogramChart = isHistogramPlot(spec);


### PR DESCRIPTION
## Summary

An empty subgroup used to render its \`h3\` title and description followed by a blank grid. Extend the existing \`.chart-wrapper:has(.no-data)\` rule so the wrapping \`.subgroup\` is also hidden whenever every chart-wrapper inside it carries the \`no-data\` class (or the subgroup has no chart-wrappers at all).

CSS-only change — the \`.no-data\` class is already applied imperatively by the chart renderer when ECharts determines there's nothing to plot, so the hide is reactive without any JS changes.

## Test plan

- [x] Load a recording where a dashboard section has partial data (e.g. a non-NVIDIA host viewing the GPU section, or a minimal recording with only CPU metrics): subgroups whose charts are all empty disappear, including their title and description.
- [x] Subgroups with at least one chart carrying data still render title + description.
- [x] Individual empty charts inside a mixed subgroup are still hidden by the pre-existing \`.chart-wrapper:has(.no-data)\` rule.