### PR TITLE
feat(dashboard): suppress per-device charts on single-GPU/single-CPU recordings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.17"
+version = "5.11.1-alpha.18"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.17"
+version = "5.11.1-alpha.18"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/crates/dashboard/src/dashboard/cpu.rs
+++ b/crates/dashboard/src/dashboard/cpu.rs
@@ -28,15 +28,20 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let busy = utilization.subgroup("Total CPU");
     busy.describe("Overall CPU busy time across all cores, with per-core breakdown.");
-    busy.plot_promql(
-        PlotOpts::counter("Busy %", "busy-pct", Unit::Percentage).percentage_range(),
-        "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
-    );
     if multi_cpu {
+        busy.plot_promql(
+            PlotOpts::counter("Busy %", "busy-pct", Unit::Percentage).percentage_range(),
+            "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
+        );
         busy.plot_promql(
             PlotOpts::counter("Busy % (Per-CPU)", "busy-pct-per-cpu", Unit::Percentage)
                 .percentage_range(),
             "sum by (id) (irate(cpu_usage[5m])) / 1000000000".to_string(),
+        );
+    } else {
+        busy.plot_promql_full(
+            PlotOpts::counter("Busy %", "busy-pct", Unit::Percentage).percentage_range(),
+            "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
         );
     }
 
@@ -44,16 +49,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     by_state.describe("Kernel vs. user-space CPU time, aggregate and per-core.");
     for state in &["user", "system"] {
         let capitalized = if *state == "user" { "User" } else { "System" };
-        by_state.plot_promql(
-            PlotOpts::counter(
-                format!("{capitalized} %"),
-                format!("{state}-pct"),
-                Unit::Percentage,
-            )
-            .percentage_range(),
-            format!("sum(irate(cpu_usage{{state=\"{state}\"}}[5m])) / cpu_cores / 1000000000"),
-        );
         if multi_cpu {
+            by_state.plot_promql(
+                PlotOpts::counter(
+                    format!("{capitalized} %"),
+                    format!("{state}-pct"),
+                    Unit::Percentage,
+                )
+                .percentage_range(),
+                format!("sum(irate(cpu_usage{{state=\"{state}\"}}[5m])) / cpu_cores / 1000000000"),
+            );
             by_state.plot_promql(
                 PlotOpts::counter(
                     format!("{capitalized} % (Per-CPU)"),
@@ -62,6 +67,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
                 )
                 .percentage_range(),
                 format!("sum by (id) (irate(cpu_usage{{state=\"{state}\"}}[5m])) / 1000000000"),
+            );
+        } else {
+            by_state.plot_promql_full(
+                PlotOpts::counter(
+                    format!("{capitalized} %"),
+                    format!("{state}-pct"),
+                    Unit::Percentage,
+                )
+                .percentage_range(),
+                format!("sum(irate(cpu_usage{{state=\"{state}\"}}[5m])) / cpu_cores / 1000000000"),
             );
         }
     }
@@ -76,56 +91,76 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let ipc = performance.subgroup("Instructions per Cycle");
     ipc.describe("How efficiently the CPU retires instructions per clock cycle.");
-    ipc.plot_promql(
-        PlotOpts::counter("IPC", "ipc", Unit::Count),
-        "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m]))".to_string(),
-    );
     if multi_cpu {
+        ipc.plot_promql(
+            PlotOpts::counter("IPC", "ipc", Unit::Count),
+            "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m]))".to_string(),
+        );
         ipc.plot_promql(
             PlotOpts::counter("IPC (Per-CPU)", "ipc-per-cpu", Unit::Count),
             "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m]))"
                 .to_string(),
         );
+    } else {
+        ipc.plot_promql_full(
+            PlotOpts::counter("IPC", "ipc", Unit::Count),
+            "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m]))".to_string(),
+        );
     }
 
     let ipns = performance.subgroup("Instructions per Nanosecond");
     ipns.describe("Wall-clock-normalized instruction throughput — accounts for frequency scaling.");
-    ipns.plot_promql(
-        PlotOpts::counter("IPNS", "ipns", Unit::Count),
-        "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m])) * sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / 1000000000 / cpu_cores".to_string(),
-    );
     if multi_cpu {
+        ipns.plot_promql(
+            PlotOpts::counter("IPNS", "ipns", Unit::Count),
+            "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m])) * sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / 1000000000 / cpu_cores".to_string(),
+        );
         ipns.plot_promql(
             PlotOpts::counter("IPNS (Per-CPU)", "ipns-per-cpu", Unit::Count),
             "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m])) * sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m])) / 1000000000".to_string(),
+        );
+    } else {
+        ipns.plot_promql_full(
+            PlotOpts::counter("IPNS", "ipns", Unit::Count),
+            "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m])) * sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / 1000000000 / cpu_cores".to_string(),
         );
     }
 
     let l3 = performance.subgroup("L3 Cache Hit Rate");
     l3.describe("Fraction of L3 cache accesses that hit, indicating last-level cache efficiency.");
-    l3.plot_promql(
-        PlotOpts::counter("L3 Hit %", "l3-hit", Unit::Percentage).percentage_range(),
-        "1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))".to_string(),
-    );
     if multi_cpu {
+        l3.plot_promql(
+            PlotOpts::counter("L3 Hit %", "l3-hit", Unit::Percentage).percentage_range(),
+            "1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))".to_string(),
+        );
         l3.plot_promql(
             PlotOpts::counter("L3 Hit % (Per-CPU)", "l3-hit-per-cpu", Unit::Percentage)
                 .percentage_range(),
             "1 - sum by (id) (irate(cpu_l3_miss[5m])) / sum by (id) (irate(cpu_l3_access[5m]))"
                 .to_string(),
         );
+    } else {
+        l3.plot_promql_full(
+            PlotOpts::counter("L3 Hit %", "l3-hit", Unit::Percentage).percentage_range(),
+            "1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))".to_string(),
+        );
     }
 
     let freq = performance.subgroup("Frequency");
     freq.describe("Effective CPU clock speed, averaged and per-core.");
