### PR TITLE
fix(viewer): redirect stale `#/service/...` hashes to default route

### DIFF
--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -646,15 +646,32 @@ const initDashboard = (config = {}) => {
         ? `/service/${categoryName}`
         : (serviceNames.length > 0 ? `/service/${serviceNames[0]}` : '/overview');
 
-    // A stale hash (e.g. `#/service/vllm` from a previous session)
-    // would otherwise drive mithril to a route whose data fetch 404s
-    // and surfaces as a confusing "Error: null" toast. If the URL is
-    // pointing at a per-service route that isn't the canonical default
-    // for this load, drop the hash so the defaultRoute kicks in.
+    // A stale hash (e.g. `#/service/llm-perf` from a previous session
+    // or external link to a different capture) would otherwise drive
+    // mithril to a route whose data fetch throws "Unknown section" and
+    // surfaces as a confusing error. Build the set of service names
+    // that actually have a section in this load; if the hash points at
+    // anything else, drop it so `defaultRoute` kicks in.
+    const validServiceNames = new Set();
     if (categoryName) {
+        validServiceNames.add(categoryName);
+    } else {
+        for (const name of serviceNames) validServiceNames.add(name);
+        const expServiceInstances = config.experimentFileMetadata?.service_instances;
+        if (expServiceInstances) {
+            for (const name of Object.keys(expServiceInstances)) {
+                validServiceNames.add(name);
+            }
+        }
+    }
+    {
         const hash = window.location.hash || '';
-        if (hash.startsWith('#/service/') && hash !== `#${defaultRoute}`) {
-            window.location.hash = '';
+        if (hash.startsWith('#/service/')) {
+            const tail = hash.slice('#/service/'.length);
+            const requestedSvc = decodeURIComponent(tail.split('/')[0] || '');
+            if (!validServiceNames.has(requestedSvc)) {
+                window.location.hash = '';
+            }
         }
     }
 
@@ -702,6 +719,7 @@ const initDashboard = (config = {}) => {
             getCompareMode: () => compareMode,
             getSections: getCachedSections,
             withSharedSections: withCachedSections,
+            getDefaultRoute: () => defaultRoute,
         }),
         '/about': {
             render() {
@@ -799,13 +817,24 @@ const initDashboard = (config = {}) => {
                     return cachedView(params.section, requestedPath);
                 }
 
-                return loadSection(params.section).then((data) => {
-                    if (data?.sections) preloadSections(data.sections);
-                    if (heatmapEnabled && !heatmapDataCache.has(requestedPath)) {
-                        fetchSectionHeatmapData(requestedPath, data.groups);
-                    }
-                    return cachedView(params.section, requestedPath);
-                });
+                return loadSection(params.section)
+                    .then((data) => {
+                        if (data?.sections) preloadSections(data.sections);
+                        if (heatmapEnabled && !heatmapDataCache.has(requestedPath)) {
+                            fetchSectionHeatmapData(requestedPath, data.groups);
+                        }
+                        return cachedView(params.section, requestedPath);
+                    })
+                    .catch((err) => {
+                        // Stale URL pointing at a missing section. Drop
+                        // back to the dashboard's default route instead
+                        // of letting the "Unknown section" error bubble.
+                        console.warn(`[viewer] section ${params.section} not available; redirecting`, err);
+                        if (defaultRoute && defaultRoute !== m.route.get()) {
+                            m.route.set(defaultRoute);
+                        }
+                        return new Promise(function () {});
+                    });
             },
         },
     });

--- a/src/viewer/assets/lib/service.js
+++ b/src/viewer/assets/lib/service.js
@@ -109,8 +109,21 @@ const createServiceRoutes = (deps) => {
         getCompareMode,
         getSections,
         withSharedSections,
+        getDefaultRoute,
     } = deps;
     const readCompareMode = () => (typeof getCompareMode === 'function' ? !!getCompareMode() : false);
