### PR TITLE
feat(viewer): embed service templates into the release binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
 name = "dashboard"
 version = "0.1.0"
 dependencies = [
+ "include_dir",
  "metriken-query",
  "serde",
  "serde_json",
@@ -2793,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.7"
+version = "5.11.1-alpha.8"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"
 dashboard = { path = "crates/dashboard" }
+include_dir = "0.7.4"
 walkdir = "2.5.0"
 wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.7"
+version = "5.11.1-alpha.8"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true
@@ -55,7 +56,7 @@ h2 = "0.4.10"
 histogram.workspace = true
 http = "1.3.1"
 humantime = "2.2.0"
-include_dir = "0.7.4"
+include_dir.workspace = true
 lazy_static = "1.5.0"
 libc.workspace = true
 linkme = "0.3.33"

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -12,5 +12,8 @@ metriken-query.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+include_dir.workspace = true
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dashboard/src/service_extension.rs
+++ b/crates/dashboard/src/service_extension.rs
@@ -150,7 +150,7 @@ impl TemplateRegistry {
         let mut templates = HashMap::new();
         for file in dir.files() {
             let path = file.path();
-            if !path.extension().is_some_and(|e| e == "json") {
+            if path.extension().is_none_or(|e| e != "json") {
                 continue;
             }
             let content = file

--- a/crates/dashboard/src/service_extension.rs
+++ b/crates/dashboard/src/service_extension.rs
@@ -142,6 +142,31 @@ impl TemplateRegistry {
         }
     }
 
+    /// Parse every `*.json` file in an embedded `include_dir::Dir` as
+    /// `ServiceExtension` and index them. Used in release builds where
+    /// the templates are baked into the binary via `include_dir!`.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_embedded(dir: &include_dir::Dir<'_>) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut templates = HashMap::new();
+        for file in dir.files() {
+            let path = file.path();
+            if !path.extension().is_some_and(|e| e == "json") {
+                continue;
+            }
+            let content = file
+                .contents_utf8()
+                .ok_or_else(|| format!("{} is not valid UTF-8", path.display()))?;
+            let ext: ServiceExtension = serde_json::from_str(content)
+                .map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
+
+            insert_template_key(&mut templates, ext.service_name.clone(), path, &ext)?;
+            for alias in &ext.aliases {
+                insert_template_key(&mut templates, alias.clone(), path, &ext)?;
+            }
+        }
+        Ok(Self { templates })
+    }
+
     /// Scan `dir` for `*.json` files, parse each as `ServiceExtension`,
     /// and index by `service_name` and each alias.
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,15 @@ mod common;
 
 pub use common::*;
 
+/// Service extension templates baked into the release binary from
+/// `config/templates/*.json`. Used by viewer and `parquet annotate`
+/// when the user hasn't passed an explicit `--templates` path.
+/// Developer-mode builds fall back to reading the same directory off
+/// disk so template edits don't require a rebuild.
+#[cfg(not(feature = "developer-mode"))]
+pub static EMBEDDED_TEMPLATES: include_dir::Dir<'_> =
+    include_dir::include_dir!("$CARGO_MANIFEST_DIR/config/templates");
+
 static STATE: AtomicUsize = AtomicUsize::new(RUNNING);
 
 static RUNNING: usize = 0;

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -171,11 +171,11 @@ pub fn command() -> Command {
 }
 
 pub fn run(args: ArgMatches) {
-    use crate::viewer::TemplateRegistry;
+    use crate::viewer::load_template_registry;
 
     let result = match args.subcommand() {
         Some(("annotate", sub_args)) => {
-            let registry = TemplateRegistry::resolve_and_load(
+            let registry = load_template_registry(
                 sub_args
                     .get_one::<PathBuf>("templates")
                     .map(|p| p.as_path()),
@@ -185,7 +185,7 @@ pub fn run(args: ArgMatches) {
         }
         Some(("combine", sub_args)) => combine::run(sub_args),
         Some(("filter", sub_args)) => {
-            let registry = TemplateRegistry::resolve_and_load(
+            let registry = load_template_registry(
                 sub_args
                     .get_one::<PathBuf>("templates")
                     .map(|p| p.as_path()),

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -31,6 +31,30 @@ use tower_http::services::{ServeDir, ServeFile};
 #[cfg(not(feature = "developer-mode"))]
 static ASSETS: Dir<'_> = include_dir!("src/viewer/assets");
 
+/// Shared entry point for loading the template registry. Both the
+/// viewer (`rezolus view`) and `rezolus parquet annotate/filter` call
+/// this. Precedence: explicit `--templates <path>` > env var /
+/// `config/templates/` default (developer-mode or explicit path only).
+/// Release builds fall back to templates baked into the binary via
+/// `include_dir!`; developer-mode continues to read from disk so
+/// template edits don't require a rebuild.
+pub fn load_template_registry(cli_path: Option<&Path>) -> TemplateRegistry {
+    if cli_path.is_some() {
+        return TemplateRegistry::resolve_and_load(cli_path);
+    }
+    #[cfg(not(feature = "developer-mode"))]
+    {
+        TemplateRegistry::from_embedded(&crate::EMBEDDED_TEMPLATES).unwrap_or_else(|e| {
+            warn!("failed to parse embedded templates: {e}");
+            TemplateRegistry::empty()
+        })
+    }
+    #[cfg(feature = "developer-mode")]
+    {
+        TemplateRegistry::resolve_and_load(None)
+    }
+}
+
 #[cfg(test)]
 pub use dashboard::Kpi;
 pub use dashboard::{ServiceExtension, TemplateRegistry};
@@ -205,7 +229,7 @@ pub fn run(config: Config) {
     })
     .expect("failed to set ctrl-c handler");
 
-    let registry = TemplateRegistry::resolve_and_load(config.templates_dir.as_deref());
+    let registry = load_template_registry(config.templates_dir.as_deref());
 
     let state = match &config.source {
         Source::File(path) => {


### PR DESCRIPTION
## Summary
- Bake `config/templates/*.json` into the release binary via `include_dir!`, alongside the existing `ASSETS` frontend embed. Running `rezolus view <parquet>` from a working directory with no templates nearby now still surfaces every service-extension dashboard.
- New `TemplateRegistry::from_embedded(&Dir<'_>)` constructor on the dashboard crate; picks up every `*.json` in the bundled directory. Matches the existing disk `load()` semantics.
- New `load_template_registry` helper in `src/viewer/mod.rs`, used by both `rezolus view` and `rezolus parquet annotate/filter`. Precedence: explicit `--templates <path>` > embedded (release) / disk default (developer-mode). Developer-mode keeps reading from disk so template edits don't require a rebuild.
- `include_dir` added as a non-wasm dep on the `dashboard` crate — user opted to leak it (no other consumers of the crate today).

## Test plan
- [x] `cargo check --workspace` (release + `--features developer-mode` both clean)
- [x] `cargo test -p dashboard`
- [x] `cargo fmt --check`
- [x] Manual: `cd /tmp && rezolus view <parquet>` — cachecannon service section renders with no `config/templates/` in sight
- [x] Manual: `cargo build --features developer-mode && rezolus view` — edit a template, restart, change reflected without rebuild
- [x] Manual: `rezolus view --templates /alt/path/templates <parquet>` — explicit override still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)