### PR TITLE
perf(viewer): defer chart fetches, cap parallelism, stream renders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.10"
+version = "5.11.1-alpha.11"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.10"
+version = "5.11.1-alpha.11"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -12,6 +12,59 @@ const setStepOverride = (step) => { _stepOverride = step; };
 const getStepOverride = () => _stepOverride;
 
 // ---------------------------------------------------------------------------
+// Concurrency-capped query pool. Shared by every fetch path (baseline
+// per-plot, compare-mode experiment, heatmap) so we never have more than
+// `_cap` PromQL evaluations running concurrently. Tasks queued past the
+// cap run as earlier ones drain. The pool returns the original promise
+// resolution / rejection — callers handle errors as if they had run the
+// task directly.
+// ---------------------------------------------------------------------------
+
+class QueryPool {
+    constructor(cap) {
+        this._cap = Math.max(1, cap | 0);
+        this._running = 0;
+        this._queue = [];
+    }
+    setCap(cap) {
+        this._cap = Math.max(1, cap | 0);
+        this._drain();
+    }
+    enqueue(taskFn) {
+        return new Promise((resolve, reject) => {
+            const run = () => {
+                this._running++;
+                let result;
+                try {
+                    result = taskFn();
+                } catch (e) {
+                    this._running--;
+                    this._drain();
+                    reject(e);
+                    return;
+                }
+                Promise.resolve(result).then(resolve, reject).finally(() => {
+                    this._running--;
+                    this._drain();
+                });
+            };
+            if (this._running < this._cap) run();
+            else this._queue.push(run);
+        });
+    }
+    _drain() {
+        while (this._running < this._cap && this._queue.length > 0) {
+            const next = this._queue.shift();
+            next();
+        }
+    }
+    get pending() { return this._queue.length + this._running; }
+}
+
+const queryPool = new QueryPool(8);
+const setQueryConcurrencyCap = (cap) => queryPool.setCap(cap);
+
+// ---------------------------------------------------------------------------
 // Query rewriting for non-default granularity (step override)
 // ---------------------------------------------------------------------------
 // When the user picks a coarser step (e.g. 15s instead of auto ~1s), raw
