### PR TITLE
[codex] Reduce viewer chart loading memory use

### DIFF
--- a/site/viewer/lib/charts/util/heatmap_data.js
+++ b/site/viewer/lib/charts/util/heatmap_data.js
@@ -1,0 +1,1 @@
+../../../../../src/viewer/assets/lib/charts/util/heatmap_data.js

--- a/site/viewer/lib/section_cache.js
+++ b/site/viewer/lib/section_cache.js
@@ -1,0 +1,1 @@
+../../../src/viewer/assets/lib/section_cache.js

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -18,6 +18,14 @@ import { initTheme } from './theme.js';
 import { isHistogramPlot } from './charts/metric_types.js';
 import { renderServiceSection, createServiceRoutes } from './service.js';
 import { createGroupComponent, getCachedSectionMeta, buildClientOnlySectionView } from './viewer_core.js';
+import {
+    createSectionCacheState,
+    storeSectionResponse,
+    getSections,
+    withSharedSections,
+    clearSectionResponses,
+    resetSectionCacheState,
+} from './section_cache.js';
 
 // ── State ──────────────────────────────────────────────────────────
 
@@ -36,7 +44,12 @@ let heatmapLoading = false;
 const heatmapDataCache = new Map();
 const chartsState = new ChartsState();
 let currentGranularity = null;
-const sectionResponseCache = {};
+const sectionCacheState = createSectionCacheState();
+const sectionResponseCache = sectionCacheState.responses;
+const cacheSectionResponse = (section, data) =>
+    storeSectionResponse(sectionCacheState, section, data);
+const withCachedSections = (data) => withSharedSections(sectionCacheState, data);
+const getCachedSections = () => getSections(sectionCacheState);
 
 // Compare-mode state (Stage 4 of A/B compare plan)
 let compareMode = false;
@@ -197,7 +210,7 @@ const setChartToggle = (chartId, key, value) => {
 };
 
 const clearViewerCaches = () => {
-    Object.keys(sectionResponseCache).forEach((k) => delete sectionResponseCache[k]);
+    resetSectionCacheState(sectionCacheState);
     heatmapDataCache.clear();
     chartsState.clear();
 };
