### PR TITLE
feat(viewer): list unavailable charts at the bottom of regular sections

### DIFF
--- a/site/viewer/lib/section_notes.js
+++ b/site/viewer/lib/section_notes.js
@@ -1,0 +1,1 @@
+../../../src/viewer/assets/lib/section_notes.js

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -18,6 +18,7 @@ import { initTheme } from './theme.js';
 import { isHistogramPlot } from './charts/metric_types.js';
 import { renderServiceSection, createServiceRoutes } from './service.js';
 import { createGroupComponent, getCachedSectionMeta, buildClientOnlySectionView } from './viewer_core.js';
+import { renderSectionNotes } from './section_notes.js';
 import {
     createSectionCacheState,
     storeSectionResponse,
@@ -595,15 +596,16 @@ const SectionContent = {
             m('div#groups',
                 attrs.groups.map((group) => m(Group, { ...group, sectionRoute, sectionName, interval })),
             ),
-            unavailableCharts.length > 0 && m('div.section-notes', [
-                m('h3', 'Charts with no data'),
-                m('p', 'The following charts have no matching data in this recording:'),
-                m('ul', unavailableCharts.map((c) => m('li', [
+            renderSectionNotes({
+                title: 'Charts with no data',
+                lead: 'The following charts have no matching data in this recording:',
+                items: unavailableCharts,
+                formatItem: (c) => m('li', [
                     m('strong', c.title),
                     c.subgroup ? ` — ${c.subgroup}` : '',
                     c.group ? ` (${c.group})` : '',
-                ]))),
-            ]),
+                ]),
+            }),
         ]);
     },
 };

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -567,6 +567,8 @@ const SectionContent = {
             collectGroupPlots(g).some(p => isHistogramPlot(p))
         );
 
+        const unavailableCharts = attrs.metadata?.unavailable_charts || [];
+
         return m('div#section-content', [
             m('div.section-header-row', [
                 m('h1.section-title', titleText),
@@ -593,6 +595,15 @@ const SectionContent = {
             m('div#groups',
                 attrs.groups.map((group) => m(Group, { ...group, sectionRoute, sectionName, interval })),
             ),
+            unavailableCharts.length > 0 && m('div.section-notes', [
+                m('h3', 'Charts with no data'),
+                m('p', 'The following charts have no matching data in this recording:'),
+                m('ul', unavailableCharts.map((c) => m('li', [
+                    m('strong', c.title),
+                    c.subgroup ? ` — ${c.subgroup}` : '',
+                    c.group ? ` (${c.group})` : '',
+                ]))),
+            ]),
         ]);
     },
 };

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -433,6 +433,38 @@ const createDataApi = ({
             }
         }
 
+        // Pull out plots whose query yielded no data and stash the
+        // titles in a section-level "unavailable" list, mirroring the
+        // service-section UX. Empty subgroups and groups are dropped
+        // so the page doesn't carry blank chart cards.
+        const unavailable = [];
+        const plotHasData = (plot) =>
+            Array.isArray(plot.data) && plot.data.some((s) => Array.isArray(s) && s.length > 0);
+        for (const group of data.groups || []) {
+            for (const sg of group.subgroups || []) {
+                const surviving = [];
+                for (const plot of (sg.plots || [])) {
+                    if (!plot.promql_query || plotHasData(plot)) {
+                        surviving.push(plot);
+                    } else {
+                        unavailable.push({
+                            group: group.name,
+                            subgroup: sg.name || null,
+                            title: plot.opts?.title || '(unnamed chart)',
+                            query: plot.promql_query,
+                        });
+                    }
+                }
+                sg.plots = surviving;
+            }
+            group.subgroups = (group.subgroups || []).filter((sg) => (sg.plots || []).length > 0);
+        }
+        data.groups = (data.groups || []).filter((g) => (g.subgroups || []).length > 0);
+        if (unavailable.length > 0) {
+            data.metadata = data.metadata || {};
+            data.metadata.unavailable_charts = unavailable;
+        }
+
         return data;
     };
 

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -433,10 +433,8 @@ const createDataApi = ({
             }
         }
 
-        // Pull out plots whose query yielded no data and stash the
-        // titles in a section-level "unavailable" list, mirroring the
-        // service-section UX. Empty subgroups and groups are dropped
-        // so the page doesn't carry blank chart cards.
+        // Surface no-data plots at the bottom (mirrors service KPI UX)
+        // instead of leaving silent empty chart cards mid-section.
         const unavailable = [];
         const plotHasData = (plot) =>
             Array.isArray(plot.data) && plot.data.some((s) => Array.isArray(s) && s.length > 0);