@@ -389,46 +442,92 @@ const createDataApi = ({
         return q;
     };
 
+    // Walk every plot in the section's groups, run the per-plot query
+    // transforms (histogram wrap, counter rewrite, cgroup substitution,
+    // topology label injection), and stash the result on
+    // `plot._effectiveQuery`. Plots that should be skipped (e.g. cgroup
+    // pattern with no resolved selector) get `_effectiveQuery: null` so
+    // the lazy fetch path can short-circuit.
+    //
+    // The fetch ITSELF runs lazily — see `fetchPlotData` and the
+    // `LazyChart` wrapper that calls it on viewport intersection.
+    // Returns the data unchanged so callers can still cache it.
     const processDashboardData = async (data, activeCgroupPattern, sectionRoute) => {
         const metadata = cachedMetadata || await fetchMetadata();
         cachedMetadata = metadata;
-
-        const queryPlots = [];
         for (const group of data.groups || []) {
             for (const plot of collectGroupPlots(group)) {
-                if (plot.promql_query) {
-                    const queryToRun = buildEffectiveQuery(plot, {
-                        sectionRoute,
-                        activeCgroupPattern,
-                        serviceName: data.metadata?.service_name,
-                    });
-                    if (queryToRun == null) continue;
-                    queryPlots.push({ plot, query: queryToRun });
-                }
+                if (!plot.promql_query) continue;
+                plot._effectiveQuery = buildEffectiveQuery(plot, {
+                    sectionRoute,
+                    activeCgroupPattern,
+                    serviceName: data.metadata?.service_name,
+                });
+                // Drop any prior fetch state so a re-process (granularity
+                // change, cgroup pattern resolution, etc.) re-fetches.
+                plot._fetched = false;
+                plot._fetchInFlight = false;
+                plot._fetchGen = (plot._fetchGen | 0) + 1;
             }
         }
-
-        const results = await Promise.allSettled(
-            queryPlots.map(({ query }) =>
-                executePromQLRangeQuery(query, metadata),
-            ),
-        );
-
-        for (let i = 0; i < queryPlots.length; i++) {
-            const { plot } = queryPlots[i];
-            const outcome = results[i];
-            if (outcome.status === 'fulfilled') {
-                applyResultToPlot(plot, outcome.value);
-            } else {
-                console.error(
-                    `Failed to execute PromQL query "${plot.promql_query}":`,
-                    outcome.reason,
-                );
-                plot.data = [];
-            }
-        }
-
         return data;
+    };
+
+    // Fetch a single plot's PromQL result through the shared concurrency
+    // pool and apply it to the plot. Idempotent per generation: a plot
+    // already fetched (or in flight) is skipped. Returns the in-flight
+    // promise so callers (e.g. `flushAll` for save) can await completion.
+    const fetchPlotData = (plot) => {
+        if (!plot || !plot.promql_query) return Promise.resolve();
+        if (plot._effectiveQuery == null) {
+            // Pattern unresolved (e.g. cgroup) — render empty.
+            plot.data = [];
+            plot._fetched = true;
+            return Promise.resolve();
+        }
+        if (plot._fetched && !plot._fetchInFlight) return Promise.resolve();
+        if (plot._fetchInFlight) return plot._fetchPromise || Promise.resolve();
+        const gen = plot._fetchGen | 0;
+        plot._fetchInFlight = true;
+        const p = queryPool
+            .enqueue(() => executePromQLRangeQuery(plot._effectiveQuery))
+            .then(
+                (result) => {
+                    if ((plot._fetchGen | 0) !== gen) return;
+                    applyResultToPlot(plot, result);
+                },
+                (err) => {
+                    if ((plot._fetchGen | 0) !== gen) return;
+                    console.error(
+                        `Failed to execute PromQL query "${plot.promql_query}":`,
+                        err,
+                    );
+                    plot.data = [];
+                },
+            )
+            .finally(() => {
+                if ((plot._fetchGen | 0) === gen) {
+                    plot._fetched = true;
+                    plot._fetchInFlight = false;
+                    plot._fetchPromise = null;
+                }
+            });
+        plot._fetchPromise = p;
+        return p;
+    };
+
+    // Force every plot in the given groups to fetch (queueing through the
+    // pool) and return a promise that resolves when all are done. Used by
+    // the save-with-selection path which needs every chart's plot.data
+    // populated before serializing.
+    const flushAll = async (groups) => {
+        const plots = [];
+        for (const group of groups || []) {
+            for (const plot of collectGroupPlots(group)) {
+                if (plot.promql_query) plots.push(plot);
+            }
+        }
+        await Promise.allSettled(plots.map(fetchPlotData));
     };
 
     const fetchHeatmapForPlot = async (plot) => {
@@ -449,7 +548,9 @@ const createDataApi = ({
         }
 
         const strideSuffix = (_stepOverride && _stepOverride > 1) ? `, ${_stepOverride}` : '';
-        const result = await executePromQLRangeQuery(`histogram_heatmap(${metricSelector}${strideSuffix})`);
+        const result = await queryPool.enqueue(
+            () => executePromQLRangeQuery(`histogram_heatmap(${metricSelector}${strideSuffix})`),
+        );
 
         if (result.status === 'success' && result.data && result.data.resultType === 'histogram_heatmap') {
             const hr = result.data.result;
@@ -474,6 +575,8 @@ const createDataApi = ({
             }
         }
 
+        // Each fetchHeatmapForPlot already routes through the pool, so
+        // Promise.allSettled here just collects the cap-throttled results.
         const results = await Promise.allSettled(plots.map((p) => fetchHeatmapForPlot(p)));
 
         const heatmapData = new Map();
@@ -496,6 +599,8 @@ const createDataApi = ({
         applyResultToPlot,
         fetchHeatmapForPlot,
         fetchHeatmapsForGroups,
+        fetchPlotData,
+        flushAll,
         substituteCgroupPattern,
         processDashboardData,
         clearMetadataCache,
@@ -509,6 +614,8 @@ const {
     executePromQLRangeQuery,
     fetchHeatmapForPlot,
     fetchHeatmapsForGroups,
+    fetchPlotData,
+    flushAll,
     processDashboardData,
     clearMetadataCache,
     buildEffectiveQuery,
@@ -519,12 +626,15 @@ export {
     applyResultToPlot,
     fetchHeatmapForPlot,
     fetchHeatmapsForGroups,
+    fetchPlotData,
+    flushAll,
     substituteCgroupPattern,
     processDashboardData,
     clearMetadataCache,
     createDataApi,
     setStepOverride,
     getStepOverride,
+    setQueryConcurrencyCap,
     setSelectedNode,
     getSelectedNode,
     setSelectedInstance,

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -8,7 +8,7 @@ import { renderCompareChart } from './charts/compare.js';
 import {
     queryRangeForCapture, buildEffectiveQuery,
     promqlResultToHeatmapTriples, promqlResultToLinePair, promqlResultToSeriesMap,
-    getStepOverride, CAPTURE_BASELINE, CAPTURE_EXPERIMENT,
+    fetchPlotData, getStepOverride, CAPTURE_BASELINE, CAPTURE_EXPERIMENT,
 } from './data.js';
 import { canonicalQuantileLabel } from './charts/util/compare_math.js';
 import { ViewerApi } from './viewer_api.js';
@@ -264,6 +264,60 @@ const fetchExperimentResult = (vnode) => {
     })();
 };
 
+// IntersectionObserver options shared by lazy fetch wrappers. 200px
+// rootMargin gives a head-start so a chart's data is in flight just
+// before it scrolls into view, masking pool latency.
+const LAZY_VIEWPORT_OPTS = { rootMargin: '200px', threshold: 0.01 };
+
+// Wrap a baseline-only chart in an IntersectionObserver-gated fetcher.
+// processDashboardData no longer fires queries up front; this component
+// fires them on the first render where the chart is near the viewport
+// (or already inside it). Routes through the shared concurrency pool.
+const LazyChart = {
+    oncreate(vnode) {
+        this.dom = vnode.dom;
+        this.observer = new IntersectionObserver((entries) => {
+            if (!entries.some((e) => e.isIntersecting)) return;
+            this.observer.unobserve(this.dom);
+            this._fetchIfNeeded(vnode);
+        }, LAZY_VIEWPORT_OPTS);
+        this.observer.observe(this.dom);
+        // Edge case: a chart that's already on screen at mount time gets
+        // an immediate intersection callback, but if the page is
+        // backgrounded or the observer is delayed, fall through to a
+        // manual visibility nudge on the first redraw.
+        this._fetchIfNeeded(vnode);
+    },
+    onupdate(vnode) {
+        // Granularity change / experiment swap clears _fetched on the
+        // plot (see processDashboardData). Re-arm the observer so the
+        // chart refetches when next visible — but if it's still on
+        // screen, fire immediately.
+        const plot = vnode.attrs.plot;
+        if (plot && !plot._fetched && !plot._fetchInFlight) {
+            this._fetchIfNeeded(vnode);
+        }
+    },
+    onremove() {
+        if (this.observer) this.observer.disconnect();
+    },
+    _fetchIfNeeded(vnode) {
+        const { plot } = vnode.attrs;
+        if (!plot || plot._fetched || plot._fetchInFlight) return;
+        const rect = this.dom?.getBoundingClientRect();
+        // Same 200px head-start as the observer's rootMargin so manual
+        // nudges and observer-driven calls agree on "near viewport".
+        if (rect) {
+            const view = window.innerHeight || document.documentElement.clientHeight;
+            if (rect.bottom < -200 || rect.top > view + 200) return;
+        }
+        fetchPlotData(plot).then(() => m.redraw());
+    },
+    view(vnode) {
+        return m('div.lazy-chart-host', vnode.children);
+    },
+};
+
 const CompareChartWrapper = {
     oninit(vnode) {
         vnode.state.experimentResult = null;
@@ -273,8 +327,36 @@ const CompareChartWrapper = {
         // and re-fetches when they diverge (granularity selector change).
         vnode.state._lastFetchedStep = null;
         vnode.state._fetchInFlight = false;
-        // Kick off the initial fetch.
-        fetchExperimentResult(vnode);
+        // Initial fetch is deferred to oncreate where we have a DOM node
+        // for IntersectionObserver. Off-screen compare wrappers stay
+        // pending until they scroll into view.
+    },
+    oncreate(vnode) {
+        this.dom = vnode.dom;
+        this.observer = new IntersectionObserver((entries) => {
+            if (!entries.some((e) => e.isIntersecting)) return;
+            this.observer.unobserve(this.dom);
+            if (!vnode.state.experimentResult && !vnode.state.error
+                && !vnode.state._fetchInFlight) {
+                fetchExperimentResult(vnode);
+            }
+        }, LAZY_VIEWPORT_OPTS);
+        this.observer.observe(this.dom);
+        // Already on screen at mount? IntersectionObserver fires async;
+        // kick off the fetch synchronously when the rect overlaps.
+        const rect = this.dom?.getBoundingClientRect();
+        if (rect) {
+            const view = window.innerHeight || document.documentElement.clientHeight;
+            if (rect.bottom >= -200 && rect.top <= view + 200) {
+                if (!vnode.state.experimentResult && !vnode.state.error
+                    && !vnode.state._fetchInFlight) {
+                    fetchExperimentResult(vnode);
+                }
+            }
+        }
+    },
+    onremove() {
+        if (this.observer) this.observer.disconnect();
     },
 
     view(vnode) {
@@ -405,37 +487,55 @@ export function createGroupComponent(getState) {
             // the group title + subgroup headers when the whole cluster is
             // empty (e.g. a section querying metrics that don't exist on
             // the host, like GPU on a CPU-only box).
+            // A plot is "renderable" if it has data OR is still pending a
+            // lazy fetch. After all pending fetches resolve, plots whose
+            // queries returned nothing report renderable=false, which
+            // collapses sections that target metrics not present on the
+            // host (e.g. GPU on a CPU-only box). During loading, pending
+            // plots keep their groups visible so the user sees skeletons
+            // instead of a blank scroll.
+            const plotPending = (plot) =>
+                plot.promql_query && !plot._fetched;
             const plotHasData = (plot) =>
                 Array.isArray(plot.data) && plot.data.some((series) =>
                     Array.isArray(series) && series.length > 0
                 );
+            const plotRenderable = (plot) => plotHasData(plot) || plotPending(plot);
             const subgroupHasData = (sg) => (sg.plots || []).some(plotHasData);
-            const groupHasData = subgroups.some(subgroupHasData);
+            const subgroupRenderable = (sg) => (sg.plots || []).some(plotRenderable);
+            const groupRenderable = subgroups.some(subgroupRenderable);
 
-            if (!groupHasData) return null;
+            if (!groupRenderable) return null;
 
             // Build the chart-body vnode for a given (maybe-prefixed) spec.
-            // Picks the compare wrapper when in compare mode AND the spec has
-            // a promql_query (service-template charts without one fall through
-            // to the single-capture path even in compare mode).
-            const chartBody = (renderSpec, sourceSpec) => (compareMode && sourceSpec.promql_query)
-                ? m(CompareChartWrapper, {
-                    spec: renderSpec,
-                    chartsState,
-                    interval,
-                    anchors,
-                    toggles,
-                    setChartToggle,
-                    sectionRoute,
-                    // Pass the user-effective step. CompareChartWrapper
-                    // also consults _stepOverride internally, but
-                    // including it in attrs keeps the value visible in
-                    // the vnode.attrs trail for any future debugging.
-                    step: getStepOverride() || interval,
-                    experimentQueryRange,
-                    captureLabels,
-                })
-                : m(Chart, { spec: renderSpec, chartsState, interval });
+            // Compare mode + promql_query: CompareChartWrapper (which now
+            // lazy-fetches the experiment side via its own
+            // IntersectionObserver). Single-capture + promql_query: wrap
+            // the Chart in LazyChart so the baseline query also fires only
+            // when scrolled into view. Service-template / pre-baked plots
+            // (no promql_query) skip both wrappers — their data is
+            // populated upstream.
+            const chartBody = (renderSpec, sourceSpec) => {
+                if (compareMode && sourceSpec.promql_query) {
+                    return m(CompareChartWrapper, {
+                        spec: renderSpec,
+                        chartsState,
+                        interval,
+                        anchors,
+                        toggles,
+                        setChartToggle,
+                        sectionRoute,
+                        step: getStepOverride() || interval,
+                        experimentQueryRange,
+                        captureLabels,
+                    });
+                }
+                if (sourceSpec.promql_query) {
+                    return m(LazyChart, { plot: sourceSpec },
+                        m(Chart, { spec: renderSpec, chartsState, interval }));
+                }
+                return m(Chart, { spec: renderSpec, chartsState, interval });
+            };
 
             const renderChart = (spec) => {
                 const isHistogramChart = isHistogramPlot(spec);
@@ -468,10 +568,13 @@ export function createGroupComponent(getState) {
                 [
                     m('h2', `${attrs.name}`),
                     subgroups.map((sg) => {
-                        const hasData = subgroupHasData(sg);
+                        // Show the subgroup header while plots are still
+                        // pending. After fetches settle, hide it if no
+                        // plot ended up with data.
+                        const showHeader = subgroupRenderable(sg);
                         return m('div.subgroup', [
-                            hasData && sg.name && m('h3.subgroup-title', sg.name),
-                            hasData && sg.description && m('p.subgroup-description', sg.description),
+                            showHeader && sg.name && m('h3.subgroup-title', sg.name),
+                            showHeader && sg.description && m('p.subgroup-description', sg.description),
                             m('div.charts', (sg.plots || []).map(renderChart)),
                         ]);
                     }),


### PR DESCRIPTION
## Summary
Section navigation used to fire one PromQL query per plot up front through `Promise.allSettled`, awaiting all completions before painting. Big sections (CPU, scheduler, syscall) blocked first paint behind 20+ queries. This reworks the fetch pipeline along three axes:

1. **Lazy:** charts fetch their PromQL only when scrolled into view (200px head-start via `IntersectionObserver`).
2. **Capped:** every fetch path (baseline plot, compare experiment, heatmap) routes through a shared `QueryPool` with a cap of 8.
3. **Streaming:** each chart paints as its query lands — no section-wide await barrier.

## Mechanics
- New `QueryPool` (configurable cap, default 8). `setQueryConcurrencyCap(n)` exported for future tuning.
- `processDashboardData` is now a build-only pass: walks plots, runs the existing `buildEffectiveQuery` transform, attaches `_effectiveQuery`, resets `_fetched` flags and bumps a generation token.
- New `fetchPlotData(plot)`: idempotent per generation, queued through the pool. Stale-generation completions short-circuit so a rapid granularity toggle can't clobber the latest result.
- New `LazyChart` Mithril wrapper: `IntersectionObserver` triggers `fetchPlotData` on first intersect (or immediately if already on screen at mount). On redraw, re-arms if `_fetched` was reset.
- `CompareChartWrapper`: experiment fetch moved from `oninit` to `oncreate` + observer, so off-screen compare wrappers stay pending until visible. The view-time refetch on step divergence (PR #833) is preserved.
- `Group` shows a section while plots are pending OR have data; collapses only after fetches settle and none returned data (matching the prior "GPU on a CPU box" hide).
- `flushAll(groups)` exported for any future caller that needs full population (save-with-selection currently doesn't — serializes only chart id + query).

## Test plan
- [x] `node --test tests/*.mjs`
- [x] `cargo check --workspace`
- [x] `./crates/viewer/build.sh`
- [ ] Manual: load a big section (`/cpu` or `/scheduler`) — first row of charts paints quickly; subsequent rows fill in as you scroll
- [ ] Manual: granularity toggle re-fetches all visible charts; off-screen ones repopulate when scrolled to
- [ ] Manual: compare mode — same visible-first behavior on both baseline and experiment series; the existing step-diverge refetch still updates already-fetched compare charts
- [ ] Manual: heatmap toggle — fanouts route through the pool (concurrency bounded)
- [ ] Manual: section that returns no data on this host (e.g. GPU-only section on a CPU-only box) collapses after fetches settle

🤖 Generated with [Claude Code](https://claude.com/claude-code)