### PR TITLE
fix(viewer): make multi-node selector tappable on mobile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.19"
+version = "5.11.1-alpha.20"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.19"
+version = "5.11.1-alpha.20"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -2862,13 +2862,19 @@ main {
         font-size: var(--font-size-base);
     }
 
-    /* Show filename but hide expandable metadata on mobile */
+    /* Show filename but hide expandable metadata on mobile.
+     * pointer-events stays on the wrapper for the static-label case, but
+     * scope it to .topnav-source-name so the multi-node <select> child
+     * (rendered without a .topnav-source-name span) remains tappable. */
     .topnav-source {
-        pointer-events: none;
         overflow: hidden;
         text-overflow: ellipsis;
         min-width: 0;
         flex: 1;
+    }
+
+    .topnav-source-name {
+        pointer-events: none;
     }
 
     /* Shrink transport buttons */


### PR DESCRIPTION
## Summary

The mobile media query in `style.css` set `pointer-events: none` on `.topnav-source` to keep the static filename label from hijacking touches. The same wrapper class is reused as the parent of the multi-node `<select>` (added in the multi-node viewer work), so on phones the dropdown silently refused to open while desktop worked fine.

Move the `pointer-events: none` rule onto `.topnav-source-name` — that span is only emitted in the static-label case, so the wrapper itself stays interactive when its child is the `<select>`. Desktop unaffected.

## Test plan

- [ ] Open a multi-node recording on a mobile browser, tap the node dropdown in the topnav — should open
- [x] Open the same recording on desktop — node dropdown still works, filename label still non-interactive
- [x] Open a single-node recording on mobile — filename label remains a non-interactive truncating label

🤖 Generated with [Claude Code](https://claude.com/claude-code)