--- a/src/viewer/assets/lib/section_notes.js
+++ b/src/viewer/assets/lib/section_notes.js
@@ -1,0 +1,9 @@
+// Returns null on empty items so callers can inline `&&`-style.
+export function renderSectionNotes({ title, lead, items, formatItem }) {
+    if (!Array.isArray(items) || items.length === 0) return null;
+    return m('div.section-notes', [
+        m('h3', title),
+        lead && m('p', lead),
+        m('ul', items.map(formatItem)),
+    ]);
+}

--- a/src/viewer/assets/lib/service.js
+++ b/src/viewer/assets/lib/service.js
@@ -1,6 +1,8 @@
 // Shared service extension components and route builders.
 // Used by both the binary viewer and the static site viewer.
 
+import { renderSectionNotes } from './section_notes.js';
+
 /**
  * Render service section content (metadata table, KPI groups, unavailable list).
  * Returns a mithril vnode for use inside SectionContent.
@@ -57,24 +59,22 @@ const renderServiceSection = (attrs, Group, sectionRoute, sectionName, interval,
                 m(Group, { ...group, sectionRoute, sectionName, interval })
             )
         ),
-        unavailable.length > 0 && m('div.section-notes', [
-            m('h3', 'Unavailable KPIs'),
-            m('p', 'The following KPIs have no matching data in this recording:'),
-            m('ul', unavailable.map((kpi) =>
-                m('li', [m('strong', kpi.title), ` (${kpi.role})`])
-            )),
-        ]),
-        categoryUnavailable.length > 0 && m('div.section-notes', [
-            m('h3', 'Skipped Comparisons'),
-            m('p', 'The following category KPIs were skipped because one member did not have a matching chart:'),
-            m('ul', categoryUnavailable.map((entry) =>
-                m('li', [
-                    m('strong', entry.title),
-                    ' — missing in ',
-                    m('code', entry.missing_member),
-                ])
-            )),
-        ]),
+        renderSectionNotes({
+            title: 'Unavailable KPIs',
+            lead: 'The following KPIs have no matching data in this recording:',
+            items: unavailable,
+            formatItem: (kpi) => m('li', [m('strong', kpi.title), ` (${kpi.role})`]),
+        }),
+        renderSectionNotes({
+            title: 'Skipped Comparisons',
+            lead: 'The following category KPIs were skipped because one member did not have a matching chart:',
+            items: categoryUnavailable,
+            formatItem: (entry) => m('li', [
+                m('strong', entry.title),
+                ' — missing in ',
+                m('code', entry.missing_member),
+            ]),
+        }),
     ]);
 };
 


### PR DESCRIPTION
## Summary

Service sections already surface KPIs whose underlying metrics are absent in a recording — listed at the bottom under \"Unavailable KPIs.\" Regular dashboards (CPU / GPU / Memory / etc.) didn't have the equivalent: charts whose PromQL query failed (or returned no data) just rendered as silent empty cards in their original spots, indistinguishable from \"this chart hasn't loaded yet.\"

This change mirrors the service-section UX for the regular sections.

After all per-chart queries resolve in [data.js#processDashboardData](src/viewer/assets/lib/data.js):
- Plots with no data are pulled out of their subgroups
- Subgroups left empty are dropped
- Groups left empty are dropped
- The titles, subgroups, and group names are stashed in \`data.metadata.unavailable_charts\`

[app.js#SectionContent](src/viewer/assets/lib/app.js) renders that list as a \`section-notes\` block at the bottom of the section, parallel to service.js's \`Unavailable KPIs\` block.

## Why this matters

Concrete trigger: loading \`disagg/sglang-nixl-16c.parquet\` shows the GPU section. The dashboard generator emits cards for SM Activity / SM Occupancy / Tensor Activity. Those queries (`gpu_sm_utilization`, `gpu_sm_occupancy`, `gpu_tensor_utilization`) fail with \`Metric not found\` because that recording came from a host whose GPU/driver stack reports only `gpu_utilization` (no DCGM extended counters). Pre-PR: 6 silent empty chart cards in the middle of the section, plus the subgroup titles/descriptions hidden by the existing \`hasData\` filter — leaving floating empty space. Post-PR: those cards collapse out and a clear \"Charts with no data\" list at the bottom names them.

## Tests

- [x] \`node --check\` clean on the two touched files
- [x] \`node --test tests/*.mjs\` — all 30 frontend tests pass (no behavioral coupling)
- [ ] Manual: load \`disagg/sglang-nixl-16c.parquet\` (GPU section), verify the SM/Tensor entries appear in the bottom notes list and the chart cards are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)