### PR TITLE
feat(site): grouped + polished landing demos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.3"
+version = "5.11.1-alpha.4"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.3"
+version = "5.11.1-alpha.4"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -13,10 +13,26 @@ let splashLabel = null;   // non-null = show splash, null = show landing
 let splashProgress = -1;  // -1 = indeterminate, 0–1 = determinate
 let landingError = null;
 
-const demos = [
-    { label: 'vLLM + System', file: 'vllm.parquet' },
-    { label: 'Cachecannon + System', file: 'cachecannon.parquet' },
-    { label: 'System Metrics', file: 'demo.parquet' },
+const demoSections = [
+    {
+        label: 'Rezolus only',
+        demos: [
+            { label: 'demo.parquet', file: 'demo.parquet' },
+        ],
+    },
+    {
+        label: 'Rezolus + service',
+        demos: [
+            { label: 'cachecannon.parquet', file: 'cachecannon.parquet' },
+            { label: 'vllm.parquet', file: 'vllm.parquet' },
+        ],
+    },
+    {
+        label: 'Side-by-side comparison',
+        demos: [
+            { label: 'AB_base.parquet + AB_base_pin.parquet', files: ['AB_base.parquet', 'AB_base_pin.parquet'] },
+        ],
+    },
 ];
 
 // ── WASM + template initialization ─────────────────────────────────
@@ -241,8 +257,14 @@ const Root = {
             ]));
         }
         return m('div', m(FileUpload, {
-            onDemo: loadDemo,
-            demos,
+            onDemo: (demo) => {
+                if (demo && Array.isArray(demo.files) && demo.files.length === 2) {
+                    loadCompareDemo(demo.files[0], demo.files[1]);
+                } else if (demo && demo.file) {
+                    loadDemo(demo.file);
+                }
+            },
+            demoSections,
             loading: false,
             error: landingError,
         }));

--- a/src/viewer/assets/lib/landing.js
+++ b/src/viewer/assets/lib/landing.js
@@ -188,18 +188,36 @@ const FileUpload = {
                         onclick: () => onConnect(connectUrl.trim()),
                     }, 'Connect'),
                 ]),
-                (attrs.demos || (onDemo ? [{ label: 'Try Demo' }] : [])).length > 0 &&
-                    m('div', { style: 'margin-top: 1.5rem' }, [
+                // Demo area — either grouped by section (demoSections)
+                // or a flat row (demos). A demo entry may carry either a
+                // single `file` string or a `files` array (for compare
+                // demos); onDemo receives the whole entry so the caller
+                // can route single vs compare appropriately.
+                (attrs.demoSections || attrs.demos || (onDemo ? [{ label: 'Try Demo' }] : [])).length > 0 &&
+                    m('div.upload-demo-area', [
                         onFile && m('p.upload-or', 'or'),
-                        m('div', { style: 'display: flex; gap: 0.5rem; justify-content: center; margin-top: 0.75rem; flex-wrap: wrap' },
-                            (attrs.demos || [{ label: 'Try Demo' }]).map(demo =>
-                                m('button.upload-btn', {
-                                    style: 'background: #6c757d',
-                                    onclick: () => onDemo(demo.file),
-                                    disabled: loading,
-                                }, demo.label),
-                            ),
-                        ),
+                        ...(attrs.demoSections
+                            ? attrs.demoSections.map(section => m('div.upload-demo-section', [
+                                m('p.upload-section-label', section.label),
+                                m('div.upload-demo-row',
+                                    (section.demos || []).map(demo =>
+                                        m('button.upload-btn', {
+                                            onclick: () => onDemo(demo),
+                                            disabled: loading,
+                                        }, demo.label),
+                                    ),
+                                ),
+                            ]))
+                            : [
+                                m('div.upload-demo-row',
+                                    (attrs.demos || [{ label: 'Try Demo' }]).map(demo =>
+                                        m('button.upload-btn', {
+                                            onclick: () => onDemo(demo),
+                                            disabled: loading,
+                                        }, demo.label),
+                                    ),
+                                ),
+                            ]),
                     ]),
                 error && m('p.upload-error', error),
                 loading && m('p.upload-loading', 'Loading...'),

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -3046,12 +3046,13 @@ main {
 
 .upload-card {
     background: var(--bg-secondary);
-    border: 1px solid var(--border-default);
+    border: 1px solid var(--border-emphasis);
     border-radius: 12px;
     padding: 3rem;
     max-width: 520px;
     width: 100%;
     text-align: center;
+    box-shadow: var(--shadow-lg), 0 0 0 1px var(--accent-subtle);
 }
 
 .upload-title {
@@ -3120,6 +3121,34 @@ main {
 
 .upload-btn:hover {
     opacity: 0.85;
+}
+
+/* Landing-page demo area: either a flat row (.upload-demo-row) or
+ * grouped by section (.upload-demo-section). Sections get a heading
+ * and a horizontal divider against the previous section. */
+.upload-demo-area {
+    margin-top: 1.5rem;
+}
+.upload-demo-section {
+    margin-top: 1rem;
+}
+.upload-demo-section + .upload-demo-section {
+    margin-top: 1.25rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border-subtle);
+}
+.upload-section-label {
+    margin: 0 0 0.75rem;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--fg);
+    letter-spacing: 0.01em;
+}
+.upload-demo-row {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
 }
 
 .upload-error {


### PR DESCRIPTION
## Summary

Polish pass on the static-site viewer's landing splash (`site/viewer/index.html`).

- **Grouped demo catalog** into three labeled sections instead of an unstructured button row:
  - **Rezolus only** — `demo.parquet`
  - **Rezolus + service** — `cachecannon.parquet`, `vllm.parquet`
  - **Side-by-side comparison** — `AB_base.parquet + AB_base_pin.parquet`
- **Compare-demo buttons.** Demo entries can now carry a `files` array (length 2) instead of `file` (string); `onDemo` receives the whole entry and the site bootstrap routes single-file to `loadDemo()` vs compare pairs to `loadCompareDemo()`. Existing URL shape (`?demo=` for single, `?demoA=&demoB=` for compare) is preserved so bookmarks/refreshes keep working.
- **More noticeable landing card.** `.upload-card` now uses `--border-emphasis` + `--shadow-lg` + a 1px `--accent-subtle` halo. Demo buttons dropped their inline grey override so they inherit the accent-blue styling from `.upload-btn` that was already in the stylesheet.
- **Styles live in `style.css`.** New classes `.upload-demo-area`, `.upload-demo-section`, `.upload-section-label`, `.upload-demo-row` replace the inline `style=""` I started with — consistent with the rest of the upload CSS, theme-aware via existing vars.

Server viewer is unaffected (passes neither `demos` nor `demoSections`; renders dropzone only).

## Test plan

- [x] Load `site/viewer/` — card has a visible blue halo + drop shadow; sections render with headings and dividers; buttons are accent-blue.
- [x] Click `demo.parquet` — loads the single-capture viewer; URL becomes `?demo=demo.parquet`.
- [x] Click `AB_base.parquet + AB_base_pin.parquet` — loads compare mode with both captures; URL becomes `?demoA=AB_base.parquet&demoB=AB_base_pin.parquet`.
- [x] Light mode: divider lines legible against card bg; accent halo softer but visible.
- [x] Refresh on each URL shape: demos auto-load.
- [x] Server viewer (`cargo run --features developer-mode -- view`): landing shows dropzone only, no demo row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)