### PR TITLE
fix(parquet): expand array sources into per_source_metadata

### DIFF
--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -779,52 +779,63 @@ fn merge_metadata(inputs: &[InputFile]) -> Result<Vec<KeyValue>, Box<dyn std::er
             }
         }
 
-        // Determine the sub-key within this source's group
-        let sub_key = if input.source == "rezolus" {
-            input.node.as_deref().unwrap_or("unknown").to_string()
-        } else {
-            input.instance.as_deref().unwrap_or("0").to_string()
-        };
+        // Determine the source names this input contributes to. If the
+        // input was an already-combined file with a single top-level set of
+        // metadata but a JSON-array `source`, expand it into one
+        // per_source_metadata entry per array element, duplicating the
+        // top-level fields (version, node, instance) into each.
+        let source_names: Vec<String> = serde_json::from_str::<Vec<String>>(&input.source)
+            .unwrap_or_else(|_| vec![input.source.clone()]);
 
-        let source_group = per_source
-            .entry(input.source.clone())
-            .or_insert_with(|| serde_json::json!({}));
-        let serde_json::Value::Object(group_map) = source_group else {
-            continue;
-        };
-        let entry = group_map
-            .entry(sub_key)
-            .or_insert_with(|| serde_json::json!({}));
-        let serde_json::Value::Object(map) = entry else {
-            continue;
-        };
-
-        // Move top-level version into per-source entry
-        if let Some(version) = input
+        let version = input
             .kv_metadata
             .iter()
             .find(|kv| kv.key == KEY_VERSION)
-            .and_then(|kv| kv.value.clone())
-        {
-            map.entry(NESTED_VERSION.to_string())
-                .or_insert(serde_json::Value::String(version));
-        }
+            .and_then(|kv| kv.value.clone());
 
