### PR TITLE
refactor(viewer): drop global pin sync — percentile pins stay local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.6"
+version = "5.11.1-alpha.7"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.6"
+version = "5.11.1-alpha.7"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -37,15 +37,6 @@ export class ChartsState {
     // Zoom subscribers. Each entry receives (zoom, source) synchronously
     // after setZoom produces a diff.
     _zoomSubs = new Set();
-    // Global set of pinned series labels (percentile names like "p50",
-    // "p99"). A label lives here once; individual scatter charts
-    // intersect this set with their own uniqueNames to compute what
-    // they render as pinned. That gives free cross-chart pin sync
-    // (pinning p99 on one latency scatter highlights p99 on every
-    // latency scatter in the section) while charts that don't carry
-    // the label simply ignore it.
-    pinnedLabels = new Set();
-    _pinSubs = new Set();
     // Global color mapper - for consistent cgroup colors
     colorMapper = globalColorMapper;
 
@@ -57,8 +48,6 @@ export class ChartsState {
         this.globalZoom = null;
         this.charts.clear();
         this._zoomSubs.clear();
-        this.pinnedLabels = new Set();
-        this._pinSubs.clear();
     }
 
     isDefaultZoom() {
@@ -69,8 +58,9 @@ export class ChartsState {
     hasActiveSelection() {
         const hasLocalZoom = this.zoomSource === 'local' && !this.isDefaultZoom();
         if (hasLocalZoom) return true;
-        if (this.pinnedLabels.size > 0) return true;
-        return Array.from(this.charts.values()).some(c => c._tooltipFrozen);
+        return Array.from(this.charts.values()).some(c =>
+            c._tooltipFrozen || (c.pinnedSet && c.pinnedSet.size > 0)
+        );
     }
 
     /**
@@ -156,40 +146,13 @@ export class ChartsState {
         });
     }
 
-    /**
-     * Subscribe to pinned-label changes. Callback fires synchronously
-     * from setPins() with the new (cloned) `Set<string>` of pinned
-     * labels whenever setPins produces an actual change.
-     * Returns an unsubscribe function.
-     */
-    subscribePins(fn) {
-        this._pinSubs.add(fn);
-        return () => { this._pinSubs.delete(fn); };
-    }
-
-    /**
-     * The single writer for `pinnedLabels`. Diffs against the current
-     * set; on no-op returns false without notifying. On a change,
-     * writes a fresh clone and notifies every subscriber.
-     */
-    setPins(labels) {
-        const next = labels instanceof Set ? new Set(labels) : new Set(labels ?? []);
-        if (setsEqual(this.pinnedLabels, next)) return false;
-        this.pinnedLabels = next;
-        for (const fn of this._pinSubs) fn(this.pinnedLabels);
-        return true;
-    }
-
     // Reset zoom and clear all pin selections and frozen tooltips
-    // (preserves heatmap/percentile toggle)
+    // (preserves heatmap/percentile toggle). Pin state is per-chart;
+    // scatter charts that own a pinnedSet clear it in _clearPins below.
     resetAll() {
         this.resetZoom();
-        // Pin clear routes through the observable setter; subscribers
-        // (scatter charts) rebuild their legend + series styling and
-        // drop their derived pinnedSet. No explicit forEach reconfigure
-        // needed — that's the whole point of the subscribe model.
-        this.setPins(new Set());
         this.charts.forEach(chart => {
+            if (chart._clearPins) chart._clearPins();
             if (chart._tooltipFrozen) {
                 chart._toggleTooltipFreeze(false);
             }
@@ -198,15 +161,6 @@ export class ChartsState {
             chart.dispatchAction({ type: 'updateAxisPointer', currTrigger: 'leave' });
         });
     }
-}
-
-// Shallow Set equality — fine for the modest pin-label sets (handful of
-// percentile names at most).
-function setsEqual(a, b) {
-    if (a === b) return true;
-    if (a.size !== b.size) return false;
-    for (const x of a) if (!b.has(x)) return false;
-    return true;
 }
 
 // Normalize a caller-supplied zoom value into the canonical shape

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -160,12 +160,10 @@ export function configureScatterChart(chart) {
         chart._oobAxisMax = oobMax;
     }
 
-    // `chart.pinnedSet` is the DERIVED local view used by the tooltip
-    // formatter, Y-axis rescale, etc. — the SOURCE of truth lives on
-    // `chart.chartsState.pinnedLabels`. Populate it here (empty-set
-    // fallback when no global pins exist yet) so downstream reads
-    // never observe undefined. The proper re-derivation happens in
-    // the `applyPinState` + subscribeZoom callbacks below.
+    // `chart.pinnedSet` is the per-chart Set<string> of pinned series
+    // labels. Pins are intentionally local: clicking p99 on one scatter
+    // does not affect p99 on a sibling scatter. `resetAll` clears this
+    // via chart._clearPins below.
     if (!chart.pinnedSet) {
         chart.pinnedSet = new Set();
     }
@@ -264,27 +262,17 @@ export function configureScatterChart(chart) {
     document.addEventListener('keydown', onKeyDown);
     document.addEventListener('keyup', onKeyUp);
     chart.domNode.addEventListener('mousedown', onMouseDown, true);
-    // Subscribe to cross-chart pin changes. The callback re-derives
-    // our local `chart.pinnedSet` as the intersection of the global
-    // pinned labels and our own series names, then rebuilds the
-    // pinned visual state. setPins' diff guard means a pin click in
-    // one scatter doesn't echo back to us as a separate no-op write.
-    const unsubPins = chart.chartsState.subscribePins((globalPins) => {
-        chart.pinnedSet = intersectPins(globalPins, uniqueNames);
-        applyPinState();
-        chart._rescaleYAxis();
-    });
     chart._pinCleanup = () => {
         document.removeEventListener('keydown', onKeyDown);
         document.removeEventListener('keyup', onKeyUp);
         chart.domNode.removeEventListener('mousedown', onMouseDown, true);
-        unsubPins();
     };
 
-    // Seed the derived local set from the current global labels, in
-    // case this chart is mounting into a section that already has
-    // pins active (e.g. compare-mode redraw, route reload, etc.).
-    chart.pinnedSet = intersectPins(chart.chartsState.pinnedLabels, uniqueNames);
+    // Drop pins that no longer correspond to a rendered series (e.g.
+    // after a reconfigure with a different percentile set).
+    for (const name of chart.pinnedSet) {
+        if (!uniqueNames.includes(name)) chart.pinnedSet.delete(name);
+    }
 
     const applyPinState = () => {
         const pinned = chart.pinnedSet;
@@ -348,43 +336,40 @@ export function configureScatterChart(chart) {
         uniqueNames.forEach(name => { selected[name] = true; });
         chart.echart.setOption({ legend: { selected } });
 
-        // Compute the next global pin set based on the gesture, then
-        // route through chartsState.setPins. The subscription above
-        // fires back synchronously to update this chart's visual
-        // state; every other scatter chart in the section gets the
-        // same notification and pins/unpins the same label in
-        // lock-step when they carry it.
+        // Local-only pin update: mutate chart.pinnedSet directly and
+        // repaint. No fan-out to sibling charts.
         const name = params.name;
-        const current = chart.chartsState.pinnedLabels;
-        const next = new Set(current);
         if (ctrlHeld) {
             // Ctrl/Cmd+click: toggle this series in the multi-select set
-            if (next.has(name)) next.delete(name); else next.add(name);
+            if (chart.pinnedSet.has(name)) chart.pinnedSet.delete(name);
+            else chart.pinnedSet.add(name);
         } else {
             // Plain click: solo toggle (clear others and pin this one,
             // or unpin if it was already the lone pinned label).
-            if (next.size === 1 && next.has(name)) next.clear();
-            else { next.clear(); next.add(name); }
+            if (chart.pinnedSet.size === 1 && chart.pinnedSet.has(name)) {
+                chart.pinnedSet.clear();
+            } else {
+                chart.pinnedSet.clear();
+                chart.pinnedSet.add(name);
+            }
         }
-        chart.chartsState.setPins(next);
+        applyPinState();
+        chart._rescaleYAxis();
     });
 
-    // Initial mount: if the section already carries pinned labels
-    // (e.g. the user pinned p99 on a sibling chart before this one
-    // became visible), draw our derived visual state immediately.
+    // resetAll() hook: chartsState.resetAll iterates charts and calls
+    // this to clear per-chart pin state. We repaint here so the legend
+    // + series styling drop back to the unpinned look immediately.
+    chart._clearPins = () => {
+        if (chart.pinnedSet.size === 0) return;
+        chart.pinnedSet.clear();
+        applyPinState();
+        chart._rescaleYAxis();
+    };
+
+    // Redraw if any pins carried over from a previous configure.
     if (chart.pinnedSet.size > 0) {
         applyPinState();
     }
 }
 
-// Restrict a global pin set to the labels that this chart actually
-// renders. Keeps chart-local consumers (tooltip fade, Y-axis rescale)
-// from referencing labels that belong to a sibling chart only.
-function intersectPins(globalPins, uniqueNames) {
-    const out = new Set();
-    if (!globalPins || globalPins.size === 0) return out;
-    for (const name of uniqueNames) {
-        if (globalPins.has(name)) out.add(name);
-    }
-    return out;
-}


### PR DESCRIPTION
## Summary
- PR #825 introduced `ChartsState.pinnedLabels` + a `subscribePins` / `setPins` fan-out so pinning p99 on one scatter panel also pinned p99 on every sibling scatter. That cross-chart sync is the wrong UX — pinning should stay where the user clicked.
- Revert the chart-level plumbing to the pre-#825 shape: per-chart `chart.pinnedSet`, no central set, no subscription, no lateral dispatch.
- `hasActiveSelection()` now reads each chart's own `pinnedSet`; `resetAll()` calls `chart._clearPins?.()` in the same forEach that unfreezes tooltips (scatter defines the hook, others skip via optional-chain).

## Test plan
- [x] `node --test tests/*.mjs`
- [x] `./crates/viewer/build.sh`
- [x] Manual: open a section with multiple scatter/percentile charts; pin p99 on one panel — only that panel highlights p99
- [x] Manual: ctrl/cmd+click adds/removes pins on the same panel only
- [x] Manual: double-click (resetAll) clears pins on every scatter in the section
- [x] Manual: navigating between sections doesn't carry pins across

🤖 Generated with [Claude Code](https://claude.com/claude-code)