### PR TITLE
feat(site): URL params honor capture=alias=path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.8"
+version = "5.11.1-alpha.9"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.8"
+version = "5.11.1-alpha.9"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -13,6 +13,19 @@ let splashLabel = null;   // non-null = show splash, null = show landing
 let splashProgress = -1;  // -1 = indeterminate, 0–1 = determinate
 let landingError = null;
 
+// Split a "alias=path" string into [alias, path]. Mirrors the Rust
+// split_alias in src/viewer/mod.rs: alias must be non-empty, free of
+// path separators, ':' (URL-scheme guard), and whitespace. Anything
+// else parses as a bare path with alias=null.
+const splitAlias = (raw) => {
+    const eq = raw.indexOf('=');
+    if (eq <= 0) return [null, raw];
+    const lhs = raw.slice(0, eq);
+    const rhs = raw.slice(eq + 1);
+    if (/[\/\\:\s]/.test(lhs)) return [null, raw];
+    return [lhs, rhs];
+};
+
 const demoSections = [
     {
         label: 'Host (System) Metrics',
@@ -234,11 +247,18 @@ async function loadCompareDemo(fileA, fileB, legends = null) {
             experimentQueryRange,
         });
 
-        // Keep the URL shape stable so refreshes reload the same pair.
+        // Canonicalize the URL: repeated `capture=alias=path` (or bare
+        // `capture=path` when no alias). Order encodes role — first is
+        // baseline, second is experiment. Mirrors the CLI positional
+        // shape and scales naturally to N captures in the future.
         const url = new URL(window.location);
-        url.searchParams.set('demoA', fileA);
-        url.searchParams.set('demoB', fileB);
+        const encode = (file, alias) => alias ? `${alias}=${file}` : file;
         url.searchParams.delete('demo');
+        url.searchParams.delete('demoA');
+        url.searchParams.delete('demoB');
+        url.searchParams.delete('capture');
+        url.searchParams.append('capture', encode(fileA, legends?.baseline));
+        url.searchParams.append('capture', encode(fileB, legends?.experiment));
         window.history.replaceState(null, '', url);
     } catch (e) {
         splashLabel = null;
@@ -280,16 +300,37 @@ const Root = {
 
 // ── Initial mount ──────────────────────────────────────────────────
 
+// Canonical compare URL: `?capture=alias=path&capture=alias=path` (each
+// `alias=` prefix optional). Order encodes role: 1st = baseline,
+// 2nd = experiment. Legacy: `?demoA=…&demoB=…` is parsed as a fallback
+// for one release; on first load we rewrite to the canonical shape.
 const _params = new URLSearchParams(window.location.search);
+const _captureRaw = _params.getAll('capture');
 const _demoA = _params.get('demoA');
 const _demoB = _params.get('demoB');
 const _demoParam = _params.get('demo');
 
-if (_demoA && _demoB) {
-    // A/B compare demo.
-    splashLabel = `${_demoA} vs ${_demoB}`;
+const parsePair = (rawA, rawB) => {
+    const [aliasA, fileA] = splitAlias(rawA);
+    const [aliasB, fileB] = splitAlias(rawB);
+    const legends = (aliasA || aliasB)
+        ? { baseline: aliasA, experiment: aliasB }
+        : null;
+    return { fileA, fileB, legends };
+};
+
+if (_captureRaw.length >= 2) {
+    const { fileA, fileB, legends } = parsePair(_captureRaw[0], _captureRaw[1]);
+    splashLabel = `${legends?.baseline || fileA} vs ${legends?.experiment || fileB}`;
     m.mount(document.body, Root);
-    loadCompareDemo(_demoA, _demoB);
+    loadCompareDemo(fileA, fileB, legends);
+} else if (_demoA && _demoB) {
+    // Legacy A/B compare URL — parsed for one release, rewritten to
+    // canonical `?capture=…&capture=…` on load by loadCompareDemo.
+    const { fileA, fileB, legends } = parsePair(_demoA, _demoB);
+    splashLabel = `${legends?.baseline || fileA} vs ${legends?.experiment || fileB}`;
+    m.mount(document.body, Root);
+    loadCompareDemo(fileA, fileB, legends);
 } else if (_demoParam !== null) {
     splashLabel = _demoParam || 'demo.parquet';
     m.mount(document.body, Root);


### PR DESCRIPTION
## Summary
- Compare URL on the static-site viewer migrates from `?demoA=<file>&demoB=<file>` to a repeated `?capture=...` param. Each value optionally uses the same `alias=path` shape as the CLI's positional arguments. Order in the query string encodes role: 1st = baseline, 2nd = experiment, scaling to a 3rd capture in the future without renaming anything.
- New `splitAlias` helper in `site/viewer/lib/script.js` mirrors the Rust `split_alias` validation (alias non-empty, no path separators / `:` / whitespace; first `=` is the only split point).
- Legacy `?demoA=...&demoB=...` URLs still load and rewrite to the canonical `capture=` shape on first navigation via `history.replaceState`, so bookmarks survive one release.

## Example URLs
```
?capture=AB_base.parquet&capture=AB_base_pin.parquet                                    # bare paths
?capture=vllm%3Dvllm_gemma3.parquet&capture=sglang%3Dsglang_gemma3.parquet              # aliased
?demoA=AB_base.parquet&demoB=AB_base_pin.parquet                                        # legacy, still works
```

## Test plan
- [x] `node --check site/viewer/lib/script.js` and `node --test tests/*.mjs`
- [x] `splitAlias` smoke test against the CLI's edge cases (bare path, leading `=`, `/abs/=`, `http://host:port`, whitespace, repeated `=`)
- [x] Local: `cd site && python3 -m http.server` — `?capture=alias=path&capture=alias=path` loads the comparison with aliased badges
- [x] Manual: legacy `?demoA=...&demoB=...` URL still loads (one release of compat); URL bar rewrites to `capture=...` after load
- [x] Manual: rezolus.com after deploy honors `?capture=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)