### PR TITLE
perf(viewer): split sections metadata from section payloads (Phase 1)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - name: Regenerate static-site templates manifest
+        run: |
+          (
+            cd config/templates
+            printf '[\n'
+            ls -1 *.json | sort | sed 's/\.json$//' \
+              | awk 'BEGIN{first=1} {if(!first)printf ",\n"; printf "  \"%s\"", $0; first=0} END{printf "\n"}'
+            printf ']\n'
+          ) > site/viewer/templates/manifest.json
       - name: Resolve symlinks
         run: cp -rL site site-resolved
       - uses: actions/configure-pages@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.14"
+version = "5.11.1-alpha.15"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.14"
+version = "5.11.1-alpha.15"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/config/templates/cachecannon.json
+++ b/config/templates/cachecannon.json
@@ -6,7 +6,7 @@
     {
       "role": "load",
       "title": "Target Rate",
-      "query": "target_rate",
+      "query": "target_rate{source=\"cachecannon\"}",
       "type": "gauge",
       "unit_system": "count",
       "subgroup": "Target Rate",
@@ -15,14 +15,14 @@
     {
       "role": "throughput",
       "title": "Request Rate",
-      "query": "sum(irate(requests_sent[5s]))",
+      "query": "sum(irate(requests_sent{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "throughput",
       "title": "Response Rate",
-      "query": "sum(irate(responses_received[5s]))",
+      "query": "sum(irate(responses_received{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -30,21 +30,21 @@
     {
       "role": "throughput",
       "title": "Bytes Received Rate",
-      "query": "sum(irate(bytes_rx[5s]))",
+      "query": "sum(irate(bytes_rx{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "throughput",
       "title": "Bytes Sent Rate",
-      "query": "sum(irate(bytes_tx[5s]))",
+      "query": "sum(irate(bytes_tx{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "latency",
       "title": "Response Latency",
-      "query": "response_latency",
+      "query": "response_latency{source=\"cachecannon\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "unit_system": "time",
@@ -54,7 +54,7 @@
     {
       "role": "latency",
       "title": "GET Latency",
-      "query": "get_latency",
+      "query": "get_latency{source=\"cachecannon\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "unit_system": "time"
@@ -62,7 +62,7 @@
     {
       "role": "latency",
       "title": "SET Latency",
-      "query": "set_latency",
+      "query": "set_latency{source=\"cachecannon\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "unit_system": "time"
@@ -70,42 +70,42 @@
     {
       "role": "error",
       "title": "Request Error Rate",
-      "query": "sum(irate(request_errors[5s]))",
+      "query": "sum(irate(request_errors{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Connection Failure Rate",
-      "query": "sum(irate(connections_failed[5s]))",
+      "query": "sum(irate(connections_failed{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "custom",
       "title": "Cache Hit Rate",
-      "query": "sum(irate(cache_hits[5s]))",
+      "query": "sum(irate(cache_hits{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "custom",
       "title": "Cache Miss Rate",
-      "query": "sum(irate(cache_misses[5s]))",
+      "query": "sum(irate(cache_misses{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "custom",
       "title": "GET Rate",
-      "query": "sum(irate(get_count[5s]))",
+      "query": "sum(irate(get_count{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "custom",
       "title": "SET Rate",
-      "query": "sum(irate(set_count[5s]))",
+      "query": "sum(irate(set_count{source=\"cachecannon\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     }

--- a/config/templates/llm-perf.json
+++ b/config/templates/llm-perf.json
@@ -7,7 +7,7 @@
     {
       "role": "throughput",
       "title": "Output Token Rate",
-      "query": "sum(irate(tokens{direction=\"output\"}[5s]))",
+      "query": "sum(irate(tokens{direction=\"output\",source=\"llm-perf\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -15,56 +15,56 @@
     {
       "role": "load",
       "title": "Input Token Rate",
-      "query": "sum(irate(tokens{direction=\"input\"}[5s]))",
+      "query": "sum(irate(tokens{direction=\"input\",source=\"llm-perf\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "load",
       "title": "Requests In-Flight",
-      "query": "requests_inflight",
+      "query": "requests_inflight{source=\"llm-perf\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "throughput",
       "title": "Request Rate",
-      "query": "sum(irate(requests{status=\"success\"}[5s]))",
+      "query": "sum(irate(requests{status=\"success\",source=\"llm-perf\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Error Rate",
-      "query": "sum(irate(requests{status=\"error\"}[5s])) / sum(irate(requests{status=\"sent\"}[5s]))",
+      "query": "sum(irate(requests{status=\"error\",source=\"llm-perf\"}[5s])) / sum(irate(requests{status=\"sent\",source=\"llm-perf\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "percentage"
     },
     {
       "role": "error",
       "title": "Error Request Rate",
-      "query": "sum(irate(requests{status=\"error\"}[5s]))",
+      "query": "sum(irate(requests{status=\"error\",source=\"llm-perf\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Timeout Request Rate",
-      "query": "sum(irate(requests{status=\"timeout\"}[5s]))",
+      "query": "sum(irate(requests{status=\"timeout\",source=\"llm-perf\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Canceled Request Rate",
-      "query": "sum(irate(requests{status=\"canceled\"}[5s]))",
+      "query": "sum(irate(requests{status=\"canceled\",source=\"llm-perf\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "latency",
       "title": "Time to First Token (TTFT)",
-      "query": "ttft",
+      "query": "ttft{source=\"llm-perf\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -73,7 +73,7 @@
     {
       "role": "latency",
       "title": "Time per Output Token (TPOT)",
-      "query": "tpot",
+      "query": "tpot{source=\"llm-perf\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -82,7 +82,7 @@
     {
       "role": "latency",
       "title": "Inter-Token Latency (ITL)",
-      "query": "itl",
+      "query": "itl{source=\"llm-perf\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -91,7 +91,7 @@
     {
       "role": "latency",
       "title": "Request Latency",
-      "query": "request_latency",
+      "query": "request_latency{source=\"llm-perf\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -100,7 +100,7 @@
     {
       "role": "latency",
       "title": "Think Duration",
-      "query": "think_duration",
+      "query": "think_duration{source=\"llm-perf\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],

--- a/config/templates/sglang-decode.json
+++ b/config/templates/sglang-decode.json
@@ -6,21 +6,21 @@
     {
       "role": "load",
       "title": "Requests Running",
-      "query": "sglang_num_running_reqs",
+      "query": "sglang_num_running_reqs{source=\"sglang-decode\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "load",
       "title": "Requests Waiting",
-      "query": "sglang_num_queue_reqs",
+      "query": "sglang_num_queue_reqs{source=\"sglang-decode\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "throughput",
       "title": "Generation Token Rate",
-      "query": "sum(irate(sglang_generation_tokens_total[5s]))",
+      "query": "sum(irate(sglang_generation_tokens_total{source=\"sglang-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -28,21 +28,21 @@
     {
       "role": "throughput",
       "title": "Request Completion Rate",
-      "query": "sum(irate(sglang_num_requests_total[5s])) - sum(irate(sglang_num_aborted_requests_total[5s]))",
+      "query": "sum(irate(sglang_num_requests_total{source=\"sglang-decode\"}[5s])) - sum(irate(sglang_num_aborted_requests_total{source=\"sglang-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Abort Rate",
-      "query": "sum(irate(sglang_num_aborted_requests_total[5s]))",
+      "query": "sum(irate(sglang_num_aborted_requests_total{source=\"sglang-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "latency",
       "title": "Inter-Token Latency (ITL)",
-      "query": "sglang_inter_token_latency_seconds",
+      "query": "sglang_inter_token_latency_seconds{source=\"sglang-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -51,7 +51,7 @@
     {
       "role": "latency",
       "title": "Decode Time",
-      "query": "sglang_per_stage_req_latency_seconds{stage=\"decode_forward\"}",
+      "query": "sglang_per_stage_req_latency_seconds{stage=\"decode_forward\",source=\"sglang-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -60,7 +60,7 @@
     {
       "role": "latency",
       "title": "End-to-End Request Latency",
-      "query": "sglang_e2e_request_latency_seconds",
+      "query": "sglang_e2e_request_latency_seconds{source=\"sglang-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],

--- a/config/templates/sglang-prefill.json
+++ b/config/templates/sglang-prefill.json
@@ -6,28 +6,28 @@
     {
       "role": "load",
       "title": "Prompt Token Rate",
-      "query": "sum(irate(sglang_prompt_tokens_total[5s]))",
+      "query": "sum(irate(sglang_prompt_tokens_total{source=\"sglang-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "load",
       "title": "Requests Running",
-      "query": "sglang_num_running_reqs",
+      "query": "sglang_num_running_reqs{source=\"sglang-prefill\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "load",
       "title": "Requests Waiting",
-      "query": "sglang_num_queue_reqs",
+      "query": "sglang_num_queue_reqs{source=\"sglang-prefill\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "throughput",
       "title": "Prompt Token Rate",
-      "query": "sum(irate(sglang_prompt_tokens_total[5s]))",
+      "query": "sum(irate(sglang_prompt_tokens_total{source=\"sglang-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -35,21 +35,21 @@
     {
       "role": "throughput",
       "title": "Request Rate",
-      "query": "sum(irate(sglang_num_requests_total[5s]))",
+      "query": "sum(irate(sglang_num_requests_total{source=\"sglang-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Abort Rate",
-      "query": "sum(irate(sglang_num_aborted_requests_total[5s]))",
+      "query": "sum(irate(sglang_num_aborted_requests_total{source=\"sglang-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "latency",
       "title": "Time to First Token (TTFT)",
-      "query": "sglang_time_to_first_token_seconds",
+      "query": "sglang_time_to_first_token_seconds{source=\"sglang-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -58,7 +58,7 @@
     {
       "role": "latency",
       "title": "Prefill Time",
-      "query": "sglang_per_stage_req_latency_seconds{stage=\"prefill_forward\"}",
+      "query": "sglang_per_stage_req_latency_seconds{stage=\"prefill_forward\",source=\"sglang-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -67,7 +67,7 @@
     {
       "role": "latency",
       "title": "End-to-End Request Latency",
-      "query": "sglang_e2e_request_latency_seconds",
+      "query": "sglang_e2e_request_latency_seconds{source=\"sglang-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],

--- a/config/templates/sglang-router.json
+++ b/config/templates/sglang-router.json
@@ -6,21 +6,21 @@
     {
       "role": "load",
       "title": "Request Rate",
-      "query": "sum(irate(smg_http_requests_total[5s]))",
+      "query": "sum(irate(smg_http_requests_total{source=\"sglang-router\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "load",
       "title": "Active Requests",
-      "query": "sum(smg_worker_requests_active)",
+      "query": "sum(smg_worker_requests_active{source=\"sglang-router\"})",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "throughput",
       "title": "Token Rate",
-      "query": "sum(irate(smg_router_tokens_total[5s]))",
+      "query": "sum(irate(smg_router_tokens_total{source=\"sglang-router\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -28,21 +28,21 @@
     {
       "role": "throughput",
       "title": "Upstream Response Rate",
-      "query": "sum(irate(smg_router_upstream_responses_total[5s]))",
+      "query": "sum(irate(smg_router_upstream_responses_total{source=\"sglang-router\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Request Error Rate",
-      "query": "sum(irate(smg_router_request_errors_total[5s]))",
+      "query": "sum(irate(smg_router_request_errors_total{source=\"sglang-router\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "latency",
       "title": "Time to First Token (TTFT)",
-      "query": "smg_router_ttft_seconds",
+      "query": "smg_router_ttft_seconds{source=\"sglang-router\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -51,7 +51,7 @@
     {
       "role": "latency",
       "title": "Time per Output Token (TPOT)",
-      "query": "smg_router_tpot_seconds",
+      "query": "smg_router_tpot_seconds{source=\"sglang-router\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -60,7 +60,7 @@
     {
       "role": "latency",
       "title": "Generation Duration",
-      "query": "smg_router_generation_duration_seconds",
+      "query": "smg_router_generation_duration_seconds{source=\"sglang-router\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -69,7 +69,7 @@
     {
       "role": "latency",
       "title": "HTTP Request Duration",
-      "query": "smg_http_request_duration_seconds",
+      "query": "smg_http_request_duration_seconds{source=\"sglang-router\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],

--- a/config/templates/sglang.json
+++ b/config/templates/sglang.json
@@ -6,28 +6,28 @@
     {
       "role": "load",
       "title": "Prompt Token Rate",
-      "query": "sum(irate(sglang_prompt_tokens_total[5s]))",
+      "query": "sum(irate(sglang_prompt_tokens_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "load",
       "title": "Requests Running",
-      "query": "sglang_num_running_reqs",
+      "query": "sglang_num_running_reqs{source=\"sglang\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "load",
       "title": "Requests Waiting",
-      "query": "sglang_num_queue_reqs",
+      "query": "sglang_num_queue_reqs{source=\"sglang\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "throughput",
       "title": "Generation Token Rate",
-      "query": "sum(irate(sglang_generation_tokens_total[5s]))",
+      "query": "sum(irate(sglang_generation_tokens_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -35,28 +35,28 @@
     {
       "role": "throughput",
       "title": "Request Rate",
-      "query": "sum(irate(sglang_num_requests_total[5s]))",
+      "query": "sum(irate(sglang_num_requests_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "throughput",
       "title": "Request Completion Rate",
-      "query": "sum(irate(sglang_num_requests_total[5s])) - sum(irate(sglang_num_aborted_requests_total[5s]))",
+      "query": "sum(irate(sglang_num_requests_total{source=\"sglang\"}[5s])) - sum(irate(sglang_num_aborted_requests_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "error",
       "title": "Abort Rate",
-      "query": "sum(irate(sglang_num_aborted_requests_total[5s]))",
+      "query": "sum(irate(sglang_num_aborted_requests_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "latency",
       "title": "Time to First Token (TTFT)",
-      "query": "sglang_time_to_first_token_seconds",
+      "query": "sglang_time_to_first_token_seconds{source=\"sglang\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -65,7 +65,7 @@
     {
       "role": "latency",
       "title": "Inter-Token Latency (ITL)",
-      "query": "sglang_inter_token_latency_seconds",
+      "query": "sglang_inter_token_latency_seconds{source=\"sglang\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -74,7 +74,7 @@
     {
       "role": "latency",
       "title": "Prefill Time",
-      "query": "sglang_per_stage_req_latency_seconds{stage=\"prefill_forward\"}",
+      "query": "sglang_per_stage_req_latency_seconds{stage=\"prefill_forward\",source=\"sglang\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -83,7 +83,7 @@
     {
       "role": "latency",
       "title": "End-to-End Request Latency",
-      "query": "sglang_e2e_request_latency_seconds",
+      "query": "sglang_e2e_request_latency_seconds{source=\"sglang\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -92,21 +92,21 @@
     {
       "role": "throughput",
       "title": "Estimated FLOPS per GPU",
-      "query": "sum(irate(sglang_estimated_flops_per_gpu_total[5s]))",
+      "query": "sum(irate(sglang_estimated_flops_per_gpu_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "throughput",
       "title": "Estimated Memory Read Bandwidth per GPU",
-      "query": "sum(irate(sglang_estimated_read_bytes_per_gpu_total[5s]))",
+      "query": "sum(irate(sglang_estimated_read_bytes_per_gpu_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "throughput",
       "title": "Estimated Memory Write Bandwidth per GPU",
-      "query": "sum(irate(sglang_estimated_write_bytes_per_gpu_total[5s]))",
+      "query": "sum(irate(sglang_estimated_write_bytes_per_gpu_total{source=\"sglang\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     }

--- a/config/templates/valkey.json
+++ b/config/templates/valkey.json
@@ -7,7 +7,7 @@
     {
       "role": "throughput",
       "title": "Response Rate",
-      "query": "sum(irate(redis/total_commands_processed[5s]))",
+      "query": "sum(irate(redis/total_commands_processed{source=\"valkey\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -15,28 +15,28 @@
     {
       "role": "throughput",
       "title": "Read Rate",
-      "query": "sum(irate(redis/total_reads_processed[5s]))",
+      "query": "sum(irate(redis/total_reads_processed{source=\"valkey\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "throughput",
       "title": "Write Rate",
-      "query": "sum(irate(redis/total_writes_processed[5s]))",
+      "query": "sum(irate(redis/total_writes_processed{source=\"valkey\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "throughput",
       "title": "Network Input Rate",
-      "query": "sum(irate(redis/total_net_input_bytes[5s]))",
+      "query": "sum(irate(redis/total_net_input_bytes{source=\"valkey\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "throughput",
       "title": "Network Output Rate",
-      "query": "sum(irate(redis/total_net_output_bytes[5s]))",
+      "query": "sum(irate(redis/total_net_output_bytes{source=\"valkey\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     }

--- a/config/templates/vllm.json
+++ b/config/templates/vllm.json
@@ -6,28 +6,28 @@
     {
       "role": "load",
       "title": "Prompt Token Rate",
-      "query": "sum(irate(vllm_prompt_tokens_total[5s]))",
+      "query": "sum(irate(vllm_prompt_tokens_total{source=\"vllm\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "load",
       "title": "Requests Running",
-      "query": "vllm_num_requests_running",
+      "query": "vllm_num_requests_running{source=\"vllm\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "load",
       "title": "Requests Waiting",
-      "query": "vllm_num_requests_waiting",
+      "query": "vllm_num_requests_waiting{source=\"vllm\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "throughput",
       "title": "Generation Token Rate",
-      "query": "sum(irate(vllm_generation_tokens_total[5s]))",
+      "query": "sum(irate(vllm_generation_tokens_total{source=\"vllm\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -35,14 +35,14 @@
     {
       "role": "throughput",
       "title": "Request Completion Rate",
-      "query": "sum(irate(vllm_request_success_total[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "latency",
       "title": "Time to First Token (TTFT)",
-      "query": "vllm_time_to_first_token_seconds",
+      "query": "vllm_time_to_first_token_seconds{source=\"vllm\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -51,7 +51,7 @@
     {
       "role": "latency",
       "title": "Inter-Token Latency (ITL)",
-      "query": "vllm_inter_token_latency_seconds",
+      "query": "vllm_inter_token_latency_seconds{source=\"vllm\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -60,7 +60,7 @@
     {
       "role": "latency",
       "title": "Prefill Time",
-      "query": "vllm_request_prefill_time_seconds",
+      "query": "vllm_request_prefill_time_seconds{source=\"vllm\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -69,7 +69,7 @@
     {
       "role": "latency",
       "title": "End-to-End Request Latency",
-      "query": "vllm_e2e_request_latency_seconds",
+      "query": "vllm_e2e_request_latency_seconds{source=\"vllm\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -78,7 +78,7 @@
     {
       "role": "error",
       "title": "Preemption Rate",
-      "query": "sum(irate(vllm_num_preemptions_total[5s]))",
+      "query": "sum(irate(vllm_num_preemptions_total{source=\"vllm\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     }

--- a/crates/viewer/build.sh
+++ b/crates/viewer/build.sh
@@ -8,6 +8,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 OUT_DIR="$SCRIPT_DIR/../../site/viewer/pkg"
+TEMPLATES_DIR="$SCRIPT_DIR/../../config/templates"
+MANIFEST_PATH="$SCRIPT_DIR/../../site/viewer/templates/manifest.json"
+
+# Regenerate the static-site templates manifest from config/templates/*.json
+# so the WASM viewer picks up new templates without manual JS edits.
+(
+    cd "$TEMPLATES_DIR"
+    printf '[\n'
+    ls -1 *.json | sort | sed 's/\.json$//' \
+        | awk 'BEGIN{first=1} {if(!first)printf ",\n"; printf "  \"%s\"", $0; first=0} END{printf "\n"}'
+    printf ']\n'
+) > "$MANIFEST_PATH"
 
 # On macOS, Apple's system clang can't target wasm32 — use Homebrew's LLVM
 # for compiling zstd to wasm32. Resolve the prefix via brew so this works on

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -338,12 +338,17 @@ impl Viewer {
         "[]".to_string()
     }
 
-    /// Returns the full View JSON for a dashboard section.
+    /// Returns the full View JSON for a dashboard section. The shared
+    /// `sections` navigation array is stripped on the way out — callers
+    /// fetch it once via `get_sections()`.
     pub fn get_section(&self, key: &str) -> Option<String> {
-        self.dashboard_sections
+        let raw = self
+            .dashboard_sections
             .get(&format!("{key}.json"))
-            .or_else(|| self.dashboard_sections.get(key))
-            .cloned()
+            .or_else(|| self.dashboard_sections.get(key))?;
+        let mut value: serde_json::Value = serde_json::from_str(raw).ok()?;
+        strip_sections_from_section_body(&mut value);
+        serde_json::to_string(&value).ok()
     }
 }
 
@@ -578,6 +583,15 @@ impl Default for WasmCaptureRegistry {
     }
 }
 
+/// Drop the shared `sections` navigation array from a generated section
+/// body. The full nav list is exposed separately via `Viewer::get_sections`,
+/// so per-section payloads don't need to carry it.
+fn strip_sections_from_section_body(value: &mut serde_json::Value) {
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("sections");
+    }
+}
+
 /// Parse a templates JSON array into the service-extension subset,
 /// silently skipping `category: true` entries (those have a different
 /// schema and are handled separately by `parse_template_registry`).
@@ -736,5 +750,21 @@ fn enrich_with_multi_node_info(map: &mut serde_json::Map<String, serde_json::Val
             "service_instances".into(),
             serde_json::Value::Object(service_instances),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_sections_from_generated_section_body() {
+        let mut value = serde_json::json!({
+            "sections": [{"name": "Overview", "route": "/overview"}],
+            "groups": []
+        });
+        strip_sections_from_section_body(&mut value);
+        assert!(value.get("sections").is_none());
+        assert_eq!(value["groups"], serde_json::json!([]));
     }
 }

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -62,17 +62,16 @@ const demoSections = [
 let loadedTemplatesJson = null;
 
 const loadTemplates = async () => {
-    const templateNames = [
-        'cachecannon',
-        'inference-library',
-        'llm-perf',
-        'sglang',
-        'sglang-decode',
-        'sglang-prefill',
-        'sglang-router',
-        'valkey',
-        'vllm',
-    ];
+    // Source of truth is `templates/manifest.json`, regenerated from
+    // `config/templates/*.json` by `crates/viewer/build.sh` and the
+    // pages-deploy workflow. Adding/removing a template doesn't require
+    // editing this file.
+    let templateNames = [];
+    try {
+        const manifest = await fetch('templates/manifest.json').then(r => r.ok ? r.json() : null);
+        if (Array.isArray(manifest)) templateNames = manifest;
+    } catch (_) { /* fall through to empty registry */ }
+
     const results = await Promise.allSettled(
         templateNames.map(name => fetch(`templates/${name}.json`).then(r => r.ok ? r.json() : null))
     );

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -62,7 +62,17 @@ const demoSections = [
 let loadedTemplatesJson = null;
 
 const loadTemplates = async () => {
-    const templateNames = ['cachecannon', 'inference-library', 'llm-perf', 'sglang', 'valkey', 'vllm'];
+    const templateNames = [
+        'cachecannon',
+        'inference-library',
+        'llm-perf',
+        'sglang',
+        'sglang-decode',
+        'sglang-prefill',
+        'sglang-router',
+        'valkey',
+        'vllm',
+    ];
     const results = await Promise.allSettled(
         templateNames.map(name => fetch(`templates/${name}.json`).then(r => r.ok ? r.json() : null))
     );

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -5,7 +5,7 @@
 import { ViewerApi } from './viewer_api.js';
 import { FileUpload } from './landing.js';
 import { setStorageScope } from './selection.js';
-import { initDashboard } from './app.js';
+import { initDashboard, bootstrapSharedSections } from './app.js';
 
 // ── UI state ────────────────────────────────────────────────────────
 
@@ -113,6 +113,12 @@ const fetchInitialState = async () => {
 async function loadParquet(data, filename) {
     await initWasmViewer(data, filename);
     const state = await fetchInitialState();
+    try {
+        const sections = await ViewerApi.getSections();
+        bootstrapSharedSections(Array.isArray(sections) ? sections : (sections?.data?.sections || []));
+    } catch (_) {
+        bootstrapSharedSections([]);
+    }
     initDashboard({
         systemInfo: state.systemInfo,
         fileMetadata: state.fileMetadata,
@@ -251,6 +257,12 @@ async function loadCompareDemo(fileA, fileB, legends = null, category = null) {
             }
         }
 
+        try {
+            const sections = await ViewerApi.getSections();
+            bootstrapSharedSections(Array.isArray(sections) ? sections : (sections?.data?.sections || []));
+        } catch (_) {
+            bootstrapSharedSections([]);
+        }
         initDashboard({
             systemInfo: base.systemInfo,
             fileMetadata: base.fileMetadata,

--- a/site/viewer/templates/manifest.json
+++ b/site/viewer/templates/manifest.json
@@ -1,0 +1,11 @@
+[
+  "cachecannon",
+  "inference-library",
+  "llm-perf",
+  "sglang-decode",
+  "sglang-prefill",
+  "sglang-router",
+  "sglang",
+  "valkey",
+  "vllm"
+]

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -693,9 +693,17 @@ const initDashboard = (config = {}) => {
                 const makeSingleChartView = () => ({
                     view() {
                         const data = sectionResponseCache[sectionKey];
-                        if (!data) return m('div', 'Loading...');
                         const activeSection = getCachedSections()
                             .find(s => s.route === `/${sectionKey}`);
+                        if (!data) {
+                            return m('div#splash', m('div.card', [
+                                m('h1', activeSection?.name || 'Loading'),
+                                m('p.subtitle', 'Loading…'),
+                                m('div.progress-bar',
+                                    m('div.progress-fill.indeterminate'),
+                                ),
+                            ]));
+                        }
                         return m('div', [
                             m(TopNav, topNavAttrs(data, activeSection?.route)),
                             m('main.single-chart-main', [
@@ -811,10 +819,24 @@ const initDashboard = (config = {}) => {
                 const cachedView = (sectionKey, path) => ({
                     view() {
                         const data = sectionResponseCache[sectionKey];
-                        if (!data) return m('div', 'Loading...');
                         const activeSection = getCachedSections().find(
                             (section) => section.route === path,
                         );
+                        if (!data) {
+                            // Cache miss: the synchronous route resolution
+                            // above already unmounted the previous section's
+                            // chart canvases. Show a splash/progress bar
+                            // styled the same as the initial-load splash so
+                            // the user gets clear in-flight feedback until
+                            // loadSection settles and triggers a redraw.
+                            return m('div#splash', m('div.card', [
+                                m('h1', activeSection?.name || 'Loading'),
+                                m('p.subtitle', 'Loading…'),
+                                m('div.progress-bar',
+                                    m('div.progress-fill.indeterminate'),
+                                ),
+                            ]));
+                        }
                         return m(Main, {
                             ...withCachedSections(data),
                             activeSection,

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -21,6 +21,7 @@ import { createGroupComponent, getCachedSectionMeta, buildClientOnlySectionView 
 import {
     createSectionCacheState,
     storeSectionResponse,
+    storeSharedSections,
     getSections,
     withSharedSections,
     clearSectionResponses,
@@ -48,6 +49,8 @@ const sectionCacheState = createSectionCacheState();
 const sectionResponseCache = sectionCacheState.responses;
 const cacheSectionResponse = (section, data) =>
     storeSectionResponse(sectionCacheState, section, data);
+const bootstrapSharedSections = (sections) =>
+    storeSharedSections(sectionCacheState, sections);
 const withCachedSections = (data) => withSharedSections(sectionCacheState, data);
 const getCachedSections = () => getSections(sectionCacheState);
 
@@ -863,4 +866,4 @@ const getActiveCgroupPattern = () => activeCgroupPattern;
 const getRecording = () => recording;
 const setRecording = (value) => { recording = value; };
 
-export { initDashboard, sectionResponseCache, cacheSectionResponse, clearViewerCaches, chartsState, loadSection, preloadSections, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, attachExperiment, detachExperiment, durationFromFileMetadata, setChartToggle };
+export { initDashboard, sectionResponseCache, cacheSectionResponse, bootstrapSharedSections, clearViewerCaches, chartsState, loadSection, preloadSections, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, attachExperiment, detachExperiment, durationFromFileMetadata, setChartToggle };

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -26,6 +26,8 @@ import {
     withSharedSections,
     clearSectionResponses,
     resetSectionCacheState,
+    setSectionCacheLimit,
+    pinSectionKey,
 } from './section_cache.js';
 
 // ── State ──────────────────────────────────────────────────────────
@@ -46,6 +48,8 @@ const heatmapDataCache = new Map();
 const chartsState = new ChartsState();
 let currentGranularity = null;
 const sectionCacheState = createSectionCacheState();
+setSectionCacheLimit(sectionCacheState, 3);
+pinSectionKey(sectionCacheState, 'overview');
 const sectionResponseCache = sectionCacheState.responses;
 const cacheSectionResponse = (section, data) =>
     storeSectionResponse(sectionCacheState, section, data);

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -48,6 +48,9 @@ const heatmapDataCache = new Map();
 const chartsState = new ChartsState();
 let currentGranularity = null;
 const sectionCacheState = createSectionCacheState();
+// Cache limit: overview (pinned) + active route + one look-ahead. Keeps
+// memory bounded on the static-site WASM viewer where each section body
+// can be MB-scale.
 setSectionCacheLimit(sectionCacheState, 3);
 pinSectionKey(sectionCacheState, 'overview');
 const sectionResponseCache = sectionCacheState.responses;

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -709,11 +709,14 @@ const initDashboard = (config = {}) => {
                     },
                 });
 
-                if (sectionResponseCache[sectionKey]) {
-                    return makeSingleChartView();
+                // Resolve synchronously regardless of cache state — see
+                // the matching comment in '/:section' below for rationale.
+                if (!sectionResponseCache[sectionKey]) {
+                    loadSection(sectionKey)
+                        .then(() => m.redraw())
+                        .catch(() => {});
                 }
-
-                return loadSection(sectionKey).then(() => makeSingleChartView());
+                return makeSingleChartView();
             },
         },
         ...createServiceRoutes({
@@ -820,40 +823,41 @@ const initDashboard = (config = {}) => {
                     },
                 });
 
-                if (sectionResponseCache[params.section]) {
-                    if (heatmapEnabled && !heatmapDataCache.has(requestedPath)) {
-                        fetchSectionHeatmapData(requestedPath, sectionResponseCache[params.section].groups);
-                    }
-                    return cachedView(params.section, requestedPath);
+                // Resolve the route synchronously even on a cache miss so
+                // the old section's DOM unmounts immediately (firing each
+                // chart's onremove → echart.dispose()). cachedView falls
+                // back to a "Loading…" placeholder while data is in flight,
+                // which gets replaced by the populated view via m.redraw()
+                // once loadSection settles.
+                if (!sectionResponseCache[params.section]) {
+                    loadSection(params.section)
+                        .then((data) => {
+                            if (data?.sections) preloadSections(data.sections);
+                            if (heatmapEnabled && !heatmapDataCache.has(requestedPath)) {
+                                fetchSectionHeatmapData(requestedPath, data.groups);
+                            }
+                            m.redraw();
+                        })
+                        .catch((err) => {
+                            // Stale URL pointing at a missing section. Drop
+                            // back to the dashboard's default route instead
+                            // of letting the "Unknown section" error bubble.
+                            // If defaultRoute itself points at the failing
+                            // section (can happen when serviceInstances and
+                            // dashboard_sections disagree on naming), fall
+                            // through to /overview to avoid bouncing into
+                            // the same broken route.
+                            console.warn(`[viewer] section ${params.section} not available; redirecting`, err);
+                            const failingRoute = `/${params.section}`;
+                            const target = defaultRoute === failingRoute ? '/overview' : defaultRoute;
+                            if (target && target !== m.route.get()) {
+                                m.route.set(target);
+                            }
+                        });
+                } else if (heatmapEnabled && !heatmapDataCache.has(requestedPath)) {
+                    fetchSectionHeatmapData(requestedPath, sectionResponseCache[params.section].groups);
                 }
-
-                return loadSection(params.section)
-                    .then((data) => {
-                        if (data?.sections) preloadSections(data.sections);
-                        if (heatmapEnabled && !heatmapDataCache.has(requestedPath)) {
-                            fetchSectionHeatmapData(requestedPath, data.groups);
-                        }
-                        return cachedView(params.section, requestedPath);
-                    })
-                    .catch((err) => {
-                        // Stale URL pointing at a missing section. Drop
-                        // back to the dashboard's default route instead
-                        // of letting the "Unknown section" error bubble.
-                        // If defaultRoute itself points at the failing
-                        // section (can happen when serviceInstances and
-                        // dashboard_sections disagree on naming), fall
-                        // through to /overview to avoid bouncing into
-                        // the same broken route — m.route.get() returns
-                        // the last successfully resolved path, which
-                        // never advances when every onmatch rejects.
-                        console.warn(`[viewer] section ${params.section} not available; redirecting`, err);
-                        const failingRoute = `/${params.section}`;
-                        const target = defaultRoute === failingRoute ? '/overview' : defaultRoute;
-                        if (target && target !== m.route.get()) {
-                            m.route.set(target);
-                        }
-                        return new Promise(function () {});
-                    });
+                return cachedView(params.section, requestedPath);
             },
         },
     });

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -9,6 +9,28 @@ import { setStorageScope, loadPayloadIntoStore, reportStore, clearStore } from '
 import { clearMetadataCache, processDashboardData, CAPTURE_EXPERIMENT } from './data.js';
 import { initDashboard, cacheSectionResponse, bootstrapSharedSections, clearViewerCaches, chartsState, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, preloadSections } from './app.js';
 
+// ── Splash ──────────────────────────────────────────────────────────
+// Mounted on body before any async bootstrap step so the page never
+// shows a blank document while we fetch state. Replaced by the route
+// mount inside initDashboard() once we're ready to render the dashboard.
+
+let splashLabel = 'Initializing';
+
+const Splash = {
+    view: () => splashLabel === null ? null : m('div#splash', m('div.card', [
+        m('h1', 'Rezolus'),
+        m('p.subtitle', `${splashLabel}…`),
+        m('div.progress-bar', m('div.progress-fill.indeterminate')),
+    ])),
+};
+
+m.mount(document.body, Splash);
+
+const setSplashLabel = (label) => {
+    splashLabel = label;
+    m.redraw();
+};
+
 // ── Backend state fetching ─────────────────────────────────────────
 
 let systemInfo = null;
@@ -252,6 +274,7 @@ const showCompareLanding = () => {
 const bootstrap = async () => {
     let compareMode = false;
     let categoryName = null;
+    setSplashLabel('Connecting to viewer');
     try {
         const response = await ViewerApi.getMode();
         if (!response.loaded && !response.live) {
@@ -263,7 +286,9 @@ const bootstrap = async () => {
         categoryName = response.category || null;
     } catch (_) { /* assume loaded file mode */ }
 
+    setSplashLabel('Loading capture metadata');
     await fetchBackendState();
+    setSplashLabel('Loading section list');
     try {
         const sectionsResponse = await ViewerApi.getSections();
         bootstrapSharedSections(sectionsResponse?.data?.sections || []);
@@ -280,6 +305,7 @@ const bootstrap = async () => {
     let experimentAlias = null;
     let experimentQueryRange = null;
     if (compareMode) {
+        setSplashLabel('Loading experiment capture');
         const [sysinfo, fileMeta, expMeta] = await Promise.all([
             ViewerApi.getSystemInfo(CAPTURE_EXPERIMENT).catch(() => null),
             ViewerApi.getFileMetadata(CAPTURE_EXPERIMENT).catch(() => null),

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -264,6 +264,12 @@ const bootstrap = async () => {
     } catch (_) { /* assume loaded file mode */ }
 
     await fetchBackendState();
+    try {
+        const sectionsResponse = await ViewerApi.getSections();
+        bootstrapSharedSections(sectionsResponse?.data?.sections || []);
+    } catch (_) {
+        bootstrapSharedSections([]);
+    }
     if (fileChecksum) {
         setStorageScope({ filename: fileChecksum });
     }

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -7,7 +7,7 @@ import { FileUpload, CompareLanding } from './landing.js';
 import { notify, showSaveModal } from './overlays.js';
 import { setStorageScope, loadPayloadIntoStore, reportStore, clearStore } from './selection.js';
 import { clearMetadataCache, processDashboardData, CAPTURE_EXPERIMENT } from './data.js';
-import { initDashboard, cacheSectionResponse, clearViewerCaches, chartsState, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, preloadSections } from './app.js';
+import { initDashboard, cacheSectionResponse, bootstrapSharedSections, clearViewerCaches, chartsState, getHeatmapEnabled, heatmapDataCache, fetchSectionHeatmapData, getActiveCgroupPattern, getRecording, setRecording, preloadSections } from './app.js';
 
 // ── Backend state fetching ─────────────────────────────────────────
 
@@ -96,6 +96,9 @@ const uploadParquet = async (file) => {
             loadPayloadIntoStore(reportStore, selectionPayload);
             reportStore.loadedFrom = 'embedded report';
         }
+
+        const sectionsResponse = await ViewerApi.getSections();
+        bootstrapSharedSections(sectionsResponse?.data?.sections || []);
 
         const data = await ViewerApi.getSection('overview');
         const processed = await processDashboardData(data, null, '/overview');

--- a/src/viewer/assets/lib/section_cache.js
+++ b/src/viewer/assets/lib/section_cache.js
@@ -31,6 +31,10 @@ const storeSectionResponse = (state, key, data) => {
     const { sections, ...stored } = data;
     state.responses[key] = stored;
 
+    // Evict the oldest non-pinned, non-just-inserted entry. If everything
+    // is pinned or only the just-inserted key is unpinned, the loop falls
+    // through and the cache is allowed to exceed `limit` — pinning is a
+    // hard guarantee, not a hint.
     if (state.limit && Object.keys(state.responses).length > state.limit) {
         const pinned = state.pinned || new Set();
         for (const k of Object.keys(state.responses)) {

--- a/src/viewer/assets/lib/section_cache.js
+++ b/src/viewer/assets/lib/section_cache.js
@@ -5,6 +5,10 @@ const createSectionCacheState = () => ({
 
 const getSections = (state) => state.sections || [];
 
+const storeSharedSections = (state, sections) => {
+    state.sections = Array.isArray(sections) ? sections : [];
+};
+
 const storeSectionResponse = (state, key, data) => {
     if (Array.isArray(data?.sections) && data.sections.length > 0) {
         state.sections = data.sections;
@@ -41,6 +45,7 @@ const resetSectionCacheState = (state) => {
 export {
     createSectionCacheState,
     storeSectionResponse,
+    storeSharedSections,
     getSections,
     withSharedSections,
     clearSectionResponses,

--- a/src/viewer/assets/lib/section_cache.js
+++ b/src/viewer/assets/lib/section_cache.js
@@ -9,6 +9,15 @@ const storeSharedSections = (state, sections) => {
     state.sections = Array.isArray(sections) ? sections : [];
 };
 
+const setSectionCacheLimit = (state, limit) => {
+    state.limit = Math.max(1, limit | 0);
+};
+
+const pinSectionKey = (state, key) => {
+    state.pinned = state.pinned || new Set();
+    state.pinned.add(key);
+};
+
 const storeSectionResponse = (state, key, data) => {
     if (Array.isArray(data?.sections) && data.sections.length > 0) {
         state.sections = data.sections;
@@ -21,6 +30,17 @@ const storeSectionResponse = (state, key, data) => {
 
     const { sections, ...stored } = data;
     state.responses[key] = stored;
+
+    if (state.limit && Object.keys(state.responses).length > state.limit) {
+        const pinned = state.pinned || new Set();
+        for (const k of Object.keys(state.responses)) {
+            if (k !== key && !pinned.has(k)) {
+                delete state.responses[k];
+                break;
+            }
+        }
+    }
+
     return stored;
 };
 
@@ -50,4 +70,6 @@ export {
     withSharedSections,
     clearSectionResponses,
     resetSectionCacheState,
+    setSectionCacheLimit,
+    pinSectionKey,
 };

--- a/src/viewer/assets/lib/service.js
+++ b/src/viewer/assets/lib/service.js
@@ -174,16 +174,26 @@ const createServiceRoutes = (deps) => {
         '/service/:serviceName/chart/:chartId': {
             onmatch(params) {
                 const svcKey = `service/${params.serviceName}`;
+                const sectionRoute = `/service/${params.serviceName}`;
 
                 const makeView = () => ({
                     view() {
                         const data = sectionResponseCache[svcKey];
-                        if (!data) return m('div', 'Loading...');
+                        const sections = readSections(data || {});
+                        const activeSection = sections.find(s => s.route === sectionRoute)
+                            || { name: params.serviceName, route: sectionRoute };
+                        if (!data) {
+                            return m('div#splash', m('div.card', [
+                                m('h1', activeSection.name),
+                                m('p.subtitle', 'Loading…'),
+                                m('div.progress-bar',
+                                    m('div.progress-fill.indeterminate'),
+                                ),
+                            ]));
+                        }
                         const viewData = hydrateSections(data);
-                        const activeSection = readSections(viewData)
-                            .find(s => s.route === `/service/${params.serviceName}`);
                         return m('div', [
-                            m(TopNav, topNavAttrs(viewData, activeSection?.route, { compareMode: readCompareMode() })),
+                            m(TopNav, topNavAttrs(viewData, activeSection.route, { compareMode: readCompareMode() })),
                             m('main.single-chart-main', [
                                 m(SingleChartView, {
                                     data: viewData,
@@ -195,12 +205,15 @@ const createServiceRoutes = (deps) => {
                     },
                 });
 
-                if (sectionResponseCache[svcKey]) {
-                    return makeView();
+                // Resolve synchronously regardless of cache state so the
+                // previous section's chart canvases unmount immediately
+                // and the splash placeholder renders without a stall.
+                if (!sectionResponseCache[svcKey]) {
+                    loadSection(svcKey)
+                        .then(() => m.redraw())
+                        .catch((err) => recoverFromMissingSection(svcKey, err));
                 }
-                return loadSection(svcKey)
-                    .then(() => makeView())
-                    .catch((err) => recoverFromMissingSection(svcKey, err));
+                return makeView();
             },
         },
         '/service/:serviceName': {
@@ -214,15 +227,25 @@ const createServiceRoutes = (deps) => {
                 }
 
                 const svcKey = `service/${params.serviceName}`;
+                const sectionRoute = `/service/${params.serviceName}`;
 
                 const makeView = () => ({
                     view() {
                         const data = sectionResponseCache[svcKey];
-                        if (!data) return m('div', 'Loading...');
+                        const sections = readSections(data || {});
+                        const activeSection = sections.find(
+                            (section) => section.route === sectionRoute,
+                        ) || { name: params.serviceName, route: sectionRoute };
+                        if (!data) {
+                            return m('div#splash', m('div.card', [
+                                m('h1', activeSection.name),
+                                m('p.subtitle', 'Loading…'),
+                                m('div.progress-bar',
+                                    m('div.progress-fill.indeterminate'),
+                                ),
+                            ]));
+                        }
                         const viewData = hydrateSections(data);
-                        const activeSection = readSections(viewData).find(
-                            (section) => section.route === `/service/${params.serviceName}`,
-                        );
                         return m(Main, {
                             ...viewData,
                             activeSection,
@@ -231,16 +254,19 @@ const createServiceRoutes = (deps) => {
                     },
                 });
 
-                if (sectionResponseCache[svcKey]) {
-                    return makeView();
+                // Resolve synchronously: same rationale as in app.js's
+                // '/:section' route — keep chart unmount and splash on the
+                // hot path.
+                if (!sectionResponseCache[svcKey]) {
+                    loadSection(svcKey)
+                        .then((data) => {
+                            const sections = readSections(data);
+                            if (sections.length > 0) preloadSections(sections);
+                            m.redraw();
+                        })
+                        .catch((err) => recoverFromMissingSection(svcKey, err));
                 }
-                return loadSection(svcKey)
-                    .then((data) => {
-                        const sections = readSections(data);
-                        if (sections.length > 0) preloadSections(sections);
-                        return makeView();
-                    })
-                    .catch((err) => recoverFromMissingSection(svcKey, err));
+                return makeView();
             },
         },
     };

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -86,6 +86,13 @@ const ViewerApi = {
         return '/api/v1/save';
     },
 
+    async getSections(captureId = 'baseline') {
+        return backendRequest({
+            method: 'GET',
+            url: `/api/v1/sections${captureQS(captureId)}`,
+        });
+    },
+
     async getSection(section, background = false) {
         return backendRequest({
             method: 'GET',

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -708,9 +708,7 @@ impl Default for LazySectionStore {
 /// recovered from the embedded `sections` array of any body — overview
 /// is canonical but any body works because they all carry the same nav.
 /// Bodies that fail to parse are logged and skipped.
-fn build_section_store_from_rendered(
-    rendered: HashMap<String, String>,
-) -> LazySectionStore {
+fn build_section_store_from_rendered(rendered: HashMap<String, String>) -> LazySectionStore {
     let mut bodies: HashMap<String, serde_json::Value> = HashMap::new();
     for (key, body) in rendered {
         match serde_json::from_str::<serde_json::Value>(&body) {
@@ -2448,11 +2446,14 @@ mod tests {
     #[test]
     fn lazy_section_store_caches_sections_separately_from_metadata() {
         let mut store = LazySectionStore::new(vec![
-            serde_json::json!({"name": "Overview", "route": "/overview"})
+            serde_json::json!({"name": "Overview", "route": "/overview"}),
         ]);
         assert!(store.section("overview").is_none());
         store.insert_section("overview", serde_json::json!({"groups": []}));
-        assert_eq!(store.section("overview").unwrap()["groups"], serde_json::json!([]));
+        assert_eq!(
+            store.section("overview").unwrap()["groups"],
+            serde_json::json!([])
+        );
         assert_eq!(store.sections().len(), 1);
     }
 }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -738,8 +738,11 @@ impl AppState {
             .cloned();
         drop(sections_guard);
 
-        let parsed: Option<serde_json::Value> =
-            body.as_deref().and_then(|s| serde_json::from_str(s).ok());
+        let parsed: Option<serde_json::Value> = body.as_deref().and_then(|s| {
+            serde_json::from_str(s)
+                .map_err(|e| warn!("sections cache parse error: {e}"))
+                .ok()
+        });
 
         let sections_array: Vec<serde_json::Value> = parsed
             .as_ref()
@@ -2323,5 +2326,13 @@ mod tests {
 
         assert_eq!(payload["sections"], serde_json::Value::Array(sections));
         assert!(payload.get("groups").is_none());
+        assert_eq!(payload["source"], serde_json::json!("rezolus"));
+        assert_eq!(payload["version"], serde_json::json!("test-version"));
+        assert_eq!(payload["filename"], serde_json::json!("capture.parquet"));
+        assert_eq!(payload["interval"], serde_json::json!(1.0));
+        assert_eq!(payload["filesize"], serde_json::json!(42u64));
+        assert_eq!(payload["start_time"], serde_json::json!(1000u64));
+        assert_eq!(payload["end_time"], serde_json::json!(2000u64));
+        assert_eq!(payload["num_series"], serde_json::json!(99usize));
     }
 }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -712,6 +712,98 @@ impl AppState {
             .get(CaptureId::Baseline)
             .expect("baseline capture is always present")
     }
+
+    /// Build the navigation + global params payload for the
+    /// `/api/v1/sections` endpoint. Reads any cached section body
+    /// (overview is the canonical fall-back) to recover the embedded
+    /// `sections` array and the global params (source, version,
+    /// filename, interval, filesize, time bounds, num_series). When no
+    /// section is cached yet — e.g. live mode before the first refresh,
+    /// or upload-only mode pre-upload — returns a minimal payload with
+    /// an empty sections array so the frontend never sees a 5xx for the
+    /// "we just don't have data yet" case.
+    ///
+    /// The `capture` argument is currently advisory: the cached section
+    /// bodies are produced by `regenerate_dashboards`, which today
+    /// generates a single section map keyed only by route. The same
+    /// nav list applies to both baseline and experiment, so we ignore
+    /// the id rather than silently 404 on `?capture=experiment`.
+    fn sections_metadata(&self, _capture: CaptureId) -> serde_json::Value {
+        let sections_guard = self.sections.read();
+
+        // Prefer overview (canonical), fall back to any cached section.
+        let body = sections_guard
+            .get("overview.json")
+            .or_else(|| sections_guard.values().next())
+            .cloned();
+        drop(sections_guard);
+
+        let parsed: Option<serde_json::Value> =
+            body.as_deref().and_then(|s| serde_json::from_str(s).ok());
+
+        let sections_array: Vec<serde_json::Value> = parsed
+            .as_ref()
+            .and_then(|v| v.get("sections"))
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let source = parsed
+            .as_ref()
+            .and_then(|v| v.get("source"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let version = parsed
+            .as_ref()
+            .and_then(|v| v.get("version"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let filename = parsed
+            .as_ref()
+            .and_then(|v| v.get("filename"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let interval = parsed
+            .as_ref()
+            .and_then(|v| v.get("interval"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let filesize = parsed
+            .as_ref()
+            .and_then(|v| v.get("filesize"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let start_time = parsed
+            .as_ref()
+            .and_then(|v| v.get("start_time"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let end_time = parsed
+            .as_ref()
+            .and_then(|v| v.get("end_time"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let num_series = parsed
+            .as_ref()
+            .and_then(|v| v.get("num_series"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
+        build_sections_metadata_payload(
+            sections_array,
+            &source,
+            &version,
+            &filename,
+            interval,
+            filesize,
+            start_time,
+            end_time,
+            num_series,
+        )
+    }
 }
 
 fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>, Option<String>) {
@@ -1131,6 +1223,39 @@ fn validate_service_extensions(tsdb: &Tsdb, exts: &mut [(String, ServiceExtensio
     }
 }
 
+/// Assemble the JSON payload returned by `/api/v1/sections`.
+///
+/// The viewer frontend wants the navigation list and the global capture
+/// params (source, version, filename, interval, filesize, time bounds,
+/// num_series) without any of the per-section group/plot bodies. Keeping
+/// this as a pure helper makes it trivial to unit-test the shape — the
+/// route handler does the I/O of pulling values out of the cached
+/// section bodies.
+#[allow(clippy::too_many_arguments)]
+fn build_sections_metadata_payload(
+    sections: Vec<serde_json::Value>,
+    source: &str,
+    version: &str,
+    filename: &str,
+    interval: f64,
+    filesize: u64,
+    start_time: u64,
+    end_time: u64,
+    num_series: usize,
+) -> serde_json::Value {
+    serde_json::json!({
+        "sections": sections,
+        "source": source,
+        "version": version,
+        "filename": filename,
+        "interval": interval,
+        "filesize": filesize,
+        "start_time": start_time,
+        "end_time": end_time,
+        "num_series": num_series,
+    })
+}
+
 fn compute_file_checksum(path: &Path) -> Option<String> {
     use sha2::{Digest, Sha256};
     use std::io::{Read, Seek, SeekFrom};
@@ -1189,6 +1314,7 @@ fn app(livereload: LiveReloadLayer, state: AppState) -> Router {
         .route("/save", get(save_parquet))
         .route("/systeminfo", get(systeminfo_handler))
         .route("/selection", get(selection_handler))
+        .route("/sections", get(sections_handler))
         .route("/file_metadata", get(file_metadata_handler))
         .route(
             "/upload",
@@ -1356,6 +1482,20 @@ async fn selection_handler(
             .into_response(),
         None => StatusCode::NOT_FOUND.into_response(),
     }
+}
+
+/// Returns the navigation list plus global capture params (no section
+/// bodies). Used by the frontend to build the side nav and headline
+/// metadata without paying the cost of fetching every section JSON
+/// upfront.
+async fn sections_handler(
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    axum::extract::Query(p): axum::extract::Query<CaptureParam>,
+) -> axum::response::Json<serde_json::Value> {
+    axum::response::Json(serde_json::json!({
+        "status": "success",
+        "data": state.sections_metadata(p.capture_id()),
+    }))
 }
 
 async fn file_metadata_handler(
@@ -2156,5 +2296,32 @@ async fn lib(uri: Uri) -> impl IntoResponse {
             [(header::CONTENT_TYPE, "text/plain")],
             "404 Not Found".to_string(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sections_metadata_json_omits_groups() {
+        let sections = vec![
+            serde_json::json!({"name": "Overview", "route": "/overview"}),
+            serde_json::json!({"name": "CPU", "route": "/cpu"}),
+        ];
+        let payload = build_sections_metadata_payload(
+            sections.clone(),
+            "rezolus",
+            "test-version",
+            "capture.parquet",
+            1.0,
+            42,
+            1000,
+            2000,
+            99,
+        );
+
+        assert_eq!(payload["sections"], serde_json::Value::Array(sections));
+        assert!(payload.get("groups").is_none());
     }
 }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -853,15 +853,20 @@ impl AppState {
             .and_then(|v| v.get("filesize"))
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
+        // start_time/end_time are emitted by `View` as f64 (epoch ms), so
+        // `as_u64()` returns None even on whole-millisecond values. Read
+        // as f64 and truncate to the integer payload shape.
         let start_time = body
             .as_ref()
             .and_then(|v| v.get("start_time"))
-            .and_then(|v| v.as_u64())
+            .and_then(|v| v.as_f64())
+            .map(|v| v as u64)
             .unwrap_or(0);
         let end_time = body
             .as_ref()
             .and_then(|v| v.get("end_time"))
-            .and_then(|v| v.as_u64())
+            .and_then(|v| v.as_f64())
+            .map(|v| v as u64)
             .unwrap_or(0);
         let num_series = body
             .as_ref()

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1259,6 +1259,16 @@ fn build_sections_metadata_payload(
     })
 }
 
+/// Strip the navigation `sections` array from a section payload before
+/// sending it to the frontend.  Each cached section body embeds the full
+/// nav list so that `sections_metadata` can extract it, but the frontend
+/// does not need that redundant data in per-section responses.
+fn strip_sections_from_section_payload(value: &mut serde_json::Value) {
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("sections");
+    }
+}
+
 fn compute_file_checksum(path: &Path) -> Option<String> {
     use sha2::{Digest, Sha256};
     use std::io::{Read, Seek, SeekFrom};
@@ -1417,12 +1427,33 @@ async fn data(
 
     let sections = state.sections.read();
     match sections.get(&path) {
-        Some(v) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            v.to_string(),
-        )
-            .into_response(),
+        Some(v) => {
+            // Strip the redundant nav `sections` array before sending to the
+            // frontend.  The cached body keeps it so that `sections_metadata`
+            // can still extract it (Task 4); we only remove it at response time.
+            let body = match serde_json::from_str::<serde_json::Value>(v) {
+                Ok(mut parsed) => {
+                    strip_sections_from_section_payload(&mut parsed);
+                    match serde_json::to_string(&parsed) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            warn!("section re-serialization failed for {path}: {e}");
+                            v.to_string()
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("section parse failed for {path}: {e}");
+                    v.to_string()
+                }
+            };
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "application/json")],
+                body,
+            )
+                .into_response()
+        }
         None => StatusCode::NOT_FOUND.into_response(),
     }
 }
@@ -2305,6 +2336,18 @@ async fn lib(uri: Uri) -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lean_section_payload_does_not_repeat_sections() {
+        let mut payload = serde_json::json!({
+            "sections": [{"name": "Overview", "route": "/overview"}],
+            "groups": [],
+            "interval": 1.0
+        });
+        strip_sections_from_section_payload(&mut payload);
+        assert!(payload.get("sections").is_none());
+        assert_eq!(payload["groups"], serde_json::json!([]));
+    }
 
     #[test]
     fn sections_metadata_json_omits_groups() {

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -479,7 +479,7 @@ pub fn run(config: Config) {
                 None,
                 None,
             );
-            state.sections.write().extend(rendered);
+            *state.sections.write() = build_section_store_from_rendered(rendered);
             state.live.store(true, Ordering::Relaxed);
 
             state.captures.set_baseline_systeminfo(agent_systeminfo);
@@ -653,8 +653,93 @@ async fn serve(listener: std::net::TcpListener, state: AppState) {
         .expect("failed to run http server");
 }
 
+/// Caches the navigation `sections` list separately from per-section JSON
+/// bodies, so the `/api/v1/sections` route can read the nav list without
+/// materializing any section body, and `/data/<section>.json` can read
+/// (or generate) just the requested body.
+struct LazySectionStore {
+    sections: Vec<serde_json::Value>,
+    section_bodies: std::collections::HashMap<String, serde_json::Value>,
+}
+
+impl LazySectionStore {
+    fn new(sections: Vec<serde_json::Value>) -> Self {
+        Self {
+            sections,
+            section_bodies: std::collections::HashMap::new(),
+        }
+    }
+
+    fn sections(&self) -> &[serde_json::Value] {
+        &self.sections
+    }
+
+    fn section(&self, key: &str) -> Option<&serde_json::Value> {
+        self.section_bodies.get(key)
+    }
+
+    fn insert_section(&mut self, key: &str, value: serde_json::Value) {
+        self.section_bodies.insert(key.to_string(), value);
+    }
+
+    /// Returns true when no nav list has been loaded yet — used by the
+    /// `mode` endpoint to advertise the "we don't have data yet" state
+    /// for live and upload-only modes pre-first-refresh.
+    fn is_empty(&self) -> bool {
+        self.sections.is_empty()
+    }
+
+    /// Returns any cached section body, used by `sections_metadata` to
+    /// recover the global params (source, version, filename, ...) that
+    /// are currently embedded in every section payload.
+    fn any_body(&self) -> Option<&serde_json::Value> {
+        self.section_bodies.values().next()
+    }
+}
+
+impl Default for LazySectionStore {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+/// Adapt the `dashboard::dashboard::generate` output (a HashMap of route
+/// -> serialized JSON body) into a `LazySectionStore`. The nav list is
+/// recovered from the embedded `sections` array of any body — overview
+/// is canonical but any body works because they all carry the same nav.
+/// Bodies that fail to parse are logged and skipped.
+fn build_section_store_from_rendered(
+    rendered: HashMap<String, String>,
+) -> LazySectionStore {
+    let mut bodies: HashMap<String, serde_json::Value> = HashMap::new();
+    for (key, body) in rendered {
+        match serde_json::from_str::<serde_json::Value>(&body) {
+            Ok(v) => {
+                bodies.insert(key, v);
+            }
+            Err(e) => {
+                warn!("section cache parse failed for {key}: {e}");
+            }
+        }
+    }
+
+    let nav = bodies
+        .get("overview.json")
+        .or_else(|| bodies.values().next())
+        .and_then(|v| v.get("sections"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut store = LazySectionStore::new(nav);
+    for (key, value) in bodies {
+        store.insert_section(&key, value);
+    }
+    store
+}
+
 struct AppState {
-    sections: parking_lot::RwLock<HashMap<String, String>>,
+    sections: parking_lot::RwLock<LazySectionStore>,
     /// Per-capture TSDB + metadata. Single-capture callers always target
     /// `CaptureId::Baseline`; the experiment slot is empty unless a compare
     /// mode hand-off has attached one.
@@ -714,14 +799,15 @@ impl AppState {
     }
 
     /// Build the navigation + global params payload for the
-    /// `/api/v1/sections` endpoint. Reads any cached section body
-    /// (overview is the canonical fall-back) to recover the embedded
-    /// `sections` array and the global params (source, version,
-    /// filename, interval, filesize, time bounds, num_series). When no
-    /// section is cached yet — e.g. live mode before the first refresh,
-    /// or upload-only mode pre-upload — returns a minimal payload with
-    /// an empty sections array so the frontend never sees a 5xx for the
-    /// "we just don't have data yet" case.
+    /// `/api/v1/sections` endpoint. Reads the navigation list directly
+    /// from the `LazySectionStore`, and the global params (source,
+    /// version, filename, interval, filesize, time bounds, num_series)
+    /// from any cached section body — those globals are still embedded
+    /// per-body today. When no section is cached yet — e.g. live mode
+    /// before the first refresh, or upload-only mode pre-upload —
+    /// returns a minimal payload with an empty sections array so the
+    /// frontend never sees a 5xx for the "we just don't have data yet"
+    /// case.
     ///
     /// The `capture` argument is currently advisory: the cached section
     /// bodies are produced by `regenerate_dashboards`, which today
@@ -731,65 +817,53 @@ impl AppState {
     fn sections_metadata(&self, _capture: CaptureId) -> serde_json::Value {
         let sections_guard = self.sections.read();
 
-        // Prefer overview (canonical), fall back to any cached section.
-        let body = sections_guard
-            .get("overview.json")
-            .or_else(|| sections_guard.values().next())
-            .cloned();
+        let sections_array: Vec<serde_json::Value> = sections_guard.sections().to_vec();
+
+        // Pull the global params off any cached body. They're
+        // duplicated per-body today; a future task can promote them
+        // onto the store directly.
+        let body = sections_guard.any_body().cloned();
         drop(sections_guard);
 
-        let parsed: Option<serde_json::Value> = body.as_deref().and_then(|s| {
-            serde_json::from_str(s)
-                .map_err(|e| warn!("sections cache parse error: {e}"))
-                .ok()
-        });
-
-        let sections_array: Vec<serde_json::Value> = parsed
-            .as_ref()
-            .and_then(|v| v.get("sections"))
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default();
-
-        let source = parsed
+        let source = body
             .as_ref()
             .and_then(|v| v.get("source"))
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let version = parsed
+        let version = body
             .as_ref()
             .and_then(|v| v.get("version"))
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let filename = parsed
+        let filename = body
             .as_ref()
             .and_then(|v| v.get("filename"))
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
-        let interval = parsed
+        let interval = body
             .as_ref()
             .and_then(|v| v.get("interval"))
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
-        let filesize = parsed
+        let filesize = body
             .as_ref()
             .and_then(|v| v.get("filesize"))
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
-        let start_time = parsed
+        let start_time = body
             .as_ref()
             .and_then(|v| v.get("start_time"))
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
-        let end_time = parsed
+        let end_time = body
             .as_ref()
             .and_then(|v| v.get("end_time"))
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
-        let num_series = parsed
+        let num_series = body
             .as_ref()
             .and_then(|v| v.get("num_series"))
             .and_then(|v| v.as_u64())
@@ -1088,8 +1162,7 @@ fn regenerate_dashboards(state: &AppState) {
         None,
     );
 
-    let mut sections = state.sections.write();
-    *sections = rendered;
+    *state.sections.write() = build_section_store_from_rendered(rendered);
 }
 
 /// Extract service extension metadata from a parquet file.
@@ -1426,25 +1499,19 @@ async fn data(
     use axum::response::IntoResponse;
 
     let sections = state.sections.read();
-    match sections.get(&path) {
+    match sections.section(&path) {
         Some(v) => {
             // Strip the redundant nav `sections` array before sending to the
             // frontend.  The cached body keeps it so that `sections_metadata`
             // can still extract it (Task 4); we only remove it at response time.
-            let body = match serde_json::from_str::<serde_json::Value>(v) {
-                Ok(mut parsed) => {
-                    strip_sections_from_section_payload(&mut parsed);
-                    match serde_json::to_string(&parsed) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            warn!("section re-serialization failed for {path}: {e}");
-                            v.to_string()
-                        }
-                    }
-                }
+            let mut parsed = v.clone();
+            drop(sections);
+            strip_sections_from_section_payload(&mut parsed);
+            let body = match serde_json::to_string(&parsed) {
+                Ok(s) => s,
                 Err(e) => {
-                    warn!("section parse failed for {path}: {e}");
-                    v.to_string()
+                    warn!("section re-serialization failed for {path}: {e}");
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
                 }
             };
             (
@@ -1808,10 +1875,7 @@ async fn upload_parquet(
         let mut tsdb = tsdb_handle.write();
         *tsdb = data;
     }
-    {
-        let mut sections = state.sections.write();
-        *sections = rendered;
-    }
+    *state.sections.write() = build_section_store_from_rendered(rendered);
     let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
     *state.parquet_path.write() = Some(temp_path);
     state
@@ -2011,10 +2075,7 @@ async fn connect_agent(
         let mut db = tsdb_handle.write();
         *db = tsdb;
     }
-    {
-        let mut sections = state.sections.write();
-        *sections = rendered;
-    }
+    *state.sections.write() = build_section_store_from_rendered(rendered);
     state.captures.set_baseline_systeminfo(agent_systeminfo);
     state.live.store(true, Ordering::Relaxed);
 
@@ -2377,5 +2438,16 @@ mod tests {
         assert_eq!(payload["start_time"], serde_json::json!(1000u64));
         assert_eq!(payload["end_time"], serde_json::json!(2000u64));
         assert_eq!(payload["num_series"], serde_json::json!(99usize));
+    }
+
+    #[test]
+    fn lazy_section_store_caches_sections_separately_from_metadata() {
+        let mut store = LazySectionStore::new(vec![
+            serde_json::json!({"name": "Overview", "route": "/overview"})
+        ]);
+        assert!(store.section("overview").is_none());
+        store.insert_section("overview", serde_json::json!({"groups": []}));
+        assert_eq!(store.section("overview").unwrap()["groups"], serde_json::json!([]));
+        assert_eq!(store.sections().len(), 1);
     }
 }

--- a/tests/section_cache.test.mjs
+++ b/tests/section_cache.test.mjs
@@ -58,3 +58,10 @@ test('shared sections can be bootstrapped without storing a section body', () =>
     ]);
     assert.deepEqual(state.responses, {});
 });
+
+test('withSharedSections uses bootstrapped metadata for lean section payloads', () => {
+    const state = createSectionCacheState();
+    storeSharedSections(state, [{ name: 'Overview', route: '/overview' }]);
+    const stitched = withSharedSections(state, { groups: [] });
+    assert.deepEqual(stitched.sections, [{ name: 'Overview', route: '/overview' }]);
+});

--- a/tests/section_cache.test.mjs
+++ b/tests/section_cache.test.mjs
@@ -6,6 +6,8 @@ import {
     storeSharedSections,
     getSections,
     withSharedSections,
+    setSectionCacheLimit,
+    pinSectionKey,
 } from '../src/viewer/assets/lib/section_cache.js';
 
 test('storeSectionResponse strips duplicated sections and preserves shared section metadata', () => {
@@ -64,4 +66,17 @@ test('withSharedSections uses bootstrapped metadata for lean section payloads', 
     storeSharedSections(state, [{ name: 'Overview', route: '/overview' }]);
     const stitched = withSharedSections(state, { groups: [] });
     assert.deepEqual(stitched.sections, [{ name: 'Overview', route: '/overview' }]);
+});
+
+test('bounded section cache evicts oldest non-pinned section', () => {
+    const state = createSectionCacheState();
+    storeSharedSections(state, [{ name: 'Overview', route: '/overview' }]);
+    setSectionCacheLimit(state, 2);
+    pinSectionKey(state, 'overview');
+    storeSectionResponse(state, 'overview', { groups: [] });
+    storeSectionResponse(state, 'cpu', { groups: [] });
+    storeSectionResponse(state, 'memory', { groups: [] });
+    assert.equal(state.responses.overview.groups.length, 0);
+    assert.equal(state.responses.memory.groups.length, 0);
+    assert.equal(state.responses.cpu, undefined);
 });

--- a/tests/section_cache.test.mjs
+++ b/tests/section_cache.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
     createSectionCacheState,
     storeSectionResponse,
+    storeSharedSections,
     getSections,
     withSharedSections,
 } from '../src/viewer/assets/lib/section_cache.js';
@@ -42,4 +43,18 @@ test('storeSectionResponse reuses the shared sections list for later payloads wi
     assert.deepEqual(withSharedSections(state, storedCpu).sections, [
         { name: 'Overview', route: '/overview' },
     ]);
+});
+
+test('shared sections can be bootstrapped without storing a section body', () => {
+    const state = createSectionCacheState();
+    storeSharedSections(state, [
+        { name: 'Overview', route: '/overview' },
+        { name: 'CPU', route: '/cpu' },
+    ]);
+
+    assert.deepEqual(getSections(state), [
+        { name: 'Overview', route: '/overview' },
+        { name: 'CPU', route: '/cpu' },
+    ]);
+    assert.deepEqual(state.responses, {});
 });

--- a/tests/sections_api.test.mjs
+++ b/tests/sections_api.test.mjs
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ViewerApi } from '../src/viewer/assets/lib/viewer_api.js';
+import { ViewerApi as WasmViewerApi } from '../site/viewer/lib/viewer_api.js';
 
 test('ViewerApi exposes getSections', () => {
     assert.equal(typeof ViewerApi.getSections, 'function');
+});
+
+test('WASM ViewerApi exposes getSections', () => {
+    assert.equal(typeof WasmViewerApi.getSections, 'function');
 });

--- a/tests/sections_api.test.mjs
+++ b/tests/sections_api.test.mjs
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ViewerApi } from '../src/viewer/assets/lib/viewer_api.js';
+
+test('ViewerApi exposes getSections', () => {
+    assert.equal(typeof ViewerApi.getSections, 'function');
+});


### PR DESCRIPTION
## Summary

Phase 1 of the viewer chart-loading optimization plan ([spec](docs/superpowers/specs/2026-04-26-viewer-chart-loading-optimization-design.md), [plan](docs/superpowers/plans/2026-04-26-viewer-chart-loading-optimization.md)). Splits viewer navigation metadata from per-section content, introduces a separated cache layout, and bounds the frontend route cache.

- **Server**: new `GET /api/v1/sections` returns the navigation list + global params without any section body. The `data` handler strips the embedded `sections` array from each section response. `AppState`'s section cache is now a `LazySectionStore` that exposes navigation and bodies separately.
- **WASM**: `Viewer::get_section()` now strips `sections` from each body on the way out. Frontend `ViewerApi.getSections()` was already in place; the bootstrap path now calls it before fetching the active section.
- **Frontend (server + WASM)**: `bootstrapSharedSections()` populates the navigation cache once on load. The route response cache is bounded to 3 entries with `overview` pinned, evicting the oldest non-pinned entry on overflow.

## Phase 1 vs Phase 2

The spec lists \"the producer side no longer materializes all sections eagerly\" as a success criterion. **This branch does not deliver that.** `dashboard::dashboard::generate` still iterates every section and renders all bodies upfront — the change here is the **cache layout** (separated nav + bodies, with stripping at the API boundary), not the generator. Genuine producer-side laziness would require refactoring how dashboard sections are declared (closures keyed by route name) and is deferred to Phase 2.

What this branch does deliver from the plan's success criteria:
- ✅ Initial viewer boot only needs nav metadata + active section
- ✅ Section JSON no longer repeats the full sections list inside every section body
- ✅ Route caches have explicit limits

Naming: ``LazySectionStore`` is named for the API contract (separate nav + body access) rather than for true lazy generation. The producer is still eager.

## Tests

- `cargo test --bin rezolus` — 94 passed (was 91 + 3 new: `sections_metadata_json_omits_groups`, `lean_section_payload_does_not_repeat_sections`, `lazy_section_store_caches_sections_separately_from_metadata`)
- `cd crates/viewer && cargo test` — 1 passed (`strip_sections_from_generated_section_body`)
- `node --test tests/*.mjs` — 28 passed (was 24 + 4 new across `tests/section_cache.test.mjs` and `tests/sections_api.test.mjs`)
- `cargo clippy --bin rezolus -- -D warnings` — clean

## Test plan
- [x] **Server bootstrap path**: `cargo run -- view path/to/capture.parquet`. Sidebar populates from `/api/v1/sections`. Network tab shows only `/api/v1/sections` + `overview.json` on initial render. Navigating to `/cpu` triggers a single `/data/cpu.json` fetch with no `sections` field in the response body.
- [ ] **Server upload path**: drag a parquet file onto the upload UI. Same checks.
- [ ] **WASM bootstrap (static-site demo)**: load `?demo=demo.parquet`. Navigation works; per-section JSON returned by `Viewer::get_section()` has no `sections` key.
- [ ] **Bounded cache**: navigate `overview → cpu → memory → network → blockio`. After 4+ data sections plus pinned overview, only the 2 most-recently-visited data sections + `overview` remain in `sectionResponseCache` (verify in DevTools console).
- [ ] **Compare mode**: `view a.parquet b.parquet` and the static-site \`?capture=vllm=...&capture=sglang=...\` flow. Nav still renders, lean payloads still work.
- [ ] **Granularity change**: switch the granularity dropdown. `clearSectionResponses` runs but `state.limit === 3` and `state.pinned.has('overview')` persist (no infinite refetch loop).
- [ ] **Live mode**: `view http://localhost:4241`. Live refresh fetches lean section bodies on the active route only.
- [ ] **Client-only routes**: `/systeminfo`, `/metadata`, `/selection`, `/report` render correctly (sidebar uses bootstrapped shared sections, not a cached overview body).

## Known follow-ups (not blocking)
1. **Producer-side laziness (Phase 2)** — refactor dashboard generation so individual section bodies are produced on demand, keyed by route name. Would let us truly avoid eager work for unvisited sections. Out of scope here.
2. **`LazySectionStore` perf**: the server cache stores `serde_json::Value` and the `data` handler does `clone() + strip + to_string()` on every request. Promoting the global params (`source`/`version`/`filename`/`interval`/`filesize`/`start_time`/`end_time`/`num_series`) onto the store directly and storing pre-stripped section *strings* would eliminate the per-request reserialization. Same applies to the WASM `Viewer::get_section`. Documented in the implementation comments.
3. **Test coverage of `sections_metadata` body-parsing**: this PR fixes a latent f64-vs-u64 bug in the `start_time`/`end_time` extraction, but the read path is still not directly unit-tested (the existing test covers the pure helper). Worth adding a regression test in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)