-    freq.plot_promql(
-        PlotOpts::counter("Frequency", "frequency", Unit::Frequency),
-        "sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / cpu_cores".to_string(),
-    );
     if multi_cpu {
+        freq.plot_promql(
+            PlotOpts::counter("Frequency", "frequency", Unit::Frequency),
+            "sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / cpu_cores".to_string(),
+        );
         freq.plot_promql(
             PlotOpts::counter("Frequency (Per-CPU)", "frequency-per-cpu", Unit::Frequency),
             "sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m]))".to_string(),
+        );
+    } else {
+        freq.plot_promql_full(
+            PlotOpts::counter("Frequency", "frequency", Unit::Frequency),
+            "sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / cpu_cores".to_string(),
         );
     }
 
@@ -139,12 +174,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let miss = branch.subgroup("Misprediction Rate");
     miss.describe("Fraction of branches that the predictor got wrong.");
-    miss.plot_promql(
-        PlotOpts::counter("Misprediction Rate %", "branch-miss-rate", Unit::Percentage)
-            .percentage_range(),
-        "sum(irate(cpu_branch_misses[5m])) / sum(irate(cpu_branch_instructions[5m]))".to_string(),
-    );
     if multi_cpu {
+        miss.plot_promql(
+            PlotOpts::counter("Misprediction Rate %", "branch-miss-rate", Unit::Percentage)
+                .percentage_range(),
+            "sum(irate(cpu_branch_misses[5m])) / sum(irate(cpu_branch_instructions[5m]))"
+                .to_string(),
+        );
         miss.plot_promql(
             PlotOpts::counter(
                 "Misprediction Rate % (Per-CPU)",
@@ -153,6 +189,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             )
             .percentage_range(),
             "sum by (id) (irate(cpu_branch_misses[5m])) / sum by (id) (irate(cpu_branch_instructions[5m]))"
+                .to_string(),
+        );
+    } else {
+        miss.plot_promql_full(
+            PlotOpts::counter("Misprediction Rate %", "branch-miss-rate", Unit::Percentage)
+                .percentage_range(),
+            "sum(irate(cpu_branch_misses[5m])) / sum(irate(cpu_branch_instructions[5m]))"
                 .to_string(),
         );
     }
@@ -198,28 +241,38 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let misses = dtlb.subgroup("DTLB Misses");
     misses.describe("Raw data-TLB miss rate, aggregated and per-core.");
-    misses.plot_promql(
-        PlotOpts::counter("Misses", "dtlb-misses", Unit::Rate),
-        "sum(irate(cpu_dtlb_miss[5m]))".to_string(),
-    );
     if multi_cpu {
+        misses.plot_promql(
+            PlotOpts::counter("Misses", "dtlb-misses", Unit::Rate),
+            "sum(irate(cpu_dtlb_miss[5m]))".to_string(),
+        );
         misses.plot_promql(
             PlotOpts::counter("Misses (Per-CPU)", "dtlb-misses-per-cpu", Unit::Rate),
             "sum by (id) (irate(cpu_dtlb_miss[5m]))".to_string(),
+        );
+    } else {
+        misses.plot_promql_full(
+            PlotOpts::counter("Misses", "dtlb-misses", Unit::Rate),
+            "sum(irate(cpu_dtlb_miss[5m]))".to_string(),
         );
     }
 
     let mpki = dtlb.subgroup("DTLB MPKI");
     mpki.describe("Misses per thousand instructions, normalized so workload differences don't distort the rate.");
-    mpki.plot_promql(
-        PlotOpts::counter("MPKI", "dtlb-mpki", Unit::Count),
-        "sum(irate(cpu_dtlb_miss[5m])) / sum(irate(cpu_instructions[5m])) * 1000".to_string(),
-    );
     if multi_cpu {
+        mpki.plot_promql(
+            PlotOpts::counter("MPKI", "dtlb-mpki", Unit::Count),
+            "sum(irate(cpu_dtlb_miss[5m])) / sum(irate(cpu_instructions[5m])) * 1000".to_string(),
+        );
         mpki.plot_promql(
             PlotOpts::counter("MPKI (Per-CPU)", "dtlb-mpki-per-cpu", Unit::Count),
             "sum by (id) (irate(cpu_dtlb_miss[5m])) / sum by (id) (irate(cpu_instructions[5m])) * 1000"
                 .to_string(),
+        );
+    } else {
+        mpki.plot_promql_full(
+            PlotOpts::counter("MPKI", "dtlb-mpki", Unit::Count),
+            "sum(irate(cpu_dtlb_miss[5m])) / sum(irate(cpu_instructions[5m])) * 1000".to_string(),
         );
     }
 
@@ -233,27 +286,37 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let to = migrations.subgroup("Incoming Migrations");
     to.describe("Tasks migrated onto a CPU, per second.");
-    to.plot_promql(
-        PlotOpts::counter("To", "cpu-migrations-to", Unit::Rate),
-        "sum(irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
-    );
     if multi_cpu {
+        to.plot_promql(
+            PlotOpts::counter("To", "cpu-migrations-to", Unit::Rate),
+            "sum(irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
+        );
         to.plot_promql(
             PlotOpts::counter("To (Per-CPU)", "cpu-migrations-to-per-cpu", Unit::Rate),
             "sum by (id) (irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
+        );
+    } else {
+        to.plot_promql_full(
+            PlotOpts::counter("To", "cpu-migrations-to", Unit::Rate),
+            "sum(irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
         );
     }
 
     let from = migrations.subgroup("Outgoing Migrations");
     from.describe("Tasks migrated off a CPU, per second.");
-    from.plot_promql(
-        PlotOpts::counter("From", "cpu-migrations-from", Unit::Rate),
-        "sum(irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
-    );
     if multi_cpu {
+        from.plot_promql(
+            PlotOpts::counter("From", "cpu-migrations-from", Unit::Rate),
+            "sum(irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
+        );
         from.plot_promql(
             PlotOpts::counter("From (Per-CPU)", "cpu-migrations-from-per-cpu", Unit::Rate),
             "sum by (id) (irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
+        );
+    } else {
+        from.plot_promql_full(
+            PlotOpts::counter("From", "cpu-migrations-from", Unit::Rate),
+            "sum(irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
         );
     }
 
