### PR TITLE
rename histogram_percentiles -> histogram_quantiles, drop percentile label

### DIFF
--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -377,7 +377,7 @@ impl PlotOpts {
 
     /// A histogram metric represents a distribution (e.g., latency, IO size).
     /// The subtype determines the visualization and query wrapping:
-    /// - "percentiles": shows percentile scatter plot, wraps query with histogram_percentiles()
+    /// - "percentiles": shows percentile scatter plot, wraps query with histogram_quantiles()
     /// - "buckets": shows bucket heatmap, wraps query with histogram_heatmap()
     pub fn histogram<T: Into<String>, U: Into<String>>(
         title: T,

--- a/crates/dashboard/src/service_extension.rs
+++ b/crates/dashboard/src/service_extension.rs
@@ -87,7 +87,7 @@ impl Kpi {
                             .join(", ")
                     ),
                 };
-                format!("histogram_percentiles({}, {})", quantiles, self.query)
+                format!("histogram_quantiles({}, {})", quantiles, self.query)
             }
         } else {
             self.query.clone()
@@ -166,7 +166,7 @@ impl CategoryKpi {
 
     /// Build the same effective query string that a regular `Kpi` would
     /// produce given the supplied raw query. Mirrors `Kpi::effective_query`
-    /// — histogram_percentiles wrapping, histogram_heatmap for buckets,
+    /// — histogram_quantiles wrapping, histogram_heatmap for buckets,
     /// passthrough for everything else.
     pub fn effective_query(&self, raw_query: &str) -> String {
         if self.metric_type == "histogram" {

--- a/crates/dashboard/src/service_extension.rs
+++ b/crates/dashboard/src/service_extension.rs
@@ -191,7 +191,7 @@ impl CategoryKpi {
                             .join(", ")
                     ),
                 };
-                format!("histogram_percentiles({}, {})", quantiles, raw_query)
+                format!("histogram_quantiles({}, {})", quantiles, raw_query)
             }
         } else {
             raw_query.to_string()

--- a/src/mcp/anomaly_detection/mod.rs
+++ b/src/mcp/anomaly_detection/mod.rs
@@ -737,7 +737,7 @@ fn extract_time_series(
             // Histogram heatmap data - not suitable for standard time series analysis
             Err(
                 "Histogram heatmap data is not suitable for anomaly detection. \
-                Use histogram_percentiles() instead for time series analysis."
+                Use histogram_quantiles() instead for time series analysis."
                     .into(),
             )
         }

--- a/src/mcp/correlation.rs
+++ b/src/mcp/correlation.rs
@@ -449,7 +449,7 @@ fn extract_matrix_samples(
             // Histogram heatmap data cannot be converted to matrix samples
             Err(
                 "Histogram heatmap data is not suitable for correlation analysis. \
-                Use histogram_percentiles() instead."
+                Use histogram_quantiles() instead."
                     .into(),
             )
         }

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -76,20 +76,20 @@ export function buildHistogramQuery(baseQuery, subtype, percentiles, strideSecs)
         return `histogram_heatmap(${baseQuery}${strideSuffix})`;
     }
     const quantiles = percentiles || DEFAULT_PERCENTILES;
-    return `histogram_percentiles([${quantiles.join(', ')}], ${baseQuery}${strideSuffix})`;
+    return `histogram_quantiles([${quantiles.join(', ')}], ${baseQuery}${strideSuffix})`;
 }
 
 /**
  * Returns true if the given plot spec represents a histogram chart.
  * Checks the semantic type first, with a legacy fallback for specs that
- * still use the old histogram_percentiles query format.
+ * still use the histogram_quantiles query format.
  *
  * @param {object} plot - A plot spec with opts and optional promql_query
  * @returns {boolean}
  */
 export function isHistogramPlot(plot) {
     return plot.opts?.type === 'histogram' ||
-        (plot.promql_query && plot.promql_query.includes('histogram_percentiles'));
+        (plot.promql_query && plot.promql_query.includes('histogram_quantiles'));
 }
 
 /**

--- a/src/viewer/assets/lib/charts/multi.js
+++ b/src/viewer/assets/lib/charts/multi.js
@@ -62,7 +62,7 @@ export function configureMultiSeriesChart(chart) {
     // For percentile charts, assign z-index so lower quantiles draw on top of higher ones.
     // This ensures p50 is visible when its value equals p99.99.
     const isPercentileChart = chart.spec.promql_query &&
-        chart.spec.promql_query.includes('histogram_percentiles');
+        chart.spec.promql_query.includes('histogram_quantiles');
 
     for (let i = 1; i < data.length; i++) {
         const name = seriesNames[i - 1];

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -17,15 +17,16 @@ export const intersectLabels = (setA, setB) => {
 
 // Canonicalize a histogram quantile into the shared "pXX" label form.
 // Accepts either a raw value (number or string like "0.5", "50", "p99")
-// or an object with .metric carrying percentile/quantile labels, and
-// returns either a canonical label or null when it can't be parsed.
-// metriken_query emits `percentile` as a fraction; legacy sources may
-// use `quantile`; either fraction (<=1) or percent form is accepted.
+// or an object with .metric carrying a `quantile` label (the standard
+// PromQL convention emitted by both `histogram_quantile` and the
+// rezolus-extension `histogram_quantiles`), and returns either a
+// canonical label or null when it can't be parsed. Either fraction
+// (<=1) or percent form is accepted.
 export const canonicalQuantileLabel = (input) => {
     let raw = input;
     if (input && typeof input === 'object') {
         const mm = input.metric || input;
-        raw = mm.percentile != null ? mm.percentile : mm.quantile;
+        raw = mm.quantile;
         if (raw == null) {
             for (const [k, v] of Object.entries(mm)) {
                 if (k !== '__name__') { raw = v; break; }

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -20,7 +20,7 @@ const getStepOverride = () => _stepOverride;
 //
 //   Counter:   irate(m[5m]) → rate(m[Ns])   (true average rate over window)
 //   Gauge:     no rewrite needed (engine samples at step points)
-//   Histogram: stride parameter passed to histogram_percentiles / histogram_heatmap
+//   Histogram: stride parameter passed to histogram_quantiles / histogram_heatmap
 
 // Replace all irate(...[window]) with rate(...[Ns]) in a query string.
 const rewriteCounterQuery = (query, stepSecs) => {
@@ -53,7 +53,7 @@ const getSelectedInstance = (serviceName) => _selectedInstances[serviceName] || 
 const PROMQL_KEYWORDS = new Set([
     'by', 'without', 'on', 'ignoring', 'group_left', 'group_right',
     'bool', 'sum', 'avg', 'min', 'max', 'count', 'rate', 'irate', 'increase',
-    'histogram_percentiles', 'histogram_heatmap', 'topk', 'bottomk', 'offset',
+    'histogram_quantiles', 'histogram_heatmap', 'topk', 'bottomk', 'offset',
     'abs', 'absent', 'ceil', 'floor', 'round', 'sqrt', 'exp', 'ln', 'log2',
     'log10', 'clamp', 'clamp_max', 'clamp_min', 'delta', 'deriv', 'idelta',
     'predict_linear', 'resets', 'changes', 'label_replace', 'label_join',
@@ -474,9 +474,9 @@ const createDataApi = ({
         let metricSelector;
         if (plot.opts.type === 'histogram') {
             metricSelector = query;
-        } else if (query.includes('histogram_percentiles')) {
+        } else if (query.includes('histogram_quantiles')) {
             // Legacy fallback: extract base metric from wrapped query
-            const match = query.match(/histogram_percentiles\s*\(\s*\[[^\]]*\]\s*,\s*(.+)\)$/);
+            const match = query.match(/histogram_quantiles\s*\(\s*\[[^\]]*\]\s*,\s*(.+)\)$/);
             if (!match) return null;
             metricSelector = match[1].trim();
         } else {


### PR DESCRIPTION
## Summary

Renames every reference to `histogram_percentiles` (rezolus extension) to `histogram_quantiles`, and switches consumers from the `percentile` label to the standard PromQL `quantile` label. Coordinated with the matching rename in metriken-query 0.10.0+.

## Why

The rezolus dashboards used a custom `histogram_percentiles([qs], m)` function that emitted a `percentile` label, alongside the standard PromQL `histogram_quantile(q, m)` which emitted `quantile`. The two were functionally identical (multi-quantile vs single-quantile) but used different names and label conventions, forcing the viewer to maintain a fallback (`mm.percentile != null ? mm.percentile : mm.quantile`) and creating two divergent code paths.

Renaming to `histogram_quantiles` (plural) collapses the API:
- `histogram_quantile(0.99, m)` → `{quantile: "0.99"}`
- `histogram_quantiles([0.99], m)` → `{quantile: "0.99"}`

Same operation, same label, two API shapes (scalar vs array).

## Status — runtime fix on top of #858

#858 bumped the workspace to metriken-query 0.10.2, which dropped `histogram_percentiles` entirely. Rezolus' main now still emits `histogram_percentiles(...)` query strings from:

- `crates/dashboard/src/service_extension.rs:90, :194` — service-extension KPI builder
- `src/viewer/assets/lib/charts/metric_types.js:79` — JS query emitter
- `src/viewer/assets/lib/charts/multi.js:65`, `data.js:56, :477, :479` — JS detectors / extractors

These all return `Unsupported("function not found: histogram_percentiles")` at runtime against 0.10.2. This PR completes the rename so they emit / detect `histogram_quantiles` instead.

## Changes

- **`crates/dashboard/src/service_extension.rs`** — emit `histogram_quantiles(...)` from both `Kpi::effective_query` (line 90) and `CategoryKpi::effective_query` (line 194).
- **`crates/dashboard/src/plot.rs`** — comment update.
- **`src/viewer/assets/lib/charts/metric_types.js`** — emit `histogram_quantiles(...)`; update the "is this a histogram chart" detector.
- **`src/viewer/assets/lib/charts/multi.js`** — update the percentile-chart detector.
- **`src/viewer/assets/lib/data.js`** — update the PromQL keyword set, the heatmap-extractor regex, and a comment.
- **`src/viewer/assets/lib/charts/util/compare_math.js`** — drop the `percentile` fallback in `canonicalQuantileLabel`; both `histogram_quantile` and `histogram_quantiles` now emit `{quantile: ...}`.
- **`src/mcp/{correlation,anomaly_detection}.rs`** — update user-facing error messages referencing the old function name.

## Rebased on top of current main

The earlier branch carried the metriken-query 0.10.0 bump and `http`-feature drop; both are now subsumed by #858 (which bumped to 0.10.2 and dropped `http`). Branch reset to `origin/main` with only the two rename commits cherry-picked on top.

## Test plan

- [x] `cargo test -p dashboard` — 24/24 pass
- [x] `node --test tests/*.mjs` — 37/37 pass
- [x] `cargo build -p dashboard` clean
- [ ] End-to-end viewer test: load a parquet, confirm histogram-percentile panels render
- [ ] WASM viewer rebuild + browser smoke test