### PR TITLE
fix(installer): run as root and create rezolus user on RPM systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,20 +53,10 @@ done
 # Detect the operating system
 OS_TYPE="$(uname -s)"
 
-# Check for sudo access early
-if [[ "$OS_TYPE" == "Linux" ]]; then
-    echo "This installer requires sudo access to configure package repositories and install Rezolus"
-    echo "You may be prompted for your password"
-    echo ""
-
-    # Test sudo access - this will prompt for password if needed
-    if ! sudo -v; then
-        echo "Error: This installer requires sudo access" >&2
-        exit 1
-    fi
-
-    # Keep sudo alive for the duration of the script
-    while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+# Check for root access on Linux
+if [[ "$OS_TYPE" == "Linux" ]] && [[ "$EUID" -ne 0 ]]; then
+    echo "Error: This installer must be run as root" >&2
+    exit 1
 fi
 
 if [[ "$OS_TYPE" == "Darwin" ]]; then
@@ -238,8 +228,8 @@ if [[ -z "$DISABLE_SERVICES" ]] && [[ "$SKIP_CONFIRM" == "false" ]]; then
         echo "" >&2
         echo "When piping this script, please run in a terminal that supports interaction" >&2
         echo "Or use command-line options:" >&2
-        echo "  curl -fsSL https://install.rezolus.com | bash -s -- -y" >&2
-        echo "  curl -fsSL https://install.rezolus.com | bash -s -- -y --disable-services" >&2
+        echo "  curl -fsSL https://install.rezolus.com | sudo bash -s -- -y" >&2
+        echo "  curl -fsSL https://install.rezolus.com | sudo bash -s -- -y --disable-services" >&2
         exit 1
     fi
 
@@ -262,24 +252,24 @@ fi
 case "$PACKAGE_MANAGER" in
     apt)
         echo "Adding Rezolus repository GPG signing key..."
-        if ! curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | sudo gpg --yes --dearmor -o /etc/apt/trusted.gpg.d/rezolus-archive-keyring.gpg; then
+        if ! curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --yes --dearmor -o /etc/apt/trusted.gpg.d/rezolus-archive-keyring.gpg; then
             echo "Error: Failed to add GPG signing key" >&2
             exit 1
         fi
 
         echo "Adding Rezolus APT repository..."
-        echo "deb [arch=amd64] https://us-apt.pkg.dev/projects/rezolus ${REPO_NAME} main" | sudo tee /etc/apt/sources.list.d/rezolus.list > /dev/null
+        echo "deb [arch=amd64] https://us-apt.pkg.dev/projects/rezolus ${REPO_NAME} main" | tee /etc/apt/sources.list.d/rezolus.list > /dev/null
 
         echo "Updating package list..."
-        sudo apt update
+        apt update
 
         echo "Installing Rezolus..."
-        sudo apt install -y rezolus
+        apt install -y rezolus
         ;;
 
     dnf|yum)
         echo "Adding Rezolus YUM repository..."
-        sudo tee /etc/yum.repos.d/rezolus.repo > /dev/null <<EOF
+        tee /etc/yum.repos.d/rezolus.repo > /dev/null <<EOF
 [rezolus]
 name=Rezolus Repository
 baseurl=https://us-yum.pkg.dev/projects/rezolus/${REPO_NAME}
@@ -291,7 +281,7 @@ gpgkey=https://us-yum.pkg.dev/doc/repo-signing-key.gpg
 EOF
 
         echo "Installing Rezolus..."
-        sudo $PACKAGE_MANAGER install -y rezolus
+        $PACKAGE_MANAGER install -y rezolus
         ;;
 esac
 
@@ -301,16 +291,16 @@ echo "Installation completed successfully"
 if [[ "$DISABLE_SERVICES" == "true" ]]; then
     echo ""
     echo "Disabling services..."
-    sudo systemctl disable --now rezolus.service
-    sudo systemctl disable --now rezolus-exporter.service
+    systemctl disable --now rezolus.service
+    systemctl disable --now rezolus-exporter.service
     echo ""
     echo "Services have been disabled"
     echo ""
     echo "Run 'rezolus --help' for usage information"
     echo ""
     echo "To enable services later:"
-    echo "  sudo systemctl enable --now rezolus"
-    echo "  sudo systemctl enable --now rezolus-exporter"
+    echo "  systemctl enable --now rezolus"
+    echo "  systemctl enable --now rezolus-exporter"
     echo ""
     echo "Installation complete"
 else
@@ -318,10 +308,10 @@ else
     echo "Enabling and starting services..."
 
     # Enable services in case they were previously disabled
-    sudo systemctl enable rezolus.service rezolus-exporter.service
+    systemctl enable rezolus.service rezolus-exporter.service
 
     # Start services if they're not already running
-    sudo systemctl start rezolus.service rezolus-exporter.service
+    systemctl start rezolus.service rezolus-exporter.service
 
     # Give services a moment to start
     sleep 2
@@ -329,8 +319,8 @@ else
     echo "Checking service status..."
 
     # Check if services are running
-    REZOLUS_STATUS=$(sudo systemctl is-active rezolus.service 2>/dev/null || echo "inactive")
-    EXPORTER_STATUS=$(sudo systemctl is-active rezolus-exporter.service 2>/dev/null || echo "inactive")
+    REZOLUS_STATUS=$(systemctl is-active rezolus.service 2>/dev/null || echo "inactive")
+    EXPORTER_STATUS=$(systemctl is-active rezolus-exporter.service 2>/dev/null || echo "inactive")
 
     if [[ "$REZOLUS_STATUS" == "active" ]] && [[ "$EXPORTER_STATUS" == "active" ]]; then
         echo "Services are running successfully:"