@@ -267,14 +330,19 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let total = tlb.subgroup("Total TLB Flushes");
     total.describe("Aggregate TLB invalidation rate across all reasons.");
-    total.plot_promql(
-        PlotOpts::counter("Total", "tlb-total", Unit::Rate),
-        "sum(irate(cpu_tlb_flush[5m]))".to_string(),
-    );
     if multi_cpu {
+        total.plot_promql(
+            PlotOpts::counter("Total", "tlb-total", Unit::Rate),
+            "sum(irate(cpu_tlb_flush[5m]))".to_string(),
+        );
         total.plot_promql(
             PlotOpts::counter("Total (Per-CPU)", "tlb-total-per-cpu", Unit::Rate),
             "sum by (id) (irate(cpu_tlb_flush[5m]))".to_string(),
+        );
+    } else {
+        total.plot_promql_full(
+            PlotOpts::counter("Total", "tlb-total", Unit::Rate),
+            "sum(irate(cpu_tlb_flush[5m]))".to_string(),
         );
     }
 
@@ -287,11 +355,11 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         let (reason_value, label) = reason;
         let id = format!("tlb-{}", reason_value.replace('_', "-"));
         let sg = tlb.subgroup(*label);
-        sg.plot_promql(
-            PlotOpts::counter(*label, &id, Unit::Rate),
-            format!("sum(irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
-        );
         if multi_cpu {
+            sg.plot_promql(
+                PlotOpts::counter(*label, &id, Unit::Rate),
+                format!("sum(irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
+            );
             sg.plot_promql(
                 PlotOpts::counter(
                     format!("{label} (Per-CPU)"),
@@ -299,6 +367,11 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
                     Unit::Rate,
                 ),
                 format!("sum by (id) (irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
+            );
+        } else {
+            sg.plot_promql_full(
+                PlotOpts::counter(*label, &id, Unit::Rate),
+                format!("sum(irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
             );
         }
     }

--- a/crates/dashboard/src/dashboard/cpu.rs
+++ b/crates/dashboard/src/dashboard/cpu.rs
@@ -1,8 +1,24 @@
 use crate::Tsdb;
 use crate::plot::*;
 
+/// True iff the recording has more than one CPU. Per-core charts are
+/// suppressed when this is false because they degenerate to the aggregate.
+fn has_multiple_cpus(data: &Tsdb) -> bool {
+    [
+        "cpu_usage",
+        "cpu_cycles",
+        "cpu_instructions",
+        "cpu_tsc",
+        "cpu_aperf",
+        "cpu_mperf",
+    ]
+    .iter()
+    .any(|m| metric_unique_label_count(data, m, "id") > 1)
+}
+
 pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
+    let multi_cpu = has_multiple_cpus(data);
 
     /*
      * Utilization
@@ -16,11 +32,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("Busy %", "busy-pct", Unit::Percentage).percentage_range(),
         "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000".to_string(),
     );
-    busy.plot_promql(
-        PlotOpts::counter("Busy % (Per-CPU)", "busy-pct-per-cpu", Unit::Percentage)
-            .percentage_range(),
-        "sum by (id) (irate(cpu_usage[5m])) / 1000000000".to_string(),
-    );
+    if multi_cpu {
+        busy.plot_promql(
+            PlotOpts::counter("Busy % (Per-CPU)", "busy-pct-per-cpu", Unit::Percentage)
+                .percentage_range(),
+            "sum by (id) (irate(cpu_usage[5m])) / 1000000000".to_string(),
+        );
+    }
 
     let by_state = utilization.subgroup("CPU Time by State");
     by_state.describe("Kernel vs. user-space CPU time, aggregate and per-core.");
@@ -35,15 +53,17 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .percentage_range(),
             format!("sum(irate(cpu_usage{{state=\"{state}\"}}[5m])) / cpu_cores / 1000000000"),
         );
-        by_state.plot_promql(
-            PlotOpts::counter(
-                format!("{capitalized} % (Per-CPU)"),
-                format!("{state}-pct-per-cpu"),
-                Unit::Percentage,
-            )
-            .percentage_range(),
-            format!("sum by (id) (irate(cpu_usage{{state=\"{state}\"}}[5m])) / 1000000000"),
-        );
+        if multi_cpu {
+            by_state.plot_promql(
+                PlotOpts::counter(
+                    format!("{capitalized} % (Per-CPU)"),
+                    format!("{state}-pct-per-cpu"),
+                    Unit::Percentage,
+                )
+                .percentage_range(),
+                format!("sum by (id) (irate(cpu_usage{{state=\"{state}\"}}[5m])) / 1000000000"),
+            );
+        }
     }
 
     view.group(utilization);
@@ -60,11 +80,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("IPC", "ipc", Unit::Count),
         "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m]))".to_string(),
     );
-    ipc.plot_promql(
-        PlotOpts::counter("IPC (Per-CPU)", "ipc-per-cpu", Unit::Count),
-        "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m]))"
-            .to_string(),
-    );
+    if multi_cpu {
+        ipc.plot_promql(
+            PlotOpts::counter("IPC (Per-CPU)", "ipc-per-cpu", Unit::Count),
+            "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m]))"
+                .to_string(),
+        );
+    }
 
     let ipns = performance.subgroup("Instructions per Nanosecond");
     ipns.describe("Wall-clock-normalized instruction throughput — accounts for frequency scaling.");
@@ -72,10 +94,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("IPNS", "ipns", Unit::Count),
         "sum(irate(cpu_instructions[5m])) / sum(irate(cpu_cycles[5m])) * sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / 1000000000 / cpu_cores".to_string(),
     );
-    ipns.plot_promql(
-        PlotOpts::counter("IPNS (Per-CPU)", "ipns-per-cpu", Unit::Count),
-        "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m])) * sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m])) / 1000000000".to_string(),
-    );
+    if multi_cpu {
+        ipns.plot_promql(
+            PlotOpts::counter("IPNS (Per-CPU)", "ipns-per-cpu", Unit::Count),
+            "sum by (id) (irate(cpu_instructions[5m])) / sum by (id) (irate(cpu_cycles[5m])) * sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m])) / 1000000000".to_string(),
+        );
+    }
 
     let l3 = performance.subgroup("L3 Cache Hit Rate");
     l3.describe("Fraction of L3 cache accesses that hit, indicating last-level cache efficiency.");
@@ -83,12 +107,14 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("L3 Hit %", "l3-hit", Unit::Percentage).percentage_range(),
         "1 - sum(irate(cpu_l3_miss[5m])) / sum(irate(cpu_l3_access[5m]))".to_string(),
     );
-    l3.plot_promql(
-        PlotOpts::counter("L3 Hit % (Per-CPU)", "l3-hit-per-cpu", Unit::Percentage)
-            .percentage_range(),
-        "1 - sum by (id) (irate(cpu_l3_miss[5m])) / sum by (id) (irate(cpu_l3_access[5m]))"
-            .to_string(),
-    );
+    if multi_cpu {
+        l3.plot_promql(
+            PlotOpts::counter("L3 Hit % (Per-CPU)", "l3-hit-per-cpu", Unit::Percentage)
+                .percentage_range(),
+            "1 - sum by (id) (irate(cpu_l3_miss[5m])) / sum by (id) (irate(cpu_l3_access[5m]))"
+                .to_string(),
+        );
+    }
 
     let freq = performance.subgroup("Frequency");
     freq.describe("Effective CPU clock speed, averaged and per-core.");
@@ -96,10 +122,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("Frequency", "frequency", Unit::Frequency),
         "sum(irate(cpu_tsc[5m])) * sum(irate(cpu_aperf[5m])) / sum(irate(cpu_mperf[5m])) / cpu_cores".to_string(),
     );
-    freq.plot_promql(
-        PlotOpts::counter("Frequency (Per-CPU)", "frequency-per-cpu", Unit::Frequency),
-        "sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m]))".to_string(),
-    );
+    if multi_cpu {
+        freq.plot_promql(
+            PlotOpts::counter("Frequency (Per-CPU)", "frequency-per-cpu", Unit::Frequency),
+            "sum by (id) (irate(cpu_tsc[5m])) * sum by (id) (irate(cpu_aperf[5m])) / sum by (id) (irate(cpu_mperf[5m]))".to_string(),
+        );
+    }
 
     view.group(performance);
 
@@ -116,16 +144,18 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .percentage_range(),
         "sum(irate(cpu_branch_misses[5m])) / sum(irate(cpu_branch_instructions[5m]))".to_string(),
     );
-    miss.plot_promql(
-        PlotOpts::counter(
-            "Misprediction Rate % (Per-CPU)",
-            "branch-miss-rate-per-cpu",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum by (id) (irate(cpu_branch_misses[5m])) / sum by (id) (irate(cpu_branch_instructions[5m]))"
-            .to_string(),
-    );
+    if multi_cpu {
+        miss.plot_promql(
+            PlotOpts::counter(
+                "Misprediction Rate % (Per-CPU)",
+                "branch-miss-rate-per-cpu",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "sum by (id) (irate(cpu_branch_misses[5m])) / sum by (id) (irate(cpu_branch_instructions[5m]))"
+                .to_string(),
+        );
+    }
 
     let activity = branch.subgroup("Branch Activity");
     activity.describe("Absolute branch instruction and miss rates.");
@@ -133,22 +163,26 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("Instructions", "branch-instructions", Unit::Rate),
         "sum(irate(cpu_branch_instructions[5m]))".to_string(),
     );
-    activity.plot_promql(
-        PlotOpts::counter(
-            "Instructions (Per-CPU)",
-            "branch-instructions-per-cpu",
-            Unit::Rate,
-        ),
-        "sum by (id) (irate(cpu_branch_instructions[5m]))".to_string(),
-    );
+    if multi_cpu {
+        activity.plot_promql(
+            PlotOpts::counter(
+                "Instructions (Per-CPU)",
+                "branch-instructions-per-cpu",
+                Unit::Rate,
+            ),
+            "sum by (id) (irate(cpu_branch_instructions[5m]))".to_string(),
+        );
+    }
     activity.plot_promql(
         PlotOpts::counter("Misses", "branch-misses", Unit::Rate),
         "sum(irate(cpu_branch_misses[5m]))".to_string(),
     );
-    activity.plot_promql(
-        PlotOpts::counter("Misses (Per-CPU)", "branch-misses-per-cpu", Unit::Rate),
-        "sum by (id) (irate(cpu_branch_misses[5m]))".to_string(),
-    );
+    if multi_cpu {
+        activity.plot_promql(
+            PlotOpts::counter("Misses (Per-CPU)", "branch-misses-per-cpu", Unit::Rate),
+            "sum by (id) (irate(cpu_branch_misses[5m]))".to_string(),
+        );
+    }
 
     view.group(branch);
 
@@ -168,10 +202,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("Misses", "dtlb-misses", Unit::Rate),
         "sum(irate(cpu_dtlb_miss[5m]))".to_string(),
     );
-    misses.plot_promql(
-        PlotOpts::counter("Misses (Per-CPU)", "dtlb-misses-per-cpu", Unit::Rate),
-        "sum by (id) (irate(cpu_dtlb_miss[5m]))".to_string(),
-    );
+    if multi_cpu {
+        misses.plot_promql(
+            PlotOpts::counter("Misses (Per-CPU)", "dtlb-misses-per-cpu", Unit::Rate),
+            "sum by (id) (irate(cpu_dtlb_miss[5m]))".to_string(),
+        );
+    }
 
     let mpki = dtlb.subgroup("DTLB MPKI");
     mpki.describe("Misses per thousand instructions, normalized so workload differences don't distort the rate.");
@@ -179,11 +215,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("MPKI", "dtlb-mpki", Unit::Count),
         "sum(irate(cpu_dtlb_miss[5m])) / sum(irate(cpu_instructions[5m])) * 1000".to_string(),
     );
-    mpki.plot_promql(
-        PlotOpts::counter("MPKI (Per-CPU)", "dtlb-mpki-per-cpu", Unit::Count),
-        "sum by (id) (irate(cpu_dtlb_miss[5m])) / sum by (id) (irate(cpu_instructions[5m])) * 1000"
-            .to_string(),
-    );
+    if multi_cpu {
+        mpki.plot_promql(
+            PlotOpts::counter("MPKI (Per-CPU)", "dtlb-mpki-per-cpu", Unit::Count),
+            "sum by (id) (irate(cpu_dtlb_miss[5m])) / sum by (id) (irate(cpu_instructions[5m])) * 1000"
+                .to_string(),
+        );
+    }
 
     view.group(dtlb);
 
@@ -199,10 +237,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("To", "cpu-migrations-to", Unit::Rate),
         "sum(irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
     );
-    to.plot_promql(
-        PlotOpts::counter("To (Per-CPU)", "cpu-migrations-to-per-cpu", Unit::Rate),
-        "sum by (id) (irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
-    );
+    if multi_cpu {
+        to.plot_promql(
+            PlotOpts::counter("To (Per-CPU)", "cpu-migrations-to-per-cpu", Unit::Rate),
+            "sum by (id) (irate(cpu_migrations{direction=\"to\"}[5m]))".to_string(),
+        );
+    }
 
     let from = migrations.subgroup("Outgoing Migrations");
     from.describe("Tasks migrated off a CPU, per second.");
@@ -210,10 +250,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("From", "cpu-migrations-from", Unit::Rate),
         "sum(irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
     );
-    from.plot_promql(
-        PlotOpts::counter("From (Per-CPU)", "cpu-migrations-from-per-cpu", Unit::Rate),
-        "sum by (id) (irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
-    );
+    if multi_cpu {
+        from.plot_promql(
+            PlotOpts::counter("From (Per-CPU)", "cpu-migrations-from-per-cpu", Unit::Rate),
+            "sum by (id) (irate(cpu_migrations{direction=\"from\"}[5m]))".to_string(),
+        );
+    }
 
     view.group(migrations);
 
@@ -229,10 +271,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::counter("Total", "tlb-total", Unit::Rate),
         "sum(irate(cpu_tlb_flush[5m]))".to_string(),
     );
-    total.plot_promql(
-        PlotOpts::counter("Total (Per-CPU)", "tlb-total-per-cpu", Unit::Rate),
-        "sum by (id) (irate(cpu_tlb_flush[5m]))".to_string(),
-    );
+    if multi_cpu {
+        total.plot_promql(
+            PlotOpts::counter("Total (Per-CPU)", "tlb-total-per-cpu", Unit::Rate),
+            "sum by (id) (irate(cpu_tlb_flush[5m]))".to_string(),
+        );
+    }
 
     for reason in &[
         ("local_mm_shootdown", "Local MM Shootdown"),
@@ -247,14 +291,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             PlotOpts::counter(*label, &id, Unit::Rate),
             format!("sum(irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
         );
-        sg.plot_promql(
-            PlotOpts::counter(
-                format!("{label} (Per-CPU)"),
-                format!("{id}-per-cpu"),
-                Unit::Rate,
-            ),
-            format!("sum by (id) (irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
-        );
+        if multi_cpu {
+            sg.plot_promql(
+                PlotOpts::counter(
+                    format!("{label} (Per-CPU)"),
+                    format!("{id}-per-cpu"),
+                    Unit::Rate,
+                ),
+                format!("sum by (id) (irate(cpu_tlb_flush{{reason=\"{reason_value}\"}}[5m]))"),
+            );
+        }
     }
 
     view.group(tlb);

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -104,8 +104,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     sm.describe("Streaming multiprocessor active time and warp occupancy — core indicators of compute efficiency.");
     if multi_gpu {
         sm.plot_promql(
-            PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage)
-                .percentage_range(),
+            PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).percentage_range(),
             "avg(gpu_sm_utilization) / 100".to_string(),
         );
         sm.plot_promql(
@@ -133,8 +132,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         );
     } else {
         sm.plot_promql_full(
-            PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage)
-                .percentage_range(),
+            PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).percentage_range(),
             "avg(gpu_sm_utilization) / 100".to_string(),
         );
         sm.plot_promql_full(

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -29,25 +29,31 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let gpu = utilization.subgroup("GPU Utilization");
     gpu.describe("Fraction of time the GPU has work scheduled, averaged and per-device.");
-    gpu.plot_promql(
-        PlotOpts::gauge("GPU %", "gpu-pct", Unit::Percentage).percentage_range(),
-        "avg(gpu_utilization) / 100".to_string(),
-    );
     if multi_gpu {
+        gpu.plot_promql(
+            PlotOpts::gauge("GPU %", "gpu-pct", Unit::Percentage).percentage_range(),
+            "avg(gpu_utilization) / 100".to_string(),
+        );
         gpu.plot_promql(
             PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage)
                 .percentage_range(),
             "sum by (id) (gpu_utilization) / 100".to_string(),
         );
+    } else {
+        gpu.plot_promql_full(
+            PlotOpts::gauge("GPU %", "gpu-pct", Unit::Percentage).percentage_range(),
+            "avg(gpu_utilization) / 100".to_string(),
+        );
     }
 
     let mem_ctrl = utilization.subgroup("Memory Controller");
     mem_ctrl.describe("Fraction of time the memory controller is servicing requests.");
-    mem_ctrl.plot_promql(
-        PlotOpts::gauge("Memory Controller %", "mem-ctrl-pct", Unit::Percentage).percentage_range(),
-        "avg(gpu_memory_utilization) / 100".to_string(),
-    );
     if multi_gpu {
+        mem_ctrl.plot_promql(
+            PlotOpts::gauge("Memory Controller %", "mem-ctrl-pct", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_memory_utilization) / 100".to_string(),
+        );
         mem_ctrl.plot_promql(
             PlotOpts::gauge(
                 "Memory Controller % (Per-GPU)",
@@ -57,6 +63,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .percentage_range(),
             "sum by (id) (gpu_memory_utilization) / 100".to_string(),
         );
+    } else {
+        mem_ctrl.plot_promql_full(
+            PlotOpts::gauge("Memory Controller %", "mem-ctrl-pct", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_memory_utilization) / 100".to_string(),
+        );
     }
 
     view.group(utilization);
@@ -65,12 +77,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let tensor = activity.subgroup("Tensor Activity");
     tensor.describe("Tensor core utilization — how busy the matrix-math units are.");
-    tensor.plot_promql(
-        PlotOpts::gauge("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage)
-            .percentage_range(),
-        "avg(gpu_tensor_utilization) / 100".to_string(),
-    );
     if multi_gpu {
+        tensor.plot_promql(
+            PlotOpts::gauge("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_tensor_utilization) / 100".to_string(),
+        );
         tensor.plot_promql(
             PlotOpts::gauge(
                 "GPU Tensor Activity % (Per-GPU)",
@@ -80,15 +92,22 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .percentage_range(),
             "sum by (id) (gpu_tensor_utilization) / 100".to_string(),
         );
+    } else {
+        tensor.plot_promql_full(
+            PlotOpts::gauge("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_tensor_utilization) / 100".to_string(),
+        );
     }
 
     let sm = activity.subgroup("SM Activity & Occupancy");
     sm.describe("Streaming multiprocessor active time and warp occupancy — core indicators of compute efficiency.");
-    sm.plot_promql(
-        PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).percentage_range(),
-        "avg(gpu_sm_utilization) / 100".to_string(),
-    );
     if multi_gpu {
+        sm.plot_promql(
+            PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_sm_utilization) / 100".to_string(),
+        );
         sm.plot_promql(
             PlotOpts::gauge(
                 "GPU SM Activity % (Per-GPU)",
@@ -98,12 +117,11 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .percentage_range(),
             "sum by (id) (gpu_sm_utilization) / 100".to_string(),
         );
-    }
-    sm.plot_promql(
-        PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage).percentage_range(),
-        "avg(gpu_sm_occupancy) / 100".to_string(),
-    );
-    if multi_gpu {
+        sm.plot_promql(
+            PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_sm_occupancy) / 100".to_string(),
+        );
         sm.plot_promql(
             PlotOpts::gauge(
                 "GPU SM Occupancy % (Per-GPU)",
@@ -112,6 +130,17 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             )
             .percentage_range(),
             "sum by (id) (gpu_sm_occupancy) / 100".to_string(),
+        );
+    } else {
+        sm.plot_promql_full(
+            PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_sm_utilization) / 100".to_string(),
+        );
+        sm.plot_promql_full(
+            PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage)
+                .percentage_range(),
+            "avg(gpu_sm_occupancy) / 100".to_string(),
         );
     }
 
@@ -154,16 +183,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let dram_bw = memory.subgroup("DRAM Bandwidth");
     dram_bw.describe("Fraction of peak memory bandwidth in use.");
-    dram_bw.plot_promql(
-        PlotOpts::gauge(
-            "DRAM Bandwidth Utilization %",
-            "gpu-dram-act",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
-    );
     if multi_gpu {
+        dram_bw.plot_promql(
+            PlotOpts::gauge(
+                "DRAM Bandwidth Utilization %",
+                "gpu-dram-act",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
+        );
         dram_bw.plot_promql(
             PlotOpts::gauge(
                 "DRAM Bandwidth % (Per-GPU)",
@@ -172,6 +201,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             )
             .percentage_range(),
             "sum by (id) (gpu_dram_bandwidth_utilization) / 100".to_string(),
+        );
+    } else {
+        dram_bw.plot_promql_full(
+            PlotOpts::gauge(
+                "DRAM Bandwidth Utilization %",
+                "gpu-dram-act",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
         );
     }
 
@@ -234,15 +273,20 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let draw = power.subgroup("Power Draw");
     draw.describe("Instantaneous power consumption, total and per-GPU.");
-    draw.plot_promql(
-        PlotOpts::gauge("Power (W)", "power-watts", Unit::Count).with_axis_label("Watts"),
-        "sum(gpu_power_usage) / 1000".to_string(),
-    );
     if multi_gpu {
+        draw.plot_promql(
+            PlotOpts::gauge("Power (W)", "power-watts", Unit::Count).with_axis_label("Watts"),
+            "sum(gpu_power_usage) / 1000".to_string(),
+        );
         draw.plot_promql(
             PlotOpts::gauge("Power (Per-GPU)", "power-watts-per-gpu", Unit::Count)
                 .with_axis_label("Watts"),
             "sum by (id) (gpu_power_usage) / 1000".to_string(),
+        );
+    } else {
+        draw.plot_promql_full(
+            PlotOpts::gauge("Power (W)", "power-watts", Unit::Count).with_axis_label("Watts"),
+            "sum(gpu_power_usage) / 1000".to_string(),
         );
     }
 
@@ -269,11 +313,16 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
                 .with_axis_label("°C"),
             "sum by (id) (gpu_temperature)".to_string(),
         );
+        temps.plot_promql(
+            PlotOpts::gauge("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
+            "max(gpu_temperature)".to_string(),
+        );
+    } else {
+        temps.plot_promql_full(
+            PlotOpts::gauge("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
+            "max(gpu_temperature)".to_string(),
+        );
     }
-    temps.plot_promql(
-        PlotOpts::gauge("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
-        "max(gpu_temperature)".to_string(),
-    );
 
     view.group(thermal);
 

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -1,8 +1,25 @@
 use crate::Tsdb;
 use crate::plot::*;
 
+/// True iff the recording has more than one GPU. Per-device charts are
+/// suppressed when this is false because they degenerate to the aggregate.
+fn has_multiple_gpus(data: &Tsdb) -> bool {
+    [
+        "gpu_utilization",
+        "gpu_memory",
+        "gpu_temperature",
+        "gpu_power_usage",
+        "gpu_clock",
+        "gpu_memory_utilization",
+        "gpu_dram_bandwidth_utilization",
+    ]
+    .iter()
+    .any(|m| metric_unique_label_count(data, m, "id") > 1)
+}
+
 pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
+    let multi_gpu = has_multiple_gpus(data);
 
     /*
      * Utilization
@@ -16,10 +33,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::gauge("GPU %", "gpu-pct", Unit::Percentage).percentage_range(),
         "avg(gpu_utilization) / 100".to_string(),
     );
-    gpu.plot_promql(
-        PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage).percentage_range(),
-        "sum by (id) (gpu_utilization) / 100".to_string(),
-    );
+    if multi_gpu {
+        gpu.plot_promql(
+            PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage)
+                .percentage_range(),
+            "sum by (id) (gpu_utilization) / 100".to_string(),
+        );
+    }
 
     let mem_ctrl = utilization.subgroup("Memory Controller");
     mem_ctrl.describe("Fraction of time the memory controller is servicing requests.");
@@ -27,15 +47,17 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::gauge("Memory Controller %", "mem-ctrl-pct", Unit::Percentage).percentage_range(),
         "avg(gpu_memory_utilization) / 100".to_string(),
     );
-    mem_ctrl.plot_promql(
-        PlotOpts::gauge(
-            "Memory Controller % (Per-GPU)",
-            "mem-ctrl-pct-per-gpu",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum by (id) (gpu_memory_utilization) / 100".to_string(),
-    );
+    if multi_gpu {
+        mem_ctrl.plot_promql(
+            PlotOpts::gauge(
+                "Memory Controller % (Per-GPU)",
+                "mem-ctrl-pct-per-gpu",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "sum by (id) (gpu_memory_utilization) / 100".to_string(),
+        );
+    }
 
     view.group(utilization);
 
@@ -48,15 +70,17 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .percentage_range(),
         "avg(gpu_tensor_utilization) / 100".to_string(),
     );
-    tensor.plot_promql(
-        PlotOpts::gauge(
-            "GPU Tensor Activity % (Per-GPU)",
-            "gpu-tensor-act-per-gpu",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum by (id) (gpu_tensor_utilization) / 100".to_string(),
-    );
+    if multi_gpu {
+        tensor.plot_promql(
+            PlotOpts::gauge(
+                "GPU Tensor Activity % (Per-GPU)",
+                "gpu-tensor-act-per-gpu",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "sum by (id) (gpu_tensor_utilization) / 100".to_string(),
+        );
+    }
 
     let sm = activity.subgroup("SM Activity & Occupancy");
     sm.describe("Streaming multiprocessor active time and warp occupancy — core indicators of compute efficiency.");
@@ -64,28 +88,32 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).percentage_range(),
         "avg(gpu_sm_utilization) / 100".to_string(),
     );
-    sm.plot_promql(
-        PlotOpts::gauge(
-            "GPU SM Activity % (Per-GPU)",
-            "gpu-sm-act-per-gpu",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum by (id) (gpu_sm_utilization) / 100".to_string(),
-    );
+    if multi_gpu {
+        sm.plot_promql(
+            PlotOpts::gauge(
+                "GPU SM Activity % (Per-GPU)",
+                "gpu-sm-act-per-gpu",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "sum by (id) (gpu_sm_utilization) / 100".to_string(),
+        );
+    }
     sm.plot_promql(
         PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage).percentage_range(),
         "avg(gpu_sm_occupancy) / 100".to_string(),
     );
-    sm.plot_promql(
-        PlotOpts::gauge(
-            "GPU SM Occupancy % (Per-GPU)",
-            "gpu-sm-ocp-per-gpu",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum by (id) (gpu_sm_occupancy) / 100".to_string(),
-    );
+    if multi_gpu {
+        sm.plot_promql(
+            PlotOpts::gauge(
+                "GPU SM Occupancy % (Per-GPU)",
+                "gpu-sm-ocp-per-gpu",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "sum by (id) (gpu_sm_occupancy) / 100".to_string(),
+        );
+    }
 
     view.group(activity);
 
@@ -111,16 +139,18 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         "sum(gpu_memory{state=\"used\"}) / (sum(gpu_memory{state=\"used\"}) + sum(gpu_memory{state=\"free\"}))".to_string(),
     );
 
-    let per_device = memory.subgroup("Per-Device Capacity");
-    per_device.describe("Memory used and free broken out by GPU id.");
-    per_device.plot_promql(
-        PlotOpts::gauge("Used (Per-GPU)", "mem-used-per-gpu", Unit::Bytes),
-        "sum by (id) (gpu_memory{state=\"used\"})".to_string(),
-    );
-    per_device.plot_promql(
-        PlotOpts::gauge("Free (Per-GPU)", "mem-free-per-gpu", Unit::Bytes),
-        "sum by (id) (gpu_memory{state=\"free\"})".to_string(),
-    );
+    if multi_gpu {
+        let per_device = memory.subgroup("Per-Device Capacity");
+        per_device.describe("Memory used and free broken out by GPU id.");
+        per_device.plot_promql(
+            PlotOpts::gauge("Used (Per-GPU)", "mem-used-per-gpu", Unit::Bytes),
+            "sum by (id) (gpu_memory{state=\"used\"})".to_string(),
+        );
+        per_device.plot_promql(
+            PlotOpts::gauge("Free (Per-GPU)", "mem-free-per-gpu", Unit::Bytes),
+            "sum by (id) (gpu_memory{state=\"free\"})".to_string(),
+        );
+    }
 
     let dram_bw = memory.subgroup("DRAM Bandwidth");
     dram_bw.describe("Fraction of peak memory bandwidth in use.");
@@ -133,15 +163,17 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         .percentage_range(),
         "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
     );
-    dram_bw.plot_promql(
-        PlotOpts::gauge(
-            "DRAM Bandwidth % (Per-GPU)",
-            "gpu-dram-act-per-gpu",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum by (id) (gpu_dram_bandwidth_utilization) / 100".to_string(),
-    );
+    if multi_gpu {
+        dram_bw.plot_promql(
+            PlotOpts::gauge(
+                "DRAM Bandwidth % (Per-GPU)",
+                "gpu-dram-act-per-gpu",
+                Unit::Percentage,
+            )
+            .percentage_range(),
+            "sum by (id) (gpu_dram_bandwidth_utilization) / 100".to_string(),
+        );
+    }
 
     view.group(memory);
 
@@ -206,11 +238,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         PlotOpts::gauge("Power (W)", "power-watts", Unit::Count).with_axis_label("Watts"),
         "sum(gpu_power_usage) / 1000".to_string(),
     );
-    draw.plot_promql(
-        PlotOpts::gauge("Power (Per-GPU)", "power-watts-per-gpu", Unit::Count)
-            .with_axis_label("Watts"),
-        "sum by (id) (gpu_power_usage) / 1000".to_string(),
-    );
+    if multi_gpu {
+        draw.plot_promql(
+            PlotOpts::gauge("Power (Per-GPU)", "power-watts-per-gpu", Unit::Count)
+                .with_axis_label("Watts"),
+            "sum by (id) (gpu_power_usage) / 1000".to_string(),
+        );
+    }
 
     let energy = power.subgroup("Energy");
     energy.describe("Energy consumption rate derived from the accumulating GPU energy counter.");
@@ -229,10 +263,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let temps = thermal.subgroup("Temperatures");
     temps.describe("Per-device temperatures and the hottest GPU across the system.");
-    temps.plot_promql(
-        PlotOpts::gauge("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count).with_axis_label("°C"),
-        "sum by (id) (gpu_temperature)".to_string(),
-    );
+    if multi_gpu {
+        temps.plot_promql(
+            PlotOpts::gauge("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count)
+                .with_axis_label("°C"),
+            "sum by (id) (gpu_temperature)".to_string(),
+        );
+    }
     temps.plot_promql(
         PlotOpts::gauge("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
         "max(gpu_temperature)".to_string(),

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -1,6 +1,37 @@
 use metriken_query::Tsdb;
+use metriken_query::tsdb::Labels;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
+/// Count distinct values of `key` across `labels`. Series missing the
+/// key are skipped. Used by section generators to decide whether
+/// per-device charts are worth showing (a single GPU/CPU makes the
+/// per-device variant identical to the aggregate).
+pub fn unique_label_count(labels: &[Labels], key: &str) -> usize {
+    let mut seen: HashSet<&str> = HashSet::new();
+    for l in labels {
+        if let Some(v) = l.inner.get(key) {
+            seen.insert(v.as_str());
+        }
+    }
+    seen.len()
+}
+
+/// Convenience: how many distinct values of `key` exist for `metric`
+/// in `data`, looking across counter/gauge/histogram collections.
+/// Returns 0 if the metric is unknown.
+pub fn metric_unique_label_count(data: &Tsdb, metric: &str, key: &str) -> usize {
+    if let Some(l) = data.gauge_labels(metric) {
+        return unique_label_count(&l, key);
+    }
+    if let Some(l) = data.counter_labels(metric) {
+        return unique_label_count(&l, key);
+    }
+    if let Some(l) = data.histogram_labels(metric) {
+        return unique_label_count(&l, key);
+    }
+    0
+}
 
 #[derive(Default, Serialize)]
 pub struct View {
@@ -600,6 +631,34 @@ mod tests {
             json["subgroups"][0]["description"],
             "Shows total throughput and IOPS."
         );
+    }
+
+    #[test]
+    fn unique_label_count_returns_zero_for_empty_input() {
+        let labels: Vec<metriken_query::tsdb::Labels> = vec![];
+        assert_eq!(unique_label_count(&labels, "id"), 0);
+    }
+
+    #[test]
+    fn unique_label_count_counts_distinct_values() {
+        use metriken_query::tsdb::Labels;
+        let labels: Vec<Labels> = vec![
+            Labels::from([("id", "0"), ("state", "user")].as_slice()),
+            Labels::from([("id", "0"), ("state", "system")].as_slice()),
+            Labels::from([("id", "1"), ("state", "user")].as_slice()),
+            Labels::from([("id", "1"), ("state", "system")].as_slice()),
+        ];
+        assert_eq!(unique_label_count(&labels, "id"), 2);
+    }
+
+    #[test]
+    fn unique_label_count_ignores_series_missing_the_key() {
+        use metriken_query::tsdb::Labels;
+        let labels: Vec<Labels> = vec![
+            Labels::from([("id", "0")].as_slice()),
+            Labels::from([("other", "x")].as_slice()),
+        ];
+        assert_eq!(unique_label_count(&labels, "id"), 1);
     }
 }
 


### PR DESCRIPTION
## Summary

When a recording has only a single GPU or single CPU, the `(Per-GPU)` / `(Per-CPU)` companion charts are mathematically identical to their aggregate counterparts and just add visual clutter. This PR drops those redundant charts at dashboard generation time.

## Implementation

- New `unique_label_count(&[Labels], key)` and `metric_unique_label_count(&Tsdb, metric, key)` helpers in `crates/dashboard/src/plot.rs`, with unit tests for empty input, distinct counting, and series missing the key.
- `has_multiple_gpus(data)` in `gpu.rs` and `has_multiple_cpus(data)` in `cpu.rs` union the cardinality across a handful of foundational metrics so a recording missing any one of them (e.g. no DCGM-extended counters) still gets the right answer from the others.
- Each `(Per-GPU)` / `(Per-CPU)` plot is wrapped in `if multi_gpu { … }` / `if multi_cpu { … }`. The "Per-Device Capacity" GPU memory subgroup is also dropped wholesale on single-GPU.
- The GPU **Clocks** subgroup is intentionally left alone: its charts have no aggregate counterpart, so a single-GPU view there is informative rather than redundant.

## Notes

- Existing metriken-query API (`gauge_labels` / `counter_labels` / `histogram_labels`) was sufficient — no upstream change needed. Cardinalities here are tiny (≤8 GPUs, ≤128 CPUs), so the `Vec<Labels>` clone cost is irrelevant.
- Bumps to `5.11.1-alpha.18`.

## Test plan

- [x] `cargo test -p dashboard` — 27 passed
- [x] `cargo build -p dashboard` clean
- [x] Eyeball a single-GPU recording (e.g. a Mac/laptop capture) — confirm GPU section no longer shows the duplicate per-GPU charts
- [x] Eyeball a multi-GPU recording (e.g. an H100 box) — confirm per-GPU charts still render
- [x] Same for single-CPU vs multi-CPU recordings

🤖 Generated with [Claude Code](https://claude.com/claude-code)