### PR TITLE
fix(viewer): rebuild WASM + add CI gate against bad externref-table layout

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -101,6 +101,65 @@ jobs:
           rustup component add rustfmt
           cargo fmt --all -- --check
 
+  # WASM viewer is wasm32-only and excluded from the regular build
+  # matrix above. Two checks run here on every PR:
+  #
+  #   1. Rebuild from source via crates/viewer/build.sh so a
+  #      Rust-side breakage in crates/viewer/ surfaces at PR time.
+  #
+  #   2. Structurally validate the *committed* WASM that will ship
+  #      to rezolus.com. The static-site deploy in pages.yml copies
+  #      site/viewer/pkg/wasm_viewer_bg.wasm verbatim, so a bad
+  #      committed artifact lands in production. Building locally
+  #      with the wrong binaryen silently produces a broken WASM —
+  #      e.g. binaryen 108 mis-orders the externref table so the
+  #      `__wbindgen_externrefs` export points at the locked
+  #      funcref table, and the JS shim then fails at instantiation
+  #      with `Table.grow(): failed to grow table by 4`. This step
+  #      catches that specific failure mode regardless of which
+  #      toolchain produced the committed bytes.
+  wasm-viewer:
+    name: wasm-viewer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version ^0.14 --locked
+      - name: Install wabt
+        run: sudo apt-get update && sudo apt-get -y install wabt
+      - name: Validate committed WASM structure
+        run: |
+          wasm=site/viewer/pkg/wasm_viewer_bg.wasm
+          # Find which table index the JS shim's externref slot is
+          # exported from, then confirm that table is actually an
+          # externref table. binaryen 108 swaps these and routes the
+          # export at the locked funcref table.
+          export_idx=$(wasm-objdump -x "$wasm" \
+            | grep -E '__wbindgen_externrefs' \
+            | grep -oE 'table\[[0-9]+\]' \
+            | head -1 \
+            | grep -oE '[0-9]+')
+          if [ -z "$export_idx" ]; then
+            echo "::error file=$wasm::no __wbindgen_externrefs export found"
+            exit 1
+          fi
+          target_table=$(wasm-objdump -x "$wasm" | grep -E "^ - table\\[$export_idx\\] type=")
+          if ! echo "$target_table" | grep -q externref; then
+            echo "::error file=$wasm::__wbindgen_externrefs is exported from table[$export_idx], which is not an externref table."
+            echo ""
+            wasm-objdump -x "$wasm" | grep -E '^ - table\[|__wbindgen_externrefs' | sed 's/^/    /'
+            echo ""
+            echo "Rebuild with the canonical toolchain: ./crates/viewer/build.sh"
+            echo "(needs wasm-pack >= 0.14, which pins binaryen 117)."
+            exit 1
+          fi
+      - name: Rebuild WASM viewer
+        run: ./crates/viewer/build.sh
+
   setup:
     name: setup
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Two-part fix for the broken WASM that landed via #846:

### 1. Rebuild the committed WASM with the right toolchain

The artifact in #846 was optimized with binaryen 108 (system `apt-get install binaryen` on Ubuntu 24.04). That version has a bug in its externref-table re-ordering pass — `__wbindgen_externrefs` ends up exported from `table[0]` (the locked funcref table) instead of `table[1]` (the externref table). The wasm-bindgen JS shim then calls `wasm.__wbindgen_externrefs.grow(4)` at instantiation, which fails on the locked table:

```
Failed to load compare demos: WebAssembly.Table.grow(): failed to grow table by 4
```

Rebuilt with binaryen 117 (the version `wasm-pack` 0.14 itself pins / downloads). After:

```
$ wasm-objdump -x site/viewer/pkg/wasm_viewer_bg.wasm | grep externrefs
 - table[1] -> "__wbindgen_externrefs"   # correct: externref table
```

### 2. Add a CI gate so this can't happen again

The deploy workflow copies `site/viewer/pkg/wasm_viewer_bg.wasm` verbatim — there was no PR-time check on whether the committed artifact was well-formed. Adds a `wasm-viewer` job to `cargo.yml` that:

- **Rebuilds** `crates/viewer/` via the canonical `build.sh` so a Rust-side breakage surfaces at PR time.
- **Structurally validates** the committed WASM by extracting which table the `__wbindgen_externrefs` export points at and confirming that table's type is `externref`. Catches the binaryen 108 failure mode independent of which toolchain produced the bytes.

A stricter bit-equality check between a CI rebuild and the committed artifact would also catch toolchain drift, but Rust stable updates would cause false positives. The structural check covers the actual bug class without needing pinned Rust toolchains.

## Test plan

- [x] `wasm-objdump -x site/viewer/pkg/wasm_viewer_bg.wasm | grep externrefs` → `table[1]` ✓
- [x] Validation script runs locally and exits 0 against the committed artifact.
- [ ] CI's new `wasm-viewer` job passes.
- [ ] Manual: load the inference compare demo on rezolus.com after merge, confirm `Failed to load compare demos` no longer fires.