+    // Recover from a missing service section (stale URL pointing at a
+    // service that this capture doesn't render) by sending the user to
+    // the dashboard's default route instead of letting the "Unknown
+    // section" error bubble out of mithril's loop.
+    const recoverFromMissingSection = (svcKey, err) => {
+        console.warn(`[viewer] section ${svcKey} not available; redirecting to default route`, err);
+        const target = typeof getDefaultRoute === 'function' ? getDefaultRoute() : '/overview';
+        if (target && target !== m.route.get()) {
+            m.route.set(target);
+        }
+        return new Promise(function () {});
+    };
     const readSections = (data) => {
         const sharedSections = typeof getSections === 'function' ? getSections() : [];
         if (Array.isArray(sharedSections) && sharedSections.length > 0) {
@@ -171,7 +184,9 @@ const createServiceRoutes = (deps) => {
                 if (sectionResponseCache[svcKey]) {
                     return makeView();
                 }
-                return loadSection(svcKey).then(() => makeView());
+                return loadSection(svcKey)
+                    .then(() => makeView())
+                    .catch((err) => recoverFromMissingSection(svcKey, err));
             },
         },
         '/service/:serviceName': {
@@ -205,11 +220,13 @@ const createServiceRoutes = (deps) => {
                 if (sectionResponseCache[svcKey]) {
                     return makeView();
                 }
-                return loadSection(svcKey).then((data) => {
-                    const sections = readSections(data);
-                    if (sections.length > 0) preloadSections(sections);
-                    return makeView();
-                });
+                return loadSection(svcKey)
+                    .then((data) => {
+                        const sections = readSections(data);
+                        if (sections.length > 0) preloadSections(sections);
+                        return makeView();
+                    })
+                    .catch((err) => recoverFromMissingSection(svcKey, err));
             },
         },
     };

--- a/tests/service_routes.test.mjs
+++ b/tests/service_routes.test.mjs
@@ -2,13 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createServiceRoutes } from '../src/viewer/assets/lib/service.js';
 
-const setupGlobals = () => {
+const setupGlobals = (overrides = {}) => {
     const previousM = globalThis.m;
     const previousWindow = globalThis.window;
 
     globalThis.m = (tag, attrs, children) => ({ tag, attrs, children });
     globalThis.m.route = {
         get: () => '/overview',
+        set: overrides.routeSet || (() => {}),
     };
     globalThis.window = {
         scrollTo() {},
@@ -64,6 +65,36 @@ test('service section route hydrates lean cached payloads with shared sections',
         assert.equal(vnode.attrs.activeSection.route, '/service/api');
     } finally {
         restore();
+    }
+});
+
+test('service section route redirects to default when section is missing', async () => {
+    const setRouteCalls = [];
+    const previousWarn = console.warn;
+    console.warn = () => {};
+    const restore = setupGlobals({ routeSet: (target) => setRouteCalls.push(target) });
+
+    try {
+        const routes = createServiceRoutes({
+            ...baseDeps({}),
+            loadSection: async () => { throw new Error('Unknown section: service/llm-perf'); },
+            getDefaultRoute: () => '/service/vllm',
+        });
+
+        const result = routes['/service/:serviceName'].onmatch(
+            { serviceName: 'llm-perf' },
+            '/service/llm-perf',
+        );
+
+        // recoverFromMissingSection returns a never-resolving promise; race
+        // it against a microtask tick so we can assert on the redirect
+        // without blocking the test.
+        await Promise.race([result, new Promise((r) => setTimeout(r, 10))]);
+
+        assert.deepEqual(setRouteCalls, ['/service/vllm']);
+    } finally {
+        restore();
+        console.warn = previousWarn;
     }
 });
 


### PR DESCRIPTION
## Summary

Loading a URL like
`https://rezolus.com/viewer/?capture=vllm=vllm_gemma3.parquet&capture=sglang=sglang_gemma3.parquet#/service/llm-perf`
threw `Uncaught (in promise) Error: Unknown section: service/llm-perf`.

The hash points at a service section that doesn't exist for those
captures (`llm-perf` is a separate service template, not a member of
`vllm`/`sglang`). The existing stale-hash cleanup in `app.js` only
fires in category mode, so the hash slipped through, mithril routed to
`/service/llm-perf`, and the WASM `getSection` call threw.

## Fix

- Generalize the stale-hash cleanup so it always runs when a
  `#/service/<name>` hash isn't in the load's known service set
  (baseline + experiment `service_instances`, or the active
  `categoryName`). Stale hashes are dropped so `defaultRoute` kicks in.
- Defense-in-depth: if a stale section URL still reaches mithril (e.g.
  the URL maps to a section not represented in `service_instances`),
  catch the load failure in the service routes and the generic
  `/:section` route, and redirect to `defaultRoute` instead of letting
  the error bubble out.

## Test plan
- [x] `node --test tests/*.mjs` (24 pass, including a new test for the
      missing-section redirect)
- [ ] Manual: visit the failing URL on rezolus.com staging and verify
      the dashboard now loads at `/service/vllm` (defaultRoute) instead
      of throwing.
- [ ] Manual: existing valid URLs (`#/service/inference-library` for a
      category-mode load, `#/cpu`, etc.) still resolve.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AYqBBXGXMBtbLuxz5sQ6Jc)_