@@ -350,8 +340,8 @@ else
         fi
         echo ""
         echo "Check service logs for details:" >&2
-        echo "  sudo journalctl -u rezolus.service -n 50" >&2
-        echo "  sudo journalctl -u rezolus-exporter.service -n 50" >&2
+        echo "  journalctl -u rezolus.service -n 50" >&2
+        echo "  journalctl -u rezolus-exporter.service -n 50" >&2
         echo ""
         echo "Installation completed with errors - services not running"
     fi

--- a/rpm/rezolus.spec.template
+++ b/rpm/rezolus.spec.template
@@ -15,10 +15,21 @@ High resolution systems performance telemetry agent
 %build
 # Nothing to build - using pre-built binary
 
+%pre
+#!/bin/bash
+# Create rezolus system user and group for running services
+if ! getent group rezolus > /dev/null 2>&1; then
+    groupadd -r rezolus
+fi
+if ! getent passwd rezolus > /dev/null 2>&1; then
+    useradd -r -g rezolus -d /usr/share/rezolus -s /sbin/nologin -c "Rezolus metrics agent" rezolus
+fi
+
 %install
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/etc/rezolus
 mkdir -p %{buildroot}/usr/lib/systemd/system
+mkdir -p %{buildroot}/usr/share/rezolus
 
 install -m 755 %{_sourcedir}/target/release/rezolus %{buildroot}/usr/bin/
 install -m 644 %{_sourcedir}/config/agent.toml %{buildroot}/etc/rezolus/

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -73,8 +73,6 @@
 <div id="panel-linux">
 
 <section class="mb-16">
-<h2 class="text-xl font-bold mb-4">Quick Install</h2>
-<p class="text-sm text-slate-500 dark:text-slate-400 mb-4">The installer adds the package repository for your distro, installs Rezolus, and enables the agent, exporter, and hindsight services via systemd.</p>
 <div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
 <div class="flex items-center px-4 py-2 bg-slate-800 gap-2">
 <div class="w-3 h-3 rounded-full bg-red-500/50"></div>
@@ -82,10 +80,14 @@
 <div class="w-3 h-3 rounded-full bg-green-500/50"></div>
 </div>
 <div class="p-6 font-mono text-sm leading-8">
-<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">curl -fsSL https://install.rezolus.com | bash</code></div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">#</span><code class="text-green-400">curl -fsSL https://install.rezolus.com | sudo bash</code></div>
 </div>
 </div>
-<p class="text-xs text-slate-400 mt-3">Use <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded">--disable-services</code> to install without auto-starting. Use <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded">-y</code> for non-interactive mode.</p>
+<p class="text-sm text-slate-500 dark:text-slate-400 mt-4 mb-4">The installer adds the package repository for your distro, installs Rezolus, and enables the agent, exporter, and hindsight services via systemd. Run as root or with sudo.</p>
+<div class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 mb-4">
+<span class="material-symbols-outlined text-sm">info</span>
+<span class="text-slate-600 dark:text-slate-500">Full root access required for package repository configuration</span>
+</div>
 </section>
 
 <section class="mb-16">

--- a/site/index.html
+++ b/site/index.html
@@ -166,17 +166,21 @@
 <div class="w-8 h-8 rounded-full bg-primary text-white flex items-center justify-center text-sm font-bold shrink-0">1</div>
 <h3 class="text-base font-bold text-slate-900 dark:text-white">Install and start</h3>
 </div>
-<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden mb-4">
 <div class="flex items-center px-4 py-2 bg-slate-800 gap-2">
 <div class="w-3 h-3 rounded-full bg-red-500/50"></div>
 <div class="w-3 h-3 rounded-full bg-amber-500/50"></div>
 <div class="w-3 h-3 rounded-full bg-green-500/50"></div>
 </div>
 <div class="p-6 font-mono text-sm">
-<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">curl -fsSL https://install.rezolus.com | bash</code></div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">#</span><code class="text-green-400">curl -fsSL https://install.rezolus.com | sudo bash</code></div>
 </div>
 </div>
-<p class="text-sm text-slate-500 dark:text-slate-400 mt-3">This adds the package repo, installs Rezolus, and starts the agent as a systemd service. Supports Debian, Ubuntu, Rocky Linux, and Amazon Linux.</p>
+<p class="text-sm text-slate-500 dark:text-slate-400 mb-3">This adds the package repo, installs Rezolus, and starts the agent as a systemd service. Supports Debian, Ubuntu, Rocky Linux, and Amazon Linux.</p>
+<div class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+<span class="material-symbols-outlined text-sm">info</span>
+<span class="text-slate-600 dark:text-slate-500">Run as root or with sudo</span>
+</div>
 </div>
 
 <div>


### PR DESCRIPTION
## Summary

- Simplifies install.sh to assume root execution instead of prompting for sudo password
- Adds %pre script to RPM spec template to create rezolus user/group before installation
- Fixes the issue where rezolus-exporter fails to start on Amazon Linux 2023 because the rezolus user doesn't exist

## Test plan

- [ ] Verify install.sh works when run with \`| sudo bash\`
- [ ] Verify install.sh fails appropriately when run as non-root without sudo
- [ ] Test RPM package build with the updated spec template
- [ ] Test installation on Amazon Linux 2023 to verify user creation and service startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)