### PR TITLE
style(viewer): center wrapped time range bar on narrow compare nav

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.2"
+version = "5.11.1-alpha.3"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.2"
+version = "5.11.1-alpha.3"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -373,6 +373,15 @@ body::after {
     #topnav:has(.compare-badge) .time-range-bar {
         flex: 1 1 100%;
         order: 99;
+        justify-content: center;
+        margin-left: 0;
+        margin-right: 0;
+    }
+    #topnav:has(.compare-badge) .time-range-bar .time-track {
+        width: auto;
+        flex: 1 1 auto;
+        min-width: 160px;
+        max-width: 480px;
     }
 }
 


### PR DESCRIPTION
## Summary

On narrow viewports (≤ 900px) with compare mode active, the top-nav time range bar wraps to its own second row. Previously it stuck to the default `margin-left: auto` + fixed-width track (200px desktop / 120px mobile), so the wrapped bar hugged the right edge at its original width, leaving a big empty gap on the left.

- Add `justify-content: center` + zero horizontal margins to the wrapped bar, so it sits centered on its row.
- Let the inner `.time-track` stretch via `flex: 1 1 auto`, bounded by `min-width: 160px` / `max-width: 480px`, so the track uses the room it just earned from wrapping without expanding past what the drag handles can comfortably target.

Only affects the `@media (max-width: 900px)` + `#topnav:has(.compare-badge)` branch — wide nav and single-capture mode are unchanged.

## Test plan

- [ ] Compare-mode on desktop (> 900px): unchanged, track still right-aligned at 200px.
- [ ] Compare-mode at ≤ 900px: time range bar wraps; the wrapped row is centered; track fills more of the row (visibly wider than 200px, capped before edge).
- [ ] Compare-mode at < 767px: track still usable, doesn't overflow the viewport.
- [ ] Single-capture mode at ≤ 900px: unchanged (no compare-badge selector match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)