@@ -236,19 +249,13 @@ const loadSection = async (section) => {
     if (!data) return null;
 
     const processedData = await processDashboardData(data, activeCgroupPattern, `/${section}`);
-    sectionResponseCache[section] = processedData;
-    return processedData;
+    return cacheSectionResponse(section, processedData);
 };
 
 const preloadSections = (allSections) => {
-    for (const section of allSections) {
-        const key = section.route.substring(1);
-        if (!sectionResponseCache[key]) {
-            // Skip preloading in live mode — data flows dynamically
-            if (liveMode) continue;
-            loadSection(key).then(() => m.redraw()).catch(() => {});
-        }
-    }
+    // Section bodies now load on demand. Keep this hook as a no-op so
+    // existing callers don't eagerly materialize every section payload.
+    void allSections;
 };
 
 const reloadCurrentSection = async () => {
@@ -305,9 +312,7 @@ const changeGranularity = async (step) => {
     const section = currentRoute ? currentRoute.replace(/^\//, '') : '';
 
     // All cached section data is stale against the new step.
-    for (const key of Object.keys(sectionResponseCache)) {
-        delete sectionResponseCache[key];
-    }
+    clearSectionResponses(sectionCacheState);
     heatmapDataCache.clear();
     // Route zoom clear through the observable setter so any charts
     // that are still alive at this point (explorers etc.) see the
@@ -645,7 +650,8 @@ const initDashboard = (config = {}) => {
                     view() {
                         const data = sectionResponseCache[sectionKey];
                         if (!data) return m('div', 'Loading...');
-                        const activeSection = data.sections.find(s => s.route === `/${sectionKey}`);
+                        const activeSection = getCachedSections()
+                            .find(s => s.route === `/${sectionKey}`);
                         return m('div', [
                             m(TopNav, topNavAttrs(data, activeSection?.route)),
                             m('main.single-chart-main', [
@@ -677,6 +683,8 @@ const initDashboard = (config = {}) => {
             SingleChartView,
             applyResultToPlot,
             getCompareMode: () => compareMode,
+            getSections: getCachedSections,
+            withSharedSections: withCachedSections,
         }),
         '/about': {
             render() {
@@ -710,32 +718,60 @@ const initDashboard = (config = {}) => {
 
                 if (params.section === 'systeminfo') {
                     bootstrapCacheIfNeeded();
-                    return buildClientOnlySectionView(Main, sectionResponseCache, systemInfoSection, () => compareMode);
+                    return buildClientOnlySectionView(
+                        Main,
+                        sectionResponseCache,
+                        getCachedSections,
+                        systemInfoSection,
+                        () => compareMode,
+                    );
                 }
 
                 if (params.section === 'metadata') {
                     bootstrapCacheIfNeeded();
-                    return buildClientOnlySectionView(Main, sectionResponseCache, metadataSection, () => compareMode);
+                    return buildClientOnlySectionView(
+                        Main,
+                        sectionResponseCache,
+                        getCachedSections,
+                        metadataSection,
+                        () => compareMode,
+                    );
                 }
 
                 if (params.section === 'selection') {
                     bootstrapCacheIfNeeded();
-                    return buildClientOnlySectionView(Main, sectionResponseCache, selectionSection, () => compareMode);
+                    return buildClientOnlySectionView(
+                        Main,
+                        sectionResponseCache,
+                        getCachedSections,
+                        selectionSection,
+                        () => compareMode,
+                    );
                 }
 
                 if (params.section === 'report') {
                     bootstrapCacheIfNeeded();
-                    return buildClientOnlySectionView(Main, sectionResponseCache, reportSection, () => compareMode);
+                    return buildClientOnlySectionView(
+                        Main,
+                        sectionResponseCache,
+                        getCachedSections,
+                        reportSection,
+                        () => compareMode,
+                    );
                 }
 
                 const cachedView = (sectionKey, path) => ({
                     view() {
                         const data = sectionResponseCache[sectionKey];
                         if (!data) return m('div', 'Loading...');
-                        const activeSection = data.sections.find(
+                        const activeSection = getCachedSections().find(
                             (section) => section.route === path,
                         );
-                        return m(Main, { ...data, activeSection, compareMode });
+                        return m(Main, {
+                            ...withCachedSections(data),
+                            activeSection,
+                            compareMode,
+                        });
                     },
                 });
 
@@ -772,4 +808,4 @@ const getActiveCgroupPattern = () => activeCgroupPattern;
 const getRecording = () => recording;
 const setRecording = (value) => { recording = value; };
 
-export { initDashboard, sectionResponseCache, clearViewerCaches, chartsState, loadSection, preloadSections, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, attachExperiment, detachExperiment, durationFromFileMetadata, setChartToggle };
+export { initDashboard, sectionResponseCache, cacheSectionResponse, clearViewerCaches, chartsState, loadSection, preloadSections, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, attachExperiment, detachExperiment, durationFromFileMetadata, setChartToggle };

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -40,6 +40,7 @@
 
 import { nullDiff, intersectLabels, canonicalQuantileLabel } from './util/compare_math.js';
 import { DIVERGING_BLUE_GREEN, DIVERGING_BLUE_GREEN_DARK, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
+import { ensureHeatmapMatrix } from './util/heatmap_data.js';
 import { resolvedStyle } from './metric_types.js';
 import { isDarkTheme } from './base.js';
 import { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from '../data.js';
@@ -263,19 +264,15 @@ const unifiedHeatmapRange = (a, b, spec) => {
  */
 const renderDiffHeatmap = ({ spec, captures, anchors, chartsState, interval, Chart, captureLabels }) => {
     const [a, b] = captures;
-    const aMatrix = a.heatmapMatrix || null;
-    const bMatrix = b.heatmapMatrix || null;
-
-    // Guard: diff requires both captures to provide a normalized matrix
-    // (rows × time bins). The normalization step lives in the caller
-    // (viewer_core). Without it, bail and fall through to no-data.
-    if (!aMatrix || !bMatrix) return FALLBACK;
+    const aMatrix = ensureHeatmapMatrix(a);
+    const bMatrix = ensureHeatmapMatrix(b);
 
     const rows = Math.min(aMatrix.length, bMatrix.length);
     const bins = Math.min(
         (aMatrix[0] || []).length,
         (bMatrix[0] || []).length,
     );
+    if (rows === 0 || bins === 0) return FALLBACK;
 
     const triples = [];
     let dMin = Infinity;
@@ -448,4 +445,3 @@ const sideBySideHistogramHeatmap = (opts) => sideBySidePair({
         bucket_bounds: cap.bucketBounds || opts.spec.bucket_bounds,
     }),
 });
-

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -18,6 +18,10 @@ import {
     FONTS,
 } from './base.js';
 import { VIRIDIS_COLORS, viridisColor } from './util/colormap.js';
+import {
+    createHeatmapResolutionStore,
+    ensureHeatmapResolution,
+} from './util/heatmap_data.js';
 import { buildGradientCanvas, ensureLegendBar } from './color_legend.js';
 
 /**
@@ -65,87 +69,22 @@ export function configureHeatmap(chart) {
 
     const baseOption = getBaseOption();
 
-    // Extract all unique CPU IDs
-    const yIndices = new Set();
-    data.forEach(item => {
-        yIndices.add(item[1]); // CPU ID
-    });
-
-    // Convert to array and sort numerically
-    const cpuIds = Array.from(yIndices).sort((a, b) => a - b);
-
-    // Ensure we have a continuous range of CPUs from 0 to max
-    const maxCpuId = cpuIds.length > 0 ? Math.max(...cpuIds) : 0;
-    const continuousCpuIds = Array.from({
-        length: maxCpuId + 1
-    }, (_, i) => i);
-
-    if (continuousCpuIds.length !== cpuIds.length) {
-        console.error('CPU IDs are not continuous', cpuIds);
-    }
-
-    // First, transform data into a simple 2d matrix of values.
-    // dataMatrix[cpuId][timeIndex] = value
     const xCount = timeData.length;
-    const yCount = continuousCpuIds.length;
-    const dataMatrix = new Array(yCount).fill(null).map(() => new Array(xCount).fill(null));
-    for (let i = 0; i < data.length; i++) {
-        const [timeIndex, y, value] = data[i];
-        dataMatrix[y][timeIndex] = value;
-    }
-
-    // Build data ordered by time (columns) first, then CPU (rows),
-    // so that ECharts' progressive rendering fills left-to-right. When
-    // the spec supplies a `nullCellColor`, emit null cells too so that
-    // renderItem can paint them distinctly.
     const emitNullCells = !!chart.spec.nullCellColor;
-    const processedData = [];
-    for (let t = 0; t < xCount; t++) {
-        for (let y = 0; y < yCount; y++) {
-            const v = dataMatrix[y][t];
-            if (v !== null) {
-                processedData.push([timeData[t] * 1000, y, t, null, v]);
-            } else if (emitNullCells) {
-                processedData.push([timeData[t] * 1000, y, t, null, null]);
-            }
-        }
+    const resolutionStore = createHeatmapResolutionStore(data, timeData, emitNullCells);
+    chart.heatmapResolutionStore = resolutionStore;
+    const yCount = resolutionStore.yCount;
+    const continuousCpuIds = Array.from({ length: yCount }, (_, i) => i);
+    if (continuousCpuIds.length !== resolutionStore.cpuIds.length) {
+        console.error('CPU IDs are not continuous', resolutionStore.cpuIds);
     }
 
     const MAX_DATA_POINT_DISPLAY = 50000;
-    // Create a list of options for data to display at different levels of downsampling.
-    // These are ordered from highest to lowest resolution. So, usage is to iterate through
-    // them until one is low enough resolution.
     const nullColor = chart.spec.nullCellColor || null;
-    chart.downsampleCache = [];
-    chart.downsampleCache.push({
-        factor: 1,
-        data: processedData,
-        renderItem: createRenderItemFunc(timeData, 1, nullColor),
-    });
     const originalRatioOfDataPointsToMax = xCount * yCount / MAX_DATA_POINT_DISPLAY;
-
-    if (originalRatioOfDataPointsToMax > 1) {
-        const factor = Math.ceil(originalRatioOfDataPointsToMax);
-        const downsampledData = downsample(dataMatrix, factor);
-        const downsampledXCount = downsampledData[0].length;
-        const processedDownsampledData = [];
-        // Iterate time-first so progressive rendering fills left-to-right
-        for (let x = 0; x < downsampledXCount; x++) {
-            for (let y = 0; y < yCount; y++) {
-                const minAndMax = downsampledData[y][x];
-                if (minAndMax !== null) {
-                    processedDownsampledData.push([timeData[x * factor] * 1000, y, x * factor, minAndMax[0], minAndMax[1]]);
-                } else if (emitNullCells) {
-                    processedDownsampledData.push([timeData[x * factor] * 1000, y, x * factor, null, null]);
-                }
-            }
-        }
-        chart.downsampleCache.push({
-            factor,
-            data: processedDownsampledData,
-            renderItem: createRenderItemFunc(timeData, factor, nullColor),
-        });
-    }
+    const initialFactor = Math.max(1, Math.ceil(originalRatioOfDataPointsToMax));
+    const initialResolution = ensureHeatmapResolution(resolutionStore, initialFactor);
+    chart._heatmapRenderedFactor = initialResolution.factor;
 
     // Y axis labels: if more than Y_MAX_LABELS, show every 2nd, 4th, 8th, 16th, or etc.
     const Y_MAX_LABELS = 16;
@@ -360,9 +299,9 @@ export function configureHeatmap(chart) {
         series: [{
             name: chart.spec.opts.title,
             type: 'custom',
-            renderItem: chart.downsampleCache[chart.downsampleCache.length - 1].renderItem,
+            renderItem: createRenderItemFunc(timeData, initialResolution.factor, nullColor),
             clip: true,
-            data: chart.downsampleCache[chart.downsampleCache.length - 1].data,
+            data: initialResolution.data,
             emphasis: {
                 itemStyle: {
                     shadowBlur: 10,
@@ -427,59 +366,17 @@ export function configureHeatmap(chart) {
         // User-triggered events have a batch property with the details under it.
         const zoomLevel = event.batch ? event.batch[0] : event;
         const factor = zoomLevelToFactor(zoomLevel, originalRatioOfDataPointsToMax, 1000 * (timeData[timeData.length - 1] - timeData[0]));
-        for (let i = 0; i < chart.downsampleCache.length; i++) {
-            const downsampleCacheItem = chart.downsampleCache[i];
-            if (downsampleCacheItem.factor >= factor) {
-                const data = downsampleCacheItem.data;
-                const renderItem = downsampleCacheItem.renderItem;
-                // Only update the echarts object if the data has changed.
-                if (chart.echart.getOption().series[0].data.length !== data.length) {
-                    chart.echart.setOption({
-                        series: [{
-                            data: data,
-                            renderItem: renderItem
-                        }]
-                    });
-                }
-                break;
-            }
+        const resolution = ensureHeatmapResolution(resolutionStore, factor);
+        if (chart._heatmapRenderedFactor !== resolution.factor) {
+            chart._heatmapRenderedFactor = resolution.factor;
+            chart.echart.setOption({
+                series: [{
+                    data: resolution.data,
+                    renderItem: createRenderItemFunc(timeData, resolution.factor, nullColor),
+                }],
+            });
         }
     });
-}
-
-/**
- * Create a downsampled version of the data matrix.
- * Combines every `factor` data points along the x axis into a single data point with a min and max value.
- * @param {Array<Array<number>>} dataMatrix
- * @param {number} factor
- * @returns {Array<Array<number>>}
- */
-const downsample = (dataMatrix, factor) => {
-    const yCount = dataMatrix.length;
-    const xCount = dataMatrix[0].length;
-    const downsampledXCount = Math.ceil(xCount / factor);
-    const downsampledDataMatrix = new Array(yCount).fill(null).map(() => new Array(downsampledXCount).fill(null));
-    for (let y = 0; y < yCount; y++) {
-        for (let x = 0; x < Math.ceil(xCount / factor); x++) {
-            let max = null;
-            let min = null;
-            for (let origX = x * factor; origX < (x + 1) * factor && origX < xCount; origX++) {
-                if (dataMatrix[y][origX] !== null) {
-                    if (max === null) {
-                        max = dataMatrix[y][origX];
-                        min = dataMatrix[y][origX];
-                    } else {
-                        max = Math.max(max, dataMatrix[y][origX]);
-                        min = Math.min(min, dataMatrix[y][origX]);
-                    }
-                }
-            }
-            if (max !== null) {
-                downsampledDataMatrix[y][x] = [min, max];
-            }
-        }
-    }
-    return downsampledDataMatrix;
 }
 
 /**

--- a/src/viewer/assets/lib/charts/util/heatmap_data.js
+++ b/src/viewer/assets/lib/charts/util/heatmap_data.js
@@ -1,0 +1,160 @@
+// Scan a flat [timeIdx, y, value] triple array for the numeric value
+// bounds. Returns { min: null, max: null } when there are no numeric
+// samples.
+const heatmapTriplesMinMax = (triples) => {
+    if (!Array.isArray(triples) || triples.length === 0) return { min: null, max: null };
+    let lo = Infinity;
+    let hi = -Infinity;
+    for (const t of triples) {
+        const v = Array.isArray(t) ? t[2] : null;
+        if (v == null || Number.isNaN(v)) continue;
+        if (v < lo) lo = v;
+        if (v > hi) hi = v;
+    }
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) return { min: null, max: null };
+    return { min: lo, max: hi };
+};
+
+// Build a rows × bins matrix from a flat [timeIdx, y, value] triple
+// array. Gaps fill with null.
+const heatmapTriplesToMatrix = (triples, binCount) => {
+    if (!Array.isArray(triples) || triples.length === 0) return [];
+    let maxY = -1;
+    for (const t of triples) {
+        const y = Number(t?.[1]);
+        if (Number.isFinite(y) && y > maxY) maxY = y;
+    }
+    if (maxY < 0) return [];
+    const rows = maxY + 1;
+    const cols = Math.max(1, binCount || 0);
+    const matrix = Array.from({ length: rows }, () =>
+        new Array(cols).fill(null));
+    for (const [ti, y, v] of triples) {
+        const r = Number(y);
+        const c = Number(ti);
+        if (!Number.isFinite(r) || !Number.isFinite(c)) continue;
+        if (r < 0 || r >= rows || c < 0 || c >= cols) continue;
+        matrix[r][c] = (v === null || v === undefined) ? null : Number(v);
+    }
+    return matrix;
+};
+
+// Compare-mode diff heatmaps need a dense rows × bins matrix for O(1)
+// cell lookups, but side-by-side mode only needs the original triples.
+// Materialize the matrix lazily and memoize it on the capture object.
+const ensureHeatmapMatrix = (capture) => {
+    if (!capture || typeof capture !== 'object') return [];
+    if (Array.isArray(capture.heatmapMatrix)) return capture.heatmapMatrix;
+    const matrix = heatmapTriplesToMatrix(
+        capture.heatmapData || [],
+        capture.timeData?.length || 0,
+    );
+    capture.heatmapMatrix = matrix;
+    return matrix;
+};
+
+// Build a sparse row-major index from triples so mounted heatmap charts
+// can materialize only the currently displayed resolution instead of
+// retaining both full-res and downsampled flattened arrays.
+const createHeatmapResolutionStore = (triples, timeData, emitNullCells) => {
+    const cpuIds = new Set();
+    let maxY = -1;
+    for (const t of triples || []) {
+        const y = Number(t?.[1]);
+        if (!Number.isFinite(y) || y < 0) continue;
+        cpuIds.add(y);
+        if (y > maxY) maxY = y;
+    }
+
+    const yCount = maxY + 1;
+    const rowMaps = Array.from({ length: Math.max(0, yCount) }, () => new Map());
+    for (const [timeIndex, yRaw, value] of triples || []) {
+        const y = Number(yRaw);
+        const ti = Number(timeIndex);
+        if (!Number.isFinite(y) || !Number.isFinite(ti)) continue;
+        if (y < 0 || y >= rowMaps.length || ti < 0) continue;
+        rowMaps[y].set(ti, value === null || value === undefined ? null : Number(value));
+    }
+
+    return {
+        timeData: timeData || [],
+        emitNullCells: !!emitNullCells,
+        yCount: Math.max(0, yCount),
+        cpuIds: Array.from(cpuIds).sort((a, b) => a - b),
+        rowMaps,
+        current: null,
+    };
+};
+
+const materializeHeatmapResolution = (store, factor) => {
+    const resolvedFactor = Math.max(1, factor | 0);
+    const { timeData, emitNullCells, yCount, rowMaps } = store;
+    const xCount = timeData.length;
+
+    if (resolvedFactor === 1) {
+        const out = [];
+        for (let t = 0; t < xCount; t++) {
+            for (let y = 0; y < yCount; y++) {
+                const row = rowMaps[y];
+                const v = row.has(t) ? row.get(t) : null;
+                if (v !== null) {
+                    out.push([timeData[t] * 1000, y, t, null, v]);
+                } else if (emitNullCells) {
+                    out.push([timeData[t] * 1000, y, t, null, null]);
+                }
+            }
+        }
+        return { factor: resolvedFactor, data: out };
+    }
+
+    const binCount = Math.ceil(xCount / resolvedFactor);
+    const aggregatedRows = rowMaps.map((row) => {
+        const bins = new Map();
+        row.forEach((value, timeIndex) => {
+            if (value === null || value === undefined) return;
+            const bin = Math.floor(timeIndex / resolvedFactor);
+            const current = bins.get(bin);
+            if (!current) {
+                bins.set(bin, [value, value]);
+            } else {
+                if (value < current[0]) current[0] = value;
+                if (value > current[1]) current[1] = value;
+            }
+        });
+        return bins;
+    });
+
+    const out = [];
+    for (let bin = 0; bin < binCount; bin++) {
+        const timeIndex = bin * resolvedFactor;
+        const timeValue = timeData[timeIndex];
+        if (timeValue == null) continue;
+        for (let y = 0; y < yCount; y++) {
+            const minMax = aggregatedRows[y].get(bin);
+            if (minMax) {
+                out.push([timeValue * 1000, y, timeIndex, minMax[0], minMax[1]]);
+            } else if (emitNullCells) {
+                out.push([timeValue * 1000, y, timeIndex, null, null]);
+            }
+        }
+    }
+    return { factor: resolvedFactor, data: out };
+};
+
+const ensureHeatmapResolution = (store, factor) => {
+    const resolvedFactor = Math.max(1, factor | 0);
+    if (store.current && store.current.factor === resolvedFactor) {
+        return store.current;
+    }
+    const resolution = materializeHeatmapResolution(store, resolvedFactor);
+    store.current = resolution;
+    return resolution;
+};
+
+export {
+    heatmapTriplesMinMax,
+    heatmapTriplesToMatrix,
+    ensureHeatmapMatrix,
+    createHeatmapResolutionStore,
+    ensureHeatmapResolution,
+};

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -7,7 +7,7 @@ import { FileUpload, CompareLanding } from './landing.js';
 import { notify, showSaveModal } from './overlays.js';
 import { setStorageScope, loadPayloadIntoStore, reportStore, clearStore } from './selection.js';
 import { clearMetadataCache, processDashboardData, CAPTURE_EXPERIMENT } from './data.js';
-import { initDashboard, sectionResponseCache, clearViewerCaches, chartsState, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, preloadSections } from './app.js';
+import { initDashboard, cacheSectionResponse, clearViewerCaches, chartsState, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, preloadSections } from './app.js';
 
 // ── Backend state fetching ─────────────────────────────────────────
 
@@ -99,7 +99,7 @@ const uploadParquet = async (file) => {
 
         const data = await ViewerApi.getSection('overview');
         const processed = await processDashboardData(data, null, '/overview');
-        sectionResponseCache['overview'] = processed;
+        cacheSectionResponse('overview', processed);
         if (processed.sections) preloadSections(processed.sections);
 
         if (m.route.get() !== '/overview') {
@@ -135,7 +135,7 @@ const refreshCurrentSection = async () => {
         }
         const [processed] = await Promise.all(promises);
 
-        sectionResponseCache[section] = processed;
+        cacheSectionResponse(section, processed);
         m.redraw();
     } catch (e) {
         // Keep existing data on error

--- a/src/viewer/assets/lib/section_cache.js
+++ b/src/viewer/assets/lib/section_cache.js
@@ -1,0 +1,48 @@
+const createSectionCacheState = () => ({
+    responses: {},
+    sections: [],
+});
+
+const getSections = (state) => state.sections || [];
+
+const storeSectionResponse = (state, key, data) => {
+    if (Array.isArray(data?.sections) && data.sections.length > 0) {
+        state.sections = data.sections;
+    }
+
+    if (!data || typeof data !== 'object') {
+        state.responses[key] = data;
+        return data;
+    }
+
+    const { sections, ...stored } = data;
+    state.responses[key] = stored;
+    return stored;
+};
+
+const withSharedSections = (state, data) => {
+    if (!data || typeof data !== 'object') return data;
+    if (Array.isArray(data.sections)) return data;
+    return {
+        ...data,
+        sections: getSections(state),
+    };
+};
+
+const clearSectionResponses = (state) => {
+    Object.keys(state.responses).forEach((key) => delete state.responses[key]);
+};
+
+const resetSectionCacheState = (state) => {
+    clearSectionResponses(state);
+    state.sections = [];
+};
+
+export {
+    createSectionCacheState,
+    storeSectionResponse,
+    getSections,
+    withSharedSections,
+    clearSectionResponses,
+    resetSectionCacheState,
+};

--- a/src/viewer/assets/lib/service.js
+++ b/src/viewer/assets/lib/service.js
@@ -96,6 +96,37 @@ const createServiceRoutes = (deps) => {
         withSharedSections,
     } = deps;
     const readCompareMode = () => (typeof getCompareMode === 'function' ? !!getCompareMode() : false);
+    const readSections = (data) => {
+        const sharedSections = typeof getSections === 'function' ? getSections() : [];
+        if (Array.isArray(sharedSections) && sharedSections.length > 0) {
+            return sharedSections;
+        }
+        if (Array.isArray(data?.sections)) {
+            return data.sections;
+        }
+        return [];
+    };
+    const hydrateSections = (data) => {
+        if (!data || typeof data !== 'object') return data;
+
+        const hydrated = typeof withSharedSections === 'function'
+            ? withSharedSections(data)
+            : data;
+
+        if (Array.isArray(hydrated?.sections)) {
+            return hydrated;
+        }
+
+        const sections = readSections(data);
+        if (sections.length === 0) {
+            return hydrated;
+        }
+
+        return {
+            ...hydrated,
+            sections,
+        };
+    };
 
     return {
         '/service/:serviceName/chart/:chartId': {
@@ -106,13 +137,14 @@ const createServiceRoutes = (deps) => {
                     view() {
                         const data = sectionResponseCache[svcKey];
                         if (!data) return m('div', 'Loading...');
-                        const activeSection = getSections()
+                        const viewData = hydrateSections(data);
+                        const activeSection = readSections(viewData)
                             .find(s => s.route === `/service/${params.serviceName}`);
                         return m('div', [
-                            m(TopNav, topNavAttrs(data, activeSection?.route, { compareMode: readCompareMode() })),
+                            m(TopNav, topNavAttrs(viewData, activeSection?.route, { compareMode: readCompareMode() })),
                             m('main.single-chart-main', [
                                 m(SingleChartView, {
-                                    data,
+                                    data: viewData,
                                     chartId: decodeURIComponent(params.chartId),
                                     applyResultToPlot,
                                 }),
@@ -143,11 +175,12 @@ const createServiceRoutes = (deps) => {
                     view() {
                         const data = sectionResponseCache[svcKey];
                         if (!data) return m('div', 'Loading...');
-                        const activeSection = getSections().find(
+                        const viewData = hydrateSections(data);
+                        const activeSection = readSections(viewData).find(
                             (section) => section.route === `/service/${params.serviceName}`,
                         );
                         return m(Main, {
-                            ...withSharedSections(data),
+                            ...viewData,
                             activeSection,
                             compareMode: readCompareMode(),
                         });
@@ -158,7 +191,8 @@ const createServiceRoutes = (deps) => {
                     return makeView();
                 }
                 return loadSection(svcKey).then((data) => {
-                    if (data?.sections) preloadSections(data.sections);
+                    const sections = readSections(data);
+                    if (sections.length > 0) preloadSections(sections);
                     return makeView();
                 });
             },

--- a/src/viewer/assets/lib/service.js
+++ b/src/viewer/assets/lib/service.js
@@ -76,6 +76,8 @@ const renderServiceSection = (attrs, Group, sectionRoute, sectionName, interval,
  * @param {Function} deps.topNavAttrs - (data, route) => attrs
  * @param {object} deps.SingleChartView
  * @param {Function} deps.applyResultToPlot
+ * @param {Function} deps.getSections - () => shared sections array
+ * @param {Function} deps.withSharedSections - (data) => data + shared sections
  * @returns {object} route map with '/service/:serviceName' and '/service/:serviceName/chart/:chartId'
  */
 const createServiceRoutes = (deps) => {
@@ -90,6 +92,8 @@ const createServiceRoutes = (deps) => {
         SingleChartView,
         applyResultToPlot,
         getCompareMode,
+        getSections,
+        withSharedSections,
     } = deps;
     const readCompareMode = () => (typeof getCompareMode === 'function' ? !!getCompareMode() : false);
 
@@ -102,7 +106,8 @@ const createServiceRoutes = (deps) => {
                     view() {
                         const data = sectionResponseCache[svcKey];
                         if (!data) return m('div', 'Loading...');
-                        const activeSection = data.sections.find(s => s.route === `/service/${params.serviceName}`);
+                        const activeSection = getSections()
+                            .find(s => s.route === `/service/${params.serviceName}`);
                         return m('div', [
                             m(TopNav, topNavAttrs(data, activeSection?.route, { compareMode: readCompareMode() })),
                             m('main.single-chart-main', [
@@ -138,10 +143,14 @@ const createServiceRoutes = (deps) => {
                     view() {
                         const data = sectionResponseCache[svcKey];
                         if (!data) return m('div', 'Loading...');
-                        const activeSection = data.sections.find(
+                        const activeSection = getSections().find(
                             (section) => section.route === `/service/${params.serviceName}`,
                         );
-                        return m(Main, { ...data, activeSection, compareMode: readCompareMode() });
+                        return m(Main, {
+                            ...withSharedSections(data),
+                            activeSection,
+                            compareMode: readCompareMode(),
+                        });
                     },
                 });
 

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -11,6 +11,7 @@ import {
     getStepOverride, CAPTURE_BASELINE, CAPTURE_EXPERIMENT,
 } from './data.js';
 import { canonicalQuantileLabel } from './charts/util/compare_math.js';
+import { heatmapTriplesMinMax } from './charts/util/heatmap_data.js';
 import { ViewerApi } from './viewer_api.js';
 
 // ── Normalization helpers for compare-mode captures ────────────────
@@ -58,7 +59,6 @@ const extractBaselineCapture = (spec) => {
         cap.timeData = spec.time_data || [];
         cap.heatmapData = spec.data || [];
         cap.bucketBounds = spec.bucket_bounds;
-        cap.heatmapMatrix = heatmapTriplesToMatrix(cap.heatmapData, cap.timeData.length);
         const scanned = heatmapTriplesMinMax(cap.heatmapData);
         cap.minValue = scanned.min != null ? scanned.min : spec.min_value;
         cap.maxValue = scanned.max != null ? scanned.max : spec.max_value;
@@ -78,7 +78,7 @@ const extractExperimentCapture = (spec, promqlResult) => {
     if (!Array.isArray(results) || results.length === 0) {
         if (style === 'multi' || style === 'scatter') cap.seriesMap = new Map();
         else if (style === 'heatmap' || style === 'histogram_heatmap') {
-            cap.timeData = []; cap.heatmapData = []; cap.heatmapMatrix = [];
+            cap.timeData = []; cap.heatmapData = [];
         } else {
             cap.timeData = []; cap.valueData = [];
         }
@@ -114,7 +114,6 @@ const extractExperimentCapture = (spec, promqlResult) => {
         const { timestamps, triples, minValue, maxValue } = promqlResultToHeatmapTriples(results);
         cap.timeData = timestamps.map(Number);
         cap.heatmapData = triples;
-        cap.heatmapMatrix = heatmapTriplesToMatrix(triples, cap.timeData.length);
         cap.minValue = minValue;
         cap.maxValue = maxValue;
         return cap;
@@ -126,51 +125,8 @@ const extractExperimentCapture = (spec, promqlResult) => {
     // the shape doesn't match. Full support is follow-up work.
     cap.timeData = [];
     cap.heatmapData = [];
-    cap.heatmapMatrix = [];
     return cap;
 };
-
-// Scan a flat [timeIdx, y, value] triple array for the numeric value
-// bounds. Returns { min: null, max: null } when there are no numeric
-// samples. Used once at extract time so unifiedHeatmapRange can just
-// Math.min/Math.max the two pre-computed pairs.
-function heatmapTriplesMinMax(triples) {
-    if (!Array.isArray(triples) || triples.length === 0) return { min: null, max: null };
-    let lo = Infinity;
-    let hi = -Infinity;
-    for (const t of triples) {
-        const v = Array.isArray(t) ? t[2] : null;
-        if (v == null || Number.isNaN(v)) continue;
-        if (v < lo) lo = v;
-        if (v > hi) hi = v;
-    }
-    if (!Number.isFinite(lo) || !Number.isFinite(hi)) return { min: null, max: null };
-    return { min: lo, max: hi };
-}
-
-// Build a rows × bins matrix from a flat [timeIdx, y, value] triple
-// array. Gaps fill with null. Used by the diff-heatmap strategy.
-function heatmapTriplesToMatrix(triples, binCount) {
-    if (!Array.isArray(triples) || triples.length === 0) return [];
-    let maxY = -1;
-    for (const t of triples) {
-        const y = Number(t?.[1]);
-        if (Number.isFinite(y) && y > maxY) maxY = y;
-    }
-    if (maxY < 0) return [];
-    const rows = maxY + 1;
-    const cols = Math.max(1, binCount || 0);
-    const matrix = Array.from({ length: rows }, () =>
-        new Array(cols).fill(null));
-    for (const [ti, y, v] of triples) {
-        const r = Number(y);
-        const c = Number(ti);
-        if (!Number.isFinite(r) || !Number.isFinite(c)) continue;
-        if (r < 0 || r >= rows || c < 0 || c >= cols) continue;
-        matrix[r][c] = (v === null || v === undefined) ? null : Number(v);
-    }
-    return matrix;
-}
 
 /**
  * Mithril component that fetches experiment data asynchronously and
@@ -500,15 +456,14 @@ export function getCachedSectionMeta(sectionResponseCache, interval) {
  * Build a Mithril component for a client-only section (System Info,
  * Metadata, Selection, Report) that has no backend data of its own.
  */
-export function buildClientOnlySectionView(Main, sectionResponseCache, activeSection, getCompareMode) {
+export function buildClientOnlySectionView(Main, sectionResponseCache, getSections, activeSection, getCompareMode) {
     return {
         view() {
             const anyCached = Object.values(sectionResponseCache)[0];
-            const sections = anyCached?.sections || [];
             return m(Main, {
                 activeSection,
                 groups: [],
-                sections,
+                sections: typeof getSections === 'function' ? getSections() : [],
                 compareMode: typeof getCompareMode === 'function' ? getCompareMode() : false,
                 source: anyCached?.source,
                 version: anyCached?.version,
@@ -522,4 +477,3 @@ export function buildClientOnlySectionView(Main, sectionResponseCache, activeSec
         },
     };
 }
-

--- a/tests/heatmap_data.test.mjs
+++ b/tests/heatmap_data.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    heatmapTriplesMinMax,
+    heatmapTriplesToMatrix,
+    ensureHeatmapMatrix,
+} from '../src/viewer/assets/lib/charts/util/heatmap_data.js';
+
+test('heatmapTriplesMinMax ignores nullish and NaN cells', () => {
+    assert.deepEqual(
+        heatmapTriplesMinMax([
+            [0, 0, null],
+            [1, 0, Number.NaN],
+            [2, 0, 3],
+            [3, 0, -1],
+        ]),
+        { min: -1, max: 3 },
+    );
+});
+
+test('heatmapTriplesToMatrix fills gaps with null and respects bin count', () => {
+    assert.deepEqual(
+        heatmapTriplesToMatrix(
+            [
+                [0, 0, 5],
+                [2, 1, 9],
+            ],
+            4,
+        ),
+        [
+            [5, null, null, null],
+            [null, null, 9, null],
+        ],
+    );
+});
+
+test('ensureHeatmapMatrix computes lazily and memoizes on the capture object', () => {
+    const capture = {
+        timeData: [10, 20, 30],
+        heatmapData: [
+            [0, 0, 1],
+            [2, 1, 4],
+        ],
+    };
+
+    assert.equal('heatmapMatrix' in capture, false);
+
+    const first = ensureHeatmapMatrix(capture);
+    assert.deepEqual(first, [
+        [1, null, null],
+        [null, null, 4],
+    ]);
+    assert.equal(capture.heatmapMatrix, first);
+
+    const second = ensureHeatmapMatrix(capture);
+    assert.equal(second, first);
+});

--- a/tests/heatmap_resolution.test.mjs
+++ b/tests/heatmap_resolution.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    createHeatmapResolutionStore,
+    ensureHeatmapResolution,
+} from '../src/viewer/assets/lib/charts/util/heatmap_data.js';
+
+test('ensureHeatmapResolution materializes full-resolution sparse heatmap cells', () => {
+    const store = createHeatmapResolutionStore(
+        [
+            [0, 0, 5],
+            [2, 1, 9],
+        ],
+        [10, 20, 30],
+        false,
+    );
+
+    const resolution = ensureHeatmapResolution(store, 1);
+    assert.equal(resolution.factor, 1);
+    assert.deepEqual(resolution.data, [
+        [10000, 0, 0, null, 5],
+        [30000, 1, 2, null, 9],
+    ]);
+});
+
+test('ensureHeatmapResolution downsampled output preserves min/max per bin and replaces old resolution', () => {
+    const store = createHeatmapResolutionStore(
+        [
+            [0, 0, 5],
+            [1, 0, 3],
+            [2, 0, 9],
+            [3, 0, 7],
+        ],
+        [10, 20, 30, 40],
+        false,
+    );
+
+    const first = ensureHeatmapResolution(store, 1);
+    const second = ensureHeatmapResolution(store, 2);
+
+    assert.notEqual(second, first);
+    assert.equal(store.current, second);
+    assert.deepEqual(second.data, [
+        [10000, 0, 0, 3, 5],
+        [30000, 0, 2, 7, 9],
+    ]);
+});
+
+test('emitNullCells fills missing cells in the current resolution only', () => {
+    const store = createHeatmapResolutionStore(
+        [
+            [1, 0, 4],
+        ],
+        [10, 20, 30],
+        true,
+    );
+
+    const resolution = ensureHeatmapResolution(store, 1);
+    assert.deepEqual(resolution.data, [
+        [10000, 0, 0, null, null],
+        [20000, 0, 1, null, 4],
+        [30000, 0, 2, null, null],
+    ]);
+});

--- a/tests/section_cache.test.mjs
+++ b/tests/section_cache.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    createSectionCacheState,
+    storeSectionResponse,
+    getSections,
+    withSharedSections,
+} from '../src/viewer/assets/lib/section_cache.js';
+
+test('storeSectionResponse strips duplicated sections and preserves shared section metadata', () => {
+    const state = createSectionCacheState();
+    const overview = {
+        groups: [{ id: 'cpu' }],
+        sections: [
+            { name: 'Overview', route: '/overview' },
+            { name: 'CPU', route: '/cpu' },
+        ],
+        interval: 1,
+    };
+
+    const storedOverview = storeSectionResponse(state, 'overview', overview);
+
+    assert.equal(state.responses.overview, storedOverview);
+    assert.deepEqual(getSections(state), overview.sections);
+    assert.equal('sections' in storedOverview, false);
+    assert.deepEqual(withSharedSections(state, storedOverview).sections, overview.sections);
+});
+
+test('storeSectionResponse reuses the shared sections list for later payloads without embedded sections', () => {
+    const state = createSectionCacheState();
+    storeSectionResponse(state, 'overview', {
+        groups: [],
+        sections: [{ name: 'Overview', route: '/overview' }],
+    });
+
+    const storedCpu = storeSectionResponse(state, 'cpu', {
+        groups: [{ id: 'busy' }],
+        interval: 1,
+    });
+
+    assert.equal('sections' in storedCpu, false);
+    assert.deepEqual(withSharedSections(state, storedCpu).sections, [
+        { name: 'Overview', route: '/overview' },
+    ]);
+});

--- a/tests/service_routes.test.mjs
+++ b/tests/service_routes.test.mjs
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServiceRoutes } from '../src/viewer/assets/lib/service.js';
+
+const setupGlobals = () => {
+    const previousM = globalThis.m;
+    const previousWindow = globalThis.window;
+
+    globalThis.m = (tag, attrs, children) => ({ tag, attrs, children });
+    globalThis.m.route = {
+        get: () => '/overview',
+    };
+    globalThis.window = {
+        scrollTo() {},
+    };
+
+    return () => {
+        globalThis.m = previousM;
+        globalThis.window = previousWindow;
+    };
+};
+
+const baseDeps = (sectionResponseCache) => ({
+    sectionResponseCache,
+    loadSection: async () => null,
+    preloadSections: () => {},
+    chartsState: { charts: new Map() },
+    Main: 'Main',
+    TopNav: 'TopNav',
+    topNavAttrs: (data, route, extra) => ({ data, route, extra }),
+    SingleChartView: 'SingleChartView',
+    applyResultToPlot: () => {},
+    getCompareMode: () => false,
+});
+
+test('service section route hydrates lean cached payloads with shared sections', async () => {
+    const restore = setupGlobals();
+    const sections = [
+        { name: 'Overview', route: '/overview' },
+        { name: 'API', route: '/service/api' },
+    ];
+
+    try {
+        const routes = createServiceRoutes({
+            ...baseDeps({
+                'service/api': {
+                    groups: [{ id: 'latency' }],
+                    interval: 1,
+                    metadata: {},
+                },
+            }),
+            getSections: () => sections,
+            withSharedSections: (data) => ({ ...data, sections }),
+        });
+
+        const view = await routes['/service/:serviceName'].onmatch(
+            { serviceName: 'api' },
+            '/service/api',
+        );
+        const vnode = view.view();
+
+        assert.equal(vnode.tag, 'Main');
+        assert.deepEqual(vnode.attrs.sections, sections);
+        assert.equal(vnode.attrs.activeSection.route, '/service/api');
+    } finally {
+        restore();
+    }
+});
+
+test('service section route falls back to embedded sections when shared-section helpers are absent', async () => {
+    const restore = setupGlobals();
+    const sections = [
+        { name: 'Overview', route: '/overview' },
+        { name: 'API', route: '/service/api' },
+    ];
+
+    try {
+        const routes = createServiceRoutes(baseDeps({
+            'service/api': {
+                groups: [{ id: 'latency' }],
+                interval: 1,
+                metadata: {},
+                sections,
+            },
+        }));
+
+        const view = await routes['/service/:serviceName'].onmatch(
+            { serviceName: 'api' },
+            '/service/api',
+        );
+        const vnode = view.view();
+
+        assert.equal(vnode.tag, 'Main');
+        assert.deepEqual(vnode.attrs.sections, sections);
+        assert.equal(vnode.attrs.activeSection.route, '/service/api');
+    } finally {
+        restore();
+    }
+});


### PR DESCRIPTION
## Summary

This PR reduces viewer-side memory retention and upfront compute in the chart loading path.

## What changed

- removed eager section preloading so section payloads are fetched and processed only when visited
- split shared `sections` metadata out of cached section responses to avoid retaining duplicate navigation data per section
- made compare-mode heatmap matrices lazy so side-by-side compare does not allocate dense matrices unless diff mode is enabled
- reworked mounted heatmap rendering so only the currently displayed resolution is materialized instead of retaining multiple flattened copies
- kept `site/viewer` aligned with the native viewer through the existing symlink pattern
- added focused regression tests for section cache behavior, lazy heatmap matrix creation, and active-resolution heatmap rendering

## Why

The viewer was still holding onto avoidable duplicated section metadata and multiple heatmap representations, and it was doing unnecessary work up front by preloading non-active sections. These changes reduce baseline heap growth and defer compute until a section or compare diff view is actually needed.

## Impact

- lower startup work when opening the viewer
- lower retained JS memory after navigating through sections
- lower compare-mode overhead for non-diff usage
- no backend API change required for this pass

## Validation

- `node --test tests/*.mjs`
- `node --check src/viewer/assets/lib/app.js`
- `node --check src/viewer/assets/lib/charts/compare.js`
- `node --check src/viewer/assets/lib/charts/heatmap.js`
- `node --check src/viewer/assets/lib/charts/util/heatmap_data.js`
- `node --check src/viewer/assets/lib/section_cache.js`
- `node --check src/viewer/assets/lib/script.js`
- `node --check src/viewer/assets/lib/service.js`
- `node --check src/viewer/assets/lib/viewer_core.js`
- `node --check site/viewer/lib/charts/compare.js`
- `node --check site/viewer/lib/charts/heatmap.js`
- `node --check site/viewer/lib/charts/util/heatmap_data.js`
- `node --check site/viewer/lib/section_cache.js`
- `node --check site/viewer/lib/app.js`
- `node --check site/viewer/lib/viewer_core.js`

## Follow-up

The remaining larger opportunities are backend/API-facing work: shared section metadata endpoints, lazy producer-side section generation, and bounded route cache eviction.