### PR TITLE
refactor(viewer): align setPins fan-out with setZoom pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.5"
+version = "5.11.1-alpha.6"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.5"
+version = "5.11.1-alpha.6"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -169,13 +169,24 @@ export class ChartsState {
 
     /**
      * The single writer for `pinnedLabels`. Diffs against the current
-     * set; on no-op returns false without notifying. On a change,
-     * writes a fresh clone and notifies every subscriber.
+     * set; on no-op returns false. On a change, stores a fresh clone,
+     * fans out to every registered chart by calling its `_applyPins`
+     * method (when defined — only scatter charts respond), skipping
+     * `originChart` if supplied. Non-chart subscribers registered via
+     * subscribePins are then notified.
+     *
+     * Symmetric with setZoom: charts Map is the primary fan-out
+     * channel; `_pinSubs` is the secondary API for future non-chart
+     * consumers.
      */
-    setPins(labels) {
+    setPins(labels, { originChart = null } = {}) {
         const next = labels instanceof Set ? new Set(labels) : new Set(labels ?? []);
         if (setsEqual(this.pinnedLabels, next)) return false;
         this.pinnedLabels = next;
+        this.charts.forEach(chart => {
+            if (chart === originChart) return;
+            if (chart._applyPins) chart._applyPins(this.pinnedLabels);
+        });
         for (const fn of this._pinSubs) fn(this.pinnedLabels);
         return true;
     }

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -264,26 +264,21 @@ export function configureScatterChart(chart) {
     document.addEventListener('keydown', onKeyDown);
     document.addEventListener('keyup', onKeyUp);
     chart.domNode.addEventListener('mousedown', onMouseDown, true);
-    // Subscribe to cross-chart pin changes. The callback re-derives
-    // our local `chart.pinnedSet` as the intersection of the global
-    // pinned labels and our own series names, then rebuilds the
-    // pinned visual state. setPins' diff guard means a pin click in
-    // one scatter doesn't echo back to us as a separate no-op write.
-    const unsubPins = chart.chartsState.subscribePins((globalPins) => {
-        chart.pinnedSet = intersectPins(globalPins, uniqueNames);
-        applyPinState();
-        chart._rescaleYAxis();
-    });
     chart._pinCleanup = () => {
         document.removeEventListener('keydown', onKeyDown);
         document.removeEventListener('keyup', onKeyUp);
         chart.domNode.removeEventListener('mousedown', onMouseDown, true);
-        unsubPins();
+        // Drop the chart-side pin applicator on teardown so setPins'
+        // fan-out skips this chart after it's been destroyed or is
+        // about to reconfigure.
+        chart._applyPins = null;
     };
 
-    // Seed the derived local set from the current global labels, in
-    // case this chart is mounting into a section that already has
-    // pins active (e.g. compare-mode redraw, route reload, etc.).
+    // Seed the derived local set from the current global labels so
+    // tooltip formatters / Y-axis rescale see a valid Set even before
+    // the user's first pin. Compare-mode redraws and route reloads
+    // may also mount this chart while pinnedLabels is already
+    // populated.
     chart.pinnedSet = intersectPins(chart.chartsState.pinnedLabels, uniqueNames);
 
     const applyPinState = () => {
@@ -340,6 +335,18 @@ export function configureScatterChart(chart) {
         chart.echart.setOption({ series: updatedSeries, legend: legendUpdate });
     };
 
+    // chart._applyPins is scatter's end of the setPins observable —
+    // the direct counterpart to _applyZoom for zoom. ChartsState's
+    // charts.forEach fan-out invokes it when the global pin set
+    // changes. Closes over series/legend machinery from this
+    // configure call; reconfigures replace it via _pinCleanup →
+    // this reassignment.
+    chart._applyPins = (globalPins) => {
+        chart.pinnedSet = intersectPins(globalPins, uniqueNames);
+        applyPinState();
+        chart._rescaleYAxis();
+    };
+
     // Remove any previously stacked handler before adding a new one
     chart.echart.off('legendselectchanged');
     chart.echart.on('legendselectchanged', (params) => {
@@ -349,11 +356,13 @@ export function configureScatterChart(chart) {
         chart.echart.setOption({ legend: { selected } });
 
         // Compute the next global pin set based on the gesture, then
-        // route through chartsState.setPins. The subscription above
-        // fires back synchronously to update this chart's visual
-        // state; every other scatter chart in the section gets the
-        // same notification and pins/unpins the same label in
-        // lock-step when they carry it.
+        // route through chartsState.setPins with `this` as the
+        // origin. setPins fans out to every OTHER chart's _applyPins
+        // (via the charts registry, matching setZoom's shape); we
+        // update our own visual state directly after so the active
+        // chart never double-renders. Every other scatter chart in
+        // the section that carries the same label pins/unpins in
+        // lock-step.
         const name = params.name;
         const current = chart.chartsState.pinnedLabels;
         const next = new Set(current);
@@ -366,7 +375,12 @@ export function configureScatterChart(chart) {
             if (next.size === 1 && next.has(name)) next.clear();
             else { next.clear(); next.add(name); }
         }
-        chart.chartsState.setPins(next);
+        const changed = chart.chartsState.setPins(next, { originChart: chart });
+        if (changed) {
+            // Apply our own visual state locally — setPins skipped us
+            // because we're the origin (same semantics as setZoom).
+            chart._applyPins(chart.chartsState.pinnedLabels);
+        }
     });
 
     // Initial mount: if the section already carries pinned labels


### PR DESCRIPTION
## Summary

Pin selection landed in PR #825 with `subscribePins` / `_pinSubs` as its primary fan-out channel, while zoom used `charts.forEach` + `_applyZoom`. One rough edge left in the observable refactor — both paths do the same job (fan a global state change to registered charts) but via different mechanisms. This PR aligns them.

### Before

```
setZoom  → this.charts.forEach(c => c._applyZoom(...))     // primary
        → _zoomSubs                                        // secondary
setPins  → _pinSubs (scatter subscribes here)              // primary
        → (no charts.forEach pass)
```

### After

```
setZoom  → this.charts.forEach(c => c._applyZoom(...))     // primary
        → _zoomSubs                                        // secondary
setPins  → this.charts.forEach(c => c._applyPins?.(...))   // primary
        → _pinSubs                                         // secondary
```

Both fan-outs now skip `originChart`, both expose a chart-side entry point (`_applyZoom` / `_applyPins`), and both keep their `_Xsubs` Set for future non-chart consumers.

### Changes

- `ChartsState.setPins(labels, { originChart })` — takes the origin chart and skips it during fan-out.
- `Chart._applyPins(labels)` — chart-side entry point. Default absent; scatter charts assign it as a closure after `applyPinState` is defined.
- `scatter.js`:
  - Drops `chart.chartsState.subscribePins(...)` registration.
  - Click handler calls `setPins(next, { originChart: chart })` and updates its own visual state inline on `changed` (matches zoom's pattern).
  - `_pinCleanup` nulls `chart._applyPins` so setPins fan-out skips a chart that's reconfiguring or unmounting.

### Behavior

No visible change. Cross-scatter pin sync still works identically — pin `p99` in one scatter → every sibling with a `p99` series pins in lock-step. Charts without the label stay unaffected. The refactor is about structural symmetry so future cross-chart state can follow one reference pattern.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo fmt --check`
- [x] `node --test tests/*.mjs`
- [ ] Open a section with multiple scatter charts (e.g. latency breakdowns). Click a percentile label in one chart's legend. Confirm every sibling scatter with that label highlights it in lock-step.
- [ ] Ctrl/Cmd+click a second label. Multi-pin works across charts.
- [ ] Reset (double-click a chart) clears all pins.
- [ ] Switch section, switch back. Pin state preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)