### PR TITLE
fix(viewer): break redirect loop when defaultRoute is also missing

### DIFF
--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -829,9 +829,18 @@ const initDashboard = (config = {}) => {
                         // Stale URL pointing at a missing section. Drop
                         // back to the dashboard's default route instead
                         // of letting the "Unknown section" error bubble.
+                        // If defaultRoute itself points at the failing
+                        // section (can happen when serviceInstances and
+                        // dashboard_sections disagree on naming), fall
+                        // through to /overview to avoid bouncing into
+                        // the same broken route — m.route.get() returns
+                        // the last successfully resolved path, which
+                        // never advances when every onmatch rejects.
                         console.warn(`[viewer] section ${params.section} not available; redirecting`, err);
-                        if (defaultRoute && defaultRoute !== m.route.get()) {
-                            m.route.set(defaultRoute);
+                        const failingRoute = `/${params.section}`;
+                        const target = defaultRoute === failingRoute ? '/overview' : defaultRoute;
+                        if (target && target !== m.route.get()) {
+                            m.route.set(target);
                         }
                         return new Promise(function () {});
                     });

--- a/src/viewer/assets/lib/service.js
+++ b/src/viewer/assets/lib/service.js
@@ -116,9 +116,23 @@ const createServiceRoutes = (deps) => {
     // service that this capture doesn't render) by sending the user to
     // the dashboard's default route instead of letting the "Unknown
     // section" error bubble out of mithril's loop.
+    //
+    // m.route.get() returns the last *successfully resolved* path, so
+    // when this is the very first route resolution it stays empty no
+    // matter how many times we redirect. That makes the
+    // `target !== m.route.get()` guard insufficient on its own — if
+    // getDefaultRoute() itself points at a section that isn't in
+    // dashboard_sections (e.g. compare-mode-without-category, where
+    // alias-driven section keys diverge from `serviceInstances` keys
+    // derived from per_source_metadata), we'd bounce between the
+    // broken route and itself indefinitely. Fall back to /overview
+    // when the redirect target matches the failing route — overview
+    // is always generated.
     const recoverFromMissingSection = (svcKey, err) => {
         console.warn(`[viewer] section ${svcKey} not available; redirecting to default route`, err);
-        const target = typeof getDefaultRoute === 'function' ? getDefaultRoute() : '/overview';
+        const failingRoute = `/${svcKey}`;
+        let target = typeof getDefaultRoute === 'function' ? getDefaultRoute() : '/overview';
+        if (target === failingRoute) target = '/overview';
         if (target && target !== m.route.get()) {
             m.route.set(target);
         }

--- a/tests/service_routes.test.mjs
+++ b/tests/service_routes.test.mjs
@@ -98,6 +98,49 @@ test('service section route redirects to default when section is missing', async
     }
 });
 
+test('service section route falls back to /overview when default route equals the failing route', async () => {
+    // Repro for the redirect-loop bug: when the dashboard's default
+    // route points at a section that isn't in dashboard_sections (can
+    // happen when serviceInstances and section keys disagree, e.g.
+    // compare-mode-without-category aliasing), we'd otherwise bounce
+    // between the broken route and itself indefinitely. Mithril's
+    // m.route.get() returns the last successfully resolved path;
+    // simulate an initial load (no route resolved yet) by returning
+    // undefined.
+    const setRouteCalls = [];
+    const previousWarn = console.warn;
+    const previousM = globalThis.m;
+    const previousWindow = globalThis.window;
+    console.warn = () => {};
+    globalThis.m = (tag, attrs, children) => ({ tag, attrs, children });
+    globalThis.m.route = {
+        get: () => undefined,
+        set: (target) => setRouteCalls.push(target),
+    };
+    globalThis.window = { scrollTo() {} };
+
+    try {
+        const routes = createServiceRoutes({
+            ...baseDeps({}),
+            loadSection: async () => { throw new Error('Unknown section: service/llm-perf'); },
+            getDefaultRoute: () => '/service/llm-perf',
+        });
+
+        const result = routes['/service/:serviceName'].onmatch(
+            { serviceName: 'llm-perf' },
+            '/service/llm-perf',
+        );
+
+        await Promise.race([result, new Promise((r) => setTimeout(r, 10))]);
+
+        assert.deepEqual(setRouteCalls, ['/overview']);
+    } finally {
+        globalThis.m = previousM;
+        globalThis.window = previousWindow;
+        console.warn = previousWarn;
+    }
+});
+
 test('service section route falls back to embedded sections when shared-section helpers are absent', async () => {
     const restore = setupGlobals();
     const sections = [


### PR DESCRIPTION
## Summary

Stale `#/service/llm-perf` URLs (and any other broken-section URL where the dashboard's `defaultRoute` happens to match) caused the WASM viewer to enter an infinite redirect loop instead of recovering. The browser console filled with `[viewer] section service/llm-perf not available; redirecting to default route Error: Unknown section: service/llm-perf` repeating until tab freeze.

## Root cause

`recoverFromMissingSection` and the matching catch handler in `app.js`'s top-level route both used:

```js
if (target && target !== m.route.get()) {
    m.route.set(target);
}
```

as a same-route guard. But `m.route.get()` returns mithril's *last successfully resolved* path, and `currentPath` is only set when an `onmatch` callback resolves with a component — never when every onmatch returns `recoverFromMissingSection`'s pending promise. On a fresh failed-first-resolve, the guard is effectively `target !== undefined`, which is always true, so `m.route.set(target)` fires every iteration and we bounce.

The bounce is reachable whenever `defaultRoute` points at the same broken section as the URL hash. That happens when `fileMetadata.service_instances` (derived from `per_source_metadata` keys) disagrees with `dashboard_sections` (keyed by alias-driven `service_exts`) — e.g. compare-mode-without-category, where the section is generated under the alias (`vllm`/`sglang`) but `service_instances` still reports the raw source key (`llm-perf`), and `defaultRoute` is computed from `serviceInstances`.

## Fix

In both recovery paths, when the redirect target equals the failing route, fall back to `/overview` instead. Overview is always generated by `dashboard::dashboard::generate`, so it's a safe terminal target.

## Test plan

- [x] `node --test tests/*.mjs` — all 25 tests pass, including a new regression test `service section route falls back to /overview when default route equals the failing route`.
- [ ] Manual: load `https://rezolus.com/viewer#/service/llm-perf`, trigger any demo whose `defaultRoute` would route into a non-existent section, confirm console shows a single warning and the viewer lands on `/overview` instead of looping.

---
_Generated by [Claude Code](https://claude.ai/code/session_018XdD9Q6AA78mDoxyHSV1x8)_