-        // Store node or instance label in per-source metadata
-        if input.source == "rezolus" {
-            if let Some(ref node) = input.node {
-                map.entry(NESTED_NODE.to_string())
-                    .or_insert(serde_json::Value::String(node.clone()));
+        for source_name in &source_names {
+            // Determine the sub-key within this source's group
+            let sub_key = if source_name == "rezolus" {
+                input.node.as_deref().unwrap_or("unknown").to_string()
+            } else {
+                input.instance.as_deref().unwrap_or("0").to_string()
+            };
+
+            let source_group = per_source
+                .entry(source_name.clone())
+                .or_insert_with(|| serde_json::json!({}));
+            let serde_json::Value::Object(group_map) = source_group else {
+                continue;
+            };
+            let entry = group_map
+                .entry(sub_key)
+                .or_insert_with(|| serde_json::json!({}));
+            let serde_json::Value::Object(map) = entry else {
+                continue;
+            };
+
+            // Move top-level version into per-source entry
+            if let Some(ref version) = version {
+                map.entry(NESTED_VERSION.to_string())
+                    .or_insert(serde_json::Value::String(version.clone()));
             }
-        } else {
-            if let Some(ref instance) = input.instance {
-                map.entry(NESTED_INSTANCE.to_string())
-                    .or_insert(serde_json::Value::String(instance.clone()));
-            }
-            // Also store node for service files if present (informational — which host it ran on)
-            if let Some(ref node) = input.node {
-                map.entry(NESTED_NODE.to_string())
-                    .or_insert(serde_json::Value::String(node.clone()));
+
+            // Store node or instance label in per-source metadata
+            if source_name == "rezolus" {
+                if let Some(ref node) = input.node {
+                    map.entry(NESTED_NODE.to_string())
+                        .or_insert(serde_json::Value::String(node.clone()));
+                }
+            } else {
+                if let Some(ref instance) = input.instance {
+                    map.entry(NESTED_INSTANCE.to_string())
+                        .or_insert(serde_json::Value::String(instance.clone()));
+                }
+                // Also store node for service files if present (informational — which host it ran on)
+                if let Some(ref node) = input.node {
+                    map.entry(NESTED_NODE.to_string())
+                        .or_insert(serde_json::Value::String(node.clone()));
+                }
             }
         }
     }
@@ -1815,6 +1826,82 @@ mod tests {
         ];
         expected.sort();
         assert_eq!(sources, expected);
+    }
+
+    #[test]
+    fn test_merge_metadata_expands_source_array_into_per_source() {
+        // Input file has `source` as a JSON array but only top-level metadata
+        // (no per_source_metadata). Combine should produce one
+        // per_source_metadata entry per array element, duplicating the
+        // top-level fields (version, node, instance) into each.
+        let (_t1, p1) = make_test_file_with_metadata(
+            &[SEC, 2 * SEC],
+            "m1",
+            &[Some(1), Some(2)],
+            "[\"rezolus\",\"llm-perf\"]",
+            "1000",
+            vec![
+                ("node", "web01"),
+                ("instance", "primary"),
+                ("version", "1.2.3"),
+            ],
+        );
+        let (_t2, p2) = make_test_file_with_metadata(
+            &[SEC, 2 * SEC],
+            "m2",
+            &[Some(3), Some(4)],
+            "rezolus",
+            "1000",
+            vec![("node", "web02")],
+        );
+
+        let inputs = vec![load(&p1), load(&p2)];
+        let kv = merge_metadata(&inputs).unwrap();
+
+        let psm_str = kv
+            .iter()
+            .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
+            .and_then(|kv| kv.value.as_deref())
+            .expect("per_source_metadata should exist");
+        let psm: serde_json::Value = serde_json::from_str(psm_str).unwrap();
+
+        // The array source "rezolus" element should land under web01
+        // (the top-level `node` of the array-source input).
+        let rez_web01 = psm
+            .get("rezolus")
+            .and_then(|g| g.get("web01"))
+            .expect("rezolus.web01 entry should exist");
+        assert_eq!(
+            rez_web01.get("version").and_then(|v| v.as_str()),
+            Some("1.2.3")
+        );
+        assert_eq!(
+            rez_web01.get("node").and_then(|v| v.as_str()),
+            Some("web01")
+        );
+
+        // The array source "llm-perf" element should land under instance
+        // "primary" with the top-level fields duplicated.
+        let llm_primary = psm
+            .get("llm-perf")
+            .and_then(|g| g.get("primary"))
+            .expect("llm-perf.primary entry should exist");
+        assert_eq!(
+            llm_primary.get("version").and_then(|v| v.as_str()),
+            Some("1.2.3")
+        );
+        assert_eq!(
+            llm_primary.get("instance").and_then(|v| v.as_str()),
+            Some("primary")
+        );
+        assert_eq!(
+            llm_primary.get("node").and_then(|v| v.as_str()),
+            Some("web01")
+        );
+
+        // The second input (single-source rezolus, web02) should still get
+        // its own entry alongside the expanded array source's web01.
+        assert!(psm.get("rezolus").and_then(|g| g.get("web02")).is_some());
     }
 
     #[test]

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -328,38 +328,75 @@ fn build_parquet_converter(
         converter = converter.metadata("descriptions".to_string(), json.clone());
     }
 
-    // per_source_metadata with first/last sample timestamps
-    let mut psm = serde_json::Map::new();
+    // A user-supplied --metadata source=... takes precedence over the
+    // endpoint's source. If the value parses as a JSON array the stream
+    // represents multiple logical sources and we emit one
+    // per_source_metadata entry per name.
+    let effective_source = config
+        .metadata
+        .iter()
+        .find(|(k, _)| k == "source")
+        .map(|(_, v)| v.as_str())
+        .unwrap_or(ep.config.source.as_str());
+
+    if let Some(json) = build_per_source_metadata(
+        effective_source,
+        ep.first_success_ns,
+        ep.last_success_ns,
+        ep.config.role.as_deref(),
+    ) {
+        converter = converter.metadata("per_source_metadata".to_string(), json);
+    }
+
+    converter
+}
+
+/// Build the `per_source_metadata` JSON written by the recorder.
+///
+/// When `source` is a JSON array, each name in the array becomes an entry
+/// with the same per-source fields duplicated — a single endpoint
+/// represents all the listed sources, so the timing and role apply
+/// identically to every name.
+///
+/// Returns `None` when no per-source fields are available.
+fn build_per_source_metadata(
+    source: &str,
+    first_sample_ns: Option<u64>,
+    last_sample_ns: Option<u64>,
+    role: Option<&str>,
+) -> Option<String> {
     let mut source_meta = serde_json::Map::new();
-    if let Some(ns) = ep.first_success_ns {
+    if let Some(ns) = first_sample_ns {
         source_meta.insert(
             parquet_metadata::NESTED_FIRST_SAMPLE_NS.to_string(),
             serde_json::json!(ns),
         );
     }
-    if let Some(ns) = ep.last_success_ns {
+    if let Some(ns) = last_sample_ns {
         source_meta.insert(
             parquet_metadata::NESTED_LAST_SAMPLE_NS.to_string(),
             serde_json::json!(ns),
         );
     }
-    if let Some(ref role) = ep.config.role {
+    if let Some(role) = role {
         source_meta.insert(
             parquet_metadata::NESTED_ROLE.to_string(),
             serde_json::json!(role),
         );
     }
-    if !source_meta.is_empty() {
-        psm.insert(
-            ep.config.source.clone(),
-            serde_json::Value::Object(source_meta),
-        );
-        if let Ok(json) = serde_json::to_string(&psm) {
-            converter = converter.metadata("per_source_metadata".to_string(), json);
-        }
+
+    if source_meta.is_empty() {
+        return None;
     }
 
-    converter
+    let source_names: Vec<String> =
+        serde_json::from_str::<Vec<String>>(source).unwrap_or_else(|_| vec![source.to_string()]);
+
+    let mut psm = serde_json::Map::new();
+    for name in &source_names {
+        psm.insert(name.clone(), serde_json::Value::Object(source_meta.clone()));
+    }
+    serde_json::to_string(&psm).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -847,5 +884,63 @@ mod tests {
             output_dir(&PathBuf::from("out.parquet")),
             PathBuf::from(".")
         );
+    }
+
+    #[test]
+    fn test_build_per_source_metadata_single_source() {
+        let json =
+            build_per_source_metadata("rezolus", Some(100), Some(200), Some("service")).unwrap();
+        let psm: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            psm["rezolus"]["first_sample_ns"].as_u64(),
+            Some(100),
+            "got: {psm}"
+        );
+        assert_eq!(psm["rezolus"]["last_sample_ns"].as_u64(), Some(200));
+        assert_eq!(psm["rezolus"]["role"].as_str(), Some("service"));
+        // Only one source entry
+        assert_eq!(psm.as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_build_per_source_metadata_array_source_duplicates_fields() {
+        // When the source is a JSON array, one entry per source name is
+        // emitted with the same per-source fields duplicated.
+        let json = build_per_source_metadata(
+            "[\"rezolus\",\"llm-perf\"]",
+            Some(100),
+            Some(200),
+            Some("service"),
+        )
+        .unwrap();
+        let psm: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for name in ["rezolus", "llm-perf"] {
+            assert_eq!(
+                psm[name]["first_sample_ns"].as_u64(),
+                Some(100),
+                "missing first_sample_ns for {name}"
+            );
+            assert_eq!(psm[name]["last_sample_ns"].as_u64(), Some(200));
+            assert_eq!(psm[name]["role"].as_str(), Some("service"));
+        }
+        assert_eq!(psm.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_build_per_source_metadata_returns_none_when_empty() {
+        // No per-source fields at all → no per_source_metadata.
+        assert!(build_per_source_metadata("rezolus", None, None, None).is_none());
+    }
+
+    #[test]
+    fn test_build_per_source_metadata_array_with_partial_fields() {
+        // Array source with only a subset of per-source fields populated.
+        let json = build_per_source_metadata("[\"a\",\"b\",\"c\"]", Some(50), None, None).unwrap();
+        let psm: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for name in ["a", "b", "c"] {
+            assert_eq!(psm[name]["first_sample_ns"].as_u64(), Some(50));
+            assert!(psm[name].get("last_sample_ns").is_none());
+            assert!(psm[name].get("role").is_none());
+        }
     }
 }


### PR DESCRIPTION
## Summary

When `source` is already an array, build `per_source_metadata` with one
entry per source rather than a single entry keyed by the literal array
string. Applies to both fresh recorder output and to `parquet combine`
when reading a previously-combined file that only carries one top-level
set of metadata.

### Recorder

A user-supplied `--metadata source=[...]` lets the recorder describe a
single endpoint that aggregates multiple logical sources (e.g. a
Prometheus federation endpoint surfacing both rezolus and llm-perf).
For each name in the array we emit a `per_source_metadata` entry
duplicating the per-source fields (`first_sample_ns`, `last_sample_ns`,
`role`).

### Combine

When merging an input whose `source` is a JSON array but whose
per-source data only lives at the top level (no
`per_source_metadata`), expand it into one nested entry per array
element. Each entry inherits the input's top-level `version`, `node`,
and `instance` fields. Single-source inputs are unaffected.

## Test plan

- [x] `cargo test --bin rezolus` — 97 tests pass, including 4 new recorder unit tests around the `build_per_source_metadata` helper and 1 new combine integration test that asserts the expansion lands the right entries under `rezolus.<node>` and `<service>.<instance>` with duplicated top-level fields.
- [x] `node --test tests/*.mjs` — JS viewer tests still pass (25/25).
- [x] CI green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSjwHWDsYhUAmfAQJYTLHr)_