### PR TITLE
perf(viewer): lazy section generation (Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.15"
+version = "5.11.1-alpha.16"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.15"
+version = "5.11.1-alpha.16"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -181,42 +181,6 @@ pub fn generate_section(data: &Tsdb, route: &str, ctx: &DashboardContext) -> Opt
     Some(view)
 }
 
-/// Transitional shim preserving the eager `generate` signature so
-/// `src/viewer/mod.rs` and `crates/viewer/src/lib.rs` keep building
-/// while Tasks B + C migrate them to the lazy API. Remove once those
-/// call sites are updated.
-#[deprecated(note = "use build_dashboard_context + generate_section")]
-pub fn generate(
-    data: &Tsdb,
-    filesize: Option<u64>,
-    service_exts: &[(&str, &ServiceExtension)],
-    category: Option<(&str, &CategoryExtension)>,
-    _descriptions: Option<&std::collections::HashMap<String, String>>,
-) -> std::collections::HashMap<String, String> {
-    let ctx = build_dashboard_context(filesize, service_exts, category);
-
-    let mut rendered = std::collections::HashMap::new();
-
-    // Iterate the section nav and render each one lazily. The map keys
-    // mirror the original layout: `<route-without-leading-slash>.json`,
-    // with `/` preserved in service routes (e.g. `service/vllm.json`).
-    for section in &ctx.sections {
-        if let Some(mut view) = generate_section(data, &section.route, &ctx) {
-            // Match old behavior: filesize only on overview + SECTION_META routes,
-            // not on service/category routes.
-            let is_legacy_filesize_route = section.route == "/overview"
-                || SECTION_META.iter().any(|(_, r, _)| *r == section.route);
-            if let (Some(size), true) = (filesize, is_legacy_filesize_route) {
-                view.set_filesize(size);
-            }
-            let key = format!("{}.json", &section.route[1..]);
-            rendered.insert(key, serde_json::to_string(&view).unwrap());
-        }
-    }
-
-    rendered
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -349,8 +313,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    fn generate_emits_category_section_when_category_supplied() {
+    fn build_context_emits_category_nav_entry_when_category_supplied() {
         use crate::service_extension::{CategoryExtension, CategoryKpi, Kpi, ServiceExtension};
         use std::collections::HashMap;
 
@@ -402,25 +365,28 @@ mod tests {
             }],
         };
 
-        let data = Tsdb::default();
-        let result = generate(
-            &data,
+        let ctx = build_dashboard_context(
             None,
             &[("vllm", &vllm), ("sglang", &sglang)],
             Some(("inference-library", &category)),
-            None,
         );
 
-        // Category section present.
-        assert!(result.contains_key("service/inference-library.json"));
-        // Per-member sections absent.
-        assert!(!result.contains_key("service/vllm.json"));
-        assert!(!result.contains_key("service/sglang.json"));
+        // Category nav entry present.
+        let routes: Vec<&str> = ctx.sections.iter().map(|s| s.route.as_str()).collect();
+        assert!(routes.contains(&"/service/inference-library"));
+        // Per-member nav entries absent under category mode.
+        assert!(!routes.contains(&"/service/vllm"));
+        assert!(!routes.contains(&"/service/sglang"));
+
+        // generate_section honors the same: category route renders, members 404.
+        let data = Tsdb::default();
+        assert!(generate_section(&data, "/service/inference-library", &ctx).is_some());
+        assert!(generate_section(&data, "/service/vllm", &ctx).is_none());
+        assert!(generate_section(&data, "/service/sglang", &ctx).is_none());
     }
 
     #[test]
-    #[allow(deprecated)]
-    fn generate_dedupes_section_when_two_captures_share_service_name() {
+    fn build_context_dedupes_section_when_two_captures_share_service_name() {
         use crate::service_extension::{Kpi, ServiceExtension};
         use std::collections::HashMap;
 
@@ -448,54 +414,23 @@ mod tests {
         };
         let vllm_b = vllm_a.clone();
 
-        let data = Tsdb::default();
-        let result = generate(
-            &data,
-            None,
-            &[("vllm", &vllm_a), ("vllm", &vllm_b)],
-            None,
-            None,
-        );
+        let ctx = build_dashboard_context(None, &[("vllm", &vllm_a), ("vllm", &vllm_b)], None);
 
-        assert!(result.contains_key("service/vllm.json"));
-
-        let overview_str = result.get("overview.json").expect("overview rendered");
-        let overview: serde_json::Value = serde_json::from_str(overview_str).unwrap();
-        let sections = overview
-            .get("sections")
-            .and_then(|s| s.as_array())
-            .expect("sections present");
-        let vllm_count = sections
+        // Nav contains exactly one /service/vllm entry.
+        let vllm_count = ctx
+            .sections
             .iter()
-            .filter(|s| s.get("route").and_then(|r| r.as_str()) == Some("/service/vllm"))
+            .filter(|s| s.route == "/service/vllm")
             .count();
         assert_eq!(
             vllm_count, 1,
             "expected one /service/vllm entry in nav, got {vllm_count}"
         );
-    }
 
-    #[test]
-    fn shim_filesize_applied_only_to_legacy_routes() {
-        // Build a context with a service ext so the shim renders a /service/<name> route.
-        let svc_json = r#"{"service_name":"vllm","service_metadata":{},"slo":null,"kpis":[]}"#;
-        let svc_ext: ServiceExtension = serde_json::from_str(svc_json).unwrap();
+        // The deduped service ext list also collapses to one entry, so
+        // generate_section can still render the route.
+        assert_eq!(ctx.service_exts.len(), 1);
         let data = Tsdb::default();
-        #[allow(deprecated)]
-        let rendered = generate(&data, Some(12_345), &[("vllm", &svc_ext)], None, None);
-
-        // overview and stock sections carry filesize.
-        let overview: serde_json::Value =
-            serde_json::from_str(rendered.get("overview.json").unwrap()).unwrap();
-        assert_eq!(overview["filesize"], serde_json::json!(12_345));
-
-        let cpu: serde_json::Value =
-            serde_json::from_str(rendered.get("cpu.json").unwrap()).unwrap();
-        assert_eq!(cpu["filesize"], serde_json::json!(12_345));
-
-        // Service routes do NOT carry filesize (preserves pre-Phase-2 behavior).
-        let svc: serde_json::Value =
-            serde_json::from_str(rendered.get("service/vllm.json").unwrap()).unwrap();
-        assert!(svc.get("filesize").is_none(), "service view leaked filesize");
+        assert!(generate_section(&data, "/service/vllm", &ctx).is_some());
     }
 }

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -144,11 +144,7 @@ pub fn build_dashboard_context(
 /// should call `view.set_filesize(...)` themselves.
 pub fn generate_section(data: &Tsdb, route: &str, ctx: &DashboardContext) -> Option<View> {
     let view = if route == "/overview" {
-        overview::generate(
-            data,
-            ctx.sections.clone(),
-            ctx.throughput_query.as_deref(),
-        )
+        overview::generate(data, ctx.sections.clone(), ctx.throughput_query.as_deref())
     } else if let Some((_, _, generator)) = SECTION_META.iter().find(|(_, r, _)| *r == route) {
         generator(data, ctx.sections.clone())
     } else if let Some(name) = route.strip_prefix("/service/") {
@@ -303,8 +299,8 @@ mod tests {
             Some(("inference-library", &category)),
         );
         // Category renders at /service/<category-name>.
-        let view = generate_section(&data, "/service/inference-library", &ctx)
-            .expect("category renders");
+        let view =
+            generate_section(&data, "/service/inference-library", &ctx).expect("category renders");
         let json = serde_json::to_string(&view).unwrap();
         assert!(json.contains("inference-library"));
         // Per-member sections are absent in category mode.

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -36,7 +36,7 @@ static SECTION_META: &[(&str, &str, Generator)] = &[
 /// Owned context produced by `build_dashboard_context`. Carries
 /// everything `generate_section` needs to render any single section on
 /// demand without re-deriving the dedup / category-fallback logic.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct DashboardContext {
     /// Navigation list including overview, stock sections, and any
     /// service / category sections — same order as what the eager

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -36,6 +36,7 @@ static SECTION_META: &[(&str, &str, Generator)] = &[
 /// Owned context produced by `build_dashboard_context`. Carries
 /// everything `generate_section` needs to render any single section on
 /// demand without re-deriving the dedup / category-fallback logic.
+#[derive(Default)]
 pub struct DashboardContext {
     /// Navigation list including overview, stock sections, and any
     /// service / category sections — same order as what the eager

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -33,13 +33,31 @@ static SECTION_META: &[(&str, &str, Generator)] = &[
     ("Rezolus", "/rezolus", rezolus::generate),
 ];
 
-pub fn generate(
-    data: &Tsdb,
+/// Owned context produced by `build_dashboard_context`. Carries
+/// everything `generate_section` needs to render any single section on
+/// demand without re-deriving the dedup / category-fallback logic.
+pub struct DashboardContext {
+    /// Navigation list including overview, stock sections, and any
+    /// service / category sections — same order as what the eager
+    /// generator produced.
+    pub sections: Vec<Section>,
+    pub filesize: Option<u64>,
+    /// Deduped (per `service_name`) and category-aware. The category
+    /// flow stores the same list as the per-member flow today; the
+    /// difference is whether `category` below is set.
+    pub service_exts: Vec<(String, ServiceExtension)>,
+    pub category: Option<(String, CategoryExtension)>,
+    pub throughput_query: Option<String>,
+}
+
+/// Build the navigation list and other shared state needed to render
+/// dashboard sections lazily. The dedup + category-fallback logic lives
+/// here exclusively; `generate_section` consumes the resulting context.
+pub fn build_dashboard_context(
     filesize: Option<u64>,
     service_exts: &[(&str, &ServiceExtension)],
     category: Option<(&str, &CategoryExtension)>,
-    _descriptions: Option<&std::collections::HashMap<String, String>>,
-) -> std::collections::HashMap<String, String> {
+) -> DashboardContext {
     // Two captures of the same service collapse into a single nav entry —
     // both render through the same template and the existing compare-mode
     // overlay handles the per-capture pairing. Without this dedup the nav
@@ -55,14 +73,14 @@ pub fn generate(
     // A category requires exactly two distinct member service exts. If a
     // caller passes Some(category) without that, the category can't be
     // rendered; fall back to per-member sections so the section list and
-    // the rendered map stay in agreement (no nav entry for a route the
-    // map doesn't have, no orphaned member sections).
+    // the rendered output stay in agreement (no nav entry for a route the
+    // generator can't produce, no orphaned member sections).
     let category_active = category.is_some() && unique_service_exts.len() == 2;
 
     // Build the section list. In category mode, a single category section
     // replaces the per-member sections; otherwise the per-member loop
     // runs as before.
-    let mut all_sections: Vec<Section> = std::iter::once(Section {
+    let mut sections: Vec<Section> = std::iter::once(Section {
         name: "Overview".to_string(),
         route: "/overview".to_string(),
     })
@@ -74,7 +92,7 @@ pub fn generate(
 
     if category_active {
         let (category_name, _) = category.unwrap();
-        all_sections.insert(
+        sections.insert(
             1,
             Section {
                 name: category_name.to_string(),
@@ -83,7 +101,7 @@ pub fn generate(
         );
     } else {
         for (i, (source_name, _)) in unique_service_exts.iter().enumerate() {
-            all_sections.insert(
+            sections.insert(
                 1 + i,
                 Section {
                     name: source_name.to_string(),
@@ -93,51 +111,97 @@ pub fn generate(
         }
     }
 
-    let mut rendered = std::collections::HashMap::new();
-
     let throughput_query = unique_service_exts
         .first()
         .and_then(|(_, e)| e.throughput_query())
         .map(str::to_string);
-    {
-        let mut view = overview::generate(data, all_sections.clone(), throughput_query.as_deref());
-        if let Some(size) = filesize {
-            view.set_filesize(size);
-        }
-        rendered.insert(
-            "overview.json".to_string(),
-            serde_json::to_string(&view).unwrap(),
-        );
-    }
 
-    for (_, route, generator) in SECTION_META {
-        let key = format!("{}.json", &route[1..]);
-        let mut view = generator(data, all_sections.clone());
-        if let Some(size) = filesize {
-            view.set_filesize(size);
-        }
-        rendered.insert(key, serde_json::to_string(&view).unwrap());
-    }
+    let owned_service_exts: Vec<(String, ServiceExtension)> = unique_service_exts
+        .iter()
+        .map(|(name, ext)| ((*name).to_string(), (*ext).clone()))
+        .collect();
 
-    if category_active {
-        let (category_name, category_ext) = category.unwrap();
-        let (a_name, a_ext) = unique_service_exts[0];
-        let (b_name, b_ext) = unique_service_exts[1];
-        let view = category::generate(
-            data,
-            all_sections.clone(),
-            category_ext,
-            a_name,
-            a_ext,
-            b_name,
-            b_ext,
-        );
-        let key = format!("service/{category_name}.json");
-        rendered.insert(key, serde_json::to_string(&view).unwrap());
+    let owned_category = if category_active {
+        category.map(|(name, ext)| (name.to_string(), ext.clone()))
     } else {
-        for (source_name, ext) in &unique_service_exts {
-            let view = service::generate(data, all_sections.clone(), ext);
-            let key = format!("service/{source_name}.json");
+        None
+    };
+
+    DashboardContext {
+        sections,
+        filesize,
+        service_exts: owned_service_exts,
+        category: owned_category,
+        throughput_query,
+    }
+}
+
+/// Render a single dashboard section by route. Returns `None` for an
+/// unknown route — callers (the viewer) treat this as a 404.
+pub fn generate_section(data: &Tsdb, route: &str, ctx: &DashboardContext) -> Option<View> {
+    let mut view = if route == "/overview" {
+        overview::generate(
+            data,
+            ctx.sections.clone(),
+            ctx.throughput_query.as_deref(),
+        )
+    } else if let Some((_, _, generator)) = SECTION_META.iter().find(|(_, r, _)| *r == route) {
+        generator(data, ctx.sections.clone())
+    } else if let Some(name) = route.strip_prefix("/service/") {
+        // Category route takes precedence when active.
+        if let Some((category_name, category_ext)) = &ctx.category {
+            if category_name == name && ctx.service_exts.len() == 2 {
+                let (a_name, a_ext) = &ctx.service_exts[0];
+                let (b_name, b_ext) = &ctx.service_exts[1];
+                category::generate(
+                    data,
+                    ctx.sections.clone(),
+                    category_ext,
+                    a_name,
+                    a_ext,
+                    b_name,
+                    b_ext,
+                )
+            } else {
+                return None;
+            }
+        } else if let Some((_, ext)) = ctx.service_exts.iter().find(|(n, _)| n == name) {
+            service::generate(data, ctx.sections.clone(), ext)
+        } else {
+            return None;
+        }
+    } else {
+        return None;
+    };
+
+    if let Some(size) = ctx.filesize {
+        view.set_filesize(size);
+    }
+    Some(view)
+}
+
+/// Transitional shim preserving the eager `generate` signature so
+/// `src/viewer/mod.rs` and `crates/viewer/src/lib.rs` keep building
+/// while Tasks B + C migrate them to the lazy API. Remove once those
+/// call sites are updated.
+#[deprecated(note = "use build_dashboard_context + generate_section")]
+pub fn generate(
+    data: &Tsdb,
+    filesize: Option<u64>,
+    service_exts: &[(&str, &ServiceExtension)],
+    category: Option<(&str, &CategoryExtension)>,
+    _descriptions: Option<&std::collections::HashMap<String, String>>,
+) -> std::collections::HashMap<String, String> {
+    let ctx = build_dashboard_context(filesize, service_exts, category);
+
+    let mut rendered = std::collections::HashMap::new();
+
+    // Iterate the section nav and render each one lazily. The map keys
+    // mirror the original layout: `<route-without-leading-slash>.json`,
+    // with `/` preserved in service routes (e.g. `service/vllm.json`).
+    for section in &ctx.sections {
+        if let Some(view) = generate_section(data, &section.route, &ctx) {
+            let key = format!("{}.json", &section.route[1..]);
             rendered.insert(key, serde_json::to_string(&view).unwrap());
         }
     }
@@ -150,33 +214,134 @@ mod tests {
     use super::*;
 
     #[test]
-    fn generate_produces_expected_keys() {
-        let data = Tsdb::default();
-        let result = generate(&data, None, &[], None, None);
+    fn build_context_produces_full_navigation() {
+        let ctx = build_dashboard_context(None, &[], None);
 
-        let mut keys: Vec<_> = result.keys().cloned().collect();
-        keys.sort();
+        // Sections must be: Overview, then SECTION_META in order. No
+        // service / category entries when none supplied.
+        let mut expected: Vec<(&str, &str)> = vec![("Overview", "/overview")];
+        for (name, route, _) in SECTION_META {
+            expected.push((name, route));
+        }
 
-        assert_eq!(
-            keys,
-            vec![
-                "blockio.json",
-                "cgroups.json",
-                "cpu.json",
-                "gpu.json",
-                "memory.json",
-                "network.json",
-                "overview.json",
-                "query.json",
-                "rezolus.json",
-                "scheduler.json",
-                "softirq.json",
-                "syscall.json",
-            ]
-        );
+        let actual: Vec<(&str, &str)> = ctx
+            .sections
+            .iter()
+            .map(|s| (s.name.as_str(), s.route.as_str()))
+            .collect();
+
+        assert_eq!(actual, expected);
+        assert!(ctx.service_exts.is_empty());
+        assert!(ctx.category.is_none());
+        assert!(ctx.throughput_query.is_none());
+        assert!(ctx.filesize.is_none());
     }
 
     #[test]
+    fn generate_section_renders_known_routes_returns_none_for_unknown() {
+        let data = Tsdb::default();
+        let ctx = build_dashboard_context(None, &[], None);
+
+        // Overview renders.
+        let overview = generate_section(&data, "/overview", &ctx).expect("overview some");
+        let overview_json = serde_json::to_string(&overview).unwrap();
+        assert!(overview_json.contains("\"groups\""));
+        assert!(overview_json.contains("\"sections\""));
+        assert!(overview_json.contains("\"interval\""));
+
+        // A SECTION_META route renders.
+        let cpu = generate_section(&data, "/cpu", &ctx).expect("cpu some");
+        let cpu_json = serde_json::to_string(&cpu).unwrap();
+        assert!(cpu_json.contains("\"groups\""));
+        assert!(cpu_json.contains("\"sections\""));
+        assert!(cpu_json.contains("\"interval\""));
+
+        // Unknown route returns None.
+        assert!(generate_section(&data, "/no-such-route", &ctx).is_none());
+        // Unknown service route returns None too.
+        assert!(generate_section(&data, "/service/missing", &ctx).is_none());
+    }
+
+    #[test]
+    fn generate_section_renders_service_and_category_routes() {
+        use crate::service_extension::{CategoryExtension, CategoryKpi, Kpi, ServiceExtension};
+        use std::collections::HashMap;
+
+        let kpi = |role: &str, title: &str, query: &str| Kpi {
+            role: role.to_string(),
+            title: title.to_string(),
+            description: None,
+            query: query.to_string(),
+            metric_type: "delta_counter".to_string(),
+            subtype: None,
+            unit_system: Some("rate".to_string()),
+            percentiles: None,
+            available: true,
+            denominator: false,
+            subgroup: None,
+            subgroup_description: None,
+            full_width: false,
+        };
+        let vllm = ServiceExtension {
+            service_name: "vllm".to_string(),
+            aliases: vec![],
+            service_metadata: HashMap::new(),
+            slo: None,
+            kpis: vec![kpi("throughput", "Generation Token Rate", "vllm_q")],
+        };
+        let sglang = ServiceExtension {
+            service_name: "sglang".to_string(),
+            aliases: vec![],
+            service_metadata: HashMap::new(),
+            slo: None,
+            kpis: vec![kpi("throughput", "Generation Token Rate", "sglang_q")],
+        };
+
+        let data = Tsdb::default();
+
+        // Per-service flow (no category).
+        let ctx = build_dashboard_context(None, &[("vllm", &vllm)], None);
+        let view = generate_section(&data, "/service/vllm", &ctx).expect("vllm renders");
+        let json = serde_json::to_string(&view).unwrap();
+        assert!(json.contains("\"service_name\""));
+        assert!(json.contains("\"vllm\""));
+
+        // Category flow with two members.
+        let category = CategoryExtension {
+            service_name: "inference-library".to_string(),
+            category: true,
+            members: vec!["vllm".to_string(), "sglang".to_string()],
+            kpis: vec![CategoryKpi {
+                role: "throughput".to_string(),
+                title: "Generation Token Rate".to_string(),
+                metric_type: "delta_counter".to_string(),
+                subtype: None,
+                unit_system: Some("rate".to_string()),
+                percentiles: None,
+                denominator: false,
+                subgroup: None,
+                subgroup_description: None,
+                full_width: false,
+                member_titles: HashMap::new(),
+            }],
+        };
+        let ctx = build_dashboard_context(
+            None,
+            &[("vllm", &vllm), ("sglang", &sglang)],
+            Some(("inference-library", &category)),
+        );
+        // Category renders at /service/<category-name>.
+        let view = generate_section(&data, "/service/inference-library", &ctx)
+            .expect("category renders");
+        let json = serde_json::to_string(&view).unwrap();
+        assert!(json.contains("inference-library"));
+        // Per-member sections are absent in category mode.
+        assert!(generate_section(&data, "/service/vllm", &ctx).is_none());
+        assert!(generate_section(&data, "/service/sglang", &ctx).is_none());
+    }
+
+    #[test]
+    #[allow(deprecated)]
     fn generate_emits_category_section_when_category_supplied() {
         use crate::service_extension::{CategoryExtension, CategoryKpi, Kpi, ServiceExtension};
         use std::collections::HashMap;
@@ -246,6 +411,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn generate_dedupes_section_when_two_captures_share_service_name() {
         use crate::service_extension::{Kpi, ServiceExtension};
         use std::collections::HashMap;

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -138,8 +138,11 @@ pub fn build_dashboard_context(
 
 /// Render a single dashboard section by route. Returns `None` for an
 /// unknown route — callers (the viewer) treat this as a 404.
+///
+/// Filesize is not applied — callers that want a filesize on the response
+/// should call `view.set_filesize(...)` themselves.
 pub fn generate_section(data: &Tsdb, route: &str, ctx: &DashboardContext) -> Option<View> {
-    let mut view = if route == "/overview" {
+    let view = if route == "/overview" {
         overview::generate(
             data,
             ctx.sections.clone(),
@@ -174,9 +177,6 @@ pub fn generate_section(data: &Tsdb, route: &str, ctx: &DashboardContext) -> Opt
         return None;
     };
 
-    if let Some(size) = ctx.filesize {
-        view.set_filesize(size);
-    }
     Some(view)
 }
 
@@ -200,7 +200,14 @@ pub fn generate(
     // mirror the original layout: `<route-without-leading-slash>.json`,
     // with `/` preserved in service routes (e.g. `service/vllm.json`).
     for section in &ctx.sections {
-        if let Some(view) = generate_section(data, &section.route, &ctx) {
+        if let Some(mut view) = generate_section(data, &section.route, &ctx) {
+            // Match old behavior: filesize only on overview + SECTION_META routes,
+            // not on service/category routes.
+            let is_legacy_filesize_route = section.route == "/overview"
+                || SECTION_META.iter().any(|(_, r, _)| *r == section.route);
+            if let (Some(size), true) = (filesize, is_legacy_filesize_route) {
+                view.set_filesize(size);
+            }
             let key = format!("{}.json", &section.route[1..]);
             rendered.insert(key, serde_json::to_string(&view).unwrap());
         }
@@ -465,5 +472,29 @@ mod tests {
             vllm_count, 1,
             "expected one /service/vllm entry in nav, got {vllm_count}"
         );
+    }
+
+    #[test]
+    fn shim_filesize_applied_only_to_legacy_routes() {
+        // Build a context with a service ext so the shim renders a /service/<name> route.
+        let svc_json = r#"{"service_name":"vllm","service_metadata":{},"slo":null,"kpis":[]}"#;
+        let svc_ext: ServiceExtension = serde_json::from_str(svc_json).unwrap();
+        let data = Tsdb::default();
+        #[allow(deprecated)]
+        let rendered = generate(&data, Some(12_345), &[("vllm", &svc_ext)], None, None);
+
+        // overview and stock sections carry filesize.
+        let overview: serde_json::Value =
+            serde_json::from_str(rendered.get("overview.json").unwrap()).unwrap();
+        assert_eq!(overview["filesize"], serde_json::json!(12_345));
+
+        let cpu: serde_json::Value =
+            serde_json::from_str(rendered.get("cpu.json").unwrap()).unwrap();
+        assert_eq!(cpu["filesize"], serde_json::json!(12_345));
+
+        // Service routes do NOT carry filesize (preserves pre-Phase-2 behavior).
+        let svc: serde_json::Value =
+            serde_json::from_str(rendered.get("service/vllm.json").unwrap()).unwrap();
+        assert!(svc.get("filesize").is_none(), "service view leaked filesize");
     }
 }

--- a/crates/dashboard/src/main.rs
+++ b/crates/dashboard/src/main.rs
@@ -7,15 +7,23 @@
 //! With a directory argument, writes each section as a pretty-printed JSON file.
 
 use dashboard::Tsdb;
-#[allow(deprecated)]
-use dashboard::dashboard::generate;
+use dashboard::dashboard::{build_dashboard_context, generate_section};
 use std::collections::HashMap;
 
 fn main() {
     let output_dir = std::env::args().nth(1);
 
-    #[allow(deprecated)]
-    let rendered: HashMap<String, String> = generate(&Tsdb::default(), None, &[], None, None);
+    // Render every section in the navigation list. The lazy API replaces
+    // the old eager `generate` shim — same coverage, just hand-walked.
+    let data = Tsdb::default();
+    let ctx = build_dashboard_context(None, &[], None);
+    let mut rendered: HashMap<String, String> = HashMap::new();
+    for section in &ctx.sections {
+        if let Some(view) = generate_section(&data, &section.route, &ctx) {
+            let key = format!("{}.json", &section.route[1..]);
+            rendered.insert(key, serde_json::to_string(&view).unwrap());
+        }
+    }
 
     match output_dir {
         Some(dir) => write_to_dir(&dir, &rendered),

--- a/crates/dashboard/src/main.rs
+++ b/crates/dashboard/src/main.rs
@@ -7,12 +7,14 @@
 //! With a directory argument, writes each section as a pretty-printed JSON file.
 
 use dashboard::Tsdb;
+#[allow(deprecated)]
 use dashboard::dashboard::generate;
 use std::collections::HashMap;
 
 fn main() {
     let output_dir = std::env::args().nth(1);
 
+    #[allow(deprecated)]
     let rendered: HashMap<String, String> = generate(&Tsdb::default(), None, &[], None, None);
 
     match output_dir {

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -32,7 +32,16 @@ pub fn init() {
 pub struct Viewer {
     engine: QueryEngine<Arc<Tsdb>>,
     file_metadata: std::collections::HashMap<String, String>,
-    dashboard_sections: std::collections::HashMap<String, String>,
+    /// Lazy section context. Populated by `init_templates` (single
+    /// capture) or `WasmCaptureRegistry::regenerate_combined` (compare
+    /// mode). When no templates are loaded, this is `Default` (empty
+    /// nav), and `get_sections` returns `"[]"`.
+    context: dashboard::dashboard::DashboardContext,
+    /// Memoized rendered bodies keyed by route stem (e.g. `"cpu"`,
+    /// `"service/vllm"`). RefCell because WASM is single-threaded and
+    /// the wasm-bindgen surface keeps `get_section` as `&self` to avoid
+    /// churning the JS-side method binding.
+    cached_bodies: std::cell::RefCell<std::collections::HashMap<String, serde_json::Value>>,
     /// Display alias for this capture, when the JS caller supplied
     /// one (e.g. via an `alias=path` static-site URL param). None
     /// means the UI falls back to the capture id.
@@ -82,14 +91,14 @@ impl Viewer {
         tsdb.set_filename(filename.to_string());
 
         let file_metadata = tsdb.file_metadata().clone();
-        #[allow(deprecated)]
-        let dashboard_sections = dashboard::dashboard::generate(&tsdb, None, &[], None, None);
+        let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
         let engine = QueryEngine::new(Arc::new(tsdb));
 
         Ok(Viewer {
             engine,
             file_metadata,
-            dashboard_sections,
+            context,
+            cached_bodies: std::cell::RefCell::new(std::collections::HashMap::new()),
             alias: None,
         })
     }
@@ -269,16 +278,13 @@ impl Viewer {
             .map(|(name, ext)| (name.as_str(), ext))
             .collect();
 
-        #[allow(deprecated)]
-        {
-            self.dashboard_sections = dashboard::dashboard::generate(
-                self.engine.tsdb(),
-                None,
-                &service_refs,
-                None, // single-capture: no category
-                None,
-            );
-        }
+        let context = dashboard::dashboard::build_dashboard_context(
+            None,
+            &service_refs,
+            None, // single-capture: no category
+        );
+        self.context = context;
+        self.cached_bodies.borrow_mut().clear();
         Ok(())
     }
 
@@ -332,28 +338,50 @@ impl Viewer {
 
     /// Returns the sections list as a JSON array.
     pub fn get_sections(&self) -> String {
-        if let Some(json) = self.dashboard_sections.values().next() {
-            if let Ok(view) = serde_json::from_str::<serde_json::Value>(json) {
-                if let Some(sections) = view.get("sections") {
-                    return sections.to_string();
-                }
-            }
-        }
-        "[]".to_string()
+        serde_json::to_string(&self.context.sections).unwrap_or_else(|_| "[]".to_string())
     }
 
     /// Returns the full View JSON for a dashboard section. The shared
     /// `sections` navigation array is stripped on the way out — callers
     /// fetch it once via `get_sections()`.
     pub fn get_section(&self, key: &str) -> Option<String> {
-        let raw = self
-            .dashboard_sections
-            .get(&format!("{key}.json"))
-            .or_else(|| self.dashboard_sections.get(key))?;
-        let mut value: serde_json::Value = serde_json::from_str(raw).ok()?;
+        // Frontend may pass `"cpu"` or `"cpu.json"` — normalize to the
+        // bare route stem the cache uses.
+        let stem = key.strip_suffix(".json").unwrap_or(key);
+        let route = format!("/{stem}");
+
+        // Cache hit?
+        if let Some(value) = self.cached_bodies.borrow().get(stem).cloned() {
+            return serialize_lean_section(value);
+        }
+
+        // Render on demand. The engine owns the Arc<Tsdb> so we can pass
+        // `self.engine.tsdb()` as `&Tsdb`.
+        let mut view = dashboard::dashboard::generate_section(
+            self.engine.tsdb(),
+            &route,
+            &self.context,
+        )?;
+        if let Some(size) = self.context.filesize {
+            view.set_filesize(size);
+        }
+        let mut value = serde_json::to_value(&view).ok()?;
+
+        // Cache the FULL value (with sections) so a future re-render of
+        // the same route can serve from cache without re-calling
+        // generate_section. Strip on the way out so the frontend never
+        // sees the embedded sections array.
+        self.cached_bodies
+            .borrow_mut()
+            .insert(stem.to_string(), value.clone());
         strip_sections_from_section_body(&mut value);
         serde_json::to_string(&value).ok()
     }
+}
+
+fn serialize_lean_section(mut value: serde_json::Value) -> Option<String> {
+    strip_sections_from_section_body(&mut value);
+    serde_json::to_string(&value).ok()
 }
 
 /// Registry wrapping up to two `Viewer` instances keyed by capture id
@@ -453,17 +481,17 @@ impl WasmCaptureRegistry {
             .init_templates(templates_json)
     }
 
-    /// Regenerate BOTH viewers' `dashboard_sections` using service
+    /// Regenerate BOTH viewers' lazy `DashboardContext` using service
     /// extensions from BOTH attached captures and the explicitly named
     /// category template (when provided). When the experiment slot is
     /// empty, this is a no-op (the per-capture `init_templates` call
     /// already populated baseline's sections).
     ///
-    /// Both slots get the same combined map: compare-mode chart fetches
-    /// query both slots for the active section route, so a category
-    /// route like `/service/inference-library` must resolve in the
-    /// experiment slot too — otherwise the experiment fetch 404s and
-    /// the chart surfaces "Error: null".
+    /// Both slots get the same combined `DashboardContext`: compare-mode
+    /// chart fetches query both slots for the active section route, so
+    /// a category route like `/service/inference-library` must resolve
+    /// in the experiment slot too — otherwise the experiment fetch
+    /// 404s and the chart surfaces "Error: null".
     ///
     /// `category_name` activates category mode when each detected
     /// source appears in the category template's `members` list. When
@@ -536,19 +564,18 @@ impl WasmCaptureRegistry {
             None => None,
         };
 
-        #[allow(deprecated)]
-        let combined = dashboard::dashboard::generate(
-            self.baseline.as_ref().unwrap().engine.tsdb(),
+        let context = dashboard::dashboard::build_dashboard_context(
             None,
             &service_refs,
             category,
-            None,
         );
         if let Some(baseline) = self.baseline.as_mut() {
-            baseline.dashboard_sections = combined.clone();
+            baseline.context = context.clone();
+            baseline.cached_bodies.borrow_mut().clear();
         }
         if let Some(experiment) = self.experiment.as_mut() {
-            experiment.dashboard_sections = combined;
+            experiment.context = context;
+            experiment.cached_bodies.borrow_mut().clear();
         }
         Ok(())
     }
@@ -771,5 +798,13 @@ mod tests {
         strip_sections_from_section_body(&mut value);
         assert!(value.get("sections").is_none());
         assert_eq!(value["groups"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn viewer_get_sections_empty_when_no_context() {
+        // Default context = no templates loaded = empty nav.
+        let ctx: dashboard::dashboard::DashboardContext = Default::default();
+        let json = serde_json::to_string(&ctx.sections).unwrap();
+        assert_eq!(json, "[]");
     }
 }

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -357,11 +357,8 @@ impl Viewer {
 
         // Render on demand. The engine owns the Arc<Tsdb> so we can pass
         // `self.engine.tsdb()` as `&Tsdb`.
-        let mut view = dashboard::dashboard::generate_section(
-            self.engine.tsdb(),
-            &route,
-            &self.context,
-        )?;
+        let mut view =
+            dashboard::dashboard::generate_section(self.engine.tsdb(), &route, &self.context)?;
         if let Some(size) = self.context.filesize {
             view.set_filesize(size);
         }
@@ -564,11 +561,7 @@ impl WasmCaptureRegistry {
             None => None,
         };
 
-        let context = dashboard::dashboard::build_dashboard_context(
-            None,
-            &service_refs,
-            category,
-        );
+        let context = dashboard::dashboard::build_dashboard_context(None, &service_refs, category);
         if let Some(baseline) = self.baseline.as_mut() {
             baseline.context = context.clone();
             baseline.cached_bodies.borrow_mut().clear();

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -82,6 +82,7 @@ impl Viewer {
         tsdb.set_filename(filename.to_string());
 
         let file_metadata = tsdb.file_metadata().clone();
+        #[allow(deprecated)]
         let dashboard_sections = dashboard::dashboard::generate(&tsdb, None, &[], None, None);
         let engine = QueryEngine::new(Arc::new(tsdb));
 
@@ -268,13 +269,16 @@ impl Viewer {
             .map(|(name, ext)| (name.as_str(), ext))
             .collect();
 
-        self.dashboard_sections = dashboard::dashboard::generate(
-            self.engine.tsdb(),
-            None,
-            &service_refs,
-            None, // single-capture: no category
-            None,
-        );
+        #[allow(deprecated)]
+        {
+            self.dashboard_sections = dashboard::dashboard::generate(
+                self.engine.tsdb(),
+                None,
+                &service_refs,
+                None, // single-capture: no category
+                None,
+            );
+        }
         Ok(())
     }
 
@@ -532,6 +536,7 @@ impl WasmCaptureRegistry {
             None => None,
         };
 
+        #[allow(deprecated)]
         let combined = dashboard::dashboard::generate(
             self.baseline.as_ref().unwrap().engine.tsdb(),
             None,

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -472,15 +472,8 @@ pub fn run(config: Config) {
             tsdb.set_version(version.clone());
             tsdb.set_filename(url.to_string());
             let state = AppState::new(tsdb, registry.clone());
-            #[allow(deprecated)]
-            let rendered = dashboard::dashboard::generate(
-                &state.baseline_tsdb().read(),
-                None,
-                &[],
-                None,
-                None,
-            );
-            *state.sections.write() = build_section_store_from_rendered(rendered);
+            let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
+            *state.sections.write() = LazySectionStore::new(context);
             state.live.store(true, Ordering::Relaxed);
 
             state.captures.set_baseline_systeminfo(agent_systeminfo);
@@ -654,87 +647,69 @@ async fn serve(listener: std::net::TcpListener, state: AppState) {
         .expect("failed to run http server");
 }
 
-/// Caches the navigation `sections` list separately from per-section JSON
-/// bodies, so the `/api/v1/sections` route can read the nav list without
-/// materializing any section body, and `/data/<section>.json` can read
-/// (or generate) just the requested body.
+/// Caches the navigation list (via the owned `DashboardContext`) and
+/// memoizes per-section JSON bodies, so the `/api/v1/sections` route
+/// reads the nav list without materializing any section body, and
+/// `/data/<section>.json` generates a body on first request and serves
+/// the cached value thereafter.
 struct LazySectionStore {
-    sections: Vec<serde_json::Value>,
-    section_bodies: std::collections::HashMap<String, serde_json::Value>,
+    context: dashboard::dashboard::DashboardContext,
+    /// Memoized rendered bodies keyed by the route key the frontend
+    /// requests, e.g. `cpu.json`, `service/vllm.json`. Filesize is
+    /// already applied uniformly across all routes — Phase 2 dropped
+    /// the shim's old "filesize on stock routes only" carve-out.
+    cached_bodies: HashMap<String, serde_json::Value>,
 }
 
 impl LazySectionStore {
-    fn new(sections: Vec<serde_json::Value>) -> Self {
+    fn new(context: dashboard::dashboard::DashboardContext) -> Self {
         Self {
-            sections,
-            section_bodies: std::collections::HashMap::new(),
+            context,
+            cached_bodies: HashMap::new(),
         }
     }
 
-    fn sections(&self) -> &[serde_json::Value] {
-        &self.sections
+    /// The navigation list. Borrowed directly from the context.
+    fn sections(&self) -> &[dashboard::Section] {
+        &self.context.sections
     }
 
-    fn section(&self, key: &str) -> Option<&serde_json::Value> {
-        self.section_bodies.get(key)
-    }
-
-    fn insert_section(&mut self, key: &str, value: serde_json::Value) {
-        self.section_bodies.insert(key.to_string(), value);
-    }
-
-    /// Returns true when no nav list has been loaded yet — used by the
-    /// `mode` endpoint to advertise the "we don't have data yet" state
-    /// for live and upload-only modes pre-first-refresh.
+    /// True when no context has been loaded — used by the `mode`
+    /// endpoint to advertise the not-yet-loaded state.
     fn is_empty(&self) -> bool {
-        self.sections.is_empty()
+        self.context.sections.is_empty()
     }
 
-    /// Returns any cached section body, used by `sections_metadata` to
-    /// recover the global params (source, version, filename, ...) that
-    /// are currently embedded in every section payload.
-    fn any_body(&self) -> Option<&serde_json::Value> {
-        self.section_bodies.values().next()
+    /// Read-only access to the context (for `sections_metadata` to read
+    /// filesize and other shared params).
+    fn context(&self) -> &dashboard::dashboard::DashboardContext {
+        &self.context
+    }
+
+    /// Generate (or return the cached body for) `route`. Looks up
+    /// `route` of the form `/<route>` (e.g. `/cpu`, `/service/vllm`,
+    /// `/overview`). Returns `None` if the route is unknown OR the
+    /// section has no data. Applies `context.filesize` uniformly to
+    /// every rendered View.
+    fn get_or_generate(&mut self, route: &str, data: &Tsdb) -> Option<&serde_json::Value> {
+        // route always starts with '/', so &route[1..] is the stem.
+        let key = format!("{}.json", &route[1..]);
+        if !self.cached_bodies.contains_key(&key) {
+            let mut view = dashboard::dashboard::generate_section(data, route, &self.context)?;
+            if let Some(size) = self.context.filesize {
+                view.set_filesize(size);
+            }
+            let value = serde_json::to_value(&view).ok()?;
+            self.cached_bodies.insert(key.clone(), value);
+        }
+        self.cached_bodies.get(&key)
     }
 }
 
 impl Default for LazySectionStore {
     fn default() -> Self {
-        Self::new(Vec::new())
+        Self::new(dashboard::dashboard::DashboardContext::default())
     }
-}
-
-/// Adapt the `dashboard::dashboard::generate` output (a HashMap of route
-/// -> serialized JSON body) into a `LazySectionStore`. The nav list is
-/// recovered from the embedded `sections` array of any body — overview
-/// is canonical but any body works because they all carry the same nav.
-/// Bodies that fail to parse are logged and skipped.
-fn build_section_store_from_rendered(rendered: HashMap<String, String>) -> LazySectionStore {
-    let mut bodies: HashMap<String, serde_json::Value> = HashMap::new();
-    for (key, body) in rendered {
-        match serde_json::from_str::<serde_json::Value>(&body) {
-            Ok(v) => {
-                bodies.insert(key, v);
-            }
-            Err(e) => {
-                warn!("section cache parse failed for {key}: {e}");
-            }
-        }
-    }
-
-    let nav = bodies
-        .get("overview.json")
-        .or_else(|| bodies.values().next())
-        .and_then(|v| v.get("sections"))
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-
-    let mut store = LazySectionStore::new(nav);
-    for (key, value) in bodies {
-        store.insert_section(&key, value);
-    }
-    store
 }
 
 struct AppState {
@@ -798,80 +773,53 @@ impl AppState {
     }
 
     /// Build the navigation + global params payload for the
-    /// `/api/v1/sections` endpoint. Reads the navigation list directly
-    /// from the `LazySectionStore`, and the global params (source,
-    /// version, filename, interval, filesize, time bounds, num_series)
-    /// from any cached section body — those globals are still embedded
-    /// per-body today. When no section is cached yet — e.g. live mode
-    /// before the first refresh, or upload-only mode pre-upload —
-    /// returns a minimal payload with an empty sections array so the
-    /// frontend never sees a 5xx for the "we just don't have data yet"
-    /// case.
+    /// `/api/v1/sections` endpoint. The navigation list comes from the
+    /// `LazySectionStore`'s `DashboardContext`; the global params come
+    /// from the TSDB itself (filesize from the context). When no
+    /// context has been loaded yet — e.g. live mode before the first
+    /// refresh, or upload-only mode pre-upload — returns a minimal
+    /// payload with an empty sections array and zeroed numeric fields
+    /// so the frontend never sees a 5xx for the "we just don't have
+    /// data yet" case.
     ///
-    /// The `capture` argument is currently advisory: the cached section
-    /// bodies are produced by `regenerate_dashboards`, which today
-    /// generates a single section map keyed only by route. The same
-    /// nav list applies to both baseline and experiment, so we ignore
-    /// the id rather than silently 404 on `?capture=experiment`.
+    /// The `capture` argument is currently advisory: the same nav list
+    /// applies to both baseline and experiment, so we ignore the id
+    /// rather than silently 404 on `?capture=experiment`.
     fn sections_metadata(&self, _capture: CaptureId) -> serde_json::Value {
-        let sections_guard = self.sections.read();
+        let store = self.sections.read();
+        let sections_array: Vec<serde_json::Value> = store
+            .sections()
+            .iter()
+            .map(|s| serde_json::to_value(s).unwrap_or_default())
+            .collect();
+        let filesize = store.context().filesize.unwrap_or(0);
+        drop(store);
 
-        let sections_array: Vec<serde_json::Value> = sections_guard.sections().to_vec();
-
-        // Pull the global params off any cached body. They're
-        // duplicated per-body today; a future task can promote them
-        // onto the store directly.
-        let body = sections_guard.any_body().cloned();
-        drop(sections_guard);
-
-        let source = body
-            .as_ref()
-            .and_then(|v| v.get("source"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let version = body
-            .as_ref()
-            .and_then(|v| v.get("version"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let filename = body
-            .as_ref()
-            .and_then(|v| v.get("filename"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let interval = body
-            .as_ref()
-            .and_then(|v| v.get("interval"))
-            .and_then(|v| v.as_f64())
-            .unwrap_or(0.0);
-        let filesize = body
-            .as_ref()
-            .and_then(|v| v.get("filesize"))
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
-        // start_time/end_time are emitted by `View` as f64 (epoch ms), so
-        // `as_u64()` returns None even on whole-millisecond values. Read
-        // as f64 and truncate to the integer payload shape.
-        let start_time = body
-            .as_ref()
-            .and_then(|v| v.get("start_time"))
-            .and_then(|v| v.as_f64())
-            .map(|v| v as u64)
-            .unwrap_or(0);
-        let end_time = body
-            .as_ref()
-            .and_then(|v| v.get("end_time"))
-            .and_then(|v| v.as_f64())
-            .map(|v| v as u64)
-            .unwrap_or(0);
-        let num_series = body
-            .as_ref()
-            .and_then(|v| v.get("num_series"))
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as usize;
+        let tsdb_handle = self.baseline_tsdb();
+        let data = tsdb_handle.read();
+        let interval = data.interval();
+        let source = data.source().to_string();
+        let version = data.version().to_string();
+        let filename = data.filename().to_string();
+        // Tsdb time_range is in nanoseconds; convert to milliseconds to
+        // match the View's convention.
+        let (start_time, end_time) = data
+            .time_range()
+            .map(|(min, max)| (min / 1_000_000, max / 1_000_000))
+            .unwrap_or((0, 0));
+        let num_series = {
+            let mut count = 0usize;
+            for name in data.counter_names() {
+                count += data.counter_labels(name).map_or(0, |l| l.len());
+            }
+            for name in data.gauge_names() {
+                count += data.gauge_labels(name).map_or(0, |l| l.len());
+            }
+            for name in data.histogram_names() {
+                count += data.histogram_labels(name).map_or(0, |l| l.len());
+            }
+            count
+        };
 
         build_sections_metadata_payload(
             sections_array,
@@ -1158,16 +1106,12 @@ fn regenerate_dashboards(state: &AppState) {
         .as_ref()
         .and_then(|p| std::fs::metadata(p).ok().map(|m| m.len()));
 
-    #[allow(deprecated)]
-    let rendered = dashboard::dashboard::generate(
-        &state.baseline_tsdb().read(),
+    let context = dashboard::dashboard::build_dashboard_context(
         filesize,
         &service_refs,
         category,
-        None,
     );
-
-    *state.sections.write() = build_section_store_from_rendered(rendered);
+    *state.sections.write() = LazySectionStore::new(context);
 }
 
 /// Extract service extension metadata from a parquet file.
@@ -1503,30 +1447,37 @@ async fn data(
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
 
-    let sections = state.sections.read();
-    match sections.section(&path) {
-        Some(v) => {
-            // Strip the redundant nav `sections` array before sending to the
-            // frontend.  The cached body keeps it so that `sections_metadata`
-            // can still extract it (Task 4); we only remove it at response time.
-            let mut parsed = v.clone();
-            drop(sections);
-            strip_sections_from_section_payload(&mut parsed);
-            let body = match serde_json::to_string(&parsed) {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!("section re-serialization failed for {path}: {e}");
-                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-                }
-            };
-            (
-                StatusCode::OK,
-                [(header::CONTENT_TYPE, "application/json")],
-                body,
-            )
-                .into_response()
+    // path comes in as e.g. "cpu.json" or "service/vllm.json". Convert
+    // to the route form generate_section expects (e.g. "/cpu",
+    // "/service/vllm"). Tolerate a missing ".json" suffix gracefully.
+    let stem = path.strip_suffix(".json").unwrap_or(&path);
+    let route = format!("/{stem}");
+
+    let value = {
+        let tsdb_handle = state.baseline_tsdb();
+        let tsdb = tsdb_handle.read();
+        let mut store = state.sections.write();
+        store.get_or_generate(&route, &tsdb).cloned()
+    };
+
+    let Some(mut value) = value else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    // The lazy generator already produces lean bodies, but keep the
+    // strip as cheap insurance against accidental re-introduction.
+    strip_sections_from_section_payload(&mut value);
+    match serde_json::to_string(&value) {
+        Ok(body) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            body,
+        )
+            .into_response(),
+        Err(e) => {
+            warn!("section response serialization failed for {path}: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
-        None => StatusCode::NOT_FOUND.into_response(),
     }
 }
 
@@ -1871,8 +1822,8 @@ async fn upload_parquet(
     let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
     validate_service_extensions(&data, &mut service_exts);
     let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
-    #[allow(deprecated)]
-    let rendered = dashboard::dashboard::generate(&data, filesize, &service_refs, None, None);
+    let context =
+        dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None);
     let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 
@@ -1881,7 +1832,7 @@ async fn upload_parquet(
         let mut tsdb = tsdb_handle.write();
         *tsdb = data;
     }
-    *state.sections.write() = build_section_store_from_rendered(rendered);
+    *state.sections.write() = LazySectionStore::new(context);
     let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
     *state.parquet_path.write() = Some(temp_path);
     state
@@ -2073,8 +2024,7 @@ async fn connect_agent(
     tsdb.set_source(source.clone());
     tsdb.set_version(version.clone());
     tsdb.set_filename(url.to_string());
-    #[allow(deprecated)]
-    let rendered = dashboard::dashboard::generate(&tsdb, None, &[], None, None);
+    let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
 
     // Update shared state
     {
@@ -2082,7 +2032,7 @@ async fn connect_agent(
         let mut db = tsdb_handle.write();
         *db = tsdb;
     }
-    *state.sections.write() = build_section_store_from_rendered(rendered);
+    *state.sections.write() = LazySectionStore::new(context);
     state.captures.set_baseline_systeminfo(agent_systeminfo);
     state.live.store(true, Ordering::Relaxed);
 
@@ -2448,16 +2398,32 @@ mod tests {
     }
 
     #[test]
-    fn lazy_section_store_caches_sections_separately_from_metadata() {
-        let mut store = LazySectionStore::new(vec![
-            serde_json::json!({"name": "Overview", "route": "/overview"}),
-        ]);
-        assert!(store.section("overview").is_none());
-        store.insert_section("overview", serde_json::json!({"groups": []}));
-        assert_eq!(
-            store.section("overview").unwrap()["groups"],
-            serde_json::json!([])
-        );
-        assert_eq!(store.sections().len(), 1);
+    fn lazy_section_store_exposes_context_sections() {
+        use dashboard::dashboard::DashboardContext;
+        use dashboard::Section;
+
+        let context = DashboardContext {
+            sections: vec![
+                Section {
+                    name: "Overview".to_string(),
+                    route: "/overview".to_string(),
+                },
+                Section {
+                    name: "CPU".to_string(),
+                    route: "/cpu".to_string(),
+                },
+            ],
+            ..DashboardContext::default()
+        };
+        let store = LazySectionStore::new(context);
+        assert_eq!(store.sections().len(), 2);
+        assert!(!store.is_empty());
+    }
+
+    #[test]
+    fn lazy_section_store_default_is_empty() {
+        let store = LazySectionStore::default();
+        assert!(store.is_empty());
+        assert_eq!(store.sections().len(), 0);
     }
 }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -472,6 +472,7 @@ pub fn run(config: Config) {
             tsdb.set_version(version.clone());
             tsdb.set_filename(url.to_string());
             let state = AppState::new(tsdb, registry.clone());
+            #[allow(deprecated)]
             let rendered = dashboard::dashboard::generate(
                 &state.baseline_tsdb().read(),
                 None,
@@ -1157,6 +1158,7 @@ fn regenerate_dashboards(state: &AppState) {
         .as_ref()
         .and_then(|p| std::fs::metadata(p).ok().map(|m| m.len()));
 
+    #[allow(deprecated)]
     let rendered = dashboard::dashboard::generate(
         &state.baseline_tsdb().read(),
         filesize,
@@ -1869,6 +1871,7 @@ async fn upload_parquet(
     let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
     validate_service_extensions(&data, &mut service_exts);
     let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
+    #[allow(deprecated)]
     let rendered = dashboard::dashboard::generate(&data, filesize, &service_refs, None, None);
     let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
@@ -2070,6 +2073,7 @@ async fn connect_agent(
     tsdb.set_source(source.clone());
     tsdb.set_version(version.clone());
     tsdb.set_filename(url.to_string());
+    #[allow(deprecated)]
     let rendered = dashboard::dashboard::generate(&tsdb, None, &[], None, None);
 
     // Update shared state

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1106,11 +1106,7 @@ fn regenerate_dashboards(state: &AppState) {
         .as_ref()
         .and_then(|p| std::fs::metadata(p).ok().map(|m| m.len()));
 
-    let context = dashboard::dashboard::build_dashboard_context(
-        filesize,
-        &service_refs,
-        category,
-    );
+    let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, category);
     *state.sections.write() = LazySectionStore::new(context);
 }
 
@@ -1822,8 +1818,7 @@ async fn upload_parquet(
     let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
     validate_service_extensions(&data, &mut service_exts);
     let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
-    let context =
-        dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None);
+    let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None);
     let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 


### PR DESCRIPTION
## Summary

Phase 2 of the viewer chart-loading optimization. Phase 1 ([#848](https://github.com/iopsystems/rezolus/pull/848)) split nav metadata from per-section bodies and added a bounded route cache, but the producer still rendered every dashboard section eagerly when a parquet was loaded. Phase 2 makes that lazy: section bodies are produced on first request and memoized.

- **Dashboard crate.** Replaces eager `generate(...) -> HashMap<String, String>` with a two-step API: `build_dashboard_context(filesize, service_exts, category) -> DashboardContext` (cheap; just dedup + nav assembly) and `generate_section(data, route, ctx) -> Option<View>` (renders one section on demand). The deprecated shim is gone — zero remaining callers.
- **Server viewer.** `LazySectionStore` now holds a `DashboardContext` + a memoized `cached_bodies` map. `regenerate_dashboards` builds the context (no per-section render). The `data` handler converts `path → route`, calls `store.get_or_generate(route, &tsdb)`, drops locks before the response strip + serialize. `sections_metadata` reads globals directly from the TSDB.
- **WASM viewer.** Same shape: `Viewer` holds `context: DashboardContext` + `RefCell<HashMap<String, Value>>`. `init_templates` and `regenerate_combined` build the context and clear the cache. `get_section(key)` lazily renders + memoizes; `get_sections()` serializes the context's nav.

## Phase 1 vs Phase 2

This PR closes the spec criterion ["the producer side no longer materializes all sections eagerly"](docs/superpowers/specs/2026-04-26-viewer-chart-loading-optimization-design.md) that Phase 1 explicitly deferred. Section generation is now one-per-click instead of all-up-front.

## Behavior changes (intentional)

- **File-size badge on every section.** The old eager shim only stamped `filesize` on `/overview` + the 11 stock sections. Phase 2 applies it uniformly to service / category sections too. UX consistency improvement; visible if you compare against `main`.
- **Splash screen briefly visible on every section's first click.** Phase 1's section-loading splash now covers the per-section render time. Typical render is <100ms for stock sections; the splash absorbs the cost.

## Tests

- `cargo test --bin rezolus` — 102 passed
- `cargo test -p dashboard --lib` — 24 passed (replaced + adapted tests covering the new API; old shim test removed)
- `cd crates/viewer && cargo test` — 2 passed (kept Phase 1 strip test + 1 new context-default test)
- `node --test tests/*.mjs` — 30 passed
- `cargo build --bin rezolus` — clean
- `cargo clippy --bin rezolus -- -D warnings` — clean

## Test plan
- [x] **Stock sections (single capture)**: load a parquet, click cpu / memory / network. First click triggers `generate_section` (visible as splash); subsequent clicks served from cache (instant).
- [x] **Service section (single capture)**: load a vllm or sglang parquet. Verify the service section renders. **Verify the file-size badge now appears** (it didn't before).
- [x] **Category section (compare mode)**: load vllm + sglang with `--category inference-library`. Verify the inference-library section renders; per-member service sections are absent from the nav.
- [x] **WASM static-site demo (single)**: open `?demo=demo.parquet`. Same checks as server.
- [x] **WASM compare-mode demo**: open the inference-library disagg demo. Verify both viewers render the combined section.
- [x] **Compare-mode template re-init**: attach baseline + experiment via the upload UI, re-init templates. Verify both caches clear and section bodies regenerate fresh.
- [ ] **Live mode**: connect to a running rezolus agent. Verify live-refresh fetches lean section bodies for the active route only.
- [x] **Bounded cache** (Phase 1, regression): navigate overview → cpu → memory → network → blockio. Only the most-recent 2 + pinned overview should remain in `sectionResponseCache`.

## Known follow-ups (not blocking)
1. **`reset_tsdb` cache invalidation gap.** After a live-mode reset, previously-cached section bodies retain stale TSDB-derived metadata until the next regenerate. Pre-existing on `main`; Phase 2 makes it slightly more visible because the cache is lazy-populated rather than rebuilt-on-attach. Worth a follow-up.
2. **WASM crate `cargo clippy -- -D warnings` failures.** Three collapsible-if blocks remain in `crates/viewer/src/lib.rs`; pre-existing on `main` (this PR incidentally cleaned up two). Trivial cleanup; CI doesn't gate on it.
3. **Cache-key cosmetic divergence.** Server uses `<stem>.json`; WASM uses bare `<stem>`. Functionally equivalent (each normalizes input to its own form before lookup), but easy to align in a future cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)