### PR TITLE
fix(viewer): pin compare-mode node filter to both captures

### DIFF
--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -176,6 +176,12 @@ const attachExperiment = async (file) => {
     experimentAttached = true;
     compareMode = true;
 
+    // Refresh the multi-node dropdown with the union of baseline +
+    // experiment nodes. Preserves the user's prior node selection when
+    // it still exists in the union.
+    applyMultiNodeInfo(expFileMeta);
+    clearViewerCaches();
+
     // Clamp a stale anchor when the newly-attached experiment is
     // shorter than the previously-saved offset. Avoids a chart starting
     // past the end of its data.
@@ -200,6 +206,10 @@ const detachExperiment = async () => {
     experimentAlias = null;
     experimentAttached = false;
     compareMode = false;
+
+    // Drop experiment-only nodes from the dropdown.
+    applyMultiNodeInfo(null);
+    clearViewerCaches();
     m.redraw();
 };
 
@@ -225,24 +235,48 @@ const clearViewerCaches = () => {
     chartsState.clear();
 };
 
-const applyMultiNodeInfo = () => {
+const applyMultiNodeInfo = (experimentFileMetadata = null) => {
+    const previousSelection = selectedNode;
+
     nodeList = [];
     nodeVersions = {};
     selectedNode = null;
     serviceInstances = {};
     selectedInstances = {};
 
-    if (!fileMetadata) return;
+    if (!fileMetadata) {
+        setSelectedNode(null);
+        return;
+    }
 
-    nodeList = fileMetadata.nodes || [];
+    // In compare mode, the dropdown shows the union of nodes from
+    // both captures. If the user picks a node that only exists on one
+    // side, that side renders empty rather than silently fanning out
+    // across all nodes — see buildEffectiveQuery's node injection on
+    // the cross-capture path.
+    const baselineNodes = fileMetadata.nodes || [];
+    const experimentNodes = experimentFileMetadata?.nodes || [];
+    const seen = new Set();
+    nodeList = [...baselineNodes, ...experimentNodes].filter((n) => {
+        if (seen.has(n)) return false;
+        seen.add(n);
+        return true;
+    });
     nodeVersions = fileMetadata.node_versions || {};
     serviceInstances = fileMetadata.service_instances || {};
 
     if (nodeList.length > 0) {
         const pinned = fileMetadata.pinned_node;
         const defaultNode = (pinned && nodeList.includes(pinned)) ? pinned : nodeList[0];
-        selectedNode = defaultNode;
-        setSelectedNode(defaultNode);
+        // Preserve the user's prior selection if it survives the union
+        // (e.g. attach/detach on the experiment side shouldn't reset).
+        const next = (previousSelection && nodeList.includes(previousSelection))
+            ? previousSelection
+            : defaultNode;
+        selectedNode = next;
+        setSelectedNode(next);
+    } else {
+        setSelectedNode(null);
     }
 
     for (const source of Object.keys(serviceInstances)) {
@@ -602,7 +636,7 @@ const initDashboard = (config = {}) => {
         setStepOverride(restoredStep);
     }
 
-    applyMultiNodeInfo();
+    applyMultiNodeInfo(config.experimentFileMetadata);
 
     // Apply capabilities
     liveMode = config.liveMode || false;

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -339,11 +339,16 @@ const createDataApi = ({
     //   sectionRoute       — route string, used for the service/node rule.
     //   activeCgroupPattern — resolved cgroup selector, if any.
     //   serviceName        — section's service_name, if any.
-    //   crossCapture       — default false. When true, skip BOTH node and
-    //                        instance label injection. Compare path sets
-    //                        this because the experiment capture's
-    //                        topology is independent of the baseline's,
-    //                        and the injected labels would mis-target.
+    //   crossCapture       — default false. When true, skip per-service
+    //                        instance injection because service KPIs are
+    //                        composable (e.g. sum across instances) and
+    //                        an unfiltered aggregate is the correct A/B
+    //                        baseline. Node injection still applies on
+    //                        both sides so a pinned-node compare stays
+    //                        symmetric across captures; if the selected
+    //                        node isn't present on a capture, that side
+    //                        renders empty rather than silently fanning
+    //                        out across all nodes.
     //   stepOverride       — nullable; when > 1 triggers histogram-stride /
     //                        counter-rate rewriting. Defaults to the
     //                        module-level _stepOverride.
@@ -379,7 +384,7 @@ const createDataApi = ({
                 return null;
             }
         }
-        if (injectTopologyLabels && _selectedNode && sectionRoute && !sectionRoute.startsWith('/service/')) {
+        if (_selectedNode && sectionRoute && !sectionRoute.startsWith('/service/')) {
             q = injectLabel(q, 'node', _selectedNode);
         }
         if (injectTopologyLabels && serviceName) {

--- a/tests/compare_node_filter.test.mjs
+++ b/tests/compare_node_filter.test.mjs
@@ -1,0 +1,99 @@
+// Regression tests for compare-mode topology label injection.
+//
+// Pre-fix: buildEffectiveQuery(crossCapture=true) skipped BOTH node and
+// instance label injection on the experiment side, so a multi-node
+// rezolus chart fanned out across all nodes in the experiment capture
+// while the baseline side was correctly pinned to the selected node.
+// Asymmetric and confusing.
+//
+// Post-fix: node injection always applies (so the user's pinned-node
+// selection in the top nav targets both captures consistently).
+// Instance injection still only applies on the baseline path —
+// service KPIs are composable by design (e.g. sum across instances)
+// so an unfiltered aggregate is the correct A/B baseline.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    buildEffectiveQuery,
+    setSelectedNode,
+    setSelectedInstance,
+} from '../src/viewer/assets/lib/data.js';
+
+const counterPlot = (query) => ({
+    promql_query: query,
+    opts: { type: 'delta_counter' },
+});
+
+test('node label is injected on the cross-capture (experiment) path for non-service routes', () => {
+    setSelectedNode('web01');
+    try {
+        const q = buildEffectiveQuery(
+            counterPlot('sum(irate(cpu_usage[5m]))'),
+            { sectionRoute: '/cpu', crossCapture: true },
+        );
+        assert.match(q, /node="web01"/);
+    } finally {
+        setSelectedNode(null);
+    }
+});
+
+test('node label is injected on the baseline (non-cross-capture) path too', () => {
+    setSelectedNode('web01');
+    try {
+        const q = buildEffectiveQuery(
+            counterPlot('sum(irate(cpu_usage[5m]))'),
+            { sectionRoute: '/cpu', crossCapture: false },
+        );
+        assert.match(q, /node="web01"/);
+    } finally {
+        setSelectedNode(null);
+    }
+});
+
+test('node label is NOT injected for /service/* routes (service queries are intentionally node-agnostic)', () => {
+    setSelectedNode('web01');
+    try {
+        const q = buildEffectiveQuery(
+            counterPlot('sum(irate(sglang_generation_tokens_total[5s]))'),
+            { sectionRoute: '/service/sglang', crossCapture: true },
+        );
+        assert.doesNotMatch(q, /node="/);
+    } finally {
+        setSelectedNode(null);
+    }
+});
+
+test('instance label is injected on baseline path but skipped on cross-capture path', () => {
+    setSelectedInstance('sglang', 'primary');
+    try {
+        const baseline = buildEffectiveQuery(
+            counterPlot('sum(irate(sglang_generation_tokens_total[5s]))'),
+            { sectionRoute: '/service/sglang', serviceName: 'sglang', crossCapture: false },
+        );
+        assert.match(baseline, /instance="primary"/, 'baseline side should pin instance');
+
+        const experiment = buildEffectiveQuery(
+            counterPlot('sum(irate(sglang_generation_tokens_total[5s]))'),
+            { sectionRoute: '/service/sglang', serviceName: 'sglang', crossCapture: true },
+        );
+        assert.doesNotMatch(experiment, /instance="/, 'experiment side aggregates across instances');
+    } finally {
+        setSelectedInstance('sglang', null);
+    }
+});
+
+test('with no selected node, queries pass through unchanged on either path', () => {
+    setSelectedNode(null);
+    const original = 'sum(irate(cpu_usage[5m]))';
+    const baseline = buildEffectiveQuery(
+        counterPlot(original),
+        { sectionRoute: '/cpu', crossCapture: false },
+    );
+    const experiment = buildEffectiveQuery(
+        counterPlot(original),
+        { sectionRoute: '/cpu', crossCapture: true },
+    );
+    assert.equal(baseline, original);
+    assert.equal(experiment, original);
+});


### PR DESCRIPTION
## Summary

In compare mode, `buildEffectiveQuery`'s `crossCapture` flag previously skipped both node and instance label injection on the experiment side. The result: when the user pinned a node in the top-nav dropdown, the baseline chart filtered to that node while the experiment chart fanned out across every node in its capture. Asymmetric and confusing for any multi-node A/B run.

This PR pins the user's selected node to **both** captures and updates the multi-node dropdown to show the union of baseline + experiment nodes.

### Behavior

- **Node injection**: now applies on both baseline and experiment paths. If the selected node exists in only one capture, the other side renders empty — an honest signal that the captures don't share topology. (Better than silently aggregating across all nodes.)
- **Instance injection on `/service/*` routes**: still cross-capture-skipped on purpose. Service KPIs are composable by design (`sum(...)` across instances) so an unfiltered aggregate is the correct A/B baseline. Documented the asymmetry in `buildEffectiveQuery`.
- **Top-nav dropdown**: now shows the union of `fileMetadata.nodes` and `experimentFileMetadata.nodes`. Refreshes on attach/detach. Preserves the user's prior selection across topology changes when the chosen node still exists in the new union; falls back to the pinned-or-first default otherwise.

### Files

- `src/viewer/assets/lib/data.js` — drop the `injectTopologyLabels` gate from the node branch; keep it on the instance branch. Updated doc comment.
- `src/viewer/assets/lib/app.js` — `applyMultiNodeInfo` now takes `experimentFileMetadata`, computes the union, preserves prior selection. Wired into `attach`/`detach` so the dropdown stays consistent.
- `tests/compare_node_filter.test.mjs` — five regression tests covering node injection on both paths, the `/service/*` exception, the asymmetric instance behavior, and the no-selection passthrough.

## Test plan

- [x] `node --test tests/*.mjs` — 35 tests pass (5 new + 30 existing)
- [x] `cargo test -p dashboard` — 22 tests pass
- [ ] Verify in the browser: load a combined parquet with multiple rezolus nodes, attach a multi-node experiment capture, switch nodes via the top-nav dropdown, and confirm both sides of every chart update to the selected node.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Acytud5ueePRtPw3GiGo5N)_