### PR TITLE
fix(agent): emit histograms in snapshots after metriken 0.2 core bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.10.1-alpha.0"
+version = "5.10.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.10.1-alpha.0"
+version = "5.10.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/agent/exposition/http/snapshot.rs
+++ b/src/agent/exposition/http/snapshot.rs
@@ -1,7 +1,7 @@
 use crate::agent::external_metrics::{ExternalMetric, ExternalMetricValue, ExternalMetricsStore};
 use crate::agent::*;
 
-use metriken::{RwLockHistogram, Value};
+use metriken::Value;
 use metriken_exposition::{Counter, Gauge, Histogram, Snapshot, SnapshotV2};
 
 use std::collections::HashMap;
@@ -178,24 +178,22 @@ fn create(
                     }
                 }
             }
-            Some(Value::Other(any)) => {
-                if let Some(histogram) = any.downcast_ref::<RwLockHistogram>() {
-                    if let Some(value) = histogram.load() {
-                        metadata.insert(
-                            "grouping_power".to_string(),
-                            histogram.config().grouping_power().to_string(),
-                        );
-                        metadata.insert(
-                            "max_value_power".to_string(),
-                            histogram.config().max_value_power().to_string(),
-                        );
+            Some(Value::Histogram(h)) => {
+                if let Some(value) = h.load() {
+                    metadata.insert(
+                        "grouping_power".to_string(),
+                        h.config().grouping_power().to_string(),
+                    );
+                    metadata.insert(
+                        "max_value_power".to_string(),
+                        h.config().max_value_power().to_string(),
+                    );
 
-                        s.histograms.push(Histogram {
-                            name,
-                            value,
-                            metadata,
-                        })
-                    }
+                    s.histograms.push(Histogram {
+                        name,
+                        value,
+                        metadata,
+                    })
                 }
             }
             _ => {}


### PR DESCRIPTION
The snapshot builder matched the old `Value::Other(any)` variant and downcast to `RwLockHistogram`. After the metriken-core 0.2 upgrade (#803, a65c893), `RwLockHistogram::value()` returns a dedicated `Value::Histogram(&dyn HistogramMetric)` variant instead, so every histogram fell through to the `_ => {}` arm and was silently dropped from snapshots. Recordings since that commit have been missing all histogram columns.

Match `Value::Histogram` and call `HistogramMetric::config()`/`load()` through the trait object directly.
