### PR TITLE
refactor(viewer): compare-mode simplify follow-ups + diff heatmap polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ cargo test test_name
 # Run tests for a specific package
 cargo test -p package_name
 
+# Run pure-JS viewer tests (compare-math, selection-migration) — no
+# bundler, no jsdom, just node's built-in test runner
+node --test tests/*.mjs
+
 # Format code (runs rustfmt and clang-format on .c/.h files)
 cargo xtask fmt
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.1"
+version = "5.11.1-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.1"
+version = "5.11.1-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -4,6 +4,25 @@ use metriken_query::{Bytes, QueryEngine, Tsdb};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+/// Parse a JS-side capture id into an internal slot selector. Mirrors
+/// the server-side CaptureId::parse but lives here to avoid pulling
+/// the viewer crate dependency graph into the wasm module.
+#[derive(Copy, Clone)]
+enum Slot {
+    Baseline,
+    Experiment,
+}
+
+impl Slot {
+    fn parse(capture: &str) -> Result<Self, JsValue> {
+        match capture {
+            "baseline" => Ok(Slot::Baseline),
+            "experiment" => Ok(Slot::Experiment),
+            other => Err(JsValue::from_str(&format!("unknown capture id: {other}"))),
+        }
+    }
+}
+
 #[wasm_bindgen(start)]
 pub fn init() {
     console_error_panic_hook::set_once();
@@ -312,20 +331,14 @@ impl WasmCaptureRegistry {
     /// "experiment").  Replaces any previously attached capture in that slot.
     pub fn attach(&mut self, capture: &str, data: &[u8], filename: &str) -> Result<(), JsValue> {
         let viewer = Viewer::new(data, filename)?;
-        match capture {
-            "baseline" => self.baseline = Some(viewer),
-            "experiment" => self.experiment = Some(viewer),
-            other => return Err(JsValue::from_str(&format!("unknown capture id: {other}"))),
-        }
+        *self.slot_mut(Slot::parse(capture)?) = Some(viewer);
         Ok(())
     }
 
     /// Drop the capture in the given slot (no-op if unknown or empty).
     pub fn detach(&mut self, capture: &str) {
-        match capture {
-            "baseline" => self.baseline = None,
-            "experiment" => self.experiment = None,
-            _ => {}
+        if let Ok(slot) = Slot::parse(capture) {
+            *self.slot_mut(slot) = None;
         }
     }
 
@@ -373,13 +386,11 @@ impl WasmCaptureRegistry {
     /// Initialise ServiceExtension templates for the given capture.  Mirrors
     /// `Viewer::init_templates`.
     pub fn init_templates(&mut self, capture: &str, templates_json: &str) -> Result<(), JsValue> {
-        let slot = match capture {
-            "baseline" => self.baseline.as_mut(),
-            "experiment" => self.experiment.as_mut(),
-            other => return Err(JsValue::from_str(&format!("unknown capture id: {other}"))),
-        };
-        let viewer = slot.ok_or_else(|| JsValue::from_str("capture not attached"))?;
-        viewer.init_templates(templates_json)
+        let slot = Slot::parse(capture)?;
+        self.slot_mut(slot)
+            .as_mut()
+            .ok_or_else(|| JsValue::from_str("capture not attached"))?
+            .init_templates(templates_json)
     }
 
     pub fn get_sections(&self, capture: &str) -> Option<String> {
@@ -391,20 +402,23 @@ impl WasmCaptureRegistry {
     }
 
     fn slot(&self, capture: &str) -> Option<&Viewer> {
-        match capture {
-            "baseline" => self.baseline.as_ref(),
-            "experiment" => self.experiment.as_ref(),
-            _ => None,
+        match Slot::parse(capture).ok()? {
+            Slot::Baseline => self.baseline.as_ref(),
+            Slot::Experiment => self.experiment.as_ref(),
+        }
+    }
+
+    fn slot_mut(&mut self, slot: Slot) -> &mut Option<Viewer> {
+        match slot {
+            Slot::Baseline => &mut self.baseline,
+            Slot::Experiment => &mut self.experiment,
         }
     }
 
     fn require_slot(&self, capture: &str) -> Result<&Viewer, JsValue> {
-        match capture {
-            "baseline" | "experiment" => self
-                .slot(capture)
-                .ok_or_else(|| JsValue::from_str("capture not attached")),
-            other => Err(JsValue::from_str(&format!("unknown capture id: {other}"))),
-        }
+        Slot::parse(capture)?;
+        self.slot(capture)
+            .ok_or_else(|| JsValue::from_str("capture not attached"))
     }
 }
 

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -182,17 +182,23 @@ async function loadCompareDemo(fileA, fileB) {
 
         // Fetch baseline + experiment state for initDashboard.
         const base = await fetchInitialState();
-        let experimentSystemInfo = null;
-        let experimentFileMetadata = null;
-        let experimentFilename = fileB;
-        try { experimentSystemInfo = await ViewerApi.getSystemInfo('experiment'); }
-        catch (_) { /* optional */ }
-        try { experimentFileMetadata = await ViewerApi.getFileMetadata('experiment'); }
-        catch (_) { /* optional */ }
-        try {
-            const expMeta = await ViewerApi.getMetadata('experiment');
-            experimentFilename = expMeta?.data?.filename || fileB;
-        } catch (_) { /* optional */ }
+        const [experimentSystemInfo, experimentFileMetadata, expMeta] = await Promise.all([
+            ViewerApi.getSystemInfo('experiment').catch(() => null),
+            ViewerApi.getFileMetadata('experiment').catch(() => null),
+            ViewerApi.getMetadata('experiment').catch(() => null),
+        ]);
+        const experimentFilename = expMeta?.data?.filename || fileB;
+        let experimentQueryRange = null;
+        const data = expMeta?.data ?? expMeta;
+        const minT = data?.minTime ?? data?.min_time ?? data?.start_time;
+        const maxT = data?.maxTime ?? data?.max_time ?? data?.end_time;
+        if (minT != null && maxT != null) {
+            const start = Number(minT);
+            const end = Number(maxT);
+            if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+                experimentQueryRange = { start, end, step: Math.max(1, Math.floor((end - start) / 500)) };
+            }
+        }
 
         initDashboard({
             systemInfo: base.systemInfo,
@@ -202,6 +208,7 @@ async function loadCompareDemo(fileA, fileB) {
             experimentSystemInfo,
             experimentFileMetadata,
             experimentFilename,
+            experimentQueryRange,
         });
 
         // Keep the URL shape stable so refreshes reload the same pair.

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -104,12 +104,10 @@ const durationFromFileMetadata = (fileMeta) => {
 
 const attachExperiment = async (file) => {
     const sysinfo = await ViewerApi.attachExperiment(file);
-    let expFileMeta = null;
-    let expMeta = null;
-    try { expFileMeta = await ViewerApi.getFileMetadata('experiment'); }
-    catch (_) { /* optional */ }
-    try { expMeta = await ViewerApi.getMetadata('experiment'); }
-    catch (_) { /* optional */ }
+    const [expFileMeta, expMeta] = await Promise.all([
+        ViewerApi.getFileMetadata('experiment').catch(() => null),
+        ViewerApi.getMetadata('experiment').catch(() => null),
+    ]);
     experimentSystemInfo = sysinfo || null;
     experimentDurationMs = durationFromFileMetadata(expFileMeta);
     // Prefer server-stamped filename (works in both file-drop and CLI paths);
@@ -136,7 +134,8 @@ const attachExperiment = async (file) => {
 };
 
 const detachExperiment = async () => {
-    try { await ViewerApi.detachExperiment(); } catch (_) { /* best effort */ }
+    try { await ViewerApi.detachExperiment(); }
+    catch (err) { console.warn('[compare] detachExperiment failed; server may leak a temp file', err); }
     experimentSystemInfo = null;
     experimentDurationMs = null;
     experimentFilename = null;

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -44,6 +44,11 @@ let experimentAttached = false;
 let experimentSystemInfo = null;
 let experimentDurationMs = null;
 let experimentFilename = null;
+// {start, end, step} in PromQL-native seconds, cached at compare-mode
+// entry so every CompareChartWrapper skips its per-chart
+// ViewerApi.getMetadata round-trip. Cleared on detach.
+let experimentQueryRange = null;
+export const getExperimentQueryRange = () => experimentQueryRange;
 
 // Compare-mode per-chart toggles + anchors live in `selectionStore` so
 // they persist across page reloads. See selection_migration.js for the
@@ -73,6 +78,7 @@ const initComponents = () => {
         toggles: selectionStore.chartToggles || {},
         setChartToggle,
         anchors: selectionStore.anchors || { baseline: 0, experiment: 0 },
+        experimentQueryRange,
     }));
 
     SystemInfoView = createSystemInfoView({
@@ -100,6 +106,21 @@ const durationFromFileMetadata = (fileMeta) => {
     return null;
 };
 
+// Parse /api/v1/metadata response shape into a compare-mode query range.
+// /api/v1/metadata returns minTime/maxTime in PromQL-native seconds
+// (same scale as plot.data[0] timestamps). Returns null when the
+// response shape doesn't include a recognisable time range.
+const queryRangeFromMeta = (meta) => {
+    const data = meta?.data ?? meta;
+    const minT = data?.minTime ?? data?.min_time ?? data?.start_time;
+    const maxT = data?.maxTime ?? data?.max_time ?? data?.end_time;
+    if (minT == null || maxT == null) return null;
+    const start = Number(minT);
+    const end = Number(maxT);
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return null;
+    return { start, end, step: Math.max(1, Math.floor((end - start) / 500)) };
+};
+
 // ── Compare-mode actions ───────────────────────────────────────────
 
 const attachExperiment = async (file) => {
@@ -110,6 +131,7 @@ const attachExperiment = async (file) => {
     ]);
     experimentSystemInfo = sysinfo || null;
     experimentDurationMs = durationFromFileMetadata(expFileMeta);
+    experimentQueryRange = queryRangeFromMeta(expMeta);
     // Prefer server-stamped filename (works in both file-drop and CLI paths);
     // fall back to the dropped File's name.
     experimentFilename = (expMeta?.data?.filename)
@@ -139,6 +161,7 @@ const detachExperiment = async () => {
     experimentSystemInfo = null;
     experimentDurationMs = null;
     experimentFilename = null;
+    experimentQueryRange = null;
     experimentAttached = false;
     compareMode = false;
     m.redraw();
@@ -504,6 +527,7 @@ const initDashboard = (config = {}) => {
     experimentAttached = compareMode;
     experimentSystemInfo = config.experimentSystemInfo || null;
     experimentDurationMs = durationFromFileMetadata(config.experimentFileMetadata);
+    experimentQueryRange = config.experimentQueryRange || null;
     experimentFilename = config.experimentFilename
         || (config.experimentFileMetadata
             && (config.experimentFileMetadata.filename || config.experimentFileMetadata.file_name))

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -8,7 +8,7 @@ import globalColorMapper from './charts/util/colormap.js';
 import { TopNav, Sidebar, countCharts, formatSize } from './layout.js';
 import { collectGroupPlots } from './group_utils.js';
 import { CpuTopology } from './topology.js';
-import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, setStepOverride, getStepOverride, setSelectedNode, setSelectedInstance, getSelectedNode, injectLabel } from './data.js';
+import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, setStepOverride, getStepOverride, setSelectedNode, setSelectedInstance, getSelectedNode, injectLabel, CAPTURE_EXPERIMENT } from './data.js';
 import { reportStore, selectionStore, persistSelection, setStorageScope, loadPayloadIntoStore, SelectionView, ReportView, setChartToggle as setChartToggleInStore, setAnchor } from './selection.js';
 import { SaveModal } from './overlays.js';
 import { ViewerApi } from './viewer_api.js';
@@ -105,8 +105,8 @@ const durationFromFileMetadata = (fileMeta) => {
 const attachExperiment = async (file) => {
     const sysinfo = await ViewerApi.attachExperiment(file);
     const [expFileMeta, expMeta] = await Promise.all([
-        ViewerApi.getFileMetadata('experiment').catch(() => null),
-        ViewerApi.getMetadata('experiment').catch(() => null),
+        ViewerApi.getFileMetadata(CAPTURE_EXPERIMENT).catch(() => null),
+        ViewerApi.getMetadata(CAPTURE_EXPERIMENT).catch(() => null),
     ]);
     experimentSystemInfo = sysinfo || null;
     experimentDurationMs = durationFromFileMetadata(expFileMeta);
@@ -124,7 +124,7 @@ const attachExperiment = async (file) => {
     // past the end of its data.
     const anchors = selectionStore.anchors || { baseline: 0, experiment: 0 };
     if (experimentDurationMs != null && anchors.experiment > experimentDurationMs) {
-        setAnchor('experiment', experimentDurationMs);
+        setAnchor(CAPTURE_EXPERIMENT, experimentDurationMs);
         console.info(
             `[compare] experiment anchor clamped to ${experimentDurationMs}ms to fit capture duration`,
         );

--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -5,8 +5,9 @@ import { formatDateTime } from './util/utils.js';
 import { COLORS, CHART_PALETTE } from './util/colormap.js';
 import { FONTS } from './util/fonts.js';
 
-function isDarkTheme() {
-    return document.documentElement.getAttribute('data-theme') !== 'light';
+export function isDarkTheme() {
+    return typeof document !== 'undefined'
+        && document.documentElement?.getAttribute('data-theme') !== 'light';
 }
 
 // Shared x-axis time label format used by all chart types

--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -249,6 +249,24 @@ export function getBaseYAxisOption(logScale, unitSystem) {
 }
 
 /**
+ * Merge a custom x-axis label formatter over baseOption.xAxis,
+ * preserving the surrounding axisLabel config. Returns null when the
+ * formatter is falsy, matching the `? xAxisOverride : null` pattern
+ * used at call sites so `{ xAxis: override }` only materializes when
+ * there's an override to apply.
+ */
+export function overrideXAxisFormatter(baseXAxis, customFormatter) {
+    if (!customFormatter) return null;
+    return {
+        ...baseXAxis,
+        axisLabel: {
+            ...(baseXAxis.axisLabel || {}),
+            formatter: customFormatter,
+        },
+    };
+}
+
+/**
  * Build the right-aligned circle-swatch legend shared by scatter and
  * multi-series line overlays. Pass `{ tooltipFormatter }` when the
  * legend should show hover tooltips (scatter); omit it for bare line

--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -249,6 +249,54 @@ export function getBaseYAxisOption(logScale, unitSystem) {
 }
 
 /**
+ * Build the right-aligned circle-swatch legend shared by scatter and
+ * multi-series line overlays. Pass `{ tooltipFormatter }` when the
+ * legend should show hover tooltips (scatter); omit it for bare line
+ * overlays. The caller is responsible for pairing this with
+ * `grid: { ..., top: '71' }` on the plot's option.
+ */
+export function buildOverlayLegendOption(names, { tooltipFormatter, top = '42' } = {}) {
+    const legendItemW = 56;
+    const textStyleBase = {
+        color: COLORS.fgSecondary,
+        ...FONTS.legend,
+        width: legendItemW,
+        borderColor: 'transparent',
+        borderWidth: 1,
+        borderRadius: 3,
+        padding: [2, 4],
+    };
+    const legend = {
+        show: true,
+        right: '16',
+        top,
+        icon: 'circle',
+        itemWidth: 8,
+        itemHeight: 8,
+        itemGap: 0,
+        formatter: (name) => name.padEnd(6),
+        textStyle: textStyleBase,
+        data: names.map((name) => ({
+            name,
+            itemStyle: { borderColor: 'transparent', borderWidth: 2 },
+            textStyle: {
+                color: COLORS.fgSecondary,
+                backgroundColor: 'transparent',
+                borderColor: 'transparent',
+                borderWidth: 1,
+                borderRadius: 3,
+                padding: [2, 4],
+                width: legendItemW,
+            },
+        })),
+    };
+    if (tooltipFormatter) {
+        legend.tooltip = { show: true, formatter: tooltipFormatter };
+    }
+    return legend;
+}
+
+/**
  * Calculate the minimum zoom span (as a percentage of total duration)
  * to prevent zooming tighter than 5x the sample interval.
  */

--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -129,6 +129,16 @@ export function getTooltipFormatter(valueFormatter, pinnedSet, chart, style) {
     }
 }
 
+// Plot-area top offset (pixels from the top of the Chart component
+// div to the top of the echarts grid). Chart modules that add a
+// legend above the plot (multi, scatter, line-overlay, heatmap,
+// histogram_heatmap) push the grid down by this amount.
+//
+// Keep in sync with the .compare-slot-label / .compare-split-label
+// `top: 44px` rules in style.css — those labels sit in the header
+// band that precedes the grid.
+export const CHART_GRID_TOP_WITH_LEGEND = 71;
+
 export function getBaseOption() {
     return {
         grid: {

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -419,6 +419,17 @@ export class Chart {
                 endValue = undefined;
             }
 
+            // Don't let an event with no usable zoom info (empty batch,
+            // or batch details with all-undefined coords) overwrite a
+            // zoom that was just set — this shape shows up as an echo
+            // when heatmap.js's downsample-swap setOption triggers a
+            // secondary datazoom event on a sibling chart that received
+            // our cross-dispatch.
+            const hasPct = start !== undefined && end !== undefined
+                && !Number.isNaN(start) && !Number.isNaN(end);
+            const hasValues = startValue !== undefined && endValue !== undefined;
+            if (!hasPct && !hasValues) return;
+
             this.chartsState.zoomLevel = {
                 start,
                 end,

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -628,8 +628,10 @@ export class Chart {
             || resolveStyle(this.spec.opts.type, this.spec.opts.subtype);
 
         // Clean up heatmap DOM legend bar when switching to a different chart type
+        // (e.g. heatmap-mode toggle off). The legend lives inside chart.domNode
+        // now, so clear it from the same scope.
         if (style !== 'histogram_heatmap' && style !== 'heatmap') {
-            this.domNode?.parentNode?.querySelector('.heatmap-legend-bar')?.remove();
+            this.domNode?.querySelector('.heatmap-legend-bar')?.remove();
         }
 
         // Handle different chart types by delegating to specialized modules

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -442,8 +442,17 @@ export class Chart {
                 payload.startValue = startValue;
                 payload.endValue = endValue;
             }
+            // Skip the source chart: its dataZoom is already at these
+            // values (the toolbox drag set it before firing this event).
+            // Re-dispatching to self is at best redundant; at worst, for
+            // heatmap-type charts, it can cascade through heatmap.js's
+            // own datazoom listener (which calls setOption to swap
+            // downsample level) and re-fire a batch-carrying datazoom
+            // event, clobbering chartsState.zoomLevel. Excluding self
+            // from the cross-dispatch breaks that loop without needing
+            // a re-entrancy guard.
             this.chartsState.charts.forEach(chart => {
-                chart.dispatchAction(payload);
+                if (chart !== this) chart.dispatchAction(payload);
                 chart._rescaleYAxis();
             });
             m.redraw();

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -347,9 +347,12 @@ export class Chart {
 
         this.echart.on('datazoom', (event) => {
             // 'datazoom' events triggered by the user vs dispatched by us have different formats:
-            // User-triggered events have a batch property with the details under it.
-            // (We don't want to trigger on our own dispatched zoom actions, so this is convenient.)
-            if (!event.batch) {
+            // User-triggered events have a non-empty batch array with the details under it.
+            // Programmatic dispatches (the forEach below, or compare-mode
+            // zoom sync) emit either a missing batch or an empty-batch
+            // event — either case would destructure to all-undefined
+            // below and silently reset chartsState.zoomLevel. Filter both.
+            if (!Array.isArray(event.batch) || event.batch.length === 0) {
                 return;
             }
 
@@ -418,6 +421,15 @@ export class Chart {
                 startValue = undefined;
                 endValue = undefined;
             }
+
+            // Only persist a zoom if we actually extracted meaningful
+            // values. A stray empty-batch or malformed event would
+            // otherwise write undefineds into zoomLevel and clobber a
+            // legitimate zoom on the next onupdate restore.
+            const hasPct = start !== undefined && end !== undefined
+                && !Number.isNaN(start) && !Number.isNaN(end);
+            const hasValues = startValue !== undefined && endValue !== undefined;
+            if (!hasPct && !hasValues) return;
 
             this.chartsState.zoomLevel = {
                 start,

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -347,12 +347,21 @@ export class Chart {
 
         this.echart.on('datazoom', (event) => {
             // 'datazoom' events triggered by the user vs dispatched by us have different formats:
-            // User-triggered events have a non-empty batch array with the details under it.
-            // Programmatic dispatches (the forEach below, or compare-mode
-            // zoom sync) emit either a missing batch or an empty-batch
-            // event — either case would destructure to all-undefined
-            // below and silently reset chartsState.zoomLevel. Filter both.
-            if (!Array.isArray(event.batch) || event.batch.length === 0) {
+            // User-triggered events have a batch property with the details under it.
+            // (We don't want to trigger on our own dispatched zoom actions, so this is convenient.)
+            if (!event.batch) {
+                return;
+            }
+            // Re-entrancy guard: when the forEach below dispatches to a
+            // sibling chart (the compare-mode side-by-side case), that
+            // sibling's toolbox internally re-fires a datazoom event WITH
+            // a batch payload — and if we let that sibling run the full
+            // handler, it would clobber chartsState.zoomLevel with its
+            // own axis-relative interpretation and re-dispatch back,
+            // causing the zoom to appear to reset. Mark the
+            // cross-dispatch window on chartsState and skip re-entry
+            // while it's active.
+            if (this.chartsState._inHandlerDispatch) {
                 return;
             }
 
@@ -422,15 +431,6 @@ export class Chart {
                 endValue = undefined;
             }
 
-            // Only persist a zoom if we actually extracted meaningful
-            // values. A stray empty-batch or malformed event would
-            // otherwise write undefineds into zoomLevel and clobber a
-            // legitimate zoom on the next onupdate restore.
-            const hasPct = start !== undefined && end !== undefined
-                && !Number.isNaN(start) && !Number.isNaN(end);
-            const hasValues = startValue !== undefined && endValue !== undefined;
-            if (!hasPct && !hasValues) return;
-
             this.chartsState.zoomLevel = {
                 start,
                 end,
@@ -454,10 +454,15 @@ export class Chart {
                 payload.startValue = startValue;
                 payload.endValue = endValue;
             }
-            this.chartsState.charts.forEach(chart => {
-                chart.dispatchAction(payload);
-                chart._rescaleYAxis();
-            });
+            this.chartsState._inHandlerDispatch = true;
+            try {
+                this.chartsState.charts.forEach(chart => {
+                    chart.dispatchAction(payload);
+                    chart._rescaleYAxis();
+                });
+            } finally {
+                this.chartsState._inHandlerDispatch = false;
+            }
             m.redraw();
         });
 

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -352,18 +352,6 @@ export class Chart {
             if (!event.batch) {
                 return;
             }
-            // Re-entrancy guard: when the forEach below dispatches to a
-            // sibling chart (the compare-mode side-by-side case), that
-            // sibling's toolbox internally re-fires a datazoom event WITH
-            // a batch payload — and if we let that sibling run the full
-            // handler, it would clobber chartsState.zoomLevel with its
-            // own axis-relative interpretation and re-dispatch back,
-            // causing the zoom to appear to reset. Mark the
-            // cross-dispatch window on chartsState and skip re-entry
-            // while it's active.
-            if (this.chartsState._inHandlerDispatch) {
-                return;
-            }
 
             const details = event.batch[0];
 
@@ -454,15 +442,10 @@ export class Chart {
                 payload.startValue = startValue;
                 payload.endValue = endValue;
             }
-            this.chartsState._inHandlerDispatch = true;
-            try {
-                this.chartsState.charts.forEach(chart => {
-                    chart.dispatchAction(payload);
-                    chart._rescaleYAxis();
-                });
-            } finally {
-                this.chartsState._inHandlerDispatch = false;
-            }
+            this.chartsState.charts.forEach(chart => {
+                chart.dispatchAction(payload);
+                chart._rescaleYAxis();
+            });
             m.redraw();
         });
 

--- a/src/viewer/assets/lib/charts/color_legend.js
+++ b/src/viewer/assets/lib/charts/color_legend.js
@@ -34,9 +34,13 @@ export function buildGradientCanvas(colorFn) {
  * On first call, builds: [minLabel] [colorBar] [maxLabel] + any extraElements,
  * appends the container to `wrapper`, and returns element references.
  *
- * On subsequent calls (same wrapper), returns existing element references.
+ * On subsequent calls (same wrapper), repaints the gradient from the
+ * (possibly new) barCanvas and returns existing element references. The
+ * repaint lets callers swap palettes (e.g. diff-mode diverging palette)
+ * without tearing down the container.
  *
- * @param {HTMLElement} wrapper - parent element (chart-wrapper)
+ * @param {HTMLElement} wrapper - parent element (Chart component's own
+ *     div; owned by Mithril so Mithril removes the legend on unmount)
  * @param {HTMLCanvasElement} barCanvas - pre-rendered gradient canvas
  * @param {HTMLElement[]} [extraElements] - additional elements appended after maxLabel
  * @returns {{ minLabel: HTMLElement, maxLabel: HTMLElement }}
@@ -44,6 +48,8 @@ export function buildGradientCanvas(colorFn) {
 export function ensureLegendBar(wrapper, barCanvas, extraElements) {
     let container = wrapper.querySelector('.heatmap-legend-bar');
     if (container) {
+        const bar = container.querySelector('canvas');
+        if (bar && barCanvas) bar.getContext('2d').drawImage(barCanvas, 0, 0);
         return {
             minLabel: container.querySelector('.heatmap-label-min'),
             maxLabel: container.querySelector('.heatmap-label-max'),

--- a/src/viewer/assets/lib/charts/color_legend.js
+++ b/src/viewer/assets/lib/charts/color_legend.js
@@ -31,8 +31,17 @@ export function buildGradientCanvas(colorFn) {
 /**
  * Create or reuse the legend bar container.
  *
- * On first call, builds: [minLabel] [colorBar] [maxLabel] + any extraElements,
- * appends the container to `wrapper`, and returns element references.
+ * On first call, builds:
+ *
+ *   ┌──────────── optional caption row ────────────┐
+ *   │ [leftCaption]                  [rightCaption] │
+ *   ├──────────────── legend row ───────────────────┤
+ *   │ [minLabel]  [colorBar]  [maxLabel] [extras]   │
+ *   └───────────────────────────────────────────────┘
+ *
+ * The caption row spans the same width as the legend row below, so the
+ * left caption sits directly above minLabel's left edge and the right
+ * caption sits directly above maxLabel's right edge.
  *
  * On subsequent calls (same wrapper), repaints the gradient from the
  * (possibly new) barCanvas and returns existing element references. The
@@ -43,7 +52,9 @@ export function buildGradientCanvas(colorFn) {
  *     div; owned by Mithril so Mithril removes the legend on unmount)
  * @param {HTMLCanvasElement} barCanvas - pre-rendered gradient canvas
  * @param {HTMLElement[]} [extraElements] - additional elements appended after maxLabel
- * @returns {{ minLabel: HTMLElement, maxLabel: HTMLElement }}
+ * @returns {{ minLabel, maxLabel, leftCaption, rightCaption }} -
+ *     leftCaption/rightCaption are always present (empty by default);
+ *     callers that want a caption set their textContent.
  */
 export function ensureLegendBar(wrapper, barCanvas, extraElements) {
     let container = wrapper.querySelector('.heatmap-legend-bar');
@@ -53,19 +64,58 @@ export function ensureLegendBar(wrapper, barCanvas, extraElements) {
         return {
             minLabel: container.querySelector('.heatmap-label-min'),
             maxLabel: container.querySelector('.heatmap-label-max'),
+            leftCaption: container.querySelector('.heatmap-caption-left'),
+            rightCaption: container.querySelector('.heatmap-caption-right'),
+            captionRow: container.querySelector('.heatmap-caption-row'),
         };
     }
 
     container = document.createElement('div');
     container.className = 'heatmap-legend-bar';
+    // BAR_TOP lines up the GRADIENT ROW's top edge with the previous
+    // single-row layout's position; the caption row (when visible) sits
+    // above via negative margin so the gradient stays put whether or
+    // not captions are rendered.
     container.style.cssText = `
         position: absolute;
         top: ${BAR_TOP}px;
         right: 16px;
         display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 2px;
+        z-index: 10;
+    `;
+
+    // Caption row: same width as the legend row below, so left/right
+    // captions anchor to minLabel's left edge and maxLabel's right edge.
+    // Defaults to display: none — callers that want a caption set text
+    // on leftCaption/rightCaption and toggle captionRow.style.display.
+    const captionRow = document.createElement('div');
+    captionRow.className = 'heatmap-caption-row';
+    captionRow.style.cssText = `
+        display: none;
+        justify-content: space-between;
+        align-items: center;
+        ${FONTS.cssFootnote}
+        font-size: 10px;
+        color: ${COLORS.fgSecondary};
+        pointer-events: none;
+        margin-top: -14px;
+    `;
+    const leftCaption = document.createElement('span');
+    leftCaption.className = 'heatmap-caption-left';
+    const rightCaption = document.createElement('span');
+    rightCaption.className = 'heatmap-caption-right';
+    captionRow.appendChild(leftCaption);
+    captionRow.appendChild(rightCaption);
+
+    // Legend row: [min] [gradient] [max] [extras]
+    const legendRow = document.createElement('div');
+    legendRow.style.cssText = `
+        display: flex;
         align-items: center;
         gap: ${LABEL_GAP}px;
-        z-index: 10;
     `;
 
     const minLabel = document.createElement('span');
@@ -82,13 +132,16 @@ export function ensureLegendBar(wrapper, barCanvas, extraElements) {
     maxLabel.className = 'heatmap-label-max';
     maxLabel.style.cssText = `${FONTS.cssFootnote} color: ${COLORS.fgSecondary}; pointer-events: none;`;
 
-    container.appendChild(minLabel);
-    container.appendChild(bar);
-    container.appendChild(maxLabel);
+    legendRow.appendChild(minLabel);
+    legendRow.appendChild(bar);
+    legendRow.appendChild(maxLabel);
     if (extraElements) {
-        for (const el of extraElements) container.appendChild(el);
+        for (const el of extraElements) legendRow.appendChild(el);
     }
+
+    container.appendChild(captionRow);
+    container.appendChild(legendRow);
     wrapper.appendChild(container);
 
-    return { minLabel, maxLabel };
+    return { minLabel, maxLabel, leftCaption, rightCaption, captionRow };
 }

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -211,23 +211,19 @@ const scrubStaleLegend = (vnode) => {
     vnode.dom.querySelectorAll(':scope > .heatmap-legend-bar').forEach((el) => el.remove());
 };
 
-// Scan both captures' heatmap triples and return a unified (min, max)
-// for the visualMap. Falls back to the spec's own bounds if a capture
-// has no numeric samples.
+// Unified (min, max) across both captures for the shared visualMap.
+// Each capture's extract* stashed its own scanned min/max, so this is
+// just Math.min/Math.max of the two pairs. Falls back to the spec's
+// own bounds if neither capture had numeric samples.
 const unifiedHeatmapRange = (a, b, spec) => {
-    let lo = Infinity;
-    let hi = -Infinity;
-    const visit = (triples) => {
-        if (!Array.isArray(triples)) return;
-        for (const t of triples) {
-            const v = Array.isArray(t) ? t[2] : null;
-            if (v == null || Number.isNaN(v)) continue;
-            if (v < lo) lo = v;
-            if (v > hi) hi = v;
-        }
-    };
-    visit(a?.heatmapData);
-    visit(b?.heatmapData);
+    const lo = Math.min(
+        a?.minValue != null ? a.minValue : Infinity,
+        b?.minValue != null ? b.minValue : Infinity,
+    );
+    const hi = Math.max(
+        a?.maxValue != null ? a.maxValue : -Infinity,
+        b?.maxValue != null ? b.maxValue : -Infinity,
+    );
     if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
         return {
             min: spec.min_value != null ? spec.min_value : 0,

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -30,7 +30,7 @@
 //   anchors: { baseline: ms, experiment: ms }  — subtracted from each
 //            capture's timestamps to produce a relative (`+Xs`) x-axis.
 
-import { nullDiff, intersectLabels } from './util/compare_math.js';
+import { nullDiff, intersectLabels, canonicalQuantileLabel } from './util/compare_math.js';
 import { DIVERGING_BLUE_GREEN, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
 import { resolvedStyle } from './metric_types.js';
 
@@ -396,14 +396,7 @@ const multiLabel = (r) => {
         .map((k) => `${k}=${mm[k]}`).join(',');
 };
 
-const percentileLabel = (r) => {
-    const mm = (r && r.metric) || {};
-    const raw = mm.percentile != null ? mm.percentile : mm.quantile;
-    const q = Number(raw);
-    if (!Number.isFinite(q)) return 'unknown';
-    const pct = q <= 1 ? q * 100 : q;
-    return `p${pct.toFixed(2).replace(/\.?0+$/, '')}`;
-};
+const percentileLabel = (r) => canonicalQuantileLabel(r) || 'unknown';
 
 /**
  * Render baseline and experiment histogram heatmaps side-by-side. No

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -39,7 +39,7 @@
 //            capture's timestamps to produce a relative (`+Xs`) x-axis.
 
 import { nullDiff, intersectLabels, canonicalQuantileLabel } from './util/compare_math.js';
-import { DIVERGING_BLUE_GREEN, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
+import { DIVERGING_BLUE_GREEN, DIVERGING_BLUE_GREEN_ALPHA_V, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
 import { resolvedStyle } from './metric_types.js';
 import { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from '../data.js';
 
@@ -307,7 +307,14 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
     // lands on value=0 — one-sided ranges collapse to the relevant half
     // of the palette (blue-to-neutral or neutral-to-green) and mixed
     // ranges preserve neutral at zero's natural fraction.
-    const resampledPalette = resampleDivergingForRange(DIVERGING_BLUE_GREEN, dMin, dMax);
+    //
+    // The V-shaped alpha curve fades cells near zero into whatever
+    // background is underneath (card bg on either theme) and keeps
+    // extreme cells saturated so outliers pop. No separate dark-mode
+    // opacity blanket needed — the palette stops carry their own alpha.
+    const resampledPalette = resampleDivergingForRange(
+        DIVERGING_BLUE_GREEN, dMin, dMax, 21, DIVERGING_BLUE_GREEN_ALPHA_V,
+    );
 
     const diffSpec = {
         ...spec,
@@ -318,10 +325,6 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
         max_value: dMax,
         colormap: resampledPalette,
         nullCellColor: nullCellColor(isDark),
-        // In dark mode the diverging blue/green reads too stark against the
-        // black canvas — drop cell opacity to 60% to soften without losing
-        // the sign + magnitude signal. Light mode keeps full opacity.
-        cellOpacity: isDark ? 0.6 : 1,
         // Directional caption under the gradient bar. The numeric min/max
         // labels still show the actual (experiment − baseline) extremes;
         // these labels make the directionality unambiguous at a glance.

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -332,6 +332,10 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
         // labels still show the actual (experiment − baseline) extremes;
         // these labels make the directionality unambiguous at a glance.
         diffLegendLabels: { left: 'base is higher', right: 'exp is higher' },
+        // Side-channel so heatmap.js's tooltip can show the original
+        // baseline + experiment values for a hovered cell instead of the
+        // computed delta. Indexed as matrix[row][bin].
+        diffMatrices: { baseline: aMatrix, experiment: bMatrix },
         xAxisFormatter: relativeTimeFormatter,
     };
 

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -353,13 +353,17 @@ const splitMultiToSubgroup = ({ spec, captures, anchors }) =>
     splitIntoOverlayLines({ spec, captures, anchors, labelFor: multiLabel });
 
 /**
- * Split a `scatter` chart (histogram percentiles) into one overlay line
- * chart per shared quantile label.
+ * Split a `scatter` chart (histogram percentiles) into one overlay
+ * scatter chart per shared quantile label. Percentile series are
+ * naturally discrete samples, not continuous measurements — points
+ * read more honestly than a connecting line suggests.
  */
 const splitScatterToSubgroup = ({ spec, captures, anchors }) =>
-    splitIntoOverlayLines({ spec, captures, anchors, labelFor: percentileLabel });
+    splitIntoOverlayLines({
+        spec, captures, anchors, labelFor: percentileLabel, seriesType: 'scatter',
+    });
 
-const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor }) => {
+const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor, seriesType = 'line' }) => {
     const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
     const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
     if (!baseline || !experiment) return FALLBACK;
@@ -369,6 +373,7 @@ const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor })
     const labelsA = new Set(mapA.keys());
     const labelsB = new Set(mapB.keys());
     const shared = [...intersectLabels(labelsA, labelsB)].sort();
+    const asScatter = seriesType === 'scatter';
 
     const specs = shared.map((label) => {
         const a = mapA.get(label);
@@ -394,6 +399,7 @@ const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor })
                     timeData: rebase(a.timeData, baseSec),
                     valueData: a.valueData,
                     fill: false,
+                    scatter: asScatter,
                 },
                 {
                     name: CAPTURE_EXPERIMENT,
@@ -401,6 +407,7 @@ const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor })
                     timeData: rebase(b.timeData, expSec),
                     valueData: b.valueData,
                     fill: false,
+                    scatter: asScatter,
                 },
             ],
             xAxisFormatter: relativeTimeFormatter,

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -39,7 +39,7 @@
 //            capture's timestamps to produce a relative (`+Xs`) x-axis.
 
 import { nullDiff, intersectLabels, canonicalQuantileLabel } from './util/compare_math.js';
-import { DIVERGING_BLUE_GREEN, DIVERGING_BLUE_GREEN_ALPHA_V, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
+import { DIVERGING_BLUE_GREEN, DIVERGING_BLUE_GREEN_DARK, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
 import { resolvedStyle } from './metric_types.js';
 import { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from '../data.js';
 
@@ -308,13 +308,13 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
     // of the palette (blue-to-neutral or neutral-to-green) and mixed
     // ranges preserve neutral at zero's natural fraction.
     //
-    // The V-shaped alpha curve fades cells near zero into whatever
-    // background is underneath (card bg on either theme) and keeps
-    // extreme cells saturated so outliers pop. No separate dark-mode
-    // opacity blanket needed — the palette stops carry their own alpha.
-    const resampledPalette = resampleDivergingForRange(
-        DIVERGING_BLUE_GREEN, dMin, dMax, 21, DIVERGING_BLUE_GREEN_ALPHA_V,
-    );
+    // Theme-specific base palette: the light variant fades to
+    // near-white at neutral, the dark variant fades to the dark card
+    // bg. Either way near-zero cells visually blend into the canvas
+    // while extremes stay saturated — without the per-stop alpha
+    // dilution that muddied the extreme hues in earlier attempts.
+    const basePalette = isDark ? DIVERGING_BLUE_GREEN_DARK : DIVERGING_BLUE_GREEN;
+    const resampledPalette = resampleDivergingForRange(basePalette, dMin, dMax);
 
     const diffSpec = {
         ...spec,

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -318,6 +318,14 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
         max_value: dMax,
         colormap: resampledPalette,
         nullCellColor: nullCellColor(isDark),
+        // In dark mode the diverging blue/green reads too stark against the
+        // black canvas — drop cell opacity to 60% to soften without losing
+        // the sign + magnitude signal. Light mode keeps full opacity.
+        cellOpacity: isDark ? 0.6 : 1,
+        // Directional caption under the gradient bar. The numeric min/max
+        // labels still show the actual (experiment − baseline) extremes;
+        // these labels make the directionality unambiguous at a glance.
+        diffLegendLabels: { left: 'base is higher', right: 'exp is higher' },
         xAxisFormatter: relativeTimeFormatter,
     };
 

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -41,6 +41,7 @@
 import { nullDiff, intersectLabels, canonicalQuantileLabel } from './util/compare_math.js';
 import { DIVERGING_BLUE_GREEN, DIVERGING_BLUE_GREEN_DARK, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
 import { resolvedStyle } from './metric_types.js';
+import { isDarkTheme } from './base.js';
 import { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from '../data.js';
 
 // Colors sourced from --compare-baseline / --compare-experiment in
@@ -298,9 +299,11 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
     const timeData = (a.timeData || spec.time_data || []).slice(0, bins);
     const baselineAnchorSec = anchorSecondsFor(anchors, CAPTURE_BASELINE, timeData);
 
-    const isDark = typeof document !== 'undefined'
-        && document.body
-        && document.body.classList.contains('theme-dark');
+    // Theme is applied as `data-theme` on <html> (see theme.js); the
+    // body-class probe this used to use was always false, which
+    // silently pinned both nullCellColor and the diff palette to the
+    // light-theme variant.
+    const isDark = isDarkTheme();
 
     // Use the data's actual [min, max] rather than forcing a symmetric
     // band around 0. Resample the diverging palette so neutral still

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -202,17 +202,9 @@ const sideBySidePair = ({ spec, captures, anchors, chartsState, interval, Chart,
         ]),
         m(Chart, { spec: makeSlotSpec(cap), chartsState, interval }),
     ]);
-    // scrubStaleLegend removes any diff-view legend bar that was
-    // imperatively injected as a direct child of the previous wrapper
-    // and survived Mithril's class-swap on the reused outer div. The
-    // direct-child selector leaves per-slot legends (inside .compare-
-    // slot) alone.
     return {
         kind: 'vnode',
-        vnode: m('div.compare-heatmap-pair', {
-            oncreate: scrubStaleLegend,
-            onupdate: scrubStaleLegend,
-        }, [
+        vnode: m('div.compare-heatmap-pair', [
             slot(a, 'compare-baseline-dot'),
             slot(b, 'compare-experiment-dot'),
         ]),
@@ -226,14 +218,6 @@ const sideBySideHeatmap = ({ spec, captures, anchors, toggles, chartsState, inte
         return renderDiffHeatmap({ spec, captures, anchors, chartsState, interval, Chart });
     }
     return sideBySidePair({ spec, captures, anchors, chartsState, interval, Chart });
-};
-
-// Remove any .heatmap-legend-bar that's a DIRECT child of this wrapper
-// — left over from a previous strategy's imperative injection when
-// Mithril reused the outer div across a view-tree swap.
-const scrubStaleLegend = (vnode) => {
-    if (!vnode.dom) return;
-    vnode.dom.querySelectorAll(':scope > .heatmap-legend-bar').forEach((el) => el.remove());
 };
 
 // Unified (min, max) across both captures for the shared visualMap.
@@ -337,15 +321,9 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
         xAxisFormatter: relativeTimeFormatter,
     };
 
-    // On mount/update, scrub any stale legend bar inherited from a
-    // prior side-by-side render of this same chart slot (Mithril
-    // reuses the outer div across class swaps; see scrubStaleLegend).
     return {
         kind: 'vnode',
-        vnode: m('div.compare-heatmap-diff', {
-            oncreate: scrubStaleLegend,
-            onupdate: scrubStaleLegend,
-        }, m(Chart, { spec: diffSpec, chartsState, interval })),
+        vnode: m('div.compare-heatmap-diff', m(Chart, { spec: diffSpec, chartsState, interval })),
     };
 };
 

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -162,13 +162,11 @@ const overlayLine = ({ spec, captures, anchors }) => {
  * When the per-chart `diff` toggle is on, renders a single diff heatmap
  * instead via `renderDiffHeatmap`.
  */
-const sideBySideHeatmap = ({ spec, captures, anchors, toggles, chartsState, interval, Chart }) => {
-    const chartId = spec?.opts?.id;
-    const diffMode = !!(toggles && chartId && toggles[chartId] && toggles[chartId].diff);
-    if (diffMode) {
-        return renderDiffHeatmap({ spec, captures, anchors, chartsState, interval, Chart });
-    }
-
+// Build a side-by-side pair (baseline + experiment as sibling charts)
+// with a unified color domain. `styleOverride` swaps the per-slot
+// `opts.style`; `extraSlotFields(cap)` contributes additional
+// top-level spec fields (e.g. bucket_bounds for histogram heatmaps).
+const sideBySidePair = ({ spec, captures, anchors, chartsState, interval, Chart, styleOverride, extraSlotFields }) => {
     const [a, b] = captures;
     // Unify color domain across both slots: same visualMap min/max so a
     // cell of equal intensity reads the same color on both sides.
@@ -176,16 +174,19 @@ const sideBySideHeatmap = ({ spec, captures, anchors, toggles, chartsState, inte
     const makeSlotSpec = (cap) => {
         const timeData = cap.timeData || spec.time_data || [];
         const anchorSec = anchorSecondsFor(anchors, cap.id, timeData);
+        // Per-slot id: Chart registers itself in chartsState.charts
+        // keyed by opts.id. Without this suffix both slots collide
+        // under the same key and datazoom only dispatches to one.
+        const opts = {
+            ...spec.opts,
+            id: `${spec.opts.id || 'chart'}::${cap.id}`,
+            title: `${spec.opts.title} — ${cap.id}`,
+        };
+        if (styleOverride) opts.style = styleOverride;
         return {
             ...spec,
-            // Per-slot id: Chart registers itself in chartsState.charts
-            // keyed by opts.id. Without this suffix both slots collide
-            // under the same key and datazoom only dispatches to one.
-            opts: {
-                ...spec.opts,
-                id: `${spec.opts.id || 'chart'}::${cap.id}`,
-                title: `${spec.opts.title} — ${cap.id}`,
-            },
+            ...(extraSlotFields ? extraSlotFields(cap) : null),
+            opts,
             time_data: rebase(timeData, anchorSec),
             data: cap.heatmapData || spec.data,
             min_value: sharedMin,
@@ -201,8 +202,6 @@ const sideBySideHeatmap = ({ spec, captures, anchors, toggles, chartsState, inte
         ]),
         m(Chart, { spec: makeSlotSpec(cap), chartsState, interval }),
     ]);
-    // Both slots render their legend — with the unified color domain
-    // both display the same scale (visual symmetry).
     // scrubStaleLegend removes any diff-view legend bar that was
     // imperatively injected as a direct child of the previous wrapper
     // and survived Mithril's class-swap on the reused outer div. The
@@ -218,6 +217,15 @@ const sideBySideHeatmap = ({ spec, captures, anchors, toggles, chartsState, inte
             slot(b, 'compare-experiment-dot'),
         ]),
     };
+};
+
+const sideBySideHeatmap = ({ spec, captures, anchors, toggles, chartsState, interval, Chart }) => {
+    const chartId = spec?.opts?.id;
+    const diffMode = !!(toggles && chartId && toggles[chartId] && toggles[chartId].diff);
+    if (diffMode) {
+        return renderDiffHeatmap({ spec, captures, anchors, chartsState, interval, Chart });
+    }
+    return sideBySidePair({ spec, captures, anchors, chartsState, interval, Chart });
 };
 
 // Remove any .heatmap-legend-bar that's a DIRECT child of this wrapper
@@ -419,47 +427,11 @@ const percentileLabel = (r) => canonicalQuantileLabel(r) || 'unknown';
  * diff variant — a meaningful diff would need a per-bucket log-scale
  * divergence metric that's out of scope for this iteration.
  */
-const sideBySideHistogramHeatmap = ({ spec, captures, anchors, chartsState, interval, Chart }) => {
-    const [a, b] = captures;
-    const { min: sharedMin, max: sharedMax } = unifiedHeatmapRange(a, b, spec);
-    const makeSlotSpec = (cap) => {
-        const timeData = cap.timeData || spec.time_data || [];
-        const anchorSec = anchorSecondsFor(anchors, cap.id, timeData);
-        return {
-            ...spec,
-            opts: {
-                ...spec.opts,
-                // Per-slot id so Chart's chartsState.charts map keeps
-                // both slots registered (see sideBySideHeatmap).
-                id: `${spec.opts.id || 'chart'}::${cap.id}`,
-                title: `${spec.opts.title} — ${cap.id}`,
-                style: 'histogram_heatmap',
-            },
-            time_data: rebase(timeData, anchorSec),
-            data: cap.heatmapData || spec.data,
-            bucket_bounds: cap.bucketBounds || spec.bucket_bounds,
-            min_value: sharedMin,
-            max_value: sharedMax,
-            xAxisFormatter: relativeTimeFormatter,
-        };
-    };
-
-    const slot = (cap, dotCls) => m('div.compare-slot', [
-        m('div.compare-slot-label', [
-            m(`span.compare-dot.${dotCls}`, '\u25CF'),
-            m('span', cap.id),
-        ]),
-        m(Chart, { spec: makeSlotSpec(cap), chartsState, interval }),
-    ]);
-    return {
-        kind: 'vnode',
-        vnode: m('div.compare-heatmap-pair', {
-            oncreate: scrubStaleLegend,
-            onupdate: scrubStaleLegend,
-        }, [
-            slot(a, 'compare-baseline-dot'),
-            slot(b, 'compare-experiment-dot'),
-        ]),
-    };
-};
+const sideBySideHistogramHeatmap = (opts) => sideBySidePair({
+    ...opts,
+    styleOverride: 'histogram_heatmap',
+    extraSlotFields: (cap) => ({
+        bucket_bounds: cap.bucketBounds || opts.spec.bucket_bounds,
+    }),
+});
 

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -33,6 +33,7 @@
 import { nullDiff, intersectLabels, canonicalQuantileLabel } from './util/compare_math.js';
 import { DIVERGING_BLUE_GREEN, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
 import { resolvedStyle } from './metric_types.js';
+import { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from '../data.js';
 
 // Colors sourced from --compare-baseline / --compare-experiment in
 // style.css. The getter reads CSS custom properties lazily so a theme
@@ -107,17 +108,17 @@ const anchorSecondsFor = (anchors, id, timeDataSec) => {
  * capture is unusable — the caller can then render baseline-only.
  */
 const overlayLine = ({ spec, captures, anchors }) => {
-    const baseline = captures.find((c) => c.id === 'baseline');
-    const experiment = captures.find((c) => c.id === 'experiment');
+    const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
+    const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
     if (!baseline || !experiment) return false;
 
-    const baseSec = anchorSecondsFor(anchors, 'baseline', baseline.timeData);
-    const expSec = anchorSecondsFor(anchors, 'experiment', experiment.timeData);
+    const baseSec = anchorSecondsFor(anchors, CAPTURE_BASELINE, baseline.timeData);
+    const expSec = anchorSecondsFor(anchors, CAPTURE_EXPERIMENT, experiment.timeData);
 
     const seriesList = [];
     if (Array.isArray(baseline.timeData) && baseline.timeData.length > 0) {
         seriesList.push({
-            name: 'baseline',
+            name: CAPTURE_BASELINE,
             color: BASELINE_COLOR,
             timeData: rebase(baseline.timeData, baseSec),
             valueData: baseline.valueData || [],
@@ -126,7 +127,7 @@ const overlayLine = ({ spec, captures, anchors }) => {
     }
     if (Array.isArray(experiment.timeData) && experiment.timeData.length > 0) {
         seriesList.push({
-            name: 'experiment',
+            name: CAPTURE_EXPERIMENT,
             color: EXPERIMENT_COLOR,
             timeData: rebase(experiment.timeData, expSec),
             valueData: experiment.valueData || [],
@@ -290,7 +291,7 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
     }
 
     const timeData = (a.timeData || spec.time_data || []).slice(0, bins);
-    const baselineAnchorSec = anchorSecondsFor(anchors, 'baseline', timeData);
+    const baselineAnchorSec = anchorSecondsFor(anchors, CAPTURE_BASELINE, timeData);
 
     const isDark = typeof document !== 'undefined'
         && document.body
@@ -340,8 +341,8 @@ const splitScatterToSubgroup = ({ spec, captures, anchors }) =>
     splitIntoOverlayLines({ spec, captures, anchors, labelFor: percentileLabel });
 
 const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor }) => {
-    const baseline = captures.find((c) => c.id === 'baseline');
-    const experiment = captures.find((c) => c.id === 'experiment');
+    const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
+    const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
     if (!baseline || !experiment) return false;
 
     const mapA = baseline.seriesMap || new Map();
@@ -353,8 +354,8 @@ const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor })
     const specs = shared.map((label) => {
         const a = mapA.get(label);
         const b = mapB.get(label);
-        const baseSec = anchorSecondsFor(anchors, 'baseline', a.timeData);
-        const expSec = anchorSecondsFor(anchors, 'experiment', b.timeData);
+        const baseSec = anchorSecondsFor(anchors, CAPTURE_BASELINE, a.timeData);
+        const expSec = anchorSecondsFor(anchors, CAPTURE_EXPERIMENT, b.timeData);
         return {
             ...spec,
             opts: {
@@ -369,14 +370,14 @@ const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor })
             _splitLabel: label,
             multiSeries: [
                 {
-                    name: 'baseline',
+                    name: CAPTURE_BASELINE,
                     color: BASELINE_COLOR,
                     timeData: rebase(a.timeData, baseSec),
                     valueData: a.valueData,
                     fill: false,
                 },
                 {
-                    name: 'experiment',
+                    name: CAPTURE_EXPERIMENT,
                     color: EXPERIMENT_COLOR,
                     timeData: rebase(b.timeData, expSec),
                     valueData: b.valueData,

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -1,19 +1,27 @@
 // Compare-mode chart adapter.
 //
 // Strategies convert a normal single-capture plot spec plus two normalized
-// per-capture payloads into a rendering. Each strategy returns one of:
+// per-capture payloads into a tagged-union rendering result:
 //
-//   1. A transformed plot spec (plain object) — the caller passes it to
-//      `m(Chart, {spec, ...})` exactly like a single-capture spec. This is
-//      the overlay path, used by line charts.
+//   { kind: 'spec',     spec }    — caller renders `m(Chart, {spec, ...})`.
+//                                   Overlay path, used by line charts.
 //
-//   2. A Mithril vnode — the caller renders it directly. Used when a single
-//      chart slot becomes multiple sibling charts (side-by-side heatmaps,
-//      histogram heatmaps) or a single diff chart composed in-place.
+//   { kind: 'vnode',    vnode }   — caller renders the vnode directly.
+//                                   Used when a single chart slot becomes
+//                                   multiple sibling charts (side-by-side
+//                                   heatmaps, histogram heatmaps) or a
+//                                   single diff chart composed in-place.
 //
-//   3. An object `{ _splitSpecs: Spec[] }` — the caller iterates and wraps
-//      each spec in its own `m(Chart, ...)` sibling. Used when multi-series
-//      or percentile charts split into one sub-chart per intersected label.
+//   { kind: 'split',    specs }   — caller iterates and wraps each spec
+//                                   in its own `m(Chart, ...)` sibling.
+//                                   Used when multi-series or percentile
+//                                   charts split into one sub-chart per
+//                                   intersected label.
+//
+//   { kind: 'fallback' }          — style not handled, or the captures
+//                                   can't be combined (missing data).
+//                                   Caller falls back to single-capture
+//                                   baseline-only rendering.
 //
 // Timestamp translation, null propagation for diff math, and the label
 // intersection rule for multi/scatter are owned here. No DOM, no echarts
@@ -61,11 +69,14 @@ export const relativeTimeFormatter = (ms) => {
     return `${sign}${sec}s`;
 };
 
+// Shared fallback sentinel — tells the caller to render the baseline
+// single-capture spec instead. Frozen so no strategy can mutate it.
+const FALLBACK = Object.freeze({ kind: 'fallback' });
+
 /**
  * Dispatch on chart style and delegate to the matching strategy.
- * Returns a transformed spec, a Mithril vnode, a `{ _splitSpecs }` marker,
- * or `false` when the style is not handled (caller should fall back to
- * single-capture rendering).
+ * Returns a tagged-union result; see the module docstring above for
+ * the four kinds.
  */
 export const renderCompareChart = (opts) => {
     const style = resolvedStyle(opts.spec);
@@ -76,7 +87,7 @@ export const renderCompareChart = (opts) => {
         case 'scatter':           return splitScatterToSubgroup(opts);
         case 'histogram_heatmap': return sideBySideHistogramHeatmap(opts);
         default:
-            return false;
+            return FALLBACK;
     }
 };
 
@@ -134,12 +145,15 @@ const overlayLine = ({ spec, captures, anchors }) => {
             fill: false,
         });
     }
-    if (seriesList.length === 0) return false;
+    if (seriesList.length === 0) return FALLBACK;
 
     return {
-        ...spec,
-        multiSeries: seriesList,
-        xAxisFormatter: relativeTimeFormatter,
+        kind: 'spec',
+        spec: {
+            ...spec,
+            multiSeries: seriesList,
+            xAxisFormatter: relativeTimeFormatter,
+        },
     };
 };
 
@@ -194,13 +208,16 @@ const sideBySideHeatmap = ({ spec, captures, anchors, toggles, chartsState, inte
     // and survived Mithril's class-swap on the reused outer div. The
     // direct-child selector leaves per-slot legends (inside .compare-
     // slot) alone.
-    return m('div.compare-heatmap-pair', {
-        oncreate: scrubStaleLegend,
-        onupdate: scrubStaleLegend,
-    }, [
-        slot(a, 'compare-baseline-dot'),
-        slot(b, 'compare-experiment-dot'),
-    ]);
+    return {
+        kind: 'vnode',
+        vnode: m('div.compare-heatmap-pair', {
+            oncreate: scrubStaleLegend,
+            onupdate: scrubStaleLegend,
+        }, [
+            slot(a, 'compare-baseline-dot'),
+            slot(b, 'compare-experiment-dot'),
+        ]),
+    };
 };
 
 // Remove any .heatmap-legend-bar that's a DIRECT child of this wrapper
@@ -252,7 +269,7 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
     // Guard: diff requires both captures to provide a normalized matrix
     // (rows × time bins). The normalization step lives in the caller
     // (viewer_core). Without it, bail and fall through to no-data.
-    if (!aMatrix || !bMatrix) return false;
+    if (!aMatrix || !bMatrix) return FALLBACK;
 
     const rows = Math.min(aMatrix.length, bMatrix.length);
     const bins = Math.min(
@@ -315,11 +332,13 @@ const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Cha
     // On mount/update, scrub any stale legend bar inherited from a
     // prior side-by-side render of this same chart slot (Mithril
     // reuses the outer div across class swaps; see scrubStaleLegend).
-    return m('div.compare-heatmap-diff', {
-        oncreate: scrubStaleLegend,
-        onupdate: scrubStaleLegend,
-    },
-        m(Chart, { spec: diffSpec, chartsState, interval }));
+    return {
+        kind: 'vnode',
+        vnode: m('div.compare-heatmap-diff', {
+            oncreate: scrubStaleLegend,
+            onupdate: scrubStaleLegend,
+        }, m(Chart, { spec: diffSpec, chartsState, interval })),
+    };
 };
 
 /**
@@ -339,7 +358,7 @@ const splitScatterToSubgroup = ({ spec, captures, anchors }) =>
 const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor }) => {
     const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
     const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
-    if (!baseline || !experiment) return false;
+    if (!baseline || !experiment) return FALLBACK;
 
     const mapA = baseline.seriesMap || new Map();
     const mapB = experiment.seriesMap || new Map();
@@ -384,7 +403,7 @@ const splitIntoOverlayLines = ({ spec, captures, anchors, labelFor: _labelFor })
         };
     });
 
-    return { _splitSpecs: specs };
+    return { kind: 'split', specs };
 };
 
 const multiLabel = (r) => {
@@ -432,12 +451,15 @@ const sideBySideHistogramHeatmap = ({ spec, captures, anchors, chartsState, inte
         ]),
         m(Chart, { spec: makeSlotSpec(cap), chartsState, interval }),
     ]);
-    return m('div.compare-heatmap-pair', {
-        oncreate: scrubStaleLegend,
-        onupdate: scrubStaleLegend,
-    }, [
-        slot(a, 'compare-baseline-dot'),
-        slot(b, 'compare-experiment-dot'),
-    ]);
+    return {
+        kind: 'vnode',
+        vnode: m('div.compare-heatmap-pair', {
+            oncreate: scrubStaleLegend,
+            onupdate: scrubStaleLegend,
+        }, [
+            slot(a, 'compare-baseline-dot'),
+            slot(b, 'compare-experiment-dot'),
+        ]),
+    };
 };
 

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -10,6 +10,7 @@ import {
     applyNoData,
     getTooltipFreezeFooter,
     applyChartOption,
+    overrideXAxisFormatter,
     COLORS,
     FONTS,
 } from './base.js';
@@ -270,18 +271,8 @@ export function configureHeatmap(chart) {
 
     // Compare-mode renderers override the x-axis formatter so labels
     // read as relative offsets (`+Xs`, `+XmYs`) instead of absolute
-    // wall-clock times. When the spec sets `xAxisFormatter`, build a
-    // merged xAxis that swaps only the `axisLabel.formatter` field.
-    const customXFormatter = chart.spec.xAxisFormatter;
-    const xAxisOverride = customXFormatter
-        ? {
-            ...baseOption.xAxis,
-            axisLabel: {
-                ...(baseOption.xAxis.axisLabel || {}),
-                formatter: customXFormatter,
-            },
-        }
-        : null;
+    // wall-clock times.
+    const xAxisOverride = overrideXAxisFormatter(baseOption.xAxis, chart.spec.xAxisFormatter);
 
     const option = {
         ...baseOption,

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -114,11 +114,12 @@ export function configureHeatmap(chart) {
     // These are ordered from highest to lowest resolution. So, usage is to iterate through
     // them until one is low enough resolution.
     const nullColor = chart.spec.nullCellColor || null;
+    const cellOpacity = chart.spec.cellOpacity != null ? chart.spec.cellOpacity : 1;
     chart.downsampleCache = [];
     chart.downsampleCache.push({
         factor: 1,
         data: processedData,
-        renderItem: createRenderItemFunc(timeData, 1, nullColor),
+        renderItem: createRenderItemFunc(timeData, 1, nullColor, cellOpacity),
     });
     const originalRatioOfDataPointsToMax = xCount * yCount / MAX_DATA_POINT_DISPLAY;
 
@@ -141,7 +142,7 @@ export function configureHeatmap(chart) {
         chart.downsampleCache.push({
             factor,
             data: processedDownsampledData,
-            renderItem: createRenderItemFunc(timeData, factor, nullColor),
+            renderItem: createRenderItemFunc(timeData, factor, nullColor, cellOpacity),
         });
     }
 
@@ -361,6 +362,30 @@ export function configureHeatmap(chart) {
     minLabel.textContent = formatter(sig(visualMapMin));
     maxLabel.textContent = formatter(sig(visualMapMax));
 
+    // Diff-heatmap directional caption: two small muted labels pinned
+    // under the gradient bar's left and right ends. Keeps the numeric
+    // min/max above for magnitude; the sub-labels carry the sign.
+    const diffLabels = chart.spec.diffLegendLabels;
+    if (diffLabels) {
+        let sub = chart.domNode.querySelector('.heatmap-diff-sublabels');
+        if (!sub) {
+            sub = document.createElement('div');
+            sub.className = 'heatmap-diff-sublabels';
+            sub.style.cssText = `${FONTS.cssFootnote} position: absolute; top: 64px; right: 4px; width: 144px; display: flex; justify-content: space-between; color: ${COLORS.fgMuted}; font-size: 10px; pointer-events: none; z-index: 10;`;
+            const leftEl = document.createElement('span');
+            leftEl.className = 'heatmap-diff-sublabel-left';
+            const rightEl = document.createElement('span');
+            rightEl.className = 'heatmap-diff-sublabel-right';
+            sub.appendChild(leftEl);
+            sub.appendChild(rightEl);
+            chart.domNode.appendChild(sub);
+        }
+        sub.querySelector('.heatmap-diff-sublabel-left').textContent = diffLabels.left;
+        sub.querySelector('.heatmap-diff-sublabel-right').textContent = diffLabels.right;
+    } else {
+        chart.domNode.querySelector('.heatmap-diff-sublabels')?.remove();
+    }
+
     // When this echart's zoom level changes, pick which set of potentially downsampled data to use.
     chart.echart.on('datazoom', (event) => {
         // 'datazoom' events triggered by the user vs dispatched by us have different formats:
@@ -454,9 +479,12 @@ const zoomLevelToFactor = (zoomLevel, originalRatioOfDataPointsToMax, originalXD
  * @param {number} factor the downsampling factor
  * @param {string|null} nullColor fill color for null cells (compare-mode
  *        diff heatmaps). When null, null cells are skipped entirely.
+ * @param {number} cellOpacity 0..1 alpha applied to every painted cell.
+ *        Defaults to 1 (opaque); diff heatmap in dark mode drops to 0.6
+ *        so the diverging palette reads softer against the dark bg.
  * @returns {function} renderItem function for echarts
  */
-const createRenderItemFunc = (timeData, factor, nullColor) => {
+const createRenderItemFunc = (timeData, factor, nullColor, cellOpacity = 1) => {
     return function (params, api) {
         const x = api.value(0);
         const y = api.value(1);
@@ -487,6 +515,7 @@ const createRenderItemFunc = (timeData, factor, nullColor) => {
                     // Use the appropriate fill color from the color scale,
                     // or the configured null color for missing data.
                     fill: isNull ? nullColor : api.style().fill,
+                    opacity: cellOpacity,
                 }
             }
         );

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -345,24 +345,15 @@ export function configureHeatmap(chart) {
     applyChartOption(chart, option);
 
     // DOM legend bar: [minLabel] [colorBar] [maxLabel] in a flex row.
+    // Mounted inside chart.domNode (Chart's own Mithril-managed div) so
+    // the legend is removed with the Chart on unmount/swap — no scrubber,
+    // no palette-signature dance.
     const formatter = createAxisLabelFormatter(unitSystem || 'count');
-    const wrapper = chart.domNode.parentNode;
     const legendColorFn = chart.spec.colormap
         ? buildRampColorFn(chart.spec.colormap)
         : viridisColor;
-    // Invalidate a retained legend bar whose gradient no longer matches
-    // the current colormap (e.g. side-by-side → diff toggle).
-    const paletteSig = Array.isArray(chart.spec.colormap)
-        ? chart.spec.colormap.join(',')
-        : 'viridis';
-    const existing = wrapper.querySelector('.heatmap-legend-bar');
-    if (existing && existing.dataset.palette !== paletteSig) {
-        existing.remove();
-    }
     const barCanvas = buildGradientCanvas(legendColorFn);
-    const { minLabel, maxLabel } = ensureLegendBar(wrapper, barCanvas);
-    const bar = wrapper.querySelector('.heatmap-legend-bar');
-    if (bar) bar.dataset.palette = paletteSig;
+    const { minLabel, maxLabel } = ensureLegendBar(chart.domNode, barCanvas);
     const sig = (v) => {
         if (!Number.isFinite(v) || v === 0) return v;
         return parseFloat(v.toPrecision(2));

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -11,6 +11,7 @@ import {
     getTooltipFreezeFooter,
     applyChartOption,
     overrideXAxisFormatter,
+    CHART_GRID_TOP_WITH_LEGEND,
     COLORS,
     FONTS,
 } from './base.js';
@@ -277,7 +278,7 @@ export function configureHeatmap(chart) {
     const option = {
         ...baseOption,
         ...(xAxisOverride ? { xAxis: xAxisOverride } : {}),
-        grid: { ...baseOption.grid, top: '71' },
+        grid: { ...baseOption.grid, top: String(CHART_GRID_TOP_WITH_LEGEND) },
         yAxis,
         // Echarts has two render modes for hover effects. When number of chart elements is
         // below this threshold, it just draws the hover effect onto the same canvas.

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -383,7 +383,8 @@ export function configureHeatmap(chart) {
         ? buildRampColorFn(chart.spec.colormap)
         : viridisColor;
     const barCanvas = buildGradientCanvas(legendColorFn);
-    const { minLabel, maxLabel } = ensureLegendBar(chart.domNode, barCanvas);
+    const { minLabel, maxLabel, leftCaption, rightCaption, captionRow } =
+        ensureLegendBar(chart.domNode, barCanvas);
     const sig = (v) => {
         if (!Number.isFinite(v) || v === 0) return v;
         return parseFloat(v.toPrecision(2));
@@ -391,29 +392,18 @@ export function configureHeatmap(chart) {
     minLabel.textContent = formatter(sig(visualMapMin));
     maxLabel.textContent = formatter(sig(visualMapMax));
 
-    // Diff-heatmap directional caption: two labels pinned above the
-    // gradient bar's left and right ends. Uses fg-secondary (not muted)
-    // so the directional signal reads clearly; the numeric min/max
-    // below the bar still carry magnitude.
+    // Diff-heatmap directional caption above the gradient bar. The
+    // captions share the legend row's width, so each sits directly
+    // above its numeric counterpart (min/max label).
     const diffLabels = chart.spec.diffLegendLabels;
     if (diffLabels) {
-        let sub = chart.domNode.querySelector('.heatmap-diff-sublabels');
-        if (!sub) {
-            sub = document.createElement('div');
-            sub.className = 'heatmap-diff-sublabels';
-            sub.style.cssText = `${FONTS.cssFootnote} position: absolute; top: 32px; right: 4px; width: 144px; display: flex; justify-content: space-between; color: ${COLORS.fgSecondary}; font-size: 10px; pointer-events: none; z-index: 10;`;
-            const leftEl = document.createElement('span');
-            leftEl.className = 'heatmap-diff-sublabel-left';
-            const rightEl = document.createElement('span');
-            rightEl.className = 'heatmap-diff-sublabel-right';
-            sub.appendChild(leftEl);
-            sub.appendChild(rightEl);
-            chart.domNode.appendChild(sub);
-        }
-        sub.querySelector('.heatmap-diff-sublabel-left').textContent = diffLabels.left;
-        sub.querySelector('.heatmap-diff-sublabel-right').textContent = diffLabels.right;
+        leftCaption.textContent = diffLabels.left;
+        rightCaption.textContent = diffLabels.right;
+        captionRow.style.display = 'flex';
     } else {
-        chart.domNode.querySelector('.heatmap-diff-sublabels')?.remove();
+        leftCaption.textContent = '';
+        rightCaption.textContent = '';
+        captionRow.style.display = 'none';
     }
 
     // When this echart's zoom level changes, pick which set of potentially downsampled data to use.

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -114,12 +114,11 @@ export function configureHeatmap(chart) {
     // These are ordered from highest to lowest resolution. So, usage is to iterate through
     // them until one is low enough resolution.
     const nullColor = chart.spec.nullCellColor || null;
-    const cellOpacity = chart.spec.cellOpacity != null ? chart.spec.cellOpacity : 1;
     chart.downsampleCache = [];
     chart.downsampleCache.push({
         factor: 1,
         data: processedData,
-        renderItem: createRenderItemFunc(timeData, 1, nullColor, cellOpacity),
+        renderItem: createRenderItemFunc(timeData, 1, nullColor),
     });
     const originalRatioOfDataPointsToMax = xCount * yCount / MAX_DATA_POINT_DISPLAY;
 
@@ -142,7 +141,7 @@ export function configureHeatmap(chart) {
         chart.downsampleCache.push({
             factor,
             data: processedDownsampledData,
-            renderItem: createRenderItemFunc(timeData, factor, nullColor, cellOpacity),
+            renderItem: createRenderItemFunc(timeData, factor, nullColor),
         });
     }
 
@@ -479,12 +478,9 @@ const zoomLevelToFactor = (zoomLevel, originalRatioOfDataPointsToMax, originalXD
  * @param {number} factor the downsampling factor
  * @param {string|null} nullColor fill color for null cells (compare-mode
  *        diff heatmaps). When null, null cells are skipped entirely.
- * @param {number} cellOpacity 0..1 alpha applied to every painted cell.
- *        Defaults to 1 (opaque); diff heatmap in dark mode drops to 0.6
- *        so the diverging palette reads softer against the dark bg.
  * @returns {function} renderItem function for echarts
  */
-const createRenderItemFunc = (timeData, factor, nullColor, cellOpacity = 1) => {
+const createRenderItemFunc = (timeData, factor, nullColor) => {
     return function (params, api) {
         const x = api.value(0);
         const y = api.value(1);
@@ -515,7 +511,6 @@ const createRenderItemFunc = (timeData, factor, nullColor, cellOpacity = 1) => {
                     // Use the appropriate fill color from the color scale,
                     // or the configured null color for missing data.
                     fill: isNull ? nullColor : api.style().fill,
-                    opacity: cellOpacity,
                 }
             }
         );

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -11,6 +11,8 @@ import {
     getTooltipFreezeFooter,
     applyChartOption,
     overrideXAxisFormatter,
+    calculateMinZoomSpan,
+    getDataZoomConfig,
     CHART_GRID_TOP_WITH_LEGEND,
     COLORS,
     FONTS,
@@ -310,6 +312,11 @@ export function configureHeatmap(chart) {
         ...(xAxisOverride ? { xAxis: xAxisOverride } : {}),
         grid: { ...baseOption.grid, top: String(CHART_GRID_TOP_WITH_LEGEND) },
         yAxis,
+        // dataZoom is the component takeGlobalCursor's dataZoomSelect
+        // attaches to when the user drags a selection on the canvas.
+        // Without this, the drag does nothing on heatmaps — which was
+        // the long-standing heatmap-drag-zoom bug.
+        dataZoom: getDataZoomConfig(calculateMinZoomSpan(timeData)),
         // Echarts has two render modes for hover effects. When number of chart elements is
         // below this threshold, it just draws the hover effect onto the same canvas.
         // When above this threshold, it draws them onto a separate canvas element (zrender's

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -389,8 +389,15 @@ export function configureHeatmap(chart) {
         if (!Number.isFinite(v) || v === 0) return v;
         return parseFloat(v.toPrecision(2));
     };
-    minLabel.textContent = formatter(sig(visualMapMin));
-    maxLabel.textContent = formatter(sig(visualMapMax));
+    // Diff heatmap: the left end is "baseline higher by X"; the right
+    // end is "experiment higher by Y". The sign is already carried by
+    // the caption row, so show magnitudes (absolute values) on both
+    // ends instead of a negative number on the left.
+    const isDiff = !!chart.spec.diffLegendLabels;
+    const minForLabel = isDiff ? Math.abs(visualMapMin) : visualMapMin;
+    const maxForLabel = isDiff ? Math.abs(visualMapMax) : visualMapMax;
+    minLabel.textContent = formatter(sig(minForLabel));
+    maxLabel.textContent = formatter(sig(maxForLabel));
 
     // Diff-heatmap directional caption above the gradient bar. The
     // captions share the legend row's width, so each sits directly

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -166,6 +166,7 @@ export function configureHeatmap(chart) {
 
     // Configure tooltip with unit formatting if specified
     const customXFormatterForTooltip = chart.spec.xAxisFormatter;
+    const diffMatrices = chart.spec.diffMatrices;
     let tooltipFormatter = function (params) {
         if (params.data === undefined) {
             return '';
@@ -203,6 +204,35 @@ export function configureHeatmap(chart) {
         const fmt = unitSystem
             ? createAxisLabelFormatter(unitSystem)
             : (v) => v.toFixed(6);
+
+        // Diff heatmap: pull baseline + experiment absolute values from
+        // the side-channel matrices and render both instead of the
+        // computed delta. The delta itself is one subtraction away and
+        // the user can read it off the color already; the absolute
+        // values tell them where on the scale each capture actually sat.
+        if (diffMatrices) {
+            const bv = diffMatrices.baseline?.[cpu]?.[timeIndex];
+            const ev = diffMatrices.experiment?.[cpu]?.[timeIndex];
+            const fmtCell = (v) => (v == null || Number.isNaN(v)) ? '—' : fmt(v);
+            return `<div style="${FONTS.cssSans}">
+                        <div style="${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.fgSecondary}; margin-bottom: 8px;">
+                            ${formattedTime}
+                        </div>
+                        <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 4px;">
+                            <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
+                                CPU ${cpu}
+                            </span>
+                        </div>
+                        <div style="display: grid; grid-template-columns: max-content max-content; gap: 2px 12px; ${FONTS.cssMono} font-size: ${FONTS.tooltipValue.fontSize}px;">
+                            <span style="color: var(--compare-baseline, ${COLORS.fgSecondary});">baseline</span>
+                            <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${fmtCell(bv)}</span>
+                            <span style="color: var(--compare-experiment, ${COLORS.fgSecondary});">experiment</span>
+                            <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${fmtCell(ev)}</span>
+                        </div>
+                        ${getTooltipFreezeFooter(chart)}
+                    </div>`;
+        }
+
         const label = valueLabel ? `<span style="margin-left: 10px;">${valueLabel}: </span>` : '';
 
         const [clampedVal, rawVal] = clampToRange(value, range);

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -391,16 +391,17 @@ export function configureHeatmap(chart) {
     minLabel.textContent = formatter(sig(visualMapMin));
     maxLabel.textContent = formatter(sig(visualMapMax));
 
-    // Diff-heatmap directional caption: two small muted labels pinned
-    // under the gradient bar's left and right ends. Keeps the numeric
-    // min/max above for magnitude; the sub-labels carry the sign.
+    // Diff-heatmap directional caption: two labels pinned above the
+    // gradient bar's left and right ends. Uses fg-secondary (not muted)
+    // so the directional signal reads clearly; the numeric min/max
+    // below the bar still carry magnitude.
     const diffLabels = chart.spec.diffLegendLabels;
     if (diffLabels) {
         let sub = chart.domNode.querySelector('.heatmap-diff-sublabels');
         if (!sub) {
             sub = document.createElement('div');
             sub.className = 'heatmap-diff-sublabels';
-            sub.style.cssText = `${FONTS.cssFootnote} position: absolute; top: 64px; right: 4px; width: 144px; display: flex; justify-content: space-between; color: ${COLORS.fgMuted}; font-size: 10px; pointer-events: none; z-index: 10;`;
+            sub.style.cssText = `${FONTS.cssFootnote} position: absolute; top: 32px; right: 4px; width: 144px; display: flex; justify-content: space-between; color: ${COLORS.fgSecondary}; font-size: 10px; pointer-events: none; z-index: 10;`;
             const leftEl = document.createElement('span');
             leftEl.className = 'heatmap-diff-sublabel-left';
             const rightEl = document.createElement('span');

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -356,11 +356,11 @@ export function configureHistogramHeatmap(chart) {
     const pctMaxLabel = pctMax.toFixed(1) + '%';
 
     // DOM legend bar: [minLabel] [colorBar] [maxLabel] [checkbox] in a flex row.
-    const wrapper = chart.domNode.parentNode;
+    // Mounted inside chart.domNode so Mithril owns the legend's lifetime.
     const barCanvas = buildGradientCanvas(infernoColor);
 
     // Build the checkbox element to pass as an extra element into the shared legend bar
-    let checkboxEl = wrapper.querySelector('.heatmap-legend-bar .histogram-toggle');
+    let checkboxEl = chart.domNode.querySelector('.heatmap-legend-bar .histogram-toggle');
     const checkboxExtra = [];
     if (!checkboxEl) {
         checkboxEl = document.createElement('span');
@@ -370,7 +370,7 @@ export function configureHistogramHeatmap(chart) {
     }
 
     const { minLabel: minLabelEl, maxLabel: maxLabelEl } =
-        ensureLegendBar(wrapper, barCanvas, checkboxExtra);
+        ensureLegendBar(chart.domNode, barCanvas, checkboxExtra);
 
     const updateLabels = () => {
         const isRaw = chart.histogramDisplayMode === 'raw';

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -14,6 +14,7 @@ import {
     getDataZoomConfig,
     applyChartOption,
     TIME_AXIS_FORMATTER,
+    CHART_GRID_TOP_WITH_LEGEND,
     COLORS,
     FONTS,
 } from './base.js';
@@ -267,7 +268,7 @@ export function configureHistogramHeatmap(chart) {
         grid: {
             left: '12',
             right: '17',
-            top: '71',
+            top: String(CHART_GRID_TOP_WITH_LEGEND),
             bottom: '24',
             containLabel: true,
         },

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -13,9 +13,9 @@ import {
     calculateMinZoomSpan,
     getDataZoomConfig,
     applyChartOption,
+    buildOverlayLegendOption,
     COLORS,
 } from './base.js';
-import { FONTS } from './util/fonts.js';
 
 /**
  * Configures the Chart based on Chart.spec
@@ -136,43 +136,8 @@ export function configureLineChart(chart) {
 
     // Multi-series charts get the same legend treatment scatter uses
     // (right-aligned circle swatches, padded names, grid pushed down).
-    // This is the style the user expects for A/B overlays — no new
-    // compare-specific legend invented.
     if (seriesList.length > 1) {
-        const legendItemW = 56;
-        const names = seriesList.map((s) => s.name);
-        option.legend = {
-            show: true,
-            right: '16',
-            top: '42',
-            icon: 'circle',
-            itemWidth: 8,
-            itemHeight: 8,
-            itemGap: 0,
-            formatter: (name) => name.padEnd(6),
-            textStyle: {
-                color: COLORS.fgSecondary,
-                ...FONTS.legend,
-                width: legendItemW,
-                borderColor: 'transparent',
-                borderWidth: 1,
-                borderRadius: 3,
-                padding: [2, 4],
-            },
-            data: names.map((name) => ({
-                name,
-                itemStyle: { borderColor: 'transparent', borderWidth: 2 },
-                textStyle: {
-                    color: COLORS.fgSecondary,
-                    backgroundColor: 'transparent',
-                    borderColor: 'transparent',
-                    borderWidth: 1,
-                    borderRadius: 3,
-                    padding: [2, 4],
-                    width: legendItemW,
-                },
-            })),
-        };
+        option.legend = buildOverlayLegendOption(seriesList.map((s) => s.name));
         // Preserve user's show/hide toggles across re-renders.
         // applyChartOption uses setOption(..., {notMerge: true}), which
         // otherwise wipes echarts' internal legend.selected state on

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -14,6 +14,7 @@ import {
     getDataZoomConfig,
     applyChartOption,
     buildOverlayLegendOption,
+    overrideXAxisFormatter,
     COLORS,
 } from './base.js';
 
@@ -103,16 +104,7 @@ export function configureLineChart(chart) {
     // Compare-mode line overlays want relative-time labels (+Xs) on
     // the x-axis. Honor `spec.xAxisFormatter` if set; otherwise use
     // the base time formatter.
-    const customXFormatter = chart.spec.xAxisFormatter;
-    const xAxisOverride = customXFormatter
-        ? {
-            ...baseOption.xAxis,
-            axisLabel: {
-                ...(baseOption.xAxis.axisLabel || {}),
-                formatter: customXFormatter,
-            },
-        }
-        : null;
+    const xAxisOverride = overrideXAxisFormatter(baseOption.xAxis, chart.spec.xAxisFormatter);
 
     // TODO(compare): when `xAxisFormatter` is set we should prepend the
     // relative offset to the tooltip timestamp too. Today the tooltip

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -71,7 +71,22 @@ export function configureLineChart(chart) {
             const [v, raw] = clampToRange(s.valueData[i], range);
             return [t * 1000, v, raw];
         });
-        zipped = insertGapNulls(zipped, chart.interval);
+        // Scatter-mode series render as discrete points — no gap-nulls
+        // (they only matter for the line-connecting path).
+        if (!s.scatter) zipped = insertGapNulls(zipped, chart.interval);
+
+        if (s.scatter) {
+            return {
+                data: zipped,
+                type: 'scatter',
+                name: s.name,
+                symbol: 'circle',
+                symbolSize: 5,
+                itemStyle: { color: s.color, opacity: 0.85 },
+                emphasis: { focus: 'series' },
+                animationDuration: 0,
+            };
+        }
 
         const base = {
             data: zipped,

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -15,6 +15,7 @@ import {
     applyChartOption,
     buildOverlayLegendOption,
     overrideXAxisFormatter,
+    CHART_GRID_TOP_WITH_LEGEND,
     COLORS,
 } from './base.js';
 
@@ -140,7 +141,7 @@ export function configureLineChart(chart) {
         }
         // Push the plot grid down so the legend has room above it,
         // matching scatter's layout.
-        option.grid = { ...(baseOption.grid || {}), top: '71' };
+        option.grid = { ...(baseOption.grid || {}), top: String(CHART_GRID_TOP_WITH_LEGEND) };
     }
 
     applyChartOption(chart, option);

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -66,28 +66,45 @@ export function configureLineChart(chart) {
         seriesList[0].timeData,
     );
 
-    const echartsSeries = seriesList.map((s) => {
-        let zipped = s.timeData.map((t, i) => {
+    const echartsSeries = seriesList.flatMap((s) => {
+        const zippedRaw = s.timeData.map((t, i) => {
             const [v, raw] = clampToRange(s.valueData[i], range);
             return [t * 1000, v, raw];
         });
-        // Scatter-mode series render as discrete points — no gap-nulls
-        // (they only matter for the line-connecting path).
-        if (!s.scatter) zipped = insertGapNulls(zipped, chart.interval);
 
+        // Scatter-mode series: faded connecting line underneath + crisp
+        // dots on top, matching single-capture scatter.js's treatment of
+        // percentile series. The line is a visual guide (opacity 0.4,
+        // tooltip suppressed) so the eye follows the trend; hovering
+        // triggers only the scatter series.
         if (s.scatter) {
-            return {
-                data: zipped,
-                type: 'scatter',
-                name: s.name,
-                symbol: 'circle',
-                symbolSize: 5,
-                itemStyle: { color: s.color, opacity: 0.85 },
-                emphasis: { focus: 'series' },
-                animationDuration: 0,
-            };
+            const guideLine = insertGapNulls(zippedRaw, chart.interval);
+            return [
+                {
+                    name: s.name,
+                    type: 'line',
+                    data: guideLine,
+                    showSymbol: false,
+                    lineStyle: { color: s.color, width: 1.5, opacity: 0.4 },
+                    itemStyle: { color: s.color },
+                    tooltip: { show: false },
+                    connectNulls: false,
+                    animationDuration: 0,
+                },
+                {
+                    name: s.name,
+                    type: 'scatter',
+                    data: zippedRaw,
+                    symbol: 'circle',
+                    symbolSize: 3,
+                    itemStyle: { color: s.color },
+                    emphasis: { focus: 'series' },
+                    animationDuration: 0,
+                },
+            ];
         }
 
+        const zipped = insertGapNulls(zippedRaw, chart.interval);
         const base = {
             data: zipped,
             type: 'line',
@@ -114,7 +131,7 @@ export function configureLineChart(chart) {
                 },
             };
         }
-        return base;
+        return [base];
     });
 
     // Compare-mode line overlays want relative-time labels (+Xs) on

--- a/src/viewer/assets/lib/charts/multi.js
+++ b/src/viewer/assets/lib/charts/multi.js
@@ -13,6 +13,7 @@ import {
     getTooltipFormatter,
     applyNoData,
     applyChartOption,
+    CHART_GRID_TOP_WITH_LEGEND,
     COLORS,
     FONTS,
 } from './base.js';
@@ -121,7 +122,7 @@ export function configureMultiSeriesChart(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '71' },
+        grid: { ...baseOption.grid, top: String(CHART_GRID_TOP_WITH_LEGEND) },
         legend: {
             show: true,
             top: '42',

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -16,6 +16,7 @@ import {
     getDataZoomConfig,
     applyChartOption,
     buildOverlayLegendOption,
+    CHART_GRID_TOP_WITH_LEGEND,
     COLORS,
 } from './base.js';
 import { SCATTER_PALETTE } from './util/colormap.js';
@@ -196,7 +197,7 @@ export function configureScatterChart(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: '71' },
+        grid: { ...baseOption.grid, top: String(CHART_GRID_TOP_WITH_LEGEND) },
         legend: buildOverlayLegendOption(uniqueNamesForLayout, {
             tooltipFormatter: () => 'Click to pin, ⌘/Ctrl+click to multi-select',
         }),

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -15,8 +15,8 @@ import {
     calculateMinZoomSpan,
     getDataZoomConfig,
     applyChartOption,
+    buildOverlayLegendOption,
     COLORS,
-    FONTS,
 } from './base.js';
 import { SCATTER_PALETTE } from './util/colormap.js';
 import { DEFAULT_PERCENTILES } from './metric_types.js';
@@ -194,47 +194,12 @@ export function configureScatterChart(chart) {
         yAxisConfig = baseYAxis;
     }
 
-    // Build legend config — will be adjusted for narrow charts after first render
-    const legendItemW = 56;
-    const legendShared = {
-        show: true,
-        right: '16',
-        icon: 'circle',
-        itemWidth: 8,
-        itemHeight: 8,
-        itemGap: 0,
-        tooltip: {
-            show: true,
-            formatter: () => 'Click to pin, ⌘/Ctrl+click to multi-select',
-        },
-        formatter: (name) => name.padEnd(6),
-        textStyle: {
-            color: COLORS.fgSecondary,
-            ...FONTS.legend,
-            width: legendItemW,
-            borderColor: 'transparent',
-            borderWidth: 1,
-            borderRadius: 3,
-            padding: [2, 4],
-        },
-    };
-    const legendInitData = (names) => names.map(name => ({
-        name,
-        itemStyle: { borderColor: 'transparent', borderWidth: 2 },
-        textStyle: {
-            color: COLORS.fgSecondary,
-            backgroundColor: 'transparent',
-            borderColor: 'transparent',
-            borderWidth: 1,
-            borderRadius: 3,
-            padding: [2, 4],
-            width: legendItemW,
-        },
-    }));
     const option = {
         ...baseOption,
         grid: { ...baseOption.grid, top: '71' },
-        legend: { ...legendShared, top: '42', data: legendInitData(uniqueNamesForLayout) },
+        legend: buildOverlayLegendOption(uniqueNamesForLayout, {
+            tooltipFormatter: () => 'Click to pin, ⌘/Ctrl+click to multi-select',
+        }),
         dataZoom: getDataZoomConfig(minZoomSpan),
         yAxis: yAxisConfig,
         tooltip: {

--- a/src/viewer/assets/lib/charts/util/colormap.js
+++ b/src/viewer/assets/lib/charts/util/colormap.js
@@ -105,27 +105,33 @@ function interpolateRamp(ramp, t) {
     const idx = t * (ramp.length - 1);
     const i = Math.floor(idx);
     const f = idx - i;
-
-    if (i >= ramp.length - 1) {
-        return `rgb(${ramp[ramp.length - 1].join(',')})`;
-    }
-
-    const c0 = ramp[i];
-    const c1 = ramp[i + 1];
+    const clampIdx = Math.min(i, ramp.length - 1);
+    const c0 = ramp[clampIdx];
+    const c1 = ramp[Math.min(clampIdx + 1, ramp.length - 1)];
+    const hasAlpha = c0.length === 4;
     const r = Math.round(c0[0] + f * (c1[0] - c0[0]));
     const g = Math.round(c0[1] + f * (c1[1] - c0[1]));
     const b = Math.round(c0[2] + f * (c1[2] - c0[2]));
-
-    return `rgb(${r},${g},${b})`;
+    if (!hasAlpha) return `rgb(${r},${g},${b})`;
+    const a = c0[3] + f * (c1[3] - c0[3]);
+    return `rgba(${r},${g},${b},${a.toFixed(3)})`;
 }
 
-/** Parse a hex color array into an RGB ramp for interpolateRamp. */
-function hexToRgbRamp(colors) {
-    return colors.map(hex => [
-        parseInt(hex.slice(1, 3), 16),
-        parseInt(hex.slice(3, 5), 16),
-        parseInt(hex.slice(5, 7), 16),
-    ]);
+/**
+ * Parse a hex color array into an RGB(A) ramp for interpolateRamp.
+ * When `alphas` is supplied, its length must match `colors` — each hex
+ * stop is paired with the matching alpha, yielding rgba interpolation.
+ */
+function hexToRgbRamp(colors, alphas) {
+    return colors.map((hex, i) => {
+        const stop = [
+            parseInt(hex.slice(1, 3), 16),
+            parseInt(hex.slice(3, 5), 16),
+            parseInt(hex.slice(5, 7), 16),
+        ];
+        if (alphas) stop.push(alphas[i]);
+        return stop;
+    });
 }
 
 /** Viridis hex ramp (darkest stops removed for visibility on dark bg) */
@@ -176,6 +182,19 @@ export const DIVERGING_BLUE_GREEN = [
     '#CFEBD7', '#9ED6B2', '#5FBD83', '#00C46A',
 ];
 
+/**
+ * V-shaped alpha curve matched to DIVERGING_BLUE_GREEN's 9 stops.
+ * Neutral sits at 0.1 so cells near zero-diff fade into whatever
+ * background they're painted against (white on light theme, near-black
+ * on dark theme). Extremes ramp to 0.9 so the interesting values stay
+ * saturated and demand attention.
+ */
+export const DIVERGING_BLUE_GREEN_ALPHA_V = [
+    0.9, 0.7, 0.5, 0.3,
+    0.1,
+    0.3, 0.5, 0.7, 0.9,
+];
+
 /** Theme-aware null cell color for diff heatmaps — distinct from zero. */
 export const NULL_CELL_COLOR_DARK = 'rgba(255,255,255,0.04)';
 export const NULL_CELL_COLOR_LIGHT = 'rgba(0,0,0,0.04)';
@@ -206,11 +225,11 @@ export function nullCellColor(isDark) {
  * @param {number} [sampleCount] - number of output stops (defaults to 21).
  * @returns {string[]} resampled hex/rgb color array for echarts `inRange.color`.
  */
-export function resampleDivergingForRange(palette, min, max, sampleCount = 21) {
+export function resampleDivergingForRange(palette, min, max, sampleCount = 21, alphas) {
     if (!Array.isArray(palette) || palette.length === 0 || !(max > min)) {
         return palette;
     }
-    const ramp = hexToRgbRamp(palette);
+    const ramp = hexToRgbRamp(palette, alphas);
     const clamp = (t) => Math.max(0, Math.min(1, t));
     // Map value to the palette's native t in [0,1]:
     //   min >= 0  → only the upper half of the palette (neutral..green)

--- a/src/viewer/assets/lib/charts/util/colormap.js
+++ b/src/viewer/assets/lib/charts/util/colormap.js
@@ -190,9 +190,9 @@ export const DIVERGING_BLUE_GREEN = [
  * saturated and demand attention.
  */
 export const DIVERGING_BLUE_GREEN_ALPHA_V = [
-    0.9, 0.7, 0.5, 0.3,
-    0.1,
-    0.3, 0.5, 0.7, 0.9,
+    0.9, 0.8, 0.7, 0.6,
+    0.5,
+    0.6, 0.7, 0.8, 0.9,
 ];
 
 /** Theme-aware null cell color for diff heatmaps — distinct from zero. */

--- a/src/viewer/assets/lib/charts/util/colormap.js
+++ b/src/viewer/assets/lib/charts/util/colormap.js
@@ -105,33 +105,27 @@ function interpolateRamp(ramp, t) {
     const idx = t * (ramp.length - 1);
     const i = Math.floor(idx);
     const f = idx - i;
-    const clampIdx = Math.min(i, ramp.length - 1);
-    const c0 = ramp[clampIdx];
-    const c1 = ramp[Math.min(clampIdx + 1, ramp.length - 1)];
-    const hasAlpha = c0.length === 4;
+
+    if (i >= ramp.length - 1) {
+        return `rgb(${ramp[ramp.length - 1].join(',')})`;
+    }
+
+    const c0 = ramp[i];
+    const c1 = ramp[i + 1];
     const r = Math.round(c0[0] + f * (c1[0] - c0[0]));
     const g = Math.round(c0[1] + f * (c1[1] - c0[1]));
     const b = Math.round(c0[2] + f * (c1[2] - c0[2]));
-    if (!hasAlpha) return `rgb(${r},${g},${b})`;
-    const a = c0[3] + f * (c1[3] - c0[3]);
-    return `rgba(${r},${g},${b},${a.toFixed(3)})`;
+
+    return `rgb(${r},${g},${b})`;
 }
 
-/**
- * Parse a hex color array into an RGB(A) ramp for interpolateRamp.
- * When `alphas` is supplied, its length must match `colors` — each hex
- * stop is paired with the matching alpha, yielding rgba interpolation.
- */
-function hexToRgbRamp(colors, alphas) {
-    return colors.map((hex, i) => {
-        const stop = [
-            parseInt(hex.slice(1, 3), 16),
-            parseInt(hex.slice(3, 5), 16),
-            parseInt(hex.slice(5, 7), 16),
-        ];
-        if (alphas) stop.push(alphas[i]);
-        return stop;
-    });
+/** Parse a hex color array into an RGB ramp for interpolateRamp. */
+function hexToRgbRamp(colors) {
+    return colors.map(hex => [
+        parseInt(hex.slice(1, 3), 16),
+        parseInt(hex.slice(3, 5), 16),
+        parseInt(hex.slice(5, 7), 16),
+    ]);
 }
 
 /** Viridis hex ramp (darkest stops removed for visibility on dark bg) */
@@ -183,16 +177,21 @@ export const DIVERGING_BLUE_GREEN = [
 ];
 
 /**
- * V-shaped alpha curve matched to DIVERGING_BLUE_GREEN's 9 stops.
- * Neutral sits at 0.1 so cells near zero-diff fade into whatever
- * background they're painted against (white on light theme, near-black
- * on dark theme). Extremes ramp to 0.9 so the interesting values stay
- * saturated and demand attention.
+ * Dark-theme sibling of DIVERGING_BLUE_GREEN. Same extreme hues so the
+ * "blue == baseline higher, green == experiment higher" signal is
+ * consistent across themes. Mid stops are interpolated toward the dark
+ * card-bg neutral so near-zero cells fade into the canvas without
+ * needing per-stop alpha (which dilutes toward whatever happens to be
+ * behind the canvas, not toward the perceptual neutral).
+ *
+ * Derivation: RGB-linear interpolation from each extreme toward
+ * `#1C2128` (--bg-elevated) at 25%/50%/75% steps. The extreme stops
+ * (0 and 8) are unchanged so saturated outliers stay vivid.
  */
-export const DIVERGING_BLUE_GREEN_ALPHA_V = [
-    0.9, 0.8, 0.7, 0.6,
-    0.5,
-    0.6, 0.7, 0.8, 0.9,
+export const DIVERGING_BLUE_GREEN_DARK = [
+    '#2E5BFF', '#294DC9', '#253E94', '#202F5E',
+    '#1C2128',
+    '#154A39', '#0E7249', '#079B5A', '#00C46A',
 ];
 
 /** Theme-aware null cell color for diff heatmaps — distinct from zero. */
@@ -225,11 +224,11 @@ export function nullCellColor(isDark) {
  * @param {number} [sampleCount] - number of output stops (defaults to 21).
  * @returns {string[]} resampled hex/rgb color array for echarts `inRange.color`.
  */
-export function resampleDivergingForRange(palette, min, max, sampleCount = 21, alphas) {
+export function resampleDivergingForRange(palette, min, max, sampleCount = 21) {
     if (!Array.isArray(palette) || palette.length === 0 || !(max > min)) {
         return palette;
     }
-    const ramp = hexToRgbRamp(palette, alphas);
+    const ramp = hexToRgbRamp(palette);
     const clamp = (t) => Math.max(0, Math.min(1, t));
     // Map value to the palette's native t in [0,1]:
     //   min >= 0  → only the upper half of the palette (neutral..green)

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -14,3 +14,30 @@ export const intersectLabels = (setA, setB) => {
     for (const x of setA) if (setB.has(x)) out.add(x);
     return out;
 };
+
+// Canonicalize a histogram quantile into the shared "pXX" label form.
+// Accepts either a raw value (number or string like "0.5", "50", "p99")
+// or an object with .metric carrying percentile/quantile labels, and
+// returns either a canonical label or null when it can't be parsed.
+// metriken_query emits `percentile` as a fraction; legacy sources may
+// use `quantile`; either fraction (<=1) or percent form is accepted.
+export const canonicalQuantileLabel = (input) => {
+    let raw = input;
+    if (input && typeof input === 'object') {
+        const mm = input.metric || input;
+        raw = mm.percentile != null ? mm.percentile : mm.quantile;
+        if (raw == null) {
+            for (const [k, v] of Object.entries(mm)) {
+                if (k !== '__name__') { raw = v; break; }
+            }
+        }
+    }
+    if (typeof raw === 'string') {
+        const m = raw.match(/^p?(\d+(?:\.\d+)?)$/);
+        if (m) raw = m[1];
+    }
+    const q = Number(raw);
+    if (!Number.isFinite(q)) return null;
+    const pct = q <= 1 ? q * 100 : q;
+    return `p${pct.toFixed(2).replace(/\.?0+$/, '')}`;
+};

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -130,6 +130,88 @@ const substituteCgroupPattern = (query, pattern) => {
     return query;
 };
 
+// ── PromQL result → plot-data shape helpers (pure) ───────────────────
+// These are the same transforms the baseline path (applyResultToPlot)
+// and the compare path (extractExperimentCapture in viewer_core) apply.
+// Extracted so the two callers can't drift.
+
+const parseNumeric = (v) => {
+    if (v === null || v === undefined) return null;
+    const n = typeof v === 'number' ? v : Number(v);
+    return Number.isNaN(n) ? null : n;
+};
+
+// Convert `result.data.result` (a PromQL range-query series array) into
+// a flat [timeIdx, y, value] triple table plus the sorted timestamps.
+// `y` is parsed from `item.metric.id` when present, else the series
+// index. Missing/NaN values are preserved as null so null-cell paths
+// can paint them. Returns null-valued min/max when no numeric samples.
+export const promqlResultToHeatmapTriples = (results) => {
+    const timeSet = new Set();
+    for (const item of results) {
+        for (const [ts] of item.values || []) timeSet.add(ts);
+    }
+    const timestamps = Array.from(timeSet).sort((a, b) => a - b);
+    const timestampToIndex = new Map();
+    timestamps.forEach((ts, idx) => timestampToIndex.set(ts, idx));
+
+    const triples = [];
+    let minValue = Infinity;
+    let maxValue = -Infinity;
+    results.forEach((item, idx) => {
+        let y = idx;
+        if (item.metric && item.metric.id != null) {
+            const parsed = parseInt(item.metric.id, 10);
+            if (!Number.isNaN(parsed)) y = parsed;
+        }
+        for (const [ts, rawVal] of item.values || []) {
+            const ti = timestampToIndex.get(ts);
+            if (ti === undefined) continue;
+            const v = parseNumeric(rawVal);
+            if (v != null) {
+                if (v < minValue) minValue = v;
+                if (v > maxValue) maxValue = v;
+            }
+            triples.push([ti, y, v]);
+        }
+    });
+    return {
+        timestamps,
+        triples,
+        minValue: Number.isFinite(minValue) ? minValue : null,
+        maxValue: Number.isFinite(maxValue) ? maxValue : null,
+    };
+};
+
+// Convert the first series in a PromQL range-query result into a pair
+// of parallel timeData / valueData arrays. Missing/NaN values are
+// preserved as null.
+export const promqlResultToLinePair = (results) => {
+    const first = results[0];
+    const values = Array.isArray(first?.values) ? first.values : [];
+    return {
+        timeData: values.map((pair) => Number(pair[0])),
+        valueData: values.map((pair) => parseNumeric(pair[1])),
+    };
+};
+
+// Build a Map<label, {timeData, valueData}> from a PromQL range-query
+// result. `labelFor(item, idx)` picks the series label; returning null
+// skips the series.
+export const promqlResultToSeriesMap = (results, labelFor) => {
+    const map = new Map();
+    results.forEach((item, idx) => {
+        const label = labelFor(item, idx);
+        if (label == null) return;
+        const values = Array.isArray(item.values) ? item.values : [];
+        map.set(String(label), {
+            timeData: values.map((pair) => Number(pair[0])),
+            valueData: values.map((pair) => parseNumeric(pair[1])),
+        });
+    });
+    return map;
+};
+
 const applyResultToPlot = (plot, result) => {
     if (
         result.status === 'success' &&
@@ -154,48 +236,12 @@ const applyResultToPlot = (plot, result) => {
 
         if (hasMultipleSeries) {
             if (style === 'heatmap') {
-                const heatmapData = [];
-                const timeSet = new Set();
-
-                result.data.result.forEach((item) => {
-                    if (item.values && Array.isArray(item.values)) {
-                        item.values.forEach(([timestamp, _]) => {
-                            timeSet.add(timestamp);
-                        });
-                    }
-                });
-
-                const timestamps = Array.from(timeSet).sort((a, b) => a - b);
-                const timestampToIndex = new Map();
-                timestamps.forEach((ts, idx) => {
-                    timestampToIndex.set(ts, idx);
-                });
-
-                result.data.result.forEach((item, idx) => {
-                    if (item.values && Array.isArray(item.values)) {
-                        let cpuId = idx;
-                        if (item.metric && item.metric.id) {
-                            cpuId = parseInt(item.metric.id);
-                        }
-
-                        item.values.forEach(([timestamp, value]) => {
-                            const timeIndex = timestampToIndex.get(timestamp);
-                            heatmapData.push([timeIndex, cpuId, parseFloat(value)]);
-                        });
-                    }
-                });
-
-                let minValue = Infinity;
-                let maxValue = -Infinity;
-                heatmapData.forEach(([_, __, value]) => {
-                    minValue = Math.min(minValue, value);
-                    maxValue = Math.max(maxValue, value);
-                });
-
-                plot.data = heatmapData;
+                const { timestamps, triples, minValue, maxValue } =
+                    promqlResultToHeatmapTriples(result.data.result);
+                plot.data = triples;
                 plot.time_data = timestamps;
-                plot.min_value = minValue;
-                plot.max_value = maxValue;
+                plot.min_value = minValue != null ? minValue : Infinity;
+                plot.max_value = maxValue != null ? maxValue : -Infinity;
             } else {
                 const allData = [];
                 const seriesNames = [];

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -293,8 +293,11 @@ const createDataApi = ({
     //   sectionRoute       — route string, used for the service/node rule.
     //   activeCgroupPattern — resolved cgroup selector, if any.
     //   serviceName        — section's service_name, if any.
-    //   injectNodeLabel    — default true; compare path passes false.
-    //   injectInstanceLabel — default true; compare path passes false.
+    //   crossCapture       — default false. When true, skip BOTH node and
+    //                        instance label injection. Compare path sets
+    //                        this because the experiment capture's
+    //                        topology is independent of the baseline's,
+    //                        and the injected labels would mis-target.
     //   stepOverride       — nullable; when > 1 triggers histogram-stride /
     //                        counter-rate rewriting. Defaults to the
     //                        module-level _stepOverride.
@@ -304,10 +307,10 @@ const createDataApi = ({
             sectionRoute = null,
             activeCgroupPattern = null,
             serviceName = null,
-            injectNodeLabel = true,
-            injectInstanceLabel = true,
+            crossCapture = false,
             stepOverride = _stepOverride,
         } = opts;
+        const injectTopologyLabels = !crossCapture;
 
         let q = plot.promql_query;
         const stepActive = stepOverride && stepOverride > 1;
@@ -330,10 +333,10 @@ const createDataApi = ({
                 return null;
             }
         }
-        if (injectNodeLabel && _selectedNode && sectionRoute && !sectionRoute.startsWith('/service/')) {
+        if (injectTopologyLabels && _selectedNode && sectionRoute && !sectionRoute.startsWith('/service/')) {
             q = injectLabel(q, 'node', _selectedNode);
         }
-        if (injectInstanceLabel && serviceName) {
+        if (injectTopologyLabels && serviceName) {
             const inst = _selectedInstances[serviceName];
             if (inst) q = injectLabel(q, 'instance', inst);
         }

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -2,6 +2,11 @@ import { ViewerApi } from './viewer_api.js';
 import { resolveStyle, buildHistogramQuery, isHistogramPlot } from './charts/metric_types.js';
 import { collectGroupPlots } from './group_utils.js';
 
+// Capture-id constants. Typos become grep-able; use these in place of
+// raw 'baseline' / 'experiment' string literals.
+export const CAPTURE_BASELINE = 'baseline';
+export const CAPTURE_EXPERIMENT = 'experiment';
+
 let _stepOverride = null;
 const setStepOverride = (step) => { _stepOverride = step; };
 const getStepOverride = () => _stepOverride;

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -12,6 +12,24 @@ const formatSize = (bytes) => {
     return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
 };
 
+// Shared 14px upload arrow used by every Load-parquet trigger (topnav
+// Load Parquet, Load Report, compare badge per-capture Load buttons).
+export const UPLOAD_ICON_SVG = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 2v8m0-8l-3 3m3-3l3 3"/></svg>';
+
+// Open a one-shot hidden <input type=file> and forward the selected
+// file to the caller's onPick. Returns an onclick handler so the site
+// can wire it directly to a button.
+export const openParquetPicker = (onPick) => () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.parquet,application/octet-stream';
+    input.onchange = async () => {
+        const file = input.files && input.files[0];
+        if (file && onPick) await onPick(file);
+    };
+    input.click();
+};
+
 // Mobile sidebar drawer state
 let sidebarOpen = false;
 
@@ -39,16 +57,6 @@ const TopNav = {
             // filenames stay visible so the user can see which captures
             // are being compared.
             compareMode && (() => {
-                const pickFile = (onPick) => () => {
-                    const input = document.createElement('input');
-                    input.type = 'file';
-                    input.accept = '.parquet,application/octet-stream';
-                    input.onchange = async () => {
-                        const f = input.files && input.files[0];
-                        if (f) await onPick(f);
-                    };
-                    input.click();
-                };
                 const row = (cls, label, fname, onLoad) => m('div.compare-capture', [
                     m(`span.compare-dot.${cls}`, '\u25CF'),
                     m('span.compare-capture-label', label),
@@ -56,9 +64,9 @@ const TopNav = {
                         title: fname || 'No file loaded',
                     }, fname || '—'),
                     onLoad && m(`button.compare-load.${cls}`, {
-                        onclick: pickFile(onLoad),
+                        onclick: openParquetPicker(onLoad),
                         title: `Replace ${label} parquet`,
-                    }, m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 2v8m0-8l-3 3m3-3l3 3"/></svg>')),
+                    }, m.trust(UPLOAD_ICON_SVG)),
                 ]);
                 // <details> wraps both views: on wide viewports CSS hides
                 // the <summary> and always renders the rows inline (via
@@ -112,22 +120,11 @@ const TopNav = {
                 // Hidden in compare mode — use the per-capture Load buttons
                 // in the compare badge instead.
                 attrs.onUploadParquet && !liveMode && !compareMode && m('button.transport-btn.import-btn', {
-                    onclick: () => {
-                        const input = document.createElement('input');
-                        input.type = 'file';
-                        input.accept = '.parquet,application/octet-stream';
-                        input.onchange = async () => {
-                            const file = input.files && input.files[0];
-                            if (file && attrs.onUploadParquet) {
-                                await attrs.onUploadParquet(file);
-                            }
-                        };
-                        input.click();
-                    },
+                    onclick: openParquetPicker(attrs.onUploadParquet),
                     title: 'Upload parquet file',
                 }, [
                     m('span', 'Load Parquet'),
-                    m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 2v8m0-8l-3 3m3-3l3 3"/></svg>'),
+                    m.trust(UPLOAD_ICON_SVG),
                 ]),
                 // Import report JSON (server viewer only). Hidden in
                 // compare mode — reports are single-capture today.
@@ -142,7 +139,7 @@ const TopNav = {
                         : 'Load a parquet file first',
                 }, [
                     m('span', 'Load Report'),
-                    m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 2v8m0-8l-3 3m3-3l3 3"/></svg>'),
+                    m.trust(UPLOAD_ICON_SVG),
                 ]),
                 // Transport controls (live mode only)
                 liveMode && m('div.transport-controls', [

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -260,6 +260,7 @@ const bootstrap = async () => {
     let experimentSystemInfo = null;
     let experimentFileMetadata = null;
     let experimentFilename = null;
+    let experimentQueryRange = null;
     if (compareMode) {
         const [sysinfo, fileMeta, expMeta] = await Promise.all([
             ViewerApi.getSystemInfo(CAPTURE_EXPERIMENT).catch(() => null),
@@ -269,6 +270,20 @@ const bootstrap = async () => {
         experimentSystemInfo = sysinfo;
         experimentFileMetadata = fileMeta;
         experimentFilename = expMeta?.data?.filename || null;
+        const data = expMeta?.data ?? expMeta;
+        const minT = data?.minTime ?? data?.min_time ?? data?.start_time;
+        const maxT = data?.maxTime ?? data?.max_time ?? data?.end_time;
+        if (minT != null && maxT != null) {
+            const start = Number(minT);
+            const end = Number(maxT);
+            if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+                experimentQueryRange = {
+                    start,
+                    end,
+                    step: Math.max(1, Math.floor((end - start) / 500)),
+                };
+            }
+        }
     }
 
     initDashboard({
@@ -281,6 +296,7 @@ const bootstrap = async () => {
         experimentSystemInfo,
         experimentFileMetadata,
         experimentFilename,
+        experimentQueryRange,
         recording: true,
         onStartRecording: startRecording,
         onStopRecording: stopRecording,

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -261,14 +261,14 @@ const bootstrap = async () => {
     let experimentFileMetadata = null;
     let experimentFilename = null;
     if (compareMode) {
-        try { experimentSystemInfo = await ViewerApi.getSystemInfo('experiment'); }
-        catch (_) { /* optional */ }
-        try { experimentFileMetadata = await ViewerApi.getFileMetadata('experiment'); }
-        catch (_) { /* optional */ }
-        try {
-            const expMeta = await ViewerApi.getMetadata('experiment');
-            experimentFilename = expMeta?.data?.filename || null;
-        } catch (_) { /* optional */ }
+        const [sysinfo, fileMeta, expMeta] = await Promise.all([
+            ViewerApi.getSystemInfo('experiment').catch(() => null),
+            ViewerApi.getFileMetadata('experiment').catch(() => null),
+            ViewerApi.getMetadata('experiment').catch(() => null),
+        ]);
+        experimentSystemInfo = sysinfo;
+        experimentFileMetadata = fileMeta;
+        experimentFilename = expMeta?.data?.filename || null;
     }
 
     initDashboard({

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -6,7 +6,7 @@ import { ViewerApi } from './viewer_api.js';
 import { FileUpload, CompareLanding } from './landing.js';
 import { notify, showSaveModal } from './overlays.js';
 import { setStorageScope, loadPayloadIntoStore, reportStore, clearStore } from './selection.js';
-import { clearMetadataCache, processDashboardData } from './data.js';
+import { clearMetadataCache, processDashboardData, CAPTURE_EXPERIMENT } from './data.js';
 import { initDashboard, sectionResponseCache, clearViewerCaches, chartsState, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, preloadSections } from './app.js';
 
 // ── Backend state fetching ─────────────────────────────────────────
@@ -262,9 +262,9 @@ const bootstrap = async () => {
     let experimentFilename = null;
     if (compareMode) {
         const [sysinfo, fileMeta, expMeta] = await Promise.all([
-            ViewerApi.getSystemInfo('experiment').catch(() => null),
-            ViewerApi.getFileMetadata('experiment').catch(() => null),
-            ViewerApi.getMetadata('experiment').catch(() => null),
+            ViewerApi.getSystemInfo(CAPTURE_EXPERIMENT).catch(() => null),
+            ViewerApi.getFileMetadata(CAPTURE_EXPERIMENT).catch(() => null),
+            ViewerApi.getMetadata(CAPTURE_EXPERIMENT).catch(() => null),
         ]);
         experimentSystemInfo = sysinfo;
         experimentFileMetadata = fileMeta;

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -3,7 +3,7 @@
 // Report: loaded from JSON import or parquet metadata (read-only mode).
 
 import { ChartsState, Chart } from './charts/chart.js';
-import { executePromQLRangeQuery, applyResultToPlot } from './data.js';
+import { executePromQLRangeQuery, applyResultToPlot, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from './data.js';
 import { notify, showSaveModal } from './overlays.js';
 import { isHistogramPlot } from './charts/metric_types.js';
 import { migrateSelection, SELECTION_SCHEMA_VERSION } from './selection_migration.js';
@@ -160,7 +160,7 @@ const persistSelection = () => persistStore(SELECTION_STORAGE_KEY, selectionStor
  * `experiment` keys are recognized. Persists + triggers a redraw.
  */
 const setAnchor = (captureId, ms) => {
-    if (captureId !== 'baseline' && captureId !== 'experiment') return;
+    if (captureId !== CAPTURE_BASELINE && captureId !== CAPTURE_EXPERIMENT) return;
     if (!selectionStore.anchors) selectionStore.anchors = { baseline: 0, experiment: 0 };
     selectionStore.anchors[captureId] = Number(ms) || 0;
     persistSelection();

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -3200,7 +3200,7 @@ main {
     left: 12px;
     font-size: 12px;
     font-weight: 600;
-    color: var(--fg-secondary, #444);
+    color: var(--fg-secondary);
     letter-spacing: 0.02em;
     pointer-events: none;
     z-index: 1;
@@ -3242,7 +3242,7 @@ main {
     left: 12px;
     font-size: 12px;
     font-weight: 600;
-    color: var(--fg-secondary, #444);
+    color: var(--fg-secondary);
     letter-spacing: 0.02em;
     font-variant-numeric: tabular-nums;
     pointer-events: none;
@@ -3354,11 +3354,11 @@ main {
 }
 .compare-badge .compare-capture + .compare-capture {
     padding-left: 12px;
-    border-left: 1px solid var(--border, rgba(0, 0, 0, 0.12));
+    border-left: 1px solid var(--border-subtle);
 }
 .compare-badge .compare-dot { font-size: 10px; line-height: 1; }
 .compare-badge .compare-capture-label {
-    color: var(--fg-muted, #888);
+    color: var(--fg-muted);
     letter-spacing: 0.02em;
 }
 .compare-badge .compare-capture-name {
@@ -3382,7 +3382,7 @@ main {
 }
 .compare-badge .compare-load svg { display: block; }
 .compare-badge .compare-load:hover {
-    background: var(--bg-hover, rgba(0, 0, 0, 0.05));
+    background: var(--bg-card-hover);
 }
 
 /* Narrow-viewport layout: collapse the badge into a dot-only trigger,
@@ -3415,8 +3415,8 @@ main {
         align-items: stretch;
         gap: 8px;
         padding: 10px 12px;
-        background: var(--bg-card, var(--bg-tertiary));
-        border: 1px solid var(--border, rgba(0, 0, 0, 0.12));
+        background: var(--bg-card);
+        border: 1px solid var(--border-subtle);
         border-radius: 6px;
         box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
         z-index: 50;
@@ -3436,7 +3436,7 @@ main {
     .compare-badge[open] .compare-capture + .compare-capture {
         padding-left: 0;
         border-left: none;
-        border-top: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+        border-top: 1px solid var(--border-subtle);
         padding-top: 8px;
     }
     .compare-badge[open] .compare-capture-name {
@@ -3476,7 +3476,7 @@ main {
     margin: 0;
     text-align: center;
     font-size: 14px;
-    color: var(--fg-muted, #888);
+    color: var(--fg-muted);
 }
 .landing-dual .upload-dropzone.disabled {
     opacity: 0.6;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -3190,7 +3190,11 @@ main {
 }
 /* Pin the baseline/experiment label just above the heatmap canvas —
  * same treatment as the percentile split label, so it sits above the
- * Y-axis tick labels rather than at the very top of the slot. */
+ * Y-axis tick labels rather than at the very top of the slot.
+ *
+ * `top: 44px` sits inside the chart's header band (44px = chart header
+ * height). The echarts grid starts at 71px (CHART_GRID_TOP_WITH_LEGEND
+ * in charts/base.js); if that constant moves, this value moves too. */
 .compare-heatmap-pair .compare-slot-label {
     display: inline-flex;
     align-items: center;

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -12,19 +12,22 @@ const backendRequest = (opts) => m.request({
 
 const sectionUrl = (section) => `/data/${section}.json`;
 
+// Return '?capture=<id>' for non-baseline captures, '' otherwise. The
+// backend treats the absence of the param as "baseline".
+const captureQS = (captureId) =>
+    (captureId && captureId !== 'baseline') ? `?capture=${captureId}` : '';
+
 const ViewerApi = {
     async getMode() {
         return backendRequest({ method: 'GET', url: '/api/v1/mode' });
     },
 
     async getMetadata(captureId = 'baseline') {
-        const q = captureId === 'experiment' ? '?capture=experiment' : '';
-        return backendRequest({ method: 'GET', url: `/api/v1/metadata${q}` });
+        return backendRequest({ method: 'GET', url: `/api/v1/metadata${captureQS(captureId)}` });
     },
 
     async getSystemInfo(captureId = 'baseline') {
-        const q = captureId === 'experiment' ? '?capture=experiment' : '';
-        return backendRequest({ method: 'GET', url: `/api/v1/systeminfo${q}` });
+        return backendRequest({ method: 'GET', url: `/api/v1/systeminfo${captureQS(captureId)}` });
     },
 
     async getSelection() {
@@ -32,8 +35,7 @@ const ViewerApi = {
     },
 
     async getFileMetadata(captureId = 'baseline') {
-        const q = captureId === 'experiment' ? '?capture=experiment' : '';
-        return backendRequest({ method: 'GET', url: `/api/v1/file_metadata${q}` });
+        return backendRequest({ method: 'GET', url: `/api/v1/file_metadata${captureQS(captureId)}` });
     },
 
     async reset() {

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -259,35 +259,35 @@ const CompareChartWrapper = {
             vnode.state.error = 'compare: query skipped (unresolved cgroup pattern)';
             return;
         }
-        // Query the experiment over its own time range. `getFileMetadata`
-        // returns start/end/duration for the specified capture; fall
-        // back to a wide default when unavailable.
+        // Query the experiment over its own time range. The compare-mode
+        // bootstrap cached {start, end, step} at attach time; fall back
+        // to a one-off metadata fetch only if the cache is missing
+        // (e.g. legacy entry paths that don't thread it through).
         (async () => {
             try {
-                let start = 0;
-                let end = 0;
-                let step = vnode.attrs.step || 1;
-                // /api/v1/metadata returns minTime/maxTime in SECONDS (PromQL
-                // native format, same as plot.data[0] timestamps). Do not
-                // divide by 1000.
-                try {
-                    const meta = await ViewerApi.getMetadata(CAPTURE_EXPERIMENT);
-                    const data = meta?.data ?? meta;
-                    const minT = data?.minTime ?? data?.min_time ?? data?.start_time;
-                    const maxT = data?.maxTime ?? data?.max_time ?? data?.end_time;
-                    if (minT != null && maxT != null) {
-                        start = Number(minT);
-                        end = Number(maxT);
-                        const dur = Math.max(1, end - start);
-                        if (!step || step <= 0) step = Math.max(1, Math.floor(dur / 500));
-                    }
-                } catch (_) { /* best effort; fall through to request anyway */ }
-                if (end <= start) {
+                let range = vnode.attrs.experimentQueryRange;
+                if (!range) {
+                    try {
+                        const meta = await ViewerApi.getMetadata(CAPTURE_EXPERIMENT);
+                        const data = meta?.data ?? meta;
+                        const minT = data?.minTime ?? data?.min_time ?? data?.start_time;
+                        const maxT = data?.maxTime ?? data?.max_time ?? data?.end_time;
+                        if (minT != null && maxT != null) {
+                            const start = Number(minT);
+                            const end = Number(maxT);
+                            if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+                                range = { start, end, step: Math.max(1, Math.floor((end - start) / 500)) };
+                            }
+                        }
+                    } catch (_) { /* best effort */ }
+                }
+                if (!range) {
                     vnode.state.error = 'experiment metadata missing time range';
                     m.redraw();
                     return;
                 }
-                const res = await queryRangeForCapture(CAPTURE_EXPERIMENT, query, start, end, step);
+                const step = vnode.attrs.step && vnode.attrs.step > 0 ? vnode.attrs.step : range.step;
+                const res = await queryRangeForCapture(CAPTURE_EXPERIMENT, query, range.start, range.end, step);
                 vnode.state.experimentResult = res;
                 m.redraw();
             } catch (e) {
@@ -370,7 +370,7 @@ export function createGroupComponent(getState) {
             const state = getState();
             const {
                 chartsState, heatmapEnabled, heatmapLoading, heatmapDataCache,
-                compareMode, toggles, setChartToggle, anchors,
+                compareMode, toggles, setChartToggle, anchors, experimentQueryRange,
             } = state;
             const sectionRoute = attrs.sectionRoute;
             const sectionName = attrs.sectionName;
@@ -441,6 +441,7 @@ export function createGroupComponent(getState) {
                                 setChartToggle,
                                 sectionRoute,
                                 step: interval,
+                                experimentQueryRange,
                             })
                             : m(Chart, { spec: heatmapSpec, chartsState, interval }),
                         expandLink(spec, sectionRoute),
@@ -462,6 +463,7 @@ export function createGroupComponent(getState) {
                             setChartToggle,
                             sectionRoute,
                             step: interval,
+                            experimentQueryRange,
                         }),
                         expandLink(spec, sectionRoute),
                         selectButton(spec, sectionRoute, sectionName),

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -307,8 +307,21 @@ const CompareChartWrapper = {
             return m('div.chart-loading', 'Loading experiment\u2026');
         }
 
-        const baselineCap = extractBaselineCapture(spec);
-        const experimentCap = extractExperimentCapture(spec, vnode.state.experimentResult);
+        // Memoize both captures on vnode.state keyed by spec.data /
+        // experimentResult identity. Each extractor walks the raw data
+        // (heatmap extract does an O(rows×bins) normalize), and nothing
+        // else mutates spec.data or experimentResult between redraws —
+        // tooltip/hover/zoom just re-run view() with the same inputs.
+        if (vnode.state._capData !== spec.data) {
+            vnode.state._capData = spec.data;
+            vnode.state._baselineCap = extractBaselineCapture(spec);
+        }
+        if (vnode.state._capExpResult !== vnode.state.experimentResult) {
+            vnode.state._capExpResult = vnode.state.experimentResult;
+            vnode.state._experimentCap = extractExperimentCapture(spec, vnode.state.experimentResult);
+        }
+        const baselineCap = vnode.state._baselineCap;
+        const experimentCap = vnode.state._experimentCap;
 
         const result = renderCompareChart({
             spec,

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -54,9 +54,10 @@ const extractBaselineCapture = (spec) => {
         cap.timeData = spec.time_data || [];
         cap.heatmapData = spec.data || [];
         cap.bucketBounds = spec.bucket_bounds;
-        cap.minValue = spec.min_value;
-        cap.maxValue = spec.max_value;
         cap.heatmapMatrix = heatmapTriplesToMatrix(cap.heatmapData, cap.timeData.length);
+        const scanned = heatmapTriplesMinMax(cap.heatmapData);
+        cap.minValue = scanned.min != null ? scanned.min : spec.min_value;
+        cap.maxValue = scanned.max != null ? scanned.max : spec.max_value;
         return cap;
     }
 
@@ -169,6 +170,9 @@ const extractExperimentCapture = (spec, promqlResult) => {
         cap.timeData = timestamps.map(Number);
         cap.heatmapData = heatmapData;
         cap.heatmapMatrix = heatmapTriplesToMatrix(heatmapData, cap.timeData.length);
+        const scanned = heatmapTriplesMinMax(heatmapData);
+        cap.minValue = scanned.min;
+        cap.maxValue = scanned.max;
         return cap;
     }
 
@@ -181,6 +185,24 @@ const extractExperimentCapture = (spec, promqlResult) => {
     cap.heatmapMatrix = [];
     return cap;
 };
+
+// Scan a flat [timeIdx, y, value] triple array for the numeric value
+// bounds. Returns { min: null, max: null } when there are no numeric
+// samples. Used once at extract time so unifiedHeatmapRange can just
+// Math.min/Math.max the two pre-computed pairs.
+function heatmapTriplesMinMax(triples) {
+    if (!Array.isArray(triples) || triples.length === 0) return { min: null, max: null };
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (const t of triples) {
+        const v = Array.isArray(t) ? t[2] : null;
+        if (v == null || Number.isNaN(v)) continue;
+        if (v < lo) lo = v;
+        if (v > hi) hi = v;
+    }
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) return { min: null, max: null };
+    return { min: lo, max: hi };
+}
 
 // Build a rows × bins matrix from a flat [timeIdx, y, value] triple
 // array. Gaps fill with null. Used by the diff-heatmap strategy.

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -6,6 +6,7 @@ import { expandLink, selectButton, compareToggle } from './chart_controls.js';
 import { isHistogramPlot, buildHistogramHeatmapSpec, resolvedStyle } from './charts/metric_types.js';
 import { renderCompareChart } from './charts/compare.js';
 import { queryRangeForCapture, buildEffectiveQuery } from './data.js';
+import { canonicalQuantileLabel } from './charts/util/compare_math.js';
 import { ViewerApi } from './viewer_api.js';
 
 // ── Normalization helpers for compare-mode captures ────────────────
@@ -38,18 +39,8 @@ const extractBaselineCapture = (spec) => {
             for (let i = 1; i < data.length; i++) {
                 let label = names[i - 1];
                 if (style === 'scatter') {
-                    // Normalize pXX label form to match quantile-derived keys
-                    // from the experiment query (percentileLabel in compare.js).
-                    // PromQL's histogram_percentiles() returns quantile as a
-                    // fraction (e.g. "0.5", "0.99"); a value <= 1 is treated
-                    // as a fraction, anything larger is assumed already in
-                    // percent form (e.g. "50").
-                    const m = typeof label === 'string' ? label.match(/^p?(\d+(?:\.\d+)?)$/) : null;
-                    if (m) {
-                        const q = Number(m[1]);
-                        const pct = q <= 1 ? q * 100 : q;
-                        label = `p${pct.toFixed(2).replace(/\.?0+$/, '')}`;
-                    }
+                    const canonical = canonicalQuantileLabel(label);
+                    if (canonical) label = canonical;
                 }
                 if (label == null) continue;
                 map.set(String(label), { timeData, valueData: data[i] || [] });
@@ -131,25 +122,10 @@ const extractExperimentCapture = (spec, promqlResult) => {
     }
 
     if (style === 'scatter') {
-        // metriken_query's histogram_percentiles labels series with
-        // `percentile` (e.g. "0.5"), not `quantile`. Fall through to any
-        // named quantile/percentile label, then to the first non-__name__
-        // label value (matches applyResultToPlot's seriesName selection
-        // for baseline). Always present as percent form ("p50", "p99.9")
-        // to match the baseline normalizer in extractBaselineCapture.
         const map = new Map();
         for (const item of results) {
-            const mm = item.metric || {};
-            let raw = mm.percentile != null ? mm.percentile : mm.quantile;
-            if (raw == null) {
-                for (const [k, v] of Object.entries(mm)) {
-                    if (k !== '__name__') { raw = v; break; }
-                }
-            }
-            const q = Number(raw);
-            if (!Number.isFinite(q)) continue;
-            const pct = q <= 1 ? q * 100 : q;
-            const canonical = `p${pct.toFixed(2).replace(/\.?0+$/, '')}`;
+            const canonical = canonicalQuantileLabel(item);
+            if (canonical == null) continue;
             const values = Array.isArray(item.values) ? item.values : [];
             map.set(canonical, {
                 timeData: values.map((p) => Number(p[0])),

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -416,6 +416,24 @@ export function createGroupComponent(getState) {
 
             if (!groupHasData) return null;
 
+            // Build the chart-body vnode for a given (maybe-prefixed) spec.
+            // Picks the compare wrapper when in compare mode AND the spec has
+            // a promql_query (service-template charts without one fall through
+            // to the single-capture path even in compare mode).
+            const chartBody = (renderSpec, sourceSpec) => (compareMode && sourceSpec.promql_query)
+                ? m(CompareChartWrapper, {
+                    spec: renderSpec,
+                    chartsState,
+                    interval,
+                    anchors,
+                    toggles,
+                    setChartToggle,
+                    sectionRoute,
+                    step: interval,
+                    experimentQueryRange,
+                })
+                : m(Chart, { spec: renderSpec, chartsState, interval });
+
             const renderChart = (spec) => {
                 const isHistogramChart = isHistogramPlot(spec);
                 // In compare mode, every chart takes the full chart-grid
@@ -426,53 +444,16 @@ export function createGroupComponent(getState) {
                     ? 'div.chart-wrapper.full-width'
                     : 'div.chart-wrapper';
 
+                let renderSpec;
                 if (isHistogramChart && isHeatmapMode && sectionHeatmapData?.has(spec.opts.id)) {
-                    const heatmapData = sectionHeatmapData.get(spec.opts.id);
-                    const heatmapSpec = buildHistogramHeatmapSpec(spec, heatmapData, prefixTitle(spec.opts));
-                    return m(wrapperClass, [
-                        chartHeader(heatmapSpec.opts, heatmapSpec),
-                        compareMode && spec.promql_query
-                            ? m(CompareChartWrapper, {
-                                spec: heatmapSpec,
-                                chartsState,
-                                interval,
-                                anchors,
-                                toggles,
-                                setChartToggle,
-                                sectionRoute,
-                                step: interval,
-                                experimentQueryRange,
-                            })
-                            : m(Chart, { spec: heatmapSpec, chartsState, interval }),
-                        expandLink(spec, sectionRoute),
-                        selectButton(spec, sectionRoute, sectionName),
-                    ]);
-                }
-
-                const prefixedSpec = { ...spec, opts: prefixTitle(spec.opts), noCollapse };
-
-                if (compareMode && spec.promql_query) {
-                    return m(wrapperClass, [
-                        chartHeader(prefixedSpec.opts, prefixedSpec),
-                        m(CompareChartWrapper, {
-                            spec: prefixedSpec,
-                            chartsState,
-                            interval,
-                            anchors,
-                            toggles,
-                            setChartToggle,
-                            sectionRoute,
-                            step: interval,
-                            experimentQueryRange,
-                        }),
-                        expandLink(spec, sectionRoute),
-                        selectButton(spec, sectionRoute, sectionName),
-                    ]);
+                    renderSpec = buildHistogramHeatmapSpec(spec, sectionHeatmapData.get(spec.opts.id), prefixTitle(spec.opts));
+                } else {
+                    renderSpec = { ...spec, opts: prefixTitle(spec.opts), noCollapse };
                 }
 
                 return m(wrapperClass, [
-                    chartHeader(prefixedSpec.opts, prefixedSpec),
-                    m(Chart, { spec: prefixedSpec, chartsState, interval }),
+                    chartHeader(renderSpec.opts, renderSpec),
+                    chartBody(renderSpec, spec),
                     expandLink(spec, sectionRoute),
                     selectButton(spec, sectionRoute, sectionName),
                 ]);

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -5,7 +5,7 @@ import { Chart } from './charts/chart.js';
 import { expandLink, selectButton, compareToggle } from './chart_controls.js';
 import { isHistogramPlot, buildHistogramHeatmapSpec, resolvedStyle } from './charts/metric_types.js';
 import { renderCompareChart } from './charts/compare.js';
-import { queryRangeForCapture, buildEffectiveQuery } from './data.js';
+import { queryRangeForCapture, buildEffectiveQuery, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from './data.js';
 import { canonicalQuantileLabel } from './charts/util/compare_math.js';
 import { ViewerApi } from './viewer_api.js';
 
@@ -16,7 +16,7 @@ import { ViewerApi } from './viewer_api.js';
 // chart style so the compare strategies can consume it uniformly.
 const extractBaselineCapture = (spec) => {
     const style = resolvedStyle(spec);
-    const cap = { id: 'baseline' };
+    const cap = { id: CAPTURE_BASELINE };
 
     if (style === 'line') {
         const data = spec.data;
@@ -68,7 +68,7 @@ const extractBaselineCapture = (spec) => {
 // produced by extractBaselineCapture.
 const extractExperimentCapture = (spec, promqlResult) => {
     const style = resolvedStyle(spec);
-    const cap = { id: 'experiment' };
+    const cap = { id: CAPTURE_EXPERIMENT };
     const results = promqlResult?.data?.result;
     if (!Array.isArray(results) || results.length === 0) {
         if (style === 'multi' || style === 'scatter') cap.seriesMap = new Map();
@@ -250,7 +250,7 @@ const CompareChartWrapper = {
                 // native format, same as plot.data[0] timestamps). Do not
                 // divide by 1000.
                 try {
-                    const meta = await ViewerApi.getMetadata('experiment');
+                    const meta = await ViewerApi.getMetadata(CAPTURE_EXPERIMENT);
                     const data = meta?.data ?? meta;
                     const minT = data?.minTime ?? data?.min_time ?? data?.start_time;
                     const maxT = data?.maxTime ?? data?.max_time ?? data?.end_time;
@@ -266,7 +266,7 @@ const CompareChartWrapper = {
                     m.redraw();
                     return;
                 }
-                const res = await queryRangeForCapture('experiment', query, start, end, step);
+                const res = await queryRangeForCapture(CAPTURE_EXPERIMENT, query, start, end, step);
                 vnode.state.experimentResult = res;
                 m.redraw();
             } catch (e) {

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -322,29 +322,26 @@ const CompareChartWrapper = {
             Chart,
         });
 
-        if (result === false || result == null) {
-            // Fall through to baseline-only rendering.
-            return m(Chart, { spec, chartsState, interval });
-        }
-        // `_splitSpecs` marker: render each sub-spec as its own Chart in
-        // a grid wrapper so a multi/scatter split lays out cleanly.
-        if (result._splitSpecs) {
-            const specs = result._splitSpecs;
-            if (!specs || specs.length === 0) {
-                return m('div.chart-error', 'compare: no shared labels between captures');
+        switch (result && result.kind) {
+            case 'spec':
+                return m(Chart, { spec: result.spec, chartsState, interval });
+            case 'vnode':
+                return result.vnode;
+            case 'split': {
+                const specs = result.specs;
+                if (!specs || specs.length === 0) {
+                    return m('div.chart-error', 'compare: no shared labels between captures');
+                }
+                return m('div.compare-split-subgroup',
+                    specs.map((s) => m('div.chart-wrapper', [
+                        s._splitLabel && m('div.compare-split-label', s._splitLabel),
+                        m(Chart, { spec: s, chartsState, interval }),
+                    ])));
             }
-            return m('div.compare-split-subgroup',
-                specs.map((s) => m('div.chart-wrapper', [
-                    s._splitLabel && m('div.compare-split-label', s._splitLabel),
-                    m(Chart, { spec: s, chartsState, interval }),
-                ])));
+            case 'fallback':
+            default:
+                return m(Chart, { spec, chartsState, interval });
         }
-        // Mithril vnode (has a `tag` or is an array) — render directly.
-        if (Array.isArray(result) || (result && (result.tag || result.view || result.children))) {
-            return result;
-        }
-        // Otherwise treat as a transformed spec.
-        return m(Chart, { spec: result, chartsState, interval });
     },
 };
 

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -253,8 +253,7 @@ const CompareChartWrapper = {
         // different hostnames or instance IDs.
         const query = buildEffectiveQuery(spec, {
             sectionRoute,
-            injectNodeLabel: false,
-            injectInstanceLabel: false,
+            crossCapture: true,
         });
         if (query == null) {
             vnode.state.error = 'compare: query skipped (unresolved cgroup pattern)';

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -5,7 +5,11 @@ import { Chart } from './charts/chart.js';
 import { expandLink, selectButton, compareToggle } from './chart_controls.js';
 import { isHistogramPlot, buildHistogramHeatmapSpec, resolvedStyle } from './charts/metric_types.js';
 import { renderCompareChart } from './charts/compare.js';
-import { queryRangeForCapture, buildEffectiveQuery, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from './data.js';
+import {
+    queryRangeForCapture, buildEffectiveQuery,
+    promqlResultToHeatmapTriples, promqlResultToLinePair, promqlResultToSeriesMap,
+    CAPTURE_BASELINE, CAPTURE_EXPERIMENT,
+} from './data.js';
 import { canonicalQuantileLabel } from './charts/util/compare_math.js';
 import { ViewerApi } from './viewer_api.js';
 
@@ -82,97 +86,37 @@ const extractExperimentCapture = (spec, promqlResult) => {
     }
 
     if (style === 'line') {
-        const first = results[0];
-        const values = Array.isArray(first?.values) ? first.values : [];
-        cap.timeData = values.map((pair) => Number(pair[0]));
-        cap.valueData = values.map((pair) => {
-            const v = pair[1];
-            if (v === null || v === undefined) return null;
-            const n = Number(v);
-            return Number.isNaN(n) ? null : n;
-        });
+        const pair = promqlResultToLinePair(results);
+        cap.timeData = pair.timeData;
+        cap.valueData = pair.valueData;
         return cap;
     }
 
     if (style === 'multi') {
-        // Match baseline's label convention: series_names[i] is the first
-        // non-__name__ metric label's value (see applyResultToPlot's
-        // allData branch in data.js). For a gauge like cpu_usage with
-        // labels {cpu="0"}, both sides will produce "0".
-        const map = new Map();
-        for (const item of results) {
+        // Match baseline's label convention: first non-__name__ metric
+        // label's value (see applyResultToPlot's series-name loop).
+        cap.seriesMap = promqlResultToSeriesMap(results, (item) => {
             const mm = item.metric || {};
-            let key = null;
             for (const [k, v] of Object.entries(mm)) {
-                if (k !== '__name__') { key = String(v); break; }
+                if (k !== '__name__') return String(v);
             }
-            if (key == null) continue;
-            const values = Array.isArray(item.values) ? item.values : [];
-            map.set(key, {
-                timeData: values.map((p) => Number(p[0])),
-                valueData: values.map((p) => {
-                    const v = p[1];
-                    if (v === null || v === undefined) return null;
-                    const n = Number(v);
-                    return Number.isNaN(n) ? null : n;
-                }),
-            });
-        }
-        cap.seriesMap = map;
+            return null;
+        });
         return cap;
     }
 
     if (style === 'scatter') {
-        const map = new Map();
-        for (const item of results) {
-            const canonical = canonicalQuantileLabel(item);
-            if (canonical == null) continue;
-            const values = Array.isArray(item.values) ? item.values : [];
-            map.set(canonical, {
-                timeData: values.map((p) => Number(p[0])),
-                valueData: values.map((p) => {
-                    const v = p[1];
-                    if (v === null || v === undefined) return null;
-                    const n = Number(v);
-                    return Number.isNaN(n) ? null : n;
-                }),
-            });
-        }
-        cap.seriesMap = map;
+        cap.seriesMap = promqlResultToSeriesMap(results, (item) => canonicalQuantileLabel(item));
         return cap;
     }
 
     if (style === 'heatmap') {
-        // Build a flat-triple table + 2D matrix from the PromQL result,
-        // using the same transform applyResultToPlot uses for baseline.
-        const timeSet = new Set();
-        for (const item of results) {
-            for (const [ts] of item.values || []) timeSet.add(ts);
-        }
-        const timestamps = Array.from(timeSet).sort((a, b) => Number(a) - Number(b));
-        const timeIndex = new Map();
-        timestamps.forEach((ts, idx) => timeIndex.set(ts, idx));
-        const heatmapData = [];
-        for (let idx = 0; idx < results.length; idx++) {
-            const item = results[idx];
-            let cpuId = idx;
-            if (item.metric && item.metric.id != null) {
-                const parsed = parseInt(item.metric.id, 10);
-                if (!Number.isNaN(parsed)) cpuId = parsed;
-            }
-            for (const [ts, val] of item.values || []) {
-                const ti = timeIndex.get(ts);
-                if (ti === undefined) continue;
-                const v = val === null || val === undefined ? null : parseFloat(val);
-                heatmapData.push([ti, cpuId, v]);
-            }
-        }
+        const { timestamps, triples, minValue, maxValue } = promqlResultToHeatmapTriples(results);
         cap.timeData = timestamps.map(Number);
-        cap.heatmapData = heatmapData;
-        cap.heatmapMatrix = heatmapTriplesToMatrix(heatmapData, cap.timeData.length);
-        const scanned = heatmapTriplesMinMax(heatmapData);
-        cap.minValue = scanned.min;
-        cap.maxValue = scanned.max;
+        cap.heatmapData = triples;
+        cap.heatmapMatrix = heatmapTriplesToMatrix(triples, cap.timeData.length);
+        cap.minValue = minValue;
+        cap.maxValue = maxValue;
         return cap;
     }
 

--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -23,6 +23,12 @@ impl CaptureId {
             _ => None,
         }
     }
+
+    /// Parse an optional `?capture=…` query param. Missing or unknown
+    /// values resolve to the default (Baseline).
+    pub fn parse_opt(s: Option<&str>) -> Self {
+        s.and_then(Self::parse).unwrap_or_default()
+    }
 }
 
 pub struct CaptureSlot {

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1031,10 +1031,7 @@ struct CaptureParam {
 
 impl CaptureParam {
     fn capture_id(&self) -> CaptureId {
-        self.capture
-            .as_deref()
-            .and_then(CaptureId::parse)
-            .unwrap_or_default()
+        CaptureId::parse_opt(self.capture.as_deref())
     }
 }
 
@@ -1113,12 +1110,6 @@ struct RangeQueryParams {
     capture: Option<String>,
 }
 
-fn capture_id_from(opt: &Option<String>) -> CaptureId {
-    opt.as_deref()
-        .and_then(CaptureId::parse)
-        .unwrap_or_default()
-}
-
 #[derive(serde::Serialize)]
 struct ApiResponse<T: serde::Serialize> {
     status: String,
@@ -1164,7 +1155,7 @@ async fn instant_query(
     axum::extract::Query(params): axum::extract::Query<QueryParams>,
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
 ) -> axum::response::Json<ApiResponse<promql::QueryResult>> {
-    let capture = capture_id_from(&params.capture);
+    let capture = CaptureId::parse_opt(params.capture.as_deref());
     let tsdb_handle = match state.captures.get(capture) {
         Some(t) => t,
         None => {
@@ -1189,7 +1180,7 @@ async fn range_query(
     axum::extract::Query(params): axum::extract::Query<RangeQueryParams>,
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
 ) -> axum::response::Json<ApiResponse<promql::QueryResult>> {
-    let capture = capture_id_from(&params.capture);
+    let capture = CaptureId::parse_opt(params.capture.as_deref());
     let tsdb_handle = match state.captures.get(capture) {
         Some(t) => t,
         None => {


### PR DESCRIPTION
## Summary

Execution of the deferred simplify-review items from the post-PR #821 memo, plus a pass of diff-heatmap polish that fell out during verification.

**Dedup / abstraction (22 items)**
- `E4`/`Q20`: Promise.all compare-mode metadata fans + warn on detach failure
- `R4`: hoist `canonicalQuantileLabel` into `compare_math.js`
- `Q14`/`R11`: `CAPTURE_BASELINE` / `CAPTURE_EXPERIMENT` constants + `captureQS` helper
- `R12`/`R13`: `buildOverlayLegendOption` / `overrideXAxisFormatter` in `charts/base.js`
- `Q12`: drop CSS fallback theater for already-declared vars
- `R15`: `unifiedHeatmapRange` uses pre-scanned bounds
- `Q15`: tagged-union return from `renderCompareChart`
- `Q8`: collapse `injectNode/Instance` → single `crossCapture` flag
- `R9`/`R10`: internal `Slot::parse` in WASM registry; `CaptureId::parse_opt` on the server enum
- `R6`/`R7`: `UPLOAD_ICON_SVG` + `openParquetPicker` hoisted
- `R8`/`Q9`: `sideBySidePair` helper; `sideBySideHistogramHeatmap` becomes a one-liner
- `E2`/`E3`: memoize compare-mode capture extractors per redraw
- `E1`: cache `{start, end, step}` once at compare-mode entry, thread via state factory
- `R14`: collapse `renderChart` compare branching into `chartBody` picker
- `R1`: pure `promqlResultToHeatmapTriples` / `…LinePair` / `…SeriesMap` shared between `applyResultToPlot` and `extractExperimentCapture`
- `Q19`: `CHART_GRID_TOP_WITH_LEGEND` constant shared across line/scatter/multi/heatmap/histogram_heatmap
- `Q10`: heatmap legend now mounts inside `chart.domNode`, deleting `scrubStaleLegend` + `paletteSig`

**Diff-heatmap polish**
- Theme-aware `DIVERGING_BLUE_GREEN_DARK` palette (same extreme hues, mid stops interpolate toward dark card bg). Fixes a latent `isDark` probe bug where both themes got the light palette.
- Diff-legend caption row (\"base is higher\" / \"exp is higher\") above the numeric min/max, sharing the gradient bar's width so each caption anchors to its numeric counterpart.
- Diff legend min/max shown as absolute magnitudes (the sign is carried by the captions).
- Diff heatmap tooltip surfaces baseline + experiment absolute values instead of the computed delta.
- Percentile split chart (compare scatter) renders as scatter pairs (faded guide line + 3px dots) matching single-capture scatter style, except colors stay at `BASELINE_COLOR` / `EXPERIMENT_COLOR`.

## Test plan

- [x] `node --test tests/*.mjs` passes (13 tests)
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --bins capture_registry` passes (3 tests, incl. new `parse_opt`)
- [x] `./crates/viewer/build.sh` builds the WASM bundle
- [x] Compare two captures; verify overlay line, side-by-side heatmap, diff heatmap, split multi, split scatter
- [x] Dark mode: confirm diff heatmap neutral reads as background, extremes saturated
- [x] Hover diff heatmap cell: tooltip shows baseline + experiment values
- [x] Percentile comparison: dots overlay as scatter with faded guide line
- [x] Heatmap legend correctly unmounts on strategy swap (side-by-side → diff → split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)