### PR TITLE
feat(viewer): preserve step override across save/load of selection

### DIFF
--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -9,7 +9,7 @@ import { TopNav, Sidebar, countCharts, formatSize } from './layout.js';
 import { collectGroupPlots } from './group_utils.js';
 import { CpuTopology } from './topology.js';
 import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, setStepOverride, getStepOverride, setSelectedNode, setSelectedInstance, getSelectedNode, injectLabel } from './data.js';
-import { reportStore, setStorageScope, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
+import { reportStore, selectionStore, persistSelection, setStorageScope, loadPayloadIntoStore, SelectionView, ReportView } from './selection.js';
 import { SaveModal } from './overlays.js';
 import { ViewerApi } from './viewer_api.js';
 import { createSystemInfoView, createMetadataView, renderCgroupSection } from './section_views.js';
@@ -164,6 +164,8 @@ const changeInstance = async (serviceName, instanceId) => {
 const changeGranularity = async (step) => {
     currentGranularity = step;
     setStepOverride(step);
+    selectionStore.stepOverride = step ?? null;
+    persistSelection();
 
     const currentRoute = m.route.get();
     const section = currentRoute ? currentRoute.replace(/^\//, '') : '';
@@ -273,6 +275,7 @@ const SectionContent = {
                 fileChecksum,
                 heatmapEnabled,
                 heatmapLoading,
+                stepOverride: currentGranularity,
                 onToggleHeatmap: toggleGlobalHeatmap,
             });
         }
@@ -286,6 +289,7 @@ const SectionContent = {
                 fileChecksum,
                 heatmapEnabled,
                 heatmapLoading,
+                stepOverride: currentGranularity,
                 onToggleHeatmap: toggleGlobalHeatmap,
             });
         }
@@ -381,6 +385,16 @@ const initDashboard = (config = {}) => {
     if (config.selectionPayload && Array.isArray(config.selectionPayload.entries)) {
         loadPayloadIntoStore(reportStore, config.selectionPayload);
         reportStore.loadedFrom = 'embedded report';
+    }
+
+    // Restore step override from whichever store carries one. Report
+    // (loaded-from-parquet) wins when both exist so a shared annotated
+    // parquet shows the granularity its author intended.
+    const restoredStep =
+        reportStore.stepOverride ?? selectionStore.stepOverride ?? null;
+    if (restoredStep != null) {
+        currentGranularity = restoredStep;
+        setStepOverride(restoredStep);
     }
 
     applyMultiNodeInfo();

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -161,6 +161,14 @@ const changeInstance = async (serviceName, instanceId) => {
     await reloadCurrentSection();
 };
 
+const CLIENT_ONLY_SECTIONS = new Set([
+    'selection',
+    'report',
+    'systeminfo',
+    'metadata',
+    'query_explorer',
+]);
+
 const changeGranularity = async (step) => {
     currentGranularity = step;
     setStepOverride(step);
@@ -170,19 +178,23 @@ const changeGranularity = async (step) => {
     const currentRoute = m.route.get();
     const section = currentRoute ? currentRoute.replace(/^\//, '') : '';
 
+    // All cached section data is stale against the new step.
     for (const key of Object.keys(sectionResponseCache)) {
-        if (key !== section) delete sectionResponseCache[key];
+        delete sectionResponseCache[key];
     }
     heatmapDataCache.clear();
     chartsState.zoomLevel = null;
     chartsState.zoomSource = null;
     chartsState.globalZoom = null;
 
-    if (!section) return;
+    // Data sections refetch themselves; client-only sections (Selection,
+    // Report, System Info, Metadata, Query Explorer) need overview
+    // primed so the sidebar + topnav meta stays populated after the
+    // cache wipe — otherwise the whole nav collapses.
+    const target = !section || CLIENT_ONLY_SECTIONS.has(section) ? 'overview' : section;
 
     try {
-        delete sectionResponseCache[section];
-        const data = await loadSection(section);
+        const data = await loadSection(target);
         if (data?.sections) preloadSections(data.sections);
         m.redraw();
     } catch (_) { /* keep existing view on error */ }

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -5,7 +5,7 @@
 import { ViewerApi } from './viewer_api.js';
 import { FileUpload } from './landing.js';
 import { notify, showSaveModal } from './overlays.js';
-import { setStorageScope } from './selection.js';
+import { setStorageScope, loadPayloadIntoStore, reportStore, clearStore } from './selection.js';
 import { clearMetadataCache, processDashboardData } from './data.js';
 import { initDashboard, sectionResponseCache, clearViewerCaches, chartsState, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, preloadSections } from './app.js';
 
@@ -81,6 +81,16 @@ const uploadParquet = async (file) => {
         if (fileChecksum) {
             setStorageScope({ filename: fileChecksum });
         }
+
+        // If the uploaded parquet has an embedded selection/report, load
+        // it into the reportStore so the "Report" sidebar link appears
+        // and the view can render the saved charts.
+        clearStore(reportStore);
+        if (selectionPayload && Array.isArray(selectionPayload.entries)) {
+            loadPayloadIntoStore(reportStore, selectionPayload);
+            reportStore.loadedFrom = 'embedded report';
+        }
+
         const data = await ViewerApi.getSection('overview');
         const processed = await processDashboardData(data, null, '/overview');
         sectionResponseCache['overview'] = processed;

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -31,12 +31,14 @@ const selectionStore = {
     tagline: '',
     entries: [],
     zoom: null,
+    stepOverride: null,   // query step in seconds (null = auto)
 };
 
 const reportStore = {
     tagline: '',
     entries: [],
     zoom: null,
+    stepOverride: null,   // query step in seconds (null = auto)
     loadedFrom: null,    // filename of the imported JSON
     reportId: null,       // UUIDv7 from the imported report
     savedAt: null,        // ISO timestamp
@@ -81,6 +83,7 @@ const persistStore = (key, store) => {
         const data = {
             tagline: store.tagline,
             zoom: store.zoom,
+            stepOverride: store.stepOverride ?? undefined,
             loadedFrom: store.loadedFrom || undefined,
             reportId: store.reportId || undefined,
             savedAt: store.savedAt || undefined,
@@ -111,6 +114,7 @@ const restoreStore = (key, store) => {
         if (!data.entries || !Array.isArray(data.entries)) return;
         store.tagline = data.tagline || '';
         store.zoom = data.zoom || null;
+        store.stepOverride = data.stepOverride ?? null;
         if (data.loadedFrom !== undefined) store.loadedFrom = data.loadedFrom;
         if (data.reportId !== undefined) store.reportId = data.reportId;
         if (data.savedAt !== undefined) store.savedAt = data.savedAt;
@@ -177,6 +181,7 @@ const clearStore = (store) => {
     store.entries.length = 0;
     store.tagline = '';
     store.zoom = null;
+    store.stepOverride = null;
     if (store === reportStore) {
         store.loadedFrom = null;
         store.reportId = null;
@@ -205,6 +210,7 @@ const buildPayload = (store, attrs) => ({
         end_ms: attrs.end_time || 0,
     },
     zoom: attrs.chartsState?.zoomLevel || null,
+    step_override: attrs.stepOverride ?? null,
     tagline: store.tagline,
     entries: store.entries.map(e => ({
         chartId: e.chartId,
@@ -237,6 +243,7 @@ const exportJSON = async (store, attrs) => {
 const loadPayloadIntoStore = (store, payload) => {
     store.tagline = payload.tagline || '';
     store.zoom = payload.zoom || null;
+    store.stepOverride = payload.step_override ?? null;
     store.entries = payload.entries.map(e => ({
         id: crypto.randomUUID(),
         chartId: e.chartId,
@@ -603,6 +610,7 @@ export {
     selectionStore,
     reportStore,
     setStorageScope,
+    persistSelection,
     toggleSelection,
     isSelected,
     clearStore,


### PR DESCRIPTION
## Summary

The granularity/step selector (1s, 5s, 15s, …) wasn't persisted with the selection payload, so reopening an annotated parquet — or even reloading the page with a selection in localStorage — reverted to auto step.

Now \`step_override\` is round-tripped through:

1. LocalStorage persistence of the in-progress selection
2. JSON export
3. Save-to-parquet (embedded \`selection\` metadata)
4. Reload / import back into the Report view

On load, the report-side value (set by whoever annotated the parquet) wins over any locally persisted selection-side override, so a shared annotated file shows the granularity its author chose.

## Test plan

- [x] Load a recording, pick a non-default step (e.g. 5s), "Save to parquet" with a selection — reopen the parquet, step selector comes up at 5s and charts render at that step.
- [x] Change the step during an editing session, reload the page — step is restored from localStorage.
- [x] Export JSON with non-default step, clear state, re-import — step is restored.