### PR TITLE
feat(viewer): add quantile heatmap (Full + Tail) for histograms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.20"
+version = "5.11.1-alpha.21"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.20"
+version = "5.11.1-alpha.21"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/charts/quantile_heatmap.js
+++ b/site/viewer/lib/charts/quantile_heatmap.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/charts/quantile_heatmap.js

--- a/src/viewer/assets/lib/charts/base.js
+++ b/src/viewer/assets/lib/charts/base.js
@@ -140,6 +140,15 @@ export function getTooltipFormatter(valueFormatter, pinnedSet, chart, style) {
 // band that precedes the grid.
 export const CHART_GRID_TOP_WITH_LEGEND = 71;
 
+// Fixed left gutter (in px) for histogram-family charts: percentile
+// scatter, full-spectrum quantile heatmap, and tail-spectrum quantile
+// heatmap. All three share the same gutter so toggling between them
+// keeps the y-axis position rock-steady. Sized to fit typical formatted
+// histogram labels (e.g. "100 μs", "1.5 ms", "p99.99") in the
+// JetBrains Mono 10px axis font; containLabel is set to false on
+// these charts so the value here is the actual rendered gutter.
+export const HISTOGRAM_CHART_GRID_LEFT = 60;
+
 export function getBaseOption() {
     return {
         grid: {
@@ -284,7 +293,7 @@ export function overrideXAxisFormatter(baseXAxis, customFormatter) {
  * overlays. The caller is responsible for pairing this with
  * `grid: { ..., top: '71' }` on the plot's option.
  */
-export function buildOverlayLegendOption(names, { tooltipFormatter, top = '42' } = {}) {
+export function buildOverlayLegendOption(names, { tooltipFormatter, top = '42', right = '16' } = {}) {
     const legendItemW = 56;
     const textStyleBase = {
         color: COLORS.fgSecondary,
@@ -297,7 +306,7 @@ export function buildOverlayLegendOption(names, { tooltipFormatter, top = '42' }
     };
     const legend = {
         show: true,
-        right: '16',
+        right,
         top,
         icon: 'circle',
         itemWidth: 8,

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -12,6 +12,9 @@ import {
     configureHistogramHeatmap
 } from './histogram_heatmap.js';
 import {
+    configureQuantileHeatmap
+} from './quantile_heatmap.js';
+import {
     configureMultiSeriesChart
 } from './multi.js';
 import globalColorMapper, { COLORS } from './util/colormap.js';
@@ -671,7 +674,10 @@ export class Chart {
         const style = resolvedStyle(this.spec)
             || resolveStyle(this.spec.opts.type, this.spec.opts.subtype);
         // Only for chart types with a value/log Y-axis
-        if (style === 'heatmap' || style === 'histogram_heatmap') return;
+        if (style === 'heatmap' || style === 'histogram_heatmap' || style === 'quantile_heatmap') return;
+        // Scatter charts in spectrum mode (full/tail) are rendered as
+        // quantile heatmaps; they own no value Y-axis to rescale.
+        if (style === 'scatter' && this.spectrumKind) return;
 
         // In compare-mode overlays, spec.data holds only the baseline's
         // [timeData, valueData]; the experiment values live in
@@ -803,9 +809,19 @@ export class Chart {
 
         // Clean up heatmap DOM legend bar when switching to a different chart type
         // (e.g. heatmap-mode toggle off). The legend lives inside chart.domNode
-        // now, so clear it from the same scope.
-        if (style !== 'histogram_heatmap' && style !== 'heatmap') {
+        // now, so clear it from the same scope. Scatter charts in spectrum mode
+        // render as a quantile heatmap and own a legend bar too.
+        const ownsLegendBar =
+            style === 'histogram_heatmap'
+            || style === 'heatmap'
+            || style === 'quantile_heatmap'
+            || (style === 'scatter' && this.spectrumKind);
+        if (!ownsLegendBar) {
             this.domNode?.querySelector('.heatmap-legend-bar')?.remove();
+        }
+        // The spectrum controls only belong on scatter charts.
+        if (style !== 'scatter') {
+            this.domNode?.querySelector('.spectrum-controls')?.remove();
         }
 
         // Handle different chart types by delegating to specialized modules
@@ -815,6 +831,8 @@ export class Chart {
             configureHeatmap(this, this.spec, this.chartsState);
         } else if (style === 'histogram_heatmap') {
             configureHistogramHeatmap(this, this.spec, this.chartsState);
+        } else if (style === 'quantile_heatmap') {
+            configureQuantileHeatmap(this, this.spec, this.chartsState);
         } else if (style === 'scatter') {
             configureScatterChart(this, this.spec, this.chartsState);
         } else if (style === 'multi') {

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -20,7 +20,7 @@ export function compatibleStyles(type_) {
         case 'delta_counter':
             return ['line', 'heatmap', 'multi'];
         case 'histogram':
-            return ['scatter', 'histogram_heatmap'];
+            return ['scatter', 'histogram_heatmap', 'quantile_heatmap'];
         default:
             return ['line'];
     }
@@ -46,7 +46,9 @@ export function compatibleStyles(type_) {
  */
 export function resolveStyle(type_, subtype, result) {
     if (type_ === 'histogram') {
-        return subtype === 'buckets' ? 'histogram_heatmap' : 'scatter';
+        if (subtype === 'buckets') return 'histogram_heatmap';
+        if (subtype === 'quantile_heatmap') return 'quantile_heatmap';
+        return 'scatter';
     }
 
     // gauge or delta_counter: infer from result shape
@@ -75,7 +77,14 @@ export function buildHistogramQuery(baseQuery, subtype, percentiles, strideSecs)
     if (subtype === 'buckets') {
         return `histogram_heatmap(${baseQuery}${strideSuffix})`;
     }
-    const quantiles = percentiles || DEFAULT_PERCENTILES;
+    let quantiles;
+    if (subtype === 'quantile_heatmap') {
+        // 100-quantile spectrum: even, fine-grain coverage [0.01..1.00].
+        quantiles = [];
+        for (let i = 1; i <= 100; i++) quantiles.push(i / 100);
+    } else {
+        quantiles = percentiles || DEFAULT_PERCENTILES;
+    }
     return `histogram_quantiles([${quantiles.join(', ')}], ${baseQuery}${strideSuffix})`;
 }
 

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -1,0 +1,295 @@
+// quantile_heatmap.js — Heatmap of histogram quantiles vs time. Each
+// (time × quantile) cell is a colored rect; color reflects the value.
+// Color scale is log10 across the visible value range, RdYlGn flipped
+// (low value → green, high value → red).
+
+import { formatDateTime } from './util/utils.js';
+import { createAxisLabelFormatter } from './util/units.js';
+import {
+    getBaseOption,
+    applyNoData,
+    getTooltipFreezeFooter,
+    calculateMinZoomSpan,
+    getDataZoomConfig,
+    applyChartOption,
+    TIME_AXIS_FORMATTER,
+    CHART_GRID_TOP_WITH_LEGEND,
+    HISTOGRAM_CHART_GRID_LEFT,
+    COLORS,
+    FONTS,
+} from './base.js';
+import { rdYlGnColor } from './util/colormap.js';
+import { buildGradientCanvas, ensureLegendBar } from './color_legend.js';
+
+// Series names from the spectrum fetch are already formatted as `pXX`
+// (see fetchQuantileSpectrumForPlot). For specs that come from elsewhere
+// (e.g. raw fractions like "0.5"), coerce to the same `pXX` shape so
+// the y-axis labels stay uniform.
+const formatQuantileLabel = (raw) => {
+    if (typeof raw === 'string' && raw.startsWith('p')) return raw;
+    const q = parseFloat(raw);
+    if (!Number.isFinite(q)) return `p${raw}`;
+    const pct = q * 100;
+    const fixed = pct.toFixed(2).replace(/\.?0+$/, '');
+    return `p${fixed}`;
+};
+
+/**
+ * Configures the Chart for quantile heatmap visualization.
+ * Input shape matches the percentile scatter chart: data[0]=times,
+ * data[1..N]=per-quantile value series, with chart.spec.series_names
+ * carrying the raw quantile fractions (e.g. "0.5", "0.99").
+ *
+ * @param {import('./chart.js').Chart} chart
+ */
+export function configureQuantileHeatmap(chart) {
+    const { data, opts } = chart.spec;
+
+    if (!data || data.length < 2 || !data[0] || data[0].length === 0) {
+        applyNoData(chart);
+        return;
+    }
+
+    const baseOption = getBaseOption();
+    const format = opts.format || {};
+    const unitSystem = format.unit_system;
+
+    const timeData = data[0];
+    const tCount = timeData.length;
+    const seriesCount = data.length - 1;
+
+    const rawLabels = (chart.spec.series_names && chart.spec.series_names.length === seriesCount)
+        ? chart.spec.series_names
+        : Array.from({ length: seriesCount }, (_, i) => String((i + 1) / seriesCount));
+    const displayLabels = rawLabels.map(formatQuantileLabel);
+
+    // Color scale spans the non-null, positive value range across all cells.
+    let colorMin = Infinity;
+    let colorMax = -Infinity;
+    for (let s = 1; s <= seriesCount; s++) {
+        const col = data[s];
+        for (let t = 0; t < tCount; t++) {
+            const v = col[t];
+            if (v != null && !Number.isNaN(v) && v > 0) {
+                if (v < colorMin) colorMin = v;
+                if (v > colorMax) colorMax = v;
+            }
+        }
+    }
+    // Override colorMin with the p0 anchor when the spec carries one.
+    // This pins the lower bound of the color scale across spectrum
+    // kinds (full vs tail) so toggling between them doesn't repaint
+    // the whole heatmap with a different color range — Tail's rows
+    // (p99.01..p100) all sit near the top of the natural max, so
+    // without an anchor they'd remap to the full green→red span.
+    const anchor = chart.spec.color_min_anchor;
+    if (anchor != null && Number.isFinite(anchor) && anchor > 0) {
+        colorMin = anchor;
+    }
+    if (!Number.isFinite(colorMin)) colorMin = 0;
+    if (!Number.isFinite(colorMax)) colorMax = 1;
+    if (colorMax <= colorMin) colorMax = colorMin > 0 ? colorMin * 10 : 1;
+
+    // Log-scale color mapping. Guard against non-positive min by
+    // clamping inside the log to a tiny epsilon (the renderer already
+    // skips zero/negative cells, so this only matters when colorMin
+    // collapsed to its initialization value above).
+    const safeLog = (v) => Math.log10(v > 0 ? v : 1e-12);
+    const logMin = safeLog(colorMin);
+    const logMax = safeLog(colorMax);
+    const logRange = logMax - logMin || 1;
+
+    const timeIntervalMs = tCount > 1
+        ? (timeData[1] - timeData[0]) * 1000
+        : 1000;
+
+    // Cells: [timestampMs, quantileIdx, value]. Skip non-positive
+    // values — they'd be invisible anyway and break the log mapping.
+    const cells = [];
+    for (let t = 0; t < tCount; t++) {
+        const tsMs = timeData[t] * 1000;
+        for (let q = 0; q < seriesCount; q++) {
+            const v = data[q + 1][t];
+            if (v == null || Number.isNaN(v) || v <= 0) continue;
+            cells.push([tsMs, q, v]);
+        }
+    }
+
+    const renderItem = function (params, api) {
+        const tsMs = api.value(0);
+        const q = api.value(1);
+        const v = api.value(2);
+
+        const coordSys = params.coordSys;
+        const gridX = coordSys.x;
+        const gridY = coordSys.y;
+        const gridWidth = coordSys.width;
+        const gridHeight = coordSys.height;
+
+        const c0 = api.coord([tsMs, q - 0.5]);
+        const c1 = api.coord([tsMs + timeIntervalMs, q + 0.5]);
+        if (!c0 || !c1) return;
+
+        const overlap = 1;
+        let x = c0[0];
+        let y = c1[1] - overlap;
+        let width = c1[0] - c0[0] + overlap;
+        let height = c0[1] - c1[1] + overlap * 2;
+
+        if (width <= 0 || height <= 0) return;
+
+        if (x < gridX) { width -= (gridX - x); x = gridX; }
+        if (x + width > gridX + gridWidth) width = gridX + gridWidth - x;
+        if (y < gridY) { height -= (gridY - y); y = gridY; }
+        if (y + height > gridY + gridHeight) height = gridY + gridHeight - y;
+        if (width <= 0 || height <= 0) return;
+
+        const norm = Math.min(1, Math.max(0, (safeLog(v) - logMin) / logRange));
+        // Flip: low value → green (t=1), high value → red (t=0).
+        const color = rdYlGnColor(1 - norm);
+
+        return {
+            type: 'rect',
+            shape: { x, y, width, height },
+            style: { fill: color, stroke: null, lineWidth: 0 },
+        };
+    };
+
+    const valueFmt = unitSystem
+        ? createAxisLabelFormatter(unitSystem)
+        : (v) => String(v);
+
+    const customXFormatterForTooltip = chart.spec.xAxisFormatter;
+    const tooltipFormatter = function (params) {
+        if (!params.data) return '';
+        const [tsMs, q, v] = params.data;
+        const formattedTime = customXFormatterForTooltip
+            ? customXFormatterForTooltip(tsMs)
+            : formatDateTime(tsMs);
+        const label = displayLabels[q] || '';
+        return `<div style="${FONTS.cssSans}">
+            <div style="${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.fgSecondary}; margin-bottom: 8px;">
+                ${formattedTime}
+            </div>
+            <div style="display: flex; align-items: center; gap: 12px;">
+                <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
+                    ${label}
+                </span>
+                <span style="${FONTS.cssMono} font-weight: ${FONTS.tooltipValue.fontWeight}; font-size: ${FONTS.tooltipValue.fontSize}px; color: ${COLORS.fg};">
+                    ${valueFmt(v)}
+                </span>
+            </div>
+            ${getTooltipFreezeFooter(chart)}
+        </div>`;
+    };
+
+    const xAxisFormatter = chart.spec.xAxisFormatter || TIME_AXIS_FORMATTER;
+
+    // Show ~10 evenly spaced quantile labels. Walk backward from the
+    // top quantile so the highest row (most semantically meaningful)
+    // is always labeled — gives p10, p20, …, p100 for the full
+    // spectrum and p99.1, p99.2, …, p100 for the tail spectrum.
+    const labelStride = Math.max(1, Math.ceil(seriesCount / 10));
+    const tickIndices = new Set();
+    for (let i = seriesCount - 1; i >= 0; i -= labelStride) {
+        tickIndices.add(i);
+    }
+
+    const option = {
+        ...baseOption,
+        grid: {
+            // Same fixed left gutter as the scatter percentile chart so
+            // toggling Full ↔ Tail ↔ scatter keeps the y-axis position
+            // anchored. containLabel is off so this value is the
+            // actual rendered gutter, regardless of label width.
+            left: HISTOGRAM_CHART_GRID_LEFT,
+            right: '17',
+            top: String(CHART_GRID_TOP_WITH_LEGEND),
+            bottom: '24',
+            containLabel: false,
+        },
+        dataZoom: getDataZoomConfig(calculateMinZoomSpan(timeData)),
+        xAxis: {
+            type: 'time',
+            min: 'dataMin',
+            max: 'dataMax',
+            splitNumber: 5,
+            axisLine: { show: false },
+            axisTick: { show: false },
+            axisLabel: {
+                color: COLORS.fgSecondary,
+                ...FONTS.axisLabel,
+                formatter: xAxisFormatter,
+            },
+            splitLine: {
+                show: true,
+                lineStyle: { color: COLORS.gridLine, type: 'dashed' },
+            },
+        },
+        yAxis: {
+            type: 'value',
+            min: -0.5,
+            max: seriesCount - 0.5,
+            // Force a tick at every integer so the formatter sees one
+            // call per quantile row; the formatter then only labels the
+            // p10/p20/…/p100 indices and returns '' for everything else.
+            interval: 1,
+            axisLine: { show: false },
+            axisTick: { show: false },
+            axisLabel: {
+                color: COLORS.fgSecondary,
+                ...FONTS.axisLabel,
+                showMinLabel: false,
+                showMaxLabel: false,
+                formatter: (val) => {
+                    const i = Math.round(val);
+                    if (i < 0 || i >= seriesCount) return '';
+                    return tickIndices.has(i) ? displayLabels[i] : '';
+                },
+            },
+            splitLine: { show: false },
+        },
+        tooltip: {
+            ...baseOption.tooltip,
+            trigger: 'item',
+            // Position above the cursor by default. When the cell is
+            // close to the top of the canvas (no room for the tooltip
+            // above), flip below so the hovered cell stays visible
+            // instead of being covered by the tooltip.
+            position: function (point, _params, _dom, _rect, size) {
+                const [mouseX, mouseY] = point;
+                const [tipW, tipH] = size.contentSize;
+                const [viewW] = size.viewSize;
+                const gap = 12;
+                let x = mouseX - tipW / 2;
+                if (x < 0) x = 0;
+                if (x + tipW > viewW) x = viewW - tipW;
+                let y = mouseY - tipH - gap;
+                if (y < 0) y = mouseY + gap;
+                return [x, y];
+            },
+            formatter: tooltipFormatter,
+        },
+        series: [{
+            name: opts.title,
+            type: 'custom',
+            renderItem,
+            encode: { x: 0, y: 1 },
+            data: cells,
+            clip: true,
+            progressive: 5000,
+            progressiveThreshold: 3000,
+            animation: false,
+        }],
+    };
+
+    applyChartOption(chart, option);
+
+    // Legend bar: gradient is drawn left=t0 → right=t1 by buildGradientCanvas.
+    // We want left=low value=green, right=high value=red — so feed t through
+    // the same flip (1 - t) used for cell colors.
+    const barCanvas = buildGradientCanvas((t) => rdYlGnColor(1 - t));
+    const { minLabel, maxLabel } = ensureLegendBar(chart.domNode, barCanvas);
+    minLabel.textContent = valueFmt(colorMin);
+    maxLabel.textContent = valueFmt(colorMax);
+}

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -17,10 +17,14 @@ import {
     applyChartOption,
     buildOverlayLegendOption,
     CHART_GRID_TOP_WITH_LEGEND,
+    HISTOGRAM_CHART_GRID_LEFT,
     COLORS,
+    FONTS,
 } from './base.js';
 import { SCATTER_PALETTE } from './util/colormap.js';
 import { DEFAULT_PERCENTILES } from './metric_types.js';
+import { configureQuantileHeatmap } from './quantile_heatmap.js';
+import { fetchQuantileSpectrumForPlot } from '../data.js';
 
 /**
  * Configures the Chart based on Chart.spec
@@ -37,6 +41,43 @@ export function configureScatterChart(chart) {
     if (!data || data.length < 2 || !data[0] || data[0].length === 0) {
         applyNoData(chart);
         return;
+    }
+
+    // Invalidate the cached spectrum data when the underlying scatter
+    // data swaps to a different reference (e.g. parent refetch). The
+    // checkbox state itself is preserved so the user's choice persists
+    // across refreshes; the next render in spectrum mode will refetch.
+    if (chart._spectrumDataSourceRef !== data) {
+        chart._spectrumDataByKind = null;
+        chart._spectrumDataSourceRef = data;
+    }
+
+    // Spectrum mode (`full` or `tail`): render as a quantile heatmap
+    // using the cached result for that kind. If we don't have the data
+    // yet, fall through and render the normal scatter while we kick
+    // off the fetch in the background; once it lands, re-trigger.
+    if (chart.spectrumKind) {
+        const cache = chart._spectrumDataByKind?.[chart.spectrumKind];
+        if (cache) {
+            const originalSpec = chart.spec;
+            chart.spec = {
+                ...originalSpec,
+                data: cache.data,
+                series_names: cache.seriesNames,
+                // Forward the p0 anchor so the quantile-heatmap color
+                // scale starts at p0 (full and tail share the bound).
+                color_min_anchor: cache.colorMinAnchor,
+            };
+            try {
+                configureQuantileHeatmap(chart);
+            } finally {
+                chart.spec = originalSpec;
+            }
+            ensureSpectrumCheckboxes(chart);
+            return;
+        }
+        kickOffSpectrumFetch(chart, chart.spectrumKind);
+        // fall through to normal scatter render while we wait
     }
 
     const baseOption = getBaseOption();
@@ -200,9 +241,19 @@ export function configureScatterChart(chart) {
 
     const option = {
         ...baseOption,
-        grid: { ...baseOption.grid, top: String(CHART_GRID_TOP_WITH_LEGEND) },
+        grid: {
+            ...baseOption.grid,
+            top: String(CHART_GRID_TOP_WITH_LEGEND),
+            // Pin the left gutter so toggling between scatter and the
+            // quantile-heatmap variants doesn't shift the y-axis.
+            left: HISTOGRAM_CHART_GRID_LEFT,
+            containLabel: false,
+        },
         legend: buildOverlayLegendOption(uniqueNamesForLayout, {
             tooltipFormatter: () => 'Click to pin, ⌘/Ctrl+click to multi-select',
+            // Nudge the percentile legend ~2 character widths rightward
+            // so it sits closer to the chart's right edge.
+            right: '0',
         }),
         dataZoom: getDataZoomConfig(minZoomSpan),
         yAxis: yAxisConfig,
@@ -371,5 +422,173 @@ export function configureScatterChart(chart) {
     if (chart.pinnedSet.size > 0) {
         applyPinState();
     }
+
+    ensureSpectrumCheckboxes(chart);
+}
+
+// ── Spectrum toggles ─────────────────────────────────────────────────
+// Two mutually-exclusive checkboxes ("Full" and "Tail") let the user
+// promote a percentile scatter into a quantile-heatmap view. State:
+//   chart.spectrumKind: null | 'full' | 'tail'
+//   chart._spectrumPending: null | 'full' | 'tail' (in-flight fetch)
+//   chart._spectrumDataByKind: { full?, tail? } — cached fetch results,
+//     invalidated on the next configure when the source data ref swaps.
+// The DOM lives in chart.domNode (.chart already has position:relative)
+// so it survives reconfigures and rides along with the chart container.
+
+const SPECTRUM_CONTROLS_CLASS = 'spectrum-controls';
+const SPECTRUM_CHECKBOX_CLASS = 'spectrum-toggle';
+const SPECTRUM_TAIL_CHECKBOX_CLASS = 'spectrum-tail-toggle';
+
+const SPECTRUM_LABELS = { full: 'Full', tail: 'Tail' };
+
+// Build the list of quantiles to query for each spectrum kind. Use
+// integer math so 100 evenly-spaced steps don't accumulate float drift
+// (especially relevant for the tail's 0.0001-wide steps).
+function quantilesForKind(kind) {
+    const out = [];
+    if (kind === 'tail') {
+        for (let i = 1; i <= 100; i++) out.push((9900 + i) / 10000);
+    } else {
+        for (let i = 1; i <= 100; i++) out.push(i / 100);
+    }
+    return out;
+}
+
+function renderSpectrumCheckbox(el, chart, kind) {
+    const on = chart.spectrumKind === kind;
+    const pending = chart._spectrumPending === kind;
+    // fgSecondary (--fg-secondary) reads brighter than fgMuted in dark
+    // mode; the checkbox + label otherwise get lost against the chart bg.
+    const color = on ? COLORS.fg : COLORS.fgSecondary;
+    const glyph = on ? '☑' : '☐';
+    const label = pending ? `${SPECTRUM_LABELS[kind]}…` : SPECTRUM_LABELS[kind];
+    el.innerHTML =
+        `<span style="font-size: 16px; vertical-align: bottom; position: relative; top: 2px;">${glyph}</span> ${label}`;
+    el.style.color = color;
+}
+
+function refreshSpectrumCheckboxes(chart) {
+    const container = chart.domNode.querySelector('.' + SPECTRUM_CONTROLS_CLASS);
+    if (!container) return;
+    const fullEl = container.querySelector('.' + SPECTRUM_CHECKBOX_CLASS);
+    const tailEl = container.querySelector('.' + SPECTRUM_TAIL_CHECKBOX_CLASS);
+    if (fullEl) renderSpectrumCheckbox(fullEl, chart, 'full');
+    if (tailEl) renderSpectrumCheckbox(tailEl, chart, 'tail');
+}
+
+function toggleSpectrum(chart, kind) {
+    chart.spectrumKind = (chart.spectrumKind === kind) ? null : kind;
+    refreshSpectrumCheckboxes(chart);
+    chart.configureChartByType();
+}
+
+// Align the controls' left edge with the chart grid's left edge (the
+// inner plot canvas, not the y-axis label gutter). The grid rect is
+// only available after echarts has laid out the chart, and its
+// x-position depends on the rendered y-axis label width — so we query
+// it after each render via the `finished` event and reposition.
+function positionControlsAtGridLeft(chart, container) {
+    if (!chart.echart) return;
+    try {
+        const grid = chart.echart.getModel().getComponent('grid');
+        const rect = grid?.coordinateSystem?.getRect();
+        if (rect && Number.isFinite(rect.x)) {
+            container.style.left = Math.round(rect.x) + 'px';
+        }
+    } catch (_e) {
+        // Layout not ready yet — next 'finished' event will retry.
+    }
+}
+
+function ensureSpectrumCheckboxes(chart) {
+    let container = chart.domNode.querySelector('.' + SPECTRUM_CONTROLS_CLASS);
+    let fullEl, tailEl;
+    if (!container) {
+        container = document.createElement('span');
+        container.className = SPECTRUM_CONTROLS_CLASS;
+        // Sit on the same vertical row as the percentile legend
+        // (top:42 matches buildOverlayLegendOption's default). The
+        // left offset is filled in by positionControlsAtGridLeft once
+        // the grid coordinate system is ready.
+        container.style.cssText = `
+            position: absolute;
+            top: 42px;
+            left: 0px;
+            z-index: 10;
+            display: inline-flex;
+            gap: 12px;
+            ${FONTS.cssControl}
+            user-select: none;
+        `;
+        fullEl = document.createElement('span');
+        fullEl.className = SPECTRUM_CHECKBOX_CLASS;
+        fullEl.style.cursor = 'pointer';
+        tailEl = document.createElement('span');
+        tailEl.className = SPECTRUM_TAIL_CHECKBOX_CLASS;
+        tailEl.style.cursor = 'pointer';
+        container.appendChild(fullEl);
+        container.appendChild(tailEl);
+        chart.domNode.appendChild(container);
+    } else {
+        fullEl = container.querySelector('.' + SPECTRUM_CHECKBOX_CLASS);
+        tailEl = container.querySelector('.' + SPECTRUM_TAIL_CHECKBOX_CLASS);
+    }
+
+    fullEl.onclick = () => toggleSpectrum(chart, 'full');
+    tailEl.onclick = () => toggleSpectrum(chart, 'tail');
+    renderSpectrumCheckbox(fullEl, chart, 'full');
+    renderSpectrumCheckbox(tailEl, chart, 'tail');
+
+    // Reposition on every render (initial layout, theme swap, resize,
+    // zoom-driven re-layout). Replace any previous listener bound to a
+    // stale closure so we don't stack handlers across reconfigures.
+    if (chart.echart) {
+        if (chart._spectrumFinishedFn) {
+            chart.echart.off('finished', chart._spectrumFinishedFn);
+        }
+        chart._spectrumFinishedFn = () => positionControlsAtGridLeft(chart, container);
+        chart.echart.on('finished', chart._spectrumFinishedFn);
+        positionControlsAtGridLeft(chart, container);
+    }
+}
+
+function kickOffSpectrumFetch(chart, kind) {
+    if (chart._spectrumPending === kind) return;
+    const plotForFetch = {
+        promql_query: chart.spec.promql_query,
+        opts: chart.spec.opts,
+    };
+    if (!plotForFetch.promql_query) return;
+
+    chart._spectrumPending = kind;
+    refreshSpectrumCheckboxes(chart);
+
+    fetchQuantileSpectrumForPlot(plotForFetch, quantilesForKind(kind))
+        .then((res) => {
+            if (chart._spectrumPending === kind) chart._spectrumPending = null;
+            if (!res) {
+                // Fetch returned no usable data — bail back to scatter
+                // (only if the user hasn't switched to a different kind
+                // in the meantime).
+                if (chart.spectrumKind === kind) chart.spectrumKind = null;
+                refreshSpectrumCheckboxes(chart);
+                return;
+            }
+            chart._spectrumDataByKind = chart._spectrumDataByKind || {};
+            chart._spectrumDataByKind[kind] = {
+                data: res.data,
+                seriesNames: res.series_names,
+                colorMinAnchor: res.color_min_anchor,
+            };
+            if (chart.spectrumKind === kind) chart.configureChartByType();
+            else refreshSpectrumCheckboxes(chart);
+        })
+        .catch((err) => {
+            if (chart._spectrumPending === kind) chart._spectrumPending = null;
+            if (chart.spectrumKind === kind) chart.spectrumKind = null;
+            refreshSpectrumCheckboxes(chart);
+            console.error('Failed to fetch quantile spectrum:', err);
+        });
 }
 

--- a/src/viewer/assets/lib/charts/util/colormap.js
+++ b/src/viewer/assets/lib/charts/util/colormap.js
@@ -163,6 +163,25 @@ export function infernoColor(t) {
     return interpolateRamp(INFERNO_RGB, t);
 }
 
+/** d3 RdYlGn diverging hex ramp. t=0 → red, t=1 → green. */
+export const RD_YL_GN_COLORS = [
+    '#a50026', '#d73027', '#f46d43', '#fdae61', '#fee08b',
+    '#ffffbf',
+    '#d9ef8b', '#a6d96a', '#66bd63', '#1a9850', '#006837',
+];
+
+const RD_YL_GN_RGB = hexToRgbRamp(RD_YL_GN_COLORS);
+
+/**
+ * d3 RdYlGn colormap — t=0 maps to red, t=1 to green.
+ * Callers that want green-low/red-high (e.g. latency) pass `1 - t`.
+ * @param {number} t - 0..1
+ * @returns {string} `rgb(r,g,b)`
+ */
+export function rdYlGnColor(t) {
+    return interpolateRamp(RD_YL_GN_RGB, t);
+}
+
 // ── Compare-mode palette ─────────────────────────────────────────────
 
 /**

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -499,6 +499,95 @@ const createDataApi = ({
         return null;
     };
 
+    // Fetch a custom set of histogram quantiles for a percentile
+    // (scatter) plot. Issues `histogram_quantiles([q1, q2, …], <metric>)`
+    // and returns the result shaped like a percentile fetch: parallel
+    // [times, qA, qB, …] columns plus matching `pXX[.YY]` series names
+    // sorted by quantile. Caller picks the quantile set:
+    //   - Full spectrum (default): [0.01, 0.02, …, 1.00]
+    //   - Tail spectrum:           [0.9901, 0.9902, …, 1.0000]
+    const formatPercentileLabel = (q) => {
+        const trimmed = (q * 100).toFixed(2).replace(/\.?0+$/, '');
+        return `p${trimmed}`;
+    };
+
+    const fetchQuantileSpectrumForPlot = async (plot, quantiles) => {
+        const query = plot.promql_query;
+        if (!query) return null;
+
+        let metricSelector;
+        if (plot.opts.type === 'histogram') {
+            metricSelector = query;
+        } else if (query.includes('histogram_quantiles')) {
+            const match = query.match(/histogram_quantiles\s*\(\s*\[[^\]]*\]\s*,\s*(.+)\)$/);
+            if (!match) return null;
+            metricSelector = match[1].trim();
+        } else {
+            return null;
+        }
+
+        if (!Array.isArray(quantiles) || quantiles.length === 0) {
+            // Default: 100-quantile full spectrum.
+            quantiles = [];
+            for (let i = 1; i <= 100; i++) quantiles.push(i / 100);
+        }
+        // Always include q=0 (p0) to anchor the color scale's lower
+        // bound across spectrum kinds. p0's row is hidden from the
+        // heatmap rendering — it's only used to compute color_min so
+        // the Full and Tail views share the same color scale (p0..p100).
+        const queryQuantiles = quantiles.includes(0) ? quantiles : [0, ...quantiles];
+        const strideSuffix = (_stepOverride && _stepOverride > 1) ? `, ${_stepOverride}` : '';
+        const wrapped = `histogram_quantiles([${queryQuantiles.join(', ')}], ${metricSelector}${strideSuffix})`;
+        const result = await executePromQLRangeQuery(wrapped);
+
+        if (result.status !== 'success' || !result.data?.result?.length) return null;
+
+        let timestamps = null;
+        const collected = [];
+        for (const item of result.data.result) {
+            if (!item.values || !item.values.length) continue;
+            let name = null;
+            if (item.metric) {
+                for (const [k, v] of Object.entries(item.metric)) {
+                    if (k !== '__name__') { name = v; break; }
+                }
+            }
+            if (name == null) continue;
+            if (!timestamps) timestamps = item.values.map(([ts]) => ts);
+            const values = item.values.map(([, val]) => parseFloat(val));
+            collected.push({ name, values, q: parseFloat(name) });
+        }
+        if (collected.length === 0 || !timestamps) return null;
+
+        collected.sort((a, b) => a.q - b.q);
+
+        // Pop the p0 row (if present) and derive a color-scale lower
+        // bound from it. Done before building dataCols/seriesNames so
+        // the heatmap never sees p0.
+        let colorMinAnchor = null;
+        if (collected.length > 0 && collected[0].q === 0) {
+            const p0 = collected.shift();
+            let m = Infinity;
+            for (const v of p0.values) {
+                if (v != null && !Number.isNaN(v) && v > 0 && v < m) m = v;
+            }
+            if (Number.isFinite(m)) colorMinAnchor = m;
+        }
+
+        const dataCols = [timestamps, ...collected.map((c) => c.values)];
+        // The quantile-heatmap renderer uses these directly as y-axis
+        // tick labels — `pXX` for whole percents (e.g. p10, p100) and
+        // `pXX.YY` for fractional ones (e.g. p99.01).
+        const seriesNames = collected.map((c) => formatPercentileLabel(c.q));
+
+        return {
+            time_data: timestamps,
+            data: dataCols,
+            series_names: seriesNames,
+            color_min_anchor: colorMinAnchor,
+        };
+    };
+
     const fetchHeatmapsForGroups = async (groups) => {
         const plots = [];
         for (const group of groups || []) {
@@ -530,6 +619,7 @@ const createDataApi = ({
         executePromQLRangeQuery,
         applyResultToPlot,
         fetchHeatmapForPlot,
+        fetchQuantileSpectrumForPlot,
         fetchHeatmapsForGroups,
         substituteCgroupPattern,
         processDashboardData,
@@ -543,6 +633,7 @@ const defaultDataApi = createDataApi();
 const {
     executePromQLRangeQuery,
     fetchHeatmapForPlot,
+    fetchQuantileSpectrumForPlot,
     fetchHeatmapsForGroups,
     processDashboardData,
     clearMetadataCache,
@@ -553,6 +644,7 @@ export {
     executePromQLRangeQuery,
     applyResultToPlot,
     fetchHeatmapForPlot,
+    fetchQuantileSpectrumForPlot,
     fetchHeatmapsForGroups,
     substituteCgroupPattern,
     processDashboardData,

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -404,7 +404,10 @@ export function createGroupComponent(getState) {
                 // row. Single line overlays benefit from the wider x-axis
                 // to distinguish blue/green traces; split multi/scatter
                 // and side-by-side heatmaps need the room structurally.
-                const wrapperClass = (spec.width === 'full' || compareMode)
+                // Histogram charts (percentile scatter, bucket heatmap,
+                // quantile heatmap) also go full-width — the x-axis
+                // density and the heatmap legend bar both need the room.
+                const wrapperClass = (spec.width === 'full' || compareMode || isHistogramChart)
                     ? 'div.chart-wrapper.full-width'
                     : 'div.chart-wrapper';
 


### PR DESCRIPTION
## Summary
- New `quantile_heatmap` chart style for histogram metrics: renders one colored cell per (time × quantile) using a flipped d3 RdYlGn ramp on a log10 color scale (low value = green, high = red).
- Two checkboxes on the percentile chart's legend row promote the scatter into a quantile heatmap: **Full** (100 quantiles `p1..p100`) and **Tail** (100 quantiles `p99.01..p100` in 0.0001 increments). Mutually exclusive; per-kind data cache.
- Color scale is anchored at p0 (fetched but hidden) so toggling Full ↔ Tail keeps the same `[p0_min, p100_max]` color range — only the displayed quantile slice changes.

## Layout / UX details
- Histogram charts (scatter percentile, bucket heatmap, quantile heatmap) all render full-width.
- Y-axis gutter pinned to a shared fixed pixel width across the three styles, so toggling doesn't shift the plot canvas.
- Y-axis ticks always at every 10th quantile (p10/p20/.../p100 for Full; p99.1/p99.2/.../p100 for Tail).
- Heatmap tooltip flips below the cursor when near the top edge so the hovered cell stays visible.
- Compare-mode falls through to baseline-only rendering for the new style (no compare-side support yet).

## Test plan
- [x] All 38 pure-JS viewer tests pass (`node --test tests/*.mjs`).
- [x] Toggle Full → Tail on a percentile chart in the live viewer; cells repaint correctly with consistent colors.
- [x] Toggle Full → Tail in the WASM viewer; color scale stays unified after rebuilding the WASM module.
- [ ] Verify on a histogram metric whose p0 = 0 (anchor falls back to natural min cleanly).
- [ ] Visual review on dark + light themes (checkbox + RdYlGn legend bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)