### PR TITLE
feat(viewer): quantile heatmap in compare (A/B) mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.21"
+version = "5.11.1-alpha.22"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.21"
+version = "5.11.1-alpha.22"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/charts/util/spectrum_quantiles.js
+++ b/site/viewer/lib/charts/util/spectrum_quantiles.js
@@ -1,0 +1,1 @@
+../../../../../src/viewer/assets/lib/charts/util/spectrum_quantiles.js

--- a/src/viewer/assets/lib/chart_controls.js
+++ b/src/viewer/assets/lib/chart_controls.js
@@ -46,21 +46,14 @@ export const compareToggle = (spec, state) => {
             // re-enabling spectrum mode later starts in side-by-side.
             if (next == null) setToggle?.(chartId, 'diff', false);
         };
+        // Two visually-separated groups:
+        //   1. Diff — data treatment (experiment − baseline). Only
+        //      visible when a spectrum kind is selected, since diff
+        //      is meaningless without one (the dispatch ignores diff
+        //      when kind is null).
+        //   2. Full / Tail — visual style (which quantile slice the
+        //      heatmap shows). Mutually exclusive, always visible.
         return m('span.compare-toggle-group', [
-            m('label.compare-toggle', { title: 'Show full p1..p100 spectrum heatmap' }, [
-                m('input[type=checkbox]', {
-                    checked: kind === 'full',
-                    onchange: () => setKind('full'),
-                }),
-                m('span', 'Full'),
-            ]),
-            m('label.compare-toggle', { title: 'Show tail p99.01..p100 spectrum heatmap' }, [
-                m('input[type=checkbox]', {
-                    checked: kind === 'tail',
-                    onchange: () => setKind('tail'),
-                }),
-                m('span', 'Tail'),
-            ]),
             kind && m('label.compare-toggle', {
                 title: 'Show experiment − baseline diff instead of side-by-side',
             }, [
@@ -69,6 +62,29 @@ export const compareToggle = (spec, state) => {
                     onchange: (e) => setToggle?.(chartId, 'diff', e.target.checked),
                 }),
                 m('span', 'Diff'),
+            ]),
+            m('label.compare-toggle', {
+                // Add gap between the Diff group and Full/Tail only
+                // when Diff is actually rendered, so a kind-less chart
+                // doesn't show a stray indent before Full.
+                style: kind ? 'margin-left: 20px' : '',
+                title: 'Show full p1..p100 spectrum heatmap',
+            }, [
+                m('input[type=checkbox]', {
+                    checked: kind === 'full',
+                    onchange: () => setKind('full'),
+                }),
+                m('span', 'Full'),
+            ]),
+            m('label.compare-toggle', {
+                style: 'margin-left: 0.5em',
+                title: 'Show tail p99.01..p100 spectrum heatmap',
+            }, [
+                m('input[type=checkbox]', {
+                    checked: kind === 'tail',
+                    onchange: () => setKind('tail'),
+                }),
+                m('span', 'Tail'),
             ]),
         ]);
     }

--- a/src/viewer/assets/lib/chart_controls.js
+++ b/src/viewer/assets/lib/chart_controls.js
@@ -6,8 +6,11 @@ import { resolvedStyle } from './charts/metric_types.js';
 
 /**
  * Compact per-chart toggle rendered in the chart header when compare
- * mode is active and the chart style supports it (currently: heatmap
- * style only, for the `diff` toggle).
+ * mode is active and the chart style supports it.
+ *
+ * - heatmap: single `diff` checkbox (experiment − baseline)
+ * - scatter: Full / Tail (mutually exclusive) + Diff (visible only when
+ *   one of them is active)
  *
  * @param {object} spec - plot spec (reads spec.opts.id and spec.opts.style)
  * @param {object} state - { compareMode, toggles, setChartToggle }
@@ -15,25 +18,62 @@ import { resolvedStyle } from './charts/metric_types.js';
 export const compareToggle = (spec, state) => {
     if (!state || !state.compareMode) return null;
     const style = resolvedStyle(spec);
-    if (style !== 'heatmap') return null;
     const chartId = spec?.opts?.id;
     if (!chartId) return null;
-    const current = state.toggles && state.toggles[chartId];
-    const checked = !!(current && current.diff);
-    return m('label.compare-toggle', {
-        title: 'Show experiment − baseline diff instead of side-by-side',
-    }, [
-        m('input[type=checkbox]', {
-            checked,
-            onchange: (e) => {
-                const v = e.target.checked;
-                if (typeof state.setChartToggle === 'function') {
-                    state.setChartToggle(chartId, 'diff', v);
-                }
-            },
-        }),
-        m('span', 'diff'),
-    ]);
+    const current = state.toggles?.[chartId] || {};
+    const setToggle = state.setChartToggle;
+
+    if (style === 'heatmap') {
+        return m('label.compare-toggle', {
+            title: 'Show experiment − baseline diff instead of side-by-side',
+        }, [
+            m('input[type=checkbox]', {
+                checked: !!current.diff,
+                onchange: (e) => setToggle?.(chartId, 'diff', e.target.checked),
+            }),
+            m('span', 'diff'),
+        ]);
+    }
+
+    if (style === 'scatter') {
+        const kind = current.spectrumKind || null;
+        const setKind = (v) => {
+            // Mutually exclusive: clicking the active kind clears it,
+            // clicking the other kind switches.
+            const next = (kind === v) ? null : v;
+            setToggle?.(chartId, 'spectrumKind', next);
+            // When clearing the kind, also clear the diff flag so that
+            // re-enabling spectrum mode later starts in side-by-side.
+            if (next == null) setToggle?.(chartId, 'diff', false);
+        };
+        return m('span.compare-toggle-group', [
+            m('label.compare-toggle', { title: 'Show full p1..p100 spectrum heatmap' }, [
+                m('input[type=checkbox]', {
+                    checked: kind === 'full',
+                    onchange: () => setKind('full'),
+                }),
+                m('span', 'Full'),
+            ]),
+            m('label.compare-toggle', { title: 'Show tail p99.01..p100 spectrum heatmap' }, [
+                m('input[type=checkbox]', {
+                    checked: kind === 'tail',
+                    onchange: () => setKind('tail'),
+                }),
+                m('span', 'Tail'),
+            ]),
+            kind && m('label.compare-toggle', {
+                title: 'Show experiment − baseline diff instead of side-by-side',
+            }, [
+                m('input[type=checkbox]', {
+                    checked: !!current.diff,
+                    onchange: (e) => setToggle?.(chartId, 'diff', e.target.checked),
+                }),
+                m('span', 'Diff'),
+            ]),
+        ]);
+    }
+
+    return null;
 };
 
 const EXPAND_ICON_PATH = 'M10 1h5v5h-1.5V3.56L9.78 7.28 8.72 6.22l3.72-3.72H10V1zM1 6V1h5v1.5H3.56l3.72 3.72-1.06 1.06L2.5 3.56V6H1zm5 4H1v5h5v-1.5H3.56l3.72-3.72-1.06-1.06L2.5 12.44V10zm4 5h5v-5h-1.5V12.44L9.78 8.72 8.72 9.78l3.72 3.72H10V15z';

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -372,7 +372,18 @@ export class Chart {
         // change" and the chart would render stale experiment dots.
         // Detect a multiSeries swap explicitly.
         const multiSeriesChanged = multiSeriesDiffers(oldSpec.multiSeries, this.spec.multiSeries);
-        if (this.echart && (dataChanged || multiSeriesChanged || formatChanged || themeChanged)) {
+        // Compare-mode quantile heatmap (Full ↔ Tail toggle) feeds in
+        // data of identical shape (100 quantile cols, same time range)
+        // for either kind, so shallowSameShape returns true and a kind
+        // switch alone wouldn't trigger reconfigure. The two kinds DO
+        // have distinct series_names arrays (`['p1'..'p100']` vs
+        // `['p99.01'..'p100']`), and the strategy carries the cached
+        // ref through unchanged within a kind, so a reference change
+        // is a reliable kind-switch signal. (Single-capture and other
+        // chart types either don't set series_names or keep the same
+        // ref across renders, so this is a no-op for them.)
+        const seriesNamesChanged = oldSpec.series_names !== this.spec.series_names;
+        if (this.echart && (dataChanged || multiSeriesChanged || formatChanged || themeChanged || seriesNamesChanged)) {
             this._themeVersion = themeVersion;
             this.configureChartByType();
 

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -413,6 +413,8 @@ export class Chart {
 
         if (this._freezeKeyCleanup) this._freezeKeyCleanup();
         if (this._pinCleanup) this._pinCleanup();
+        if (this._compareCursorOff) this._compareCursorOff();
+        if (this._compareCursorUnsub) this._compareCursorUnsub();
 
         // Remove ourselves from the charts registry so setZoom's fan-out,
         // resetAll, hasActiveSelection, etc. don't walk a stale entry

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -40,6 +40,10 @@ export class ChartsState {
     // Zoom subscribers. Each entry receives (zoom, source) synchronously
     // after setZoom produces a diff.
     _zoomSubs = new Set();
+    // Compare-mode cursor subscribers, keyed by compare-group id (the
+    // parent spec's opts.id). Two subscribers per group max — the
+    // baseline and experiment halves of a side-by-side pair.
+    _compareCursorSubs = new Map();  // groupId → Set<fn>
     // Global color mapper - for consistent cgroup colors
     colorMapper = globalColorMapper;
 
@@ -51,6 +55,7 @@ export class ChartsState {
         this.globalZoom = null;
         this.charts.clear();
         this._zoomSubs.clear();
+        this._compareCursorSubs.clear();
     }
 
     isDefaultZoom() {
@@ -77,6 +82,55 @@ export class ChartsState {
     subscribeZoom(fn) {
         this._zoomSubs.add(fn);
         return () => { this._zoomSubs.delete(fn); };
+    }
+
+    /**
+     * Subscribe to compare-mode cursor events for a group. The
+     * callback fires synchronously from inside publishCompareCursor
+     * when a sibling chart in the same compare group hovers / leaves
+     * a cell. Payload is either { timeMs, qIdx, sourceChartId } or
+     * null (cursor left the publishing chart).
+     *
+     * Self-sourced events (when sourceChartId equals the subscriber's
+     * own id) are filtered by the publisher; subscribers don't need to
+     * filter themselves.
+     *
+     * Returns an unsubscribe function.
+     */
+    subscribeCompareCursor(groupId, fn) {
+        if (!groupId) return () => {};
+        let set = this._compareCursorSubs.get(groupId);
+        if (!set) {
+            set = new Set();
+            this._compareCursorSubs.set(groupId, set);
+        }
+        set.add(fn);
+        return () => {
+            const s = this._compareCursorSubs.get(groupId);
+            if (!s) return;
+            s.delete(fn);
+            if (s.size === 0) this._compareCursorSubs.delete(groupId);
+        };
+    }
+
+    /**
+     * Publish a compare-mode cursor event to all subscribers in the
+     * group EXCEPT the source chart itself. Payload shape:
+     *   { timeMs, qIdx, sourceChartId } | null
+     * `null` clears (the cursor left the source chart).
+     */
+    publishCompareCursor(groupId, payload) {
+        if (!groupId) return;
+        const set = this._compareCursorSubs.get(groupId);
+        if (!set) return;
+        const sourceId = payload?.sourceChartId;
+        for (const fn of set) {
+            // Subscribers tag their fn with `_chartId` (set in
+            // quantile_heatmap.js) so we can skip the publisher's own
+            // copy without round-tripping through the event payload.
+            if (sourceId && fn._chartId === sourceId) continue;
+            fn(payload);
+        }
     }
 
     /**

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -86,7 +86,20 @@ export const renderCompareChart = (opts) => {
         case 'line':              return overlayLine(opts);
         case 'heatmap':           return sideBySideHeatmap(opts);
         case 'multi':             return splitMultiToSubgroup(opts);
-        case 'scatter':           return splitScatterToSubgroup(opts);
+        case 'scatter': {
+            // Per-chart spectrumKind toggle promotes the percentile
+            // scatter into a quantile-heatmap pair (or a single diff
+            // heatmap when the diff toggle is also on).
+            const chartId = opts.spec?.opts?.id;
+            const chartToggles = chartId && opts.toggles ? opts.toggles[chartId] : null;
+            const kind = chartToggles?.spectrumKind || null;
+            if (kind === 'full' || kind === 'tail') {
+                return chartToggles?.diff
+                    ? renderDiffQuantileHeatmap(opts)
+                    : sideBySideQuantileHeatmap(opts);
+            }
+            return splitScatterToSubgroup(opts);
+        }
         case 'histogram_heatmap': return sideBySideHistogramHeatmap(opts);
         default:
             return FALLBACK;

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -562,6 +562,38 @@ const renderDiffQuantileHeatmap = ({ spec, captures, anchors, chartsState, inter
 
     let { dMin, dMax } = delta;
     if (dMin == null || dMax == null) return FALLBACK;
+
+    // Robust scale: trim outliers from each end of the sorted deltas
+    // ONE quantile step at a time (1/100 of the distribution per step)
+    // up to 5 steps from each end (so we never trim past p5 / p95).
+    // A step is trimmed only when both:
+    //   - the trimmed value is at least 2× the magnitude of the next
+    //     value inward (an order-of-magnitude outlier worth dropping)
+    //   - dropping the value doesn't change the sign of the bound
+    //     (a flat percentile cap can map a small +ε cell to the wrong
+    //     side of the diverging palette when the trimmed extreme was
+    //     of the opposite sign — wrong color for that delta)
+    // Stops at the first step that fails either condition. This
+    // anchors each diff scale to its own bulk distribution, making
+    // Full and Tail diffs visually distinct without flipping any
+    // cell's diverging-color sign.
+    const flatDeltas = [];
+    for (let q = 1; q < delta.data.length; q++) {
+        const col = delta.data[q];
+        if (!Array.isArray(col)) continue;
+        for (const v of col) {
+            if (v != null && Number.isFinite(v)) flatDeltas.push(v);
+        }
+    }
+    if (flatDeltas.length >= 20) {
+        flatDeltas.sort((a, b) => a - b);
+        const trimmed = trimDiffOutliers(flatDeltas);
+        if (trimmed.lo !== null && trimmed.hi !== null && trimmed.hi > trimmed.lo) {
+            dMin = trimmed.lo;
+            dMax = trimmed.hi;
+        }
+    }
+
     if (dMin === dMax) {
         const pad = Math.max(Math.abs(dMin), 1) * 0.5;
         dMin -= pad;
@@ -605,3 +637,43 @@ const renderDiffQuantileHeatmap = ({ spec, captures, anchors, chartsState, inter
         vnode: m('div.compare-heatmap-diff', m(Chart, { spec: diffSpec, chartsState, interval })),
     };
 };
+
+// Trim outliers from the sorted ascending delta array, walking inward
+// one quantile step (1/100 of the distribution) per iteration. A step
+// is trimmed only when the boundary value is ≥2× the magnitude of the
+// next value inward AND has the same sign — never trim across a sign
+// boundary (that would flip the diverging-palette color of cells near
+// zero). Capped at 5 steps from each end (so the band is never tighter
+// than [p5, p95]). Returns { lo, hi } or { lo: null, hi: null } when
+// the input is too small.
+function trimDiffOutliers(sorted) {
+    const n = sorted.length;
+    if (n < 20) return { lo: null, hi: null };
+    const stepSize = Math.max(1, Math.floor(n / 100));
+    const MAX_STEPS = 5;
+    const REDUCTION = 2;
+
+    let loIdx = 0;
+    for (let step = 0; step < MAX_STEPS; step++) {
+        const nxtIdx = loIdx + stepSize;
+        if (nxtIdx >= n) break;
+        const cur = sorted[loIdx];
+        const nxt = sorted[nxtIdx];
+        if (Math.sign(cur) !== Math.sign(nxt)) break;
+        if (Math.abs(cur) < REDUCTION * Math.abs(nxt)) break;
+        loIdx = nxtIdx;
+    }
+
+    let hiIdx = n - 1;
+    for (let step = 0; step < MAX_STEPS; step++) {
+        const nxtIdx = hiIdx - stepSize;
+        if (nxtIdx < 0) break;
+        const cur = sorted[hiIdx];
+        const nxt = sorted[nxtIdx];
+        if (Math.sign(cur) !== Math.sign(nxt)) break;
+        if (Math.abs(cur) < REDUCTION * Math.abs(nxt)) break;
+        hiIdx = nxtIdx;
+    }
+
+    return { lo: sorted[loIdx], hi: sorted[hiIdx] };
+}

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -521,3 +521,74 @@ function rebaseSpectrumData(data, anchorSec) {
     if (!Array.isArray(data) || data.length === 0) return data;
     return [rebase(data[0], anchorSec), ...data.slice(1)];
 }
+
+/**
+ * Render a single (experiment − baseline) quantile-heatmap diff.
+ * Uses the diverging palette resampled so neutral lands on zero.
+ * Returns FALLBACK when either capture is missing spectrum data or
+ * when no non-null deltas exist.
+ */
+const renderDiffQuantileHeatmap = ({ spec, captures, anchors, chartsState, interval, Chart, captureLabels }) => {
+    const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
+    const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
+    if (!baseline?.spectrumData || !experiment?.spectrumData) return FALLBACK;
+
+    const baseFetch = {
+        time_data: baseline.spectrumTimeData,
+        data: baseline.spectrumData,
+        series_names: baseline.spectrumSeriesNames,
+    };
+    const expFetch = {
+        time_data: experiment.spectrumTimeData,
+        data: experiment.spectrumData,
+        series_names: experiment.spectrumSeriesNames,
+    };
+
+    const delta = buildDeltaSpectrum(baseFetch, expFetch);
+    if (!delta) return FALLBACK;
+
+    let { dMin, dMax } = delta;
+    if (dMin == null || dMax == null) return FALLBACK;
+    if (dMin === dMax) {
+        const pad = Math.max(Math.abs(dMin), 1) * 0.5;
+        dMin -= pad;
+        dMax += pad;
+    }
+
+    const isDark = isDarkTheme();
+    const basePalette = isDark ? DIVERGING_BLUE_GREEN_DARK : DIVERGING_BLUE_GREEN;
+    const resampled = resampleDivergingForRange(basePalette, dMin, dMax);
+
+    const baselineAnchorSec = anchorSecondsFor(anchors, CAPTURE_BASELINE, delta.time_data);
+    const baselineLabel = labelFor(captureLabels, CAPTURE_BASELINE);
+    const experimentLabel = labelFor(captureLabels, CAPTURE_EXPERIMENT);
+
+    const diffSpec = {
+        ...spec,
+        opts: {
+            ...spec.opts,
+            id: `${spec.opts.id || 'chart'}::diff`,
+            title: `${spec.opts.title} (${experimentLabel} − ${baselineLabel})`,
+            style: 'quantile_heatmap',
+        },
+        time_data: rebase(delta.time_data, baselineAnchorSec),
+        data: [rebase(delta.data[0], baselineAnchorSec), ...delta.data.slice(1)],
+        series_names: delta.series_names,
+        color_min_anchor: dMin,
+        color_max_anchor: dMax,
+        colormap: resampled,
+        nullCellColor: nullCellColor(isDark),
+        diffMatrices: delta.matrices,
+        diffCaptureLabels: { baseline: baselineLabel, experiment: experimentLabel },
+        diffLegendLabels: {
+            left:  `${baselineLabel} is higher`,
+            right: `${experimentLabel} is higher`,
+        },
+        xAxisFormatter: relativeTimeFormatter,
+    };
+
+    return {
+        kind: 'vnode',
+        vnode: m('div.compare-heatmap-diff', m(Chart, { spec: diffSpec, chartsState, interval })),
+    };
+};

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -38,7 +38,7 @@
 //   anchors: { baseline: ms, experiment: ms }  — subtracted from each
 //            capture's timestamps to produce a relative (`+Xs`) x-axis.
 
-import { nullDiff, intersectLabels, canonicalQuantileLabel } from './util/compare_math.js';
+import { nullDiff, intersectLabels, canonicalQuantileLabel, unifyHistogramRange, buildDeltaSpectrum } from './util/compare_math.js';
 import { DIVERGING_BLUE_GREEN, DIVERGING_BLUE_GREEN_DARK, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
 import { ensureHeatmapMatrix } from './util/heatmap_data.js';
 import { resolvedStyle } from './metric_types.js';
@@ -445,3 +445,79 @@ const sideBySideHistogramHeatmap = (opts) => sideBySidePair({
         bucket_bounds: cap.bucketBounds || opts.spec.bucket_bounds,
     }),
 });
+
+/**
+ * Render baseline + experiment quantile-heatmaps side-by-side. Used in
+ * compare mode when the user has the Full or Tail spectrum toggle on
+ * for a percentile chart. Captures must carry pre-fetched spectrum
+ * data on cap.spectrumData / cap.spectrumSeriesNames /
+ * cap.spectrumColorMinAnchor (placed there by CompareChartWrapper).
+ *
+ * Returns FALLBACK when either capture's spectrum is missing, so the
+ * caller can fall back to the existing 5-percentile split.
+ */
+const sideBySideQuantileHeatmap = ({ spec, captures, anchors, chartsState, interval, Chart, captureLabels }) => {
+    const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
+    const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
+    if (!baseline?.spectrumData || !experiment?.spectrumData) return FALLBACK;
+
+    // Unified color scale across both halves so equal cells render
+    // with equal colors. Anchors win when present.
+    const range = unifyHistogramRange(
+        { data: baseline.spectrumData,   color_min_anchor: baseline.spectrumColorMinAnchor },
+        { data: experiment.spectrumData, color_min_anchor: experiment.spectrumColorMinAnchor },
+    );
+
+    const groupId = spec.opts.id;
+    const baselineLabel = labelFor(captureLabels, CAPTURE_BASELINE);
+    const experimentLabel = labelFor(captureLabels, CAPTURE_EXPERIMENT);
+
+    const makeSlotSpec = (cap, role, counterpart) => {
+        const timeData = cap.spectrumTimeData || [];
+        const anchorSec = anchorSecondsFor(anchors, cap.id, timeData);
+        const opts = {
+            ...spec.opts,
+            id: `${spec.opts.id || 'chart'}::${cap.id}`,
+            title: `${spec.opts.title} — ${labelFor(captureLabels, cap.id)}`,
+            style: 'quantile_heatmap',
+        };
+        return {
+            ...spec,
+            opts,
+            time_data: rebase(timeData, anchorSec),
+            data: rebaseSpectrumData(cap.spectrumData, anchorSec),
+            series_names: cap.spectrumSeriesNames,
+            color_min_anchor: range.colorMin,
+            color_max_anchor: range.colorMax,
+            compareGroupId: groupId,
+            compareCounterpartData: { data: counterpart.spectrumData },
+            compareCaptureLabels: { baseline: baselineLabel, experiment: experimentLabel },
+            compareSelfRole: role,
+            xAxisFormatter: relativeTimeFormatter,
+        };
+    };
+
+    const slot = (cap, role, counterpart, dotCls) => m('div.compare-slot', [
+        m('div.compare-slot-label', [
+            m(`span.compare-dot.${dotCls}`, '\u25CF'),
+            m('span', labelFor(captureLabels, cap.id)),
+        ]),
+        m(Chart, { spec: makeSlotSpec(cap, role, counterpart), chartsState, interval }),
+    ]);
+
+    return {
+        kind: 'vnode',
+        vnode: m('div.compare-heatmap-pair', [
+            slot(baseline,   'baseline',   experiment, 'compare-baseline-dot'),
+            slot(experiment, 'experiment', baseline,   'compare-experiment-dot'),
+        ]),
+    };
+};
+
+// Spectrum data has shape [timeCol, q1Col, …]. Rebasing the time column
+// in-place would mutate the cached fetch result; clone the time column
+// only and reuse the value columns by reference.
+function rebaseSpectrumData(data, anchorSec) {
+    if (!Array.isArray(data) || data.length === 0) return data;
+    return [rebase(data[0], anchorSec), ...data.slice(1)];
+}

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -354,8 +354,16 @@ export function configureHeatmap(chart) {
     // top track the chart's actual grid rect (the Y-axis). On the very
     // first call (before layout completes) the rect is unavailable and
     // we render at default dimensions; the next `finished` then resizes.
+    // Dedup on the grid-rect signature so we don't rebuild the legend
+    // DOM on every hover-emphasis render — `finished` fires on those
+    // and the resulting innerHTML reset would flash the legend.
     const renderLegend = () => {
         const rect = chart.echart?.getModel()?.getComponent('grid')?.coordinateSystem?.getRect();
+        const sig = rect
+            ? `${rect.x}:${rect.y}:${rect.width}:${rect.height}`
+            : 'none';
+        if (chart._legendLastSig === sig) return;
+        chart._legendLastSig = sig;
         ensureLegendBar(chart.domNode, barCanvas, {
             ticks,
             // Top of bar = max = positive value = "experiment is higher"
@@ -366,6 +374,7 @@ export function configureHeatmap(chart) {
             barHeight: rect?.height,
         });
     };
+    chart._legendLastSig = null;
     renderLegend();
     if (chart._legendFinishedFn) chart.echart.off('finished', chart._legendFinishedFn);
     chart._legendFinishedFn = renderLegend;

--- a/src/viewer/assets/lib/charts/histogram_heatmap.js
+++ b/src/viewer/assets/lib/charts/histogram_heatmap.js
@@ -278,6 +278,14 @@ export function configureHistogramHeatmap(chart) {
             containLabel: true,
         },
         dataZoom: getDataZoomConfig(calculateMinZoomSpan(timeData)),
+        // Force hover effects onto a separate canvas (the zrender
+        // "hoverLayer") so cell hover doesn't trigger a progressive
+        // re-render of the main canvas. Without this, hovering each
+        // cell repaints the chunk to the right of the cursor — and in
+        // compare-mode side-by-side pairs, the parent layout shift
+        // also fires the sibling chart's ResizeObserver, mirroring
+        // the redraw onto the other chart. Same fix as heatmap.js.
+        hoverLayerThreshold: 0,
         xAxis: {
             type: 'time',
             min: 'dataMin',
@@ -330,6 +338,12 @@ export function configureHistogramHeatmap(chart) {
             },
             data: allCellsData,
             clip: true,
+            // No hover state for these cells — telling ECharts
+            // explicitly avoids the default hover-handling pass that
+            // can trigger a progressive re-render of the right-of-cursor
+            // chunk on every mousemove (visible as flicker in
+            // compare-mode side-by-side pairs).
+            emphasis: { disabled: true },
             progressive: 5000,
             progressiveThreshold: 3000,
             animation: false,
@@ -408,8 +422,18 @@ export function configureHistogramHeatmap(chart) {
         return ticks;
     };
 
+    // Dedup on grid-rect signature so we don't rebuild the legend DOM
+    // on every hover-emphasis render — `finished` fires on those and
+    // the resulting innerHTML reset would flash the legend (especially
+    // visible in compare-mode side-by-side pairs). The toggle handler
+    // resets `_legendLastSig` to force a re-render when ticks change.
     const renderLegend = () => {
         const rect = chart.echart?.getModel()?.getComponent('grid')?.coordinateSystem?.getRect();
+        const sig = rect
+            ? `${rect.x}:${rect.y}:${rect.width}:${rect.height}`
+            : 'none';
+        if (chart._legendLastSig === sig) return;
+        chart._legendLastSig = sig;
         ensureLegendBar(chart.domNode, barCanvas, {
             ticks: buildTicks(),
             barTop: rect?.y,
@@ -422,6 +446,7 @@ export function configureHistogramHeatmap(chart) {
             checkboxEl.style.left = Math.round(rect.x) + 'px';
         }
     };
+    chart._legendLastSig = null;
 
     const updateCheckbox = () => {
         const isRaw = chart.histogramDisplayMode === 'raw';
@@ -447,6 +472,10 @@ export function configureHistogramHeatmap(chart) {
         const isRaw = chart.histogramDisplayMode === 'raw';
         chart.histogramDisplayMode = isRaw ? 'percentage' : 'raw';
         updateCheckbox();
+        // Invalidate the rect-signature cache so renderLegend rebuilds
+        // with the new tick labels (raw count ↔ percentage), since the
+        // grid rect itself hasn't changed.
+        chart._legendLastSig = null;
         renderLegend();
     };
 }

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -264,6 +264,55 @@ export function configureQuantileHeatmap(chart) {
             </div>`;
         }
 
+        // Compare-pair variant: when the spec carries the counterpart's
+        // spectrum data, render baseline | experiment | delta. This is
+        // the side-by-side path's tooltip (the diff path used the
+        // diffMatrices branch above).
+        if (chart.spec.compareCounterpartData
+            && chart.spec.compareCaptureLabels
+            && chart.spec.compareSelfRole) {
+            const counterpart = chart.spec.compareCounterpartData;
+            const labels = chart.spec.compareCaptureLabels;
+            const selfRole = chart.spec.compareSelfRole;  // 'baseline' | 'experiment'
+            // Find counterpart cell value at the same (timeIdx, qIdx).
+            let tIdx = -1;
+            for (let i = 0; i < tCount; i++) {
+                if (Math.abs(timeData[i] * 1000 - tsMs) < 0.5) { tIdx = i; break; }
+            }
+            const otherV = (tIdx >= 0 && Array.isArray(counterpart.data) && counterpart.data[q + 1])
+                ? counterpart.data[q + 1][tIdx]
+                : null;
+            const fmtCell = (x) => (x == null || Number.isNaN(x)) ? '—' : valueFmt(x);
+            const selfV = v;
+            const baseV = selfRole === 'baseline' ? selfV : otherV;
+            const expV  = selfRole === 'experiment' ? selfV : otherV;
+            let deltaStr = '—';
+            if (baseV != null && !Number.isNaN(baseV) && expV != null && !Number.isNaN(expV)) {
+                const d = expV - baseV;
+                const pct = baseV !== 0 ? `(${d >= 0 ? '+' : ''}${(d / baseV * 100).toFixed(1)}%)` : '';
+                deltaStr = `${d >= 0 ? '+' : ''}${valueFmt(d)} ${pct}`.trim();
+            }
+            return `<div style="${FONTS.cssSans}">
+                <div style="${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.fgSecondary}; margin-bottom: 8px;">
+                    ${formattedTime}
+                </div>
+                <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 6px;">
+                    <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
+                        ${label}
+                    </span>
+                </div>
+                <div style="display: grid; grid-template-columns: max-content max-content; gap: 2px 12px; ${FONTS.cssMono} font-size: ${FONTS.tooltipValue.fontSize}px;">
+                    <span style="color: var(--compare-baseline, ${COLORS.fgSecondary});">${labels.baseline || 'baseline'}</span>
+                    <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${fmtCell(baseV)}</span>
+                    <span style="color: var(--compare-experiment, ${COLORS.fgSecondary});">${labels.experiment || 'experiment'}</span>
+                    <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${fmtCell(expV)}</span>
+                    <span style="color: ${COLORS.fgSecondary};">Δ</span>
+                    <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${deltaStr}</span>
+                </div>
+                ${getTooltipFreezeFooter(chart)}
+            </div>`;
+        }
+
         // Default variant: single value tooltip.
         return `<div style="${FONTS.cssSans}">
             <div style="${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.fgSecondary}; margin-bottom: 8px;">
@@ -382,6 +431,35 @@ export function configureQuantileHeatmap(chart) {
     };
 
     applyChartOption(chart, option);
+
+    // Compare-mode cross-cursor publisher. When the spec carries a
+    // compareGroupId, every showtip / hidetip event publishes the
+    // cell coordinates to sibling subscribers (the other half of the
+    // pair). Off completely outside compare-mode pair rendering.
+    const compareGroupId = chart.spec.compareGroupId;
+    const chartsState = chart.chartsState;
+    if (compareGroupId && chartsState && typeof chartsState.publishCompareCursor === 'function') {
+        // Tear down any prior listener (reconfigure path).
+        if (chart._compareCursorOff) chart._compareCursorOff();
+        const onShow = (params) => {
+            if (!params || !params.data) return;
+            chartsState.publishCompareCursor(compareGroupId, {
+                timeMs: params.data[0],
+                qIdx: params.data[1],
+                sourceChartId: chart.chartId,
+            });
+        };
+        const onHide = () => {
+            chartsState.publishCompareCursor(compareGroupId, null);
+        };
+        chart.echart.on('showTip', onShow);
+        chart.echart.on('hideTip', onHide);
+        chart._compareCursorOff = () => {
+            chart.echart.off('showTip', onShow);
+            chart.echart.off('hideTip', onHide);
+            chart._compareCursorOff = null;
+        };
+    }
 
     // Vertical legend bar. For the default (RdYlGn-flipped) palette we
     // feed `1 - t` so the bottom (low value) stays green; for a custom

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -138,14 +138,22 @@ export function configureQuantileHeatmap(chart) {
         ? (timeData[1] - timeData[0]) * 1000
         : 1000;
 
-    // Cells: [timestampMs, quantileIdx, value]. Skip non-positive
-    // values — they'd be invisible anyway and break the log mapping.
+    // Cells: [timestampMs, quantileIdx, value]. When `nullCellColor`
+    // is set, emit null-valued cells too so they render with the
+    // configured color (compare-mode diff heatmap uses this). Otherwise
+    // skip them along with non-positive cells (which break log mapping).
+    const nullCellColor = chart.spec.nullCellColor || null;
     const cells = [];
     for (let t = 0; t < tCount; t++) {
         const tsMs = timeData[t] * 1000;
         for (let q = 0; q < seriesCount; q++) {
             const v = data[q + 1][t];
-            if (v == null || Number.isNaN(v) || v <= 0) continue;
+            const isNull = v == null || Number.isNaN(v);
+            if (isNull) {
+                if (nullCellColor) cells.push([tsMs, q, null]);
+                continue;
+            }
+            if (v <= 0) continue;
             cells.push([tsMs, q, v]);
         }
     }
@@ -178,6 +186,16 @@ export function configureQuantileHeatmap(chart) {
         if (y < gridY) { height -= (gridY - y); y = gridY; }
         if (y + height > gridY + gridHeight) height = gridY + gridHeight - y;
         if (width <= 0 || height <= 0) return;
+
+        // Null cells (compare-mode diff): paint with the configured
+        // null color and exit early — no log-scale mapping needed.
+        if (v === null || v === undefined || Number.isNaN(v)) {
+            return {
+                type: 'rect',
+                shape: { x, y, width, height },
+                style: { fill: nullCellColor, stroke: null, lineWidth: 0 },
+            };
+        }
 
         const norm = Math.min(1, Math.max(0, (safeLog(v) - logMin) / logRange));
         const color = cellColorFor(norm);

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -84,6 +84,11 @@ export function configureQuantileHeatmap(chart) {
         : Array.from({ length: seriesCount }, (_, i) => String((i + 1) / seriesCount));
     const displayLabels = rawLabels.map(formatQuantileLabel);
 
+    // Diff mode (signed deltas) flows through the renderer with a
+    // linear color scale and accepts negative anchors. Detected once
+    // here so the cell loop and color logic can branch consistently.
+    const isDiff = !!chart.spec.diffMatrices;
+
     // Color scale spans the non-null, positive value range across all cells.
     let colorMin = Infinity;
     let colorMax = -Infinity;
@@ -91,7 +96,9 @@ export function configureQuantileHeatmap(chart) {
         const col = data[s];
         for (let t = 0; t < tCount; t++) {
             const v = col[t];
-            if (v != null && !Number.isNaN(v) && v > 0) {
+            // Diff data is signed; only the positive log path needs the
+            // v > 0 filter (log10 is undefined at and below zero).
+            if (v != null && !Number.isNaN(v) && (isDiff || v > 0)) {
                 if (v < colorMin) colorMin = v;
                 if (v > colorMax) colorMax = v;
             }
@@ -103,16 +110,26 @@ export function configureQuantileHeatmap(chart) {
     // max anchor lets the compare-mode pair share a unified ceiling so
     // both halves render with the same color scale.
     const minAnchor = chart.spec.color_min_anchor;
-    if (minAnchor != null && Number.isFinite(minAnchor) && minAnchor > 0) {
+    if (minAnchor != null && Number.isFinite(minAnchor) && (isDiff || minAnchor > 0)) {
         colorMin = minAnchor;
     }
     const maxAnchor = chart.spec.color_max_anchor;
-    if (maxAnchor != null && Number.isFinite(maxAnchor) && maxAnchor > 0) {
+    if (maxAnchor != null && Number.isFinite(maxAnchor) && (isDiff || maxAnchor > 0)) {
         colorMax = maxAnchor;
     }
     if (!Number.isFinite(colorMin)) colorMin = 0;
     if (!Number.isFinite(colorMax)) colorMax = 1;
-    if (colorMax <= colorMin) colorMax = colorMin > 0 ? colorMin * 10 : 1;
+    if (colorMax <= colorMin) {
+        if (isDiff) {
+            // Signed range: pad symmetrically so the diverging palette
+            // resampler has a non-degenerate window to work with.
+            const pad = Math.max(Math.abs(colorMin), 1) * 0.5;
+            colorMin -= pad;
+            colorMax += pad;
+        } else {
+            colorMax = colorMin > 0 ? colorMin * 10 : 1;
+        }
+    }
 
     // Color function. Default: flipped-RdYlGn so low values are green
     // and high values are red. When the spec supplies a custom palette
@@ -125,14 +142,24 @@ export function configureQuantileHeatmap(chart) {
         ? rampFn(norm)
         : rdYlGnColor(1 - norm);  // flipped: low value → green
 
-    // Log-scale color mapping. Guard against non-positive min by
-    // clamping inside the log to a tiny epsilon (the renderer already
-    // skips zero/negative cells, so this only matters when colorMin
-    // collapsed to its initialization value above).
-    const safeLog = (v) => Math.log10(v > 0 ? v : 1e-12);
-    const logMin = safeLog(colorMin);
-    const logMax = safeLog(colorMax);
-    const logRange = logMax - logMin || 1;
+    // Color normalization. Single-capture and side-by-side compare-pair
+    // data is strictly positive — use log10 mapping (preserves visual
+    // contrast across the wide latency dynamic range). Diff mode is
+    // signed and uses a diverging palette with neutral at zero — use a
+    // linear mapping so palette stops align with semantic values.
+    // `safeLog` is lifted to function scope because the legend tick
+    // loop also computes log-spaced positions in non-diff mode.
+    const safeLog = (val) => Math.log10(val > 0 ? val : 1e-12);
+    let normalize;
+    if (isDiff) {
+        const range = (colorMax - colorMin) || 1;
+        normalize = (v) => Math.min(1, Math.max(0, (v - colorMin) / range));
+    } else {
+        const logMin = safeLog(colorMin);
+        const logMax = safeLog(colorMax);
+        const logRange = (logMax - logMin) || 1;
+        normalize = (v) => Math.min(1, Math.max(0, (safeLog(v) - logMin) / logRange));
+    }
 
     const timeIntervalMs = tCount > 1
         ? (timeData[1] - timeData[0]) * 1000
@@ -153,7 +180,9 @@ export function configureQuantileHeatmap(chart) {
                 if (nullCellColor) cells.push([tsMs, q, null]);
                 continue;
             }
-            if (v <= 0) continue;
+            // Log-scale mapping requires v > 0; the diff path uses a
+            // linear mapping that's defined for negatives too.
+            if (!isDiff && v <= 0) continue;
             cells.push([tsMs, q, v]);
         }
     }
@@ -197,7 +226,7 @@ export function configureQuantileHeatmap(chart) {
             };
         }
 
-        const norm = Math.min(1, Math.max(0, (safeLog(v) - logMin) / logRange));
+        const norm = normalize(v);
         const color = cellColorFor(norm);
 
         return {

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -81,15 +81,18 @@ export function configureQuantileHeatmap(chart) {
             }
         }
     }
-    // Override colorMin with the p0 anchor when the spec carries one.
-    // This pins the lower bound of the color scale across spectrum
-    // kinds (full vs tail) so toggling between them doesn't repaint
-    // the whole heatmap with a different color range — Tail's rows
-    // (p99.01..p100) all sit near the top of the natural max, so
-    // without an anchor they'd remap to the full green→red span.
-    const anchor = chart.spec.color_min_anchor;
-    if (anchor != null && Number.isFinite(anchor) && anchor > 0) {
-        colorMin = anchor;
+    // Override colorMin / colorMax with anchors when the spec carries
+    // them. min anchor pins the lower bound across spectrum kinds
+    // (full vs tail) so toggling between them keeps colors consistent;
+    // max anchor lets the compare-mode pair share a unified ceiling so
+    // both halves render with the same color scale.
+    const minAnchor = chart.spec.color_min_anchor;
+    if (minAnchor != null && Number.isFinite(minAnchor) && minAnchor > 0) {
+        colorMin = minAnchor;
+    }
+    const maxAnchor = chart.spec.color_max_anchor;
+    if (maxAnchor != null && Number.isFinite(maxAnchor) && maxAnchor > 0) {
+        colorMax = maxAnchor;
     }
     if (!Number.isFinite(colorMin)) colorMin = 0;
     if (!Number.isFinite(colorMax)) colorMax = 1;

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -212,6 +212,13 @@ export function configureQuantileHeatmap(chart) {
         : (v) => String(v);
 
     const customXFormatterForTooltip = chart.spec.xAxisFormatter;
+
+    // Diff side-channel: when present, the tooltip pulls the original
+    // baseline + experiment values from these matrices and renders both
+    // alongside the delta (matrices are keyed [qIdx][tIdx]).
+    const diffMatrices = chart.spec.diffMatrices;
+    const diffCaptureLabels = chart.spec.diffCaptureLabels;
+
     const tooltipFormatter = function (params) {
         if (!params.data) return '';
         const [tsMs, q, v] = params.data;
@@ -219,6 +226,45 @@ export function configureQuantileHeatmap(chart) {
             ? customXFormatterForTooltip(tsMs)
             : formatDateTime(tsMs);
         const label = displayLabels[q] || '';
+
+        // Diff variant: show baseline | experiment | delta.
+        if (diffMatrices) {
+            // Find the time index by scanning timeData for the matching ms.
+            // O(N) but tooltips fire on hover — fine at 100s of timestamps.
+            let tIdx = -1;
+            for (let i = 0; i < tCount; i++) {
+                if (Math.abs(timeData[i] * 1000 - tsMs) < 0.5) { tIdx = i; break; }
+            }
+            const bv = (tIdx >= 0) ? diffMatrices.baseline?.[q]?.[tIdx] : null;
+            const ev = (tIdx >= 0) ? diffMatrices.experiment?.[q]?.[tIdx] : null;
+            const fmtCell = (x) => (x == null || Number.isNaN(x)) ? '—' : valueFmt(x);
+            const baselineLabel = diffCaptureLabels?.baseline || 'baseline';
+            const experimentLabel = diffCaptureLabels?.experiment || 'experiment';
+            const deltaStr = (v == null || Number.isNaN(v))
+                ? '—'
+                : `${v >= 0 ? '+' : ''}${valueFmt(v)}`;
+            return `<div style="${FONTS.cssSans}">
+                <div style="${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.fgSecondary}; margin-bottom: 8px;">
+                    ${formattedTime}
+                </div>
+                <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 6px;">
+                    <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
+                        ${label}
+                    </span>
+                </div>
+                <div style="display: grid; grid-template-columns: max-content max-content; gap: 2px 12px; ${FONTS.cssMono} font-size: ${FONTS.tooltipValue.fontSize}px;">
+                    <span style="color: var(--compare-baseline, ${COLORS.fgSecondary});">${baselineLabel}</span>
+                    <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${fmtCell(bv)}</span>
+                    <span style="color: var(--compare-experiment, ${COLORS.fgSecondary});">${experimentLabel}</span>
+                    <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${fmtCell(ev)}</span>
+                    <span style="color: ${COLORS.fgSecondary};">Δ</span>
+                    <span style="color: ${COLORS.fg}; font-weight: ${FONTS.tooltipValue.fontWeight};">${deltaStr}</span>
+                </div>
+                ${getTooltipFreezeFooter(chart)}
+            </div>`;
+        }
+
+        // Default variant: single value tooltip.
         return `<div style="${FONTS.cssSans}">
             <div style="${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.fgSecondary}; margin-bottom: 8px;">
                 ${formattedTime}
@@ -346,7 +392,10 @@ export function configureQuantileHeatmap(chart) {
     const barCanvas = buildGradientCanvas(legendColorFn);
 
     // Bar gradient is linear in log10(value) space. Interpolate values
-    // at evenly spaced positions for the tick labels.
+    // at evenly spaced positions for the tick labels. In diff mode the
+    // values are signed (negative=baseline higher); the sign itself
+    // disambiguates direction across all five ticks, so we don't strip
+    // it. Captions above/below the bar reinforce the meaning.
     const TICK_COUNT = 5;
     const ticks = [];
     for (let i = 0; i < TICK_COUNT; i++) {
@@ -356,12 +405,17 @@ export function configureQuantileHeatmap(chart) {
             : colorMin + pos * (colorMax - colorMin);
         ticks.push({ pos, label: valueFmt(sigDigits(value)) });
     }
+    // Diff captions: top of bar = max = "experiment is higher" (matches
+    // the right end of the legacy horizontal layout).
+    const diffLegendLabels = chart.spec.diffLegendLabels;
     // Re-run on every `finished` so the bar's height and top track the
     // grid rect (Y-axis). First call before layout uses defaults.
     const renderLegend = () => {
         const rect = chart.echart?.getModel()?.getComponent('grid')?.coordinateSystem?.getRect();
         ensureLegendBar(chart.domNode, barCanvas, {
             ticks,
+            topCaption: diffLegendLabels ? diffLegendLabels.right : '',
+            bottomCaption: diffLegendLabels ? diffLegendLabels.left : '',
             barTop: rect?.y,
             barHeight: rect?.height,
         });

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -385,6 +385,10 @@ export function configureQuantileHeatmap(chart) {
             containLabel: false,
         },
         dataZoom: getDataZoomConfig(calculateMinZoomSpan(timeData)),
+        // Force hover effects onto the separate hoverLayer canvas so
+        // cell hover doesn't trigger a progressive re-render of the
+        // main canvas. Same fix as heatmap.js / histogram_heatmap.js.
+        hoverLayerThreshold: 0,
         xAxis: {
             type: 'time',
             min: 'dataMin',
@@ -453,6 +457,11 @@ export function configureQuantileHeatmap(chart) {
             encode: { x: 0, y: 1 },
             data: cells,
             clip: true,
+            // No hover state for these cells — telling ECharts
+            // explicitly avoids the default hover-handling pass that
+            // can trigger a progressive re-render of the right-of-cursor
+            // chunk on every mousemove. Same fix as histogram_heatmap.js.
+            emphasis: { disabled: true },
             progressive: 5000,
             progressiveThreshold: 3000,
             animation: false,
@@ -528,8 +537,17 @@ export function configureQuantileHeatmap(chart) {
     const diffLegendLabels = chart.spec.diffLegendLabels;
     // Re-run on every `finished` so the bar's height and top track the
     // grid rect (Y-axis). First call before layout uses defaults.
+    // Dedup on rect signature so we don't rebuild the legend DOM on
+    // every hover-emphasis render — `finished` fires on those and the
+    // resulting innerHTML reset would flash the legend (especially
+    // visible in compare-mode side-by-side pairs).
     const renderLegend = () => {
         const rect = chart.echart?.getModel()?.getComponent('grid')?.coordinateSystem?.getRect();
+        const sig = rect
+            ? `${rect.x}:${rect.y}:${rect.width}:${rect.height}`
+            : 'none';
+        if (chart._legendLastSig === sig) return;
+        chart._legendLastSig = sig;
         ensureLegendBar(chart.domNode, barCanvas, {
             ticks,
             topCaption: diffLegendLabels ? diffLegendLabels.right : '',
@@ -538,6 +556,7 @@ export function configureQuantileHeatmap(chart) {
             barHeight: rect?.height,
         });
     };
+    chart._legendLastSig = null;
     renderLegend();
     if (chart._legendFinishedFn) chart.echart.off('finished', chart._legendFinishedFn);
     chart._legendFinishedFn = renderLegend;

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -461,6 +461,17 @@ export function configureQuantileHeatmap(chart) {
         };
     }
 
+    // Compare-mode cross-cursor subscriber. Receives sibling events
+    // and renders a thin crosshair at the matching cell. The publisher
+    // filters out self-sourced events (via fn._chartId), so on its own
+    // hover this chart doesn't draw a redundant crosshair on itself.
+    if (compareGroupId && chartsState && typeof chartsState.subscribeCompareCursor === 'function') {
+        if (chart._compareCursorUnsub) chart._compareCursorUnsub();
+        const onCursor = (payload) => drawCompareCrosshair(chart, payload, timeData, tCount);
+        onCursor._chartId = chart.chartId;  // tag for self-filter in publishCompareCursor
+        chart._compareCursorUnsub = chartsState.subscribeCompareCursor(compareGroupId, onCursor);
+    }
+
     // Vertical legend bar. For the default (RdYlGn-flipped) palette we
     // feed `1 - t` so the bottom (low value) stays green; for a custom
     // palette (e.g. compare-mode diff diverging) use the ramp directly
@@ -502,4 +513,50 @@ export function configureQuantileHeatmap(chart) {
     if (chart._legendFinishedFn) chart.echart.off('finished', chart._legendFinishedFn);
     chart._legendFinishedFn = renderLegend;
     chart.echart.on('finished', renderLegend);
+}
+
+// Render a crosshair on `chart` at the matching cell from a sibling's
+// cursor event. Cleared when payload is null. Uses ECharts' graphic
+// component overlaid on the chart canvas — no relayout cost.
+function drawCompareCrosshair(chart, payload, timeData, tCount) {
+    if (!chart || !chart.echart) return;
+    if (!payload) {
+        chart.echart.setOption({ graphic: [] });
+        return;
+    }
+    const { timeMs, qIdx } = payload;
+    // Convert (timeMs, qIdx) to pixel coords. convertToPixel returns
+    // null when the chart hasn't laid out yet.
+    const pix = chart.echart.convertToPixel({ gridIndex: 0 }, [timeMs, qIdx]);
+    if (!pix) return;
+
+    const grid = chart.echart.getModel().getComponent('grid');
+    const rect = grid?.coordinateSystem?.getRect();
+    if (!rect) return;
+
+    // Approximate cell width/height from time interval and quantile rows.
+    const intervalMs = tCount > 1 ? (timeData[1] - timeData[0]) * 1000 : 1000;
+    const cellWidthPx = chart.echart.convertToPixel({ gridIndex: 0 }, [timeMs + intervalMs, qIdx])[0] - pix[0];
+    const cellHeightPx = chart.echart.convertToPixel({ gridIndex: 0 }, [timeMs, qIdx + 1])[1] - pix[1];
+
+    chart.echart.setOption({
+        graphic: [
+            // Horizontal line across grid at qIdx
+            {
+                type: 'rect',
+                z: 100,
+                shape: { x: rect.x, y: pix[1] + cellHeightPx, width: rect.width, height: 1 },
+                style: { fill: 'rgba(255,255,255,0.6)' },
+                silent: true,
+            },
+            // Vertical line across grid at timeMs
+            {
+                type: 'rect',
+                z: 100,
+                shape: { x: pix[0], y: rect.y, width: Math.max(1, cellWidthPx), height: rect.height },
+                style: { fill: 'rgba(255,255,255,0.15)' },
+                silent: true,
+            },
+        ],
+    });
 }

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -26,6 +26,22 @@ import {
     LEGEND_GRID_RIGHT,
 } from './color_legend.js';
 
+// Build a (t: 0..1) → cssColor function from a palette array (CSS color
+// strings). Used when the spec supplies a custom `colormap` (e.g. the
+// diverging palette for compare-mode diff heatmaps). Nearest-neighbor
+// interpolation between adjacent stops — adequate for the cell colors
+// (the gradient legend uses the same function via buildGradientCanvas).
+const buildRampColorFn = (palette) => (t) => {
+    if (!palette || palette.length === 0) return 'rgb(0,0,0)';
+    if (palette.length === 1) return palette[0];
+    const clamped = Math.max(0, Math.min(1, t));
+    const idx = clamped * (palette.length - 1);
+    const i = Math.floor(idx);
+    if (i >= palette.length - 1) return palette[palette.length - 1];
+    const f = idx - i;
+    return f < 0.5 ? palette[i] : palette[i + 1];
+};
+
 // Series names from the spectrum fetch are already formatted as `pXX`
 // (see fetchQuantileSpectrumForPlot). For specs that come from elsewhere
 // (e.g. raw fractions like "0.5"), coerce to the same `pXX` shape so
@@ -98,6 +114,17 @@ export function configureQuantileHeatmap(chart) {
     if (!Number.isFinite(colorMax)) colorMax = 1;
     if (colorMax <= colorMin) colorMax = colorMin > 0 ? colorMin * 10 : 1;
 
+    // Color function. Default: flipped-RdYlGn so low values are green
+    // and high values are red. When the spec supplies a custom palette
+    // (e.g. compare-mode diff diverging palette), use that ramp directly
+    // — palette index 0 maps to t=0 (the colorMin end), so the strategy
+    // is responsible for ordering the palette accordingly.
+    const customPalette = chart.spec.colormap;
+    const rampFn = customPalette ? buildRampColorFn(customPalette) : null;
+    const cellColorFor = (norm) => rampFn
+        ? rampFn(norm)
+        : rdYlGnColor(1 - norm);  // flipped: low value → green
+
     // Log-scale color mapping. Guard against non-positive min by
     // clamping inside the log to a tiny epsilon (the renderer already
     // skips zero/negative cells, so this only matters when colorMin
@@ -153,8 +180,7 @@ export function configureQuantileHeatmap(chart) {
         if (width <= 0 || height <= 0) return;
 
         const norm = Math.min(1, Math.max(0, (safeLog(v) - logMin) / logRange));
-        // Flip: low value → green (t=1), high value → red (t=0).
-        const color = rdYlGnColor(1 - norm);
+        const color = cellColorFor(norm);
 
         return {
             type: 'rect',
@@ -293,9 +319,13 @@ export function configureQuantileHeatmap(chart) {
 
     applyChartOption(chart, option);
 
-    // Vertical legend bar: top=red=high value, bottom=green=low value.
-    // The (1 - t) flip matches the cell color mapping above.
-    const barCanvas = buildGradientCanvas((t) => rdYlGnColor(1 - t));
+    // Vertical legend bar. For the default (RdYlGn-flipped) palette we
+    // feed `1 - t` so the bottom (low value) stays green; for a custom
+    // palette (e.g. compare-mode diff diverging) use the ramp directly
+    // — strategies that supply their own palette get exactly the colors
+    // they configured (no implicit flip).
+    const legendColorFn = customPalette ? rampFn : (t) => rdYlGnColor(1 - t);
+    const barCanvas = buildGradientCanvas(legendColorFn);
 
     // Bar gradient is linear in log10(value) space. Interpolate values
     // at evenly spaced positions for the tick labels.

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -467,7 +467,7 @@ export function configureQuantileHeatmap(chart) {
     // hover this chart doesn't draw a redundant crosshair on itself.
     if (compareGroupId && chartsState && typeof chartsState.subscribeCompareCursor === 'function') {
         if (chart._compareCursorUnsub) chart._compareCursorUnsub();
-        const onCursor = (payload) => drawCompareCrosshair(chart, payload, timeData, tCount);
+        const onCursor = (payload) => drawCompareCrosshair(chart, payload, timeData, tCount, seriesCount);
         onCursor._chartId = chart.chartId;  // tag for self-filter in publishCompareCursor
         chart._compareCursorUnsub = chartsState.subscribeCompareCursor(compareGroupId, onCursor);
     }
@@ -518,7 +518,7 @@ export function configureQuantileHeatmap(chart) {
 // Render a crosshair on `chart` at the matching cell from a sibling's
 // cursor event. Cleared when payload is null. Uses ECharts' graphic
 // component overlaid on the chart canvas — no relayout cost.
-function drawCompareCrosshair(chart, payload, timeData, tCount) {
+function drawCompareCrosshair(chart, payload, timeData, tCount, seriesCount) {
     if (!chart || !chart.echart) return;
     if (!payload) {
         chart.echart.setOption({ graphic: [] });
@@ -534,10 +534,18 @@ function drawCompareCrosshair(chart, payload, timeData, tCount) {
     const rect = grid?.coordinateSystem?.getRect();
     if (!rect) return;
 
-    // Approximate cell width/height from time interval and quantile rows.
+    // Cell width/height: try to sample neighbours via convertToPixel
+    // first (matches actual axis spacing including any non-uniform
+    // mapping). For the rightmost time column or the top quantile row
+    // the neighbour is past the axis max and convertToPixel returns
+    // null — fall back to dividing the grid rect by the cell counts.
     const intervalMs = tCount > 1 ? (timeData[1] - timeData[0]) * 1000 : 1000;
-    const cellWidthPx = chart.echart.convertToPixel({ gridIndex: 0 }, [timeMs + intervalMs, qIdx])[0] - pix[0];
-    const cellHeightPx = chart.echart.convertToPixel({ gridIndex: 0 }, [timeMs, qIdx + 1])[1] - pix[1];
+    const widthSample = chart.echart.convertToPixel({ gridIndex: 0 }, [timeMs + intervalMs, qIdx]);
+    const heightSample = chart.echart.convertToPixel({ gridIndex: 0 }, [timeMs, qIdx + 1]);
+    const fallbackCellWidth = (tCount > 0) ? rect.width / tCount : rect.width;
+    const fallbackCellHeight = (seriesCount > 0) ? rect.height / seriesCount : rect.height;
+    const cellWidthPx = widthSample ? (widthSample[0] - pix[0]) : fallbackCellWidth;
+    const cellHeightPx = heightSample ? (heightSample[1] - pix[1]) : -fallbackCellHeight;
 
     chart.echart.setOption({
         graphic: [

--- a/src/viewer/assets/lib/charts/quantile_heatmap.js
+++ b/src/viewer/assets/lib/charts/quantile_heatmap.js
@@ -564,14 +564,24 @@ export function configureQuantileHeatmap(chart) {
 }
 
 // Render a crosshair on `chart` at the matching cell from a sibling's
-// cursor event. Cleared when payload is null. Uses ECharts' graphic
-// component overlaid on the chart canvas — no relayout cost.
+// cursor event. Cleared when payload is null. Uses zrender's `add` /
+// `remove` directly — going through `setOption({ graphic: [...] })`
+// would force ECharts to re-process the option tree on every cursor
+// move and re-render the progressive custom-type series chunks, which
+// the user perceives as cell flicker. Direct zrender shape ops only
+// touch the overlay layer; the chart cells stay untouched.
 function drawCompareCrosshair(chart, payload, timeData, tCount, seriesCount) {
     if (!chart || !chart.echart) return;
-    if (!payload) {
-        chart.echart.setOption({ graphic: [] });
-        return;
+    const zr = chart.echart.getZr?.();
+    if (!zr) return;
+
+    // Tear down any prior crosshair shapes before deciding what to do.
+    if (chart._compareCrosshairShapes) {
+        for (const s of chart._compareCrosshairShapes) zr.remove(s);
+        chart._compareCrosshairShapes = null;
     }
+    if (!payload) return;
+
     const { timeMs, qIdx } = payload;
     // Convert (timeMs, qIdx) to pixel coords. convertToPixel returns
     // null when the chart hasn't laid out yet.
@@ -595,24 +605,21 @@ function drawCompareCrosshair(chart, payload, timeData, tCount, seriesCount) {
     const cellWidthPx = widthSample ? (widthSample[0] - pix[0]) : fallbackCellWidth;
     const cellHeightPx = heightSample ? (heightSample[1] - pix[1]) : -fallbackCellHeight;
 
-    chart.echart.setOption({
-        graphic: [
-            // Horizontal line across grid at qIdx
-            {
-                type: 'rect',
-                z: 100,
-                shape: { x: rect.x, y: pix[1] + cellHeightPx, width: rect.width, height: 1 },
-                style: { fill: 'rgba(255,255,255,0.6)' },
-                silent: true,
-            },
-            // Vertical line across grid at timeMs
-            {
-                type: 'rect',
-                z: 100,
-                shape: { x: pix[0], y: rect.y, width: Math.max(1, cellWidthPx), height: rect.height },
-                style: { fill: 'rgba(255,255,255,0.15)' },
-                silent: true,
-            },
-        ],
+    const Rect = (typeof echarts !== 'undefined' && echarts.graphic && echarts.graphic.Rect);
+    if (!Rect) return;
+    const horizontal = new Rect({
+        z: 100,
+        silent: true,
+        shape: { x: rect.x, y: pix[1] + cellHeightPx, width: rect.width, height: 1 },
+        style: { fill: 'rgba(255,255,255,0.6)' },
     });
+    const vertical = new Rect({
+        z: 100,
+        silent: true,
+        shape: { x: pix[0], y: rect.y, width: Math.max(1, cellWidthPx), height: rect.height },
+        style: { fill: 'rgba(255,255,255,0.15)' },
+    });
+    zr.add(horizontal);
+    zr.add(vertical);
+    chart._compareCrosshairShapes = [horizontal, vertical];
 }

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -25,6 +25,7 @@ import { SCATTER_PALETTE } from './util/colormap.js';
 import { DEFAULT_PERCENTILES } from './metric_types.js';
 import { configureQuantileHeatmap } from './quantile_heatmap.js';
 import { fetchQuantileSpectrumForPlot } from '../data.js';
+import { quantilesForKind } from './util/spectrum_quantiles.js';
 
 /**
  * Configures the Chart based on Chart.spec
@@ -441,19 +442,6 @@ const SPECTRUM_CHECKBOX_CLASS = 'spectrum-toggle';
 const SPECTRUM_TAIL_CHECKBOX_CLASS = 'spectrum-tail-toggle';
 
 const SPECTRUM_LABELS = { full: 'Full', tail: 'Tail' };
-
-// Build the list of quantiles to query for each spectrum kind. Use
-// integer math so 100 evenly-spaced steps don't accumulate float drift
-// (especially relevant for the tail's 0.0001-wide steps).
-function quantilesForKind(kind) {
-    const out = [];
-    if (kind === 'tail') {
-        for (let i = 1; i <= 100; i++) out.push((9900 + i) / 10000);
-    } else {
-        for (let i = 1; i <= 100; i++) out.push(i / 100);
-    }
-    return out;
-}
 
 function renderSpectrumCheckbox(el, chart, kind) {
     const on = chart.spectrumKind === kind;

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -471,18 +471,36 @@ function toggleSpectrum(chart, kind) {
     chart.configureChartByType();
 }
 
-// Align the controls' left edge with the chart grid's left edge (the
-// inner plot canvas, not the y-axis label gutter). The grid rect is
-// only available after echarts has laid out the chart, and its
-// x-position depends on the rendered y-axis label width — so we query
-// it after each render via the `finished` event and reposition.
+// Position the spectrum controls inside chart.domNode so they:
+//   - hug the chart grid's left edge (so they line up with the inner
+//     plot canvas, not the y-axis label gutter)
+//   - sit on the same vertical row as the right-anchored percentile
+//     legend on wide charts, OR move up to the empty area above the
+//     legend on narrow charts so they don't crowd the legend on
+//     mobile / narrow viewport widths.
+// The grid rect is only available after echarts has laid out the
+// chart, so we query it via the `finished` event and reposition.
+const SPECTRUM_CONTROLS_NARROW_WIDTH = 500;
 function positionControlsAtGridLeft(chart, container) {
     if (!chart.echart) return;
     try {
         const grid = chart.echart.getModel().getComponent('grid');
         const rect = grid?.coordinateSystem?.getRect();
-        if (rect && Number.isFinite(rect.x)) {
-            container.style.left = Math.round(rect.x) + 'px';
+        const chartWidth = chart.echart.getDom?.()?.clientWidth ?? 0;
+        const narrow = chartWidth > 0 && chartWidth < SPECTRUM_CONTROLS_NARROW_WIDTH;
+        if (narrow) {
+            // Narrow chart: stack above the legend on its own line and
+            // align to the right edge so it visually anchors to the
+            // legend's column rather than floating in the left gutter.
+            container.style.top = '28px';
+            container.style.left = 'auto';
+            container.style.right = '12px';
+        } else {
+            container.style.top = '42px';
+            container.style.right = 'auto';
+            if (rect && Number.isFinite(rect.x)) {
+                container.style.left = Math.round(rect.x) + 'px';
+            }
         }
     } catch (_e) {
         // Layout not ready yet — next 'finished' event will retry.

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -32,21 +32,19 @@ export function unifyHistogramRange(a, b) {
     const aScan = scanPositiveRange(a?.data);
     const bScan = scanPositiveRange(b?.data);
 
-    const naturalMin = Math.min(
-        Number.isFinite(aScan.min) ? aScan.min : Infinity,
-        Number.isFinite(bScan.min) ? bScan.min : Infinity,
-    );
+    // Per-capture effective min: anchor if present, otherwise the
+    // capture's own scanned positive min. Each capture stays
+    // independent so an asymmetric anchor situation (one present,
+    // one absent) doesn't clip the no-anchor capture's lower values.
+    const aMin = positiveOr(a?.color_min_anchor, Number.isFinite(aScan.min) ? aScan.min : Infinity);
+    const bMin = positiveOr(b?.color_min_anchor, Number.isFinite(bScan.min) ? bScan.min : Infinity);
+    let colorMin = Math.min(aMin, bMin);
+    if (!Number.isFinite(colorMin)) colorMin = 0;
+
     const naturalMax = Math.max(
         Number.isFinite(aScan.max) ? aScan.max : -Infinity,
         Number.isFinite(bScan.max) ? bScan.max : -Infinity,
     );
-
-    let colorMin = Math.min(
-        positiveOr(a?.color_min_anchor, Infinity),
-        positiveOr(b?.color_min_anchor, Infinity),
-    );
-    if (!Number.isFinite(colorMin)) colorMin = naturalMin;
-    if (!Number.isFinite(colorMin)) colorMin = 0;
 
     let colorMax = naturalMax;
     if (!Number.isFinite(colorMax)) colorMax = 1;

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -91,18 +91,28 @@ function positiveOr(v, fallback) {
  *
  * Return shape (or null on mismatch / empty inputs):
  *   {
- *     time_data: number[],         // same as inputs (must match)
+ *     time_data: number[],         // alias of baseline.time_data (shared reference)
  *     data: [time, ...qDeltaCols], // null preserved when either side is null/NaN
  *     series_names: string[],      // taken from baseline
- *     dMin: number | null,         // null if all deltas null
- *     dMax: number | null,
+ *     dMin: number | null,         // null if all deltas null; can be 0 (flat)
+ *     dMax: number | null,         //   — caller must pad when dMin === dMax
  *     matrices: {
  *       baseline:   number[][],    // [qIdx][tIdx] for tooltip lookup
  *       experiment: number[][],    // same
  *     },
  *   }
  *
- * Uses nullDiff (above) so undefined/NaN propagate cleanly.
+ * Uses nullDiff so undefined/NaN propagate cleanly.
+ *
+ * Caller responsibilities:
+ *   - Time axes must be VALUE-aligned, not just length-matched. This
+ *     function only verifies length; matching cadence is the upstream
+ *     fetch's job.
+ *   - When dMin === dMax (flat captures), pad before passing to a
+ *     diverging palette renderer (see renderDiffHeatmap in compare.js
+ *     for the canonical pad recipe).
+ *   - Do not mutate the returned `time_data` / `data[0]` in place;
+ *     they alias baseline.time_data.
  */
 export function buildDeltaSpectrum(baseline, experiment) {
     const baseTimes = baseline?.time_data;

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -80,6 +80,83 @@ function positiveOr(v, fallback) {
     return (v != null && Number.isFinite(v) && v > 0) ? v : fallback;
 }
 
+/**
+ * Build a columnar delta spectrum (experiment − baseline) from two
+ * spectrum-shaped captures. Returns null when the time axes or quantile
+ * counts don't match (the renderer needs aligned axes for cross-cell
+ * lookup).
+ *
+ * Shape of each input:
+ *   { time_data: number[], data: [time, ...qCols], series_names: string[] }
+ *
+ * Return shape (or null on mismatch / empty inputs):
+ *   {
+ *     time_data: number[],         // same as inputs (must match)
+ *     data: [time, ...qDeltaCols], // null preserved when either side is null/NaN
+ *     series_names: string[],      // taken from baseline
+ *     dMin: number | null,         // null if all deltas null
+ *     dMax: number | null,
+ *     matrices: {
+ *       baseline:   number[][],    // [qIdx][tIdx] for tooltip lookup
+ *       experiment: number[][],    // same
+ *     },
+ *   }
+ *
+ * Uses nullDiff (above) so undefined/NaN propagate cleanly.
+ */
+export function buildDeltaSpectrum(baseline, experiment) {
+    const baseTimes = baseline?.time_data;
+    const expTimes = experiment?.time_data;
+    if (!Array.isArray(baseTimes) || !Array.isArray(expTimes)) return null;
+    if (baseTimes.length === 0 || baseTimes.length !== expTimes.length) return null;
+
+    const baseData = baseline.data;
+    const expData = experiment.data;
+    if (!Array.isArray(baseData) || baseData.length < 2) return null;
+    if (!Array.isArray(expData) || expData.length !== baseData.length) return null;
+
+    const qCount = baseData.length - 1;
+    const tCount = baseTimes.length;
+
+    const deltaCols = [];
+    const baseMatrix = [];
+    const expMatrix = [];
+    let dMin = Infinity;
+    let dMax = -Infinity;
+
+    for (let q = 0; q < qCount; q++) {
+        const baseCol = baseData[q + 1];
+        const expCol = expData[q + 1];
+        const deltaCol = new Array(tCount);
+        const baseRow = new Array(tCount);
+        const expRow = new Array(tCount);
+        for (let t = 0; t < tCount; t++) {
+            const bv = baseCol?.[t];
+            const ev = expCol?.[t];
+            const d = nullDiff(ev, bv);
+            deltaCol[t] = d;
+            baseRow[t] = (bv != null && !Number.isNaN(bv)) ? bv : null;
+            expRow[t]  = (ev != null && !Number.isNaN(ev)) ? ev : null;
+            if (d != null) {
+                if (d < dMin) dMin = d;
+                if (d > dMax) dMax = d;
+            }
+        }
+        deltaCols.push(deltaCol);
+        baseMatrix.push(baseRow);
+        expMatrix.push(expRow);
+    }
+
+    return {
+        time_data: baseTimes,
+        data: [baseTimes, ...deltaCols],
+        series_names: baseline.series_names || [],
+        dMin: Number.isFinite(dMin) ? dMin : null,
+        dMax: Number.isFinite(dMax) ? dMax : null,
+        matrices: { baseline: baseMatrix, experiment: expMatrix },
+    };
+}
+
 // Canonicalize a histogram quantile into the shared "pXX" label form.
 // Accepts either a raw value (number or string like "0.5", "50", "p99")
 // or an object with .metric carrying a `quantile` label (the standard

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -15,6 +15,73 @@ export const intersectLabels = (setA, setB) => {
     return out;
 };
 
+/**
+ * Unify the color scale across two spectrum captures so a side-by-side
+ * pair renders with the same [colorMin, colorMax] — the same color
+ * always means the same value.
+ *
+ * `colorMin` prefers each capture's `color_min_anchor` (the p0 anchor
+ * computed by fetchQuantileSpectrumForPlot); when missing, falls back
+ * to the natural min scanned over each capture's positive cells.
+ * `colorMax` is the natural max scanned over both captures.
+ *
+ * Each capture must have shape `{ data: [times, q1Series, q2Series, …],
+ * color_min_anchor: number | null }`. Returns `{ colorMin, colorMax }`.
+ */
+export function unifyHistogramRange(a, b) {
+    const aScan = scanPositiveRange(a?.data);
+    const bScan = scanPositiveRange(b?.data);
+
+    const naturalMin = Math.min(
+        Number.isFinite(aScan.min) ? aScan.min : Infinity,
+        Number.isFinite(bScan.min) ? bScan.min : Infinity,
+    );
+    const naturalMax = Math.max(
+        Number.isFinite(aScan.max) ? aScan.max : -Infinity,
+        Number.isFinite(bScan.max) ? bScan.max : -Infinity,
+    );
+
+    let colorMin = Math.min(
+        positiveOr(a?.color_min_anchor, Infinity),
+        positiveOr(b?.color_min_anchor, Infinity),
+    );
+    if (!Number.isFinite(colorMin)) colorMin = naturalMin;
+    if (!Number.isFinite(colorMin)) colorMin = 0;
+
+    let colorMax = naturalMax;
+    if (!Number.isFinite(colorMax)) colorMax = 1;
+
+    if (colorMax <= colorMin) {
+        colorMax = colorMin > 0 ? colorMin * 10 : 1;
+    }
+
+    return { colorMin, colorMax };
+}
+
+// data shape: [timeCol, q1Col, q2Col, …]. Skips column 0 (times) and
+// only counts strictly positive, finite cells (matches the renderer's
+// own log-scale skip rule in quantile_heatmap.js).
+function scanPositiveRange(data) {
+    let min = Infinity;
+    let max = -Infinity;
+    if (!Array.isArray(data) || data.length < 2) return { min, max };
+    for (let s = 1; s < data.length; s++) {
+        const col = data[s];
+        if (!Array.isArray(col)) continue;
+        for (const v of col) {
+            if (v != null && !Number.isNaN(v) && v > 0) {
+                if (v < min) min = v;
+                if (v > max) max = v;
+            }
+        }
+    }
+    return { min, max };
+}
+
+function positiveOr(v, fallback) {
+    return (v != null && Number.isFinite(v) && v > 0) ? v : fallback;
+}
+
 // Canonicalize a histogram quantile into the shared "pXX" label form.
 // Accepts either a raw value (number or string like "0.5", "50", "p99")
 // or an object with .metric carrying a `quantile` label (the standard

--- a/src/viewer/assets/lib/charts/util/spectrum_quantiles.js
+++ b/src/viewer/assets/lib/charts/util/spectrum_quantiles.js
@@ -1,0 +1,15 @@
+// Build the list of quantiles to query for each spectrum kind. Use
+// integer math so 100 evenly-spaced steps don't accumulate float drift
+// (especially relevant for the tail's 0.0001-wide steps).
+//
+// Shared by scatter.js (single-capture toggle) and compare.js (A/B
+// strategies) so both modes always issue the same quantile set.
+export function quantilesForKind(kind) {
+    const out = [];
+    if (kind === 'tail') {
+        for (let i = 1; i <= 100; i++) out.push((9900 + i) / 10000);
+    } else {
+        for (let i = 1; i <= 100; i++) out.push(i / 100);
+    }
+    return out;
+}

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -511,7 +511,28 @@ const createDataApi = ({
         return `p${trimmed}`;
     };
 
-    const fetchQuantileSpectrumForPlot = async (plot, quantiles) => {
+    const fetchSpectrumViaCapture = async (wrappedQuery, captureId, range) => {
+        if (captureId === CAPTURE_BASELINE && !range) {
+            return executePromQLRangeQuery(wrappedQuery);
+        }
+        let r = range;
+        if (!r) {
+            const meta = cachedMetadata || await fetchMetadata();
+            const duration = meta.maxTime - meta.minTime;
+            const windowDuration = Math.min(3600, duration);
+            const start = Math.max(meta.minTime, meta.maxTime - windowDuration);
+            const step = _stepOverride || Math.max(1, Math.floor(windowDuration / 500));
+            r = { start, end: meta.maxTime, step };
+        }
+        return queryRangeForCapture(captureId, wrappedQuery, r.start, r.end, r.step);
+    };
+
+    const fetchQuantileSpectrumForPlot = async (
+        plot,
+        quantiles,
+        captureId = CAPTURE_BASELINE,
+        range = null,  // { start, end, step } — required when captureId !== baseline and the caller has the experiment's range; otherwise computed from cached metadata
+    ) => {
         const query = plot.promql_query;
         if (!query) return null;
 
@@ -538,7 +559,7 @@ const createDataApi = ({
         const queryQuantiles = quantiles.includes(0) ? quantiles : [0, ...quantiles];
         const strideSuffix = (_stepOverride && _stepOverride > 1) ? `, ${_stepOverride}` : '';
         const wrapped = `histogram_quantiles([${queryQuantiles.join(', ')}], ${metricSelector}${strideSuffix})`;
-        const result = await executePromQLRangeQuery(wrapped);
+        const result = await fetchSpectrumViaCapture(wrapped, captureId, range);
 
         if (result.status !== 'success' || !result.data?.result?.length) return null;
 

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -524,7 +524,7 @@ const createDataApi = ({
             const step = _stepOverride || Math.max(1, Math.floor(windowDuration / 500));
             r = { start, end: meta.maxTime, step };
         }
-        return queryRangeForCapture(captureId, wrappedQuery, r.start, r.end, r.step);
+        return queryRange(wrappedQuery, r.start, r.end, r.step, captureId);
     };
 
     const fetchQuantileSpectrumForPlot = async (

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -9,8 +9,10 @@ import {
     queryRangeForCapture, buildEffectiveQuery,
     promqlResultToHeatmapTriples, promqlResultToLinePair, promqlResultToSeriesMap,
     getStepOverride, CAPTURE_BASELINE, CAPTURE_EXPERIMENT,
+    fetchQuantileSpectrumForPlot,
 } from './data.js';
 import { canonicalQuantileLabel } from './charts/util/compare_math.js';
+import { quantilesForKind } from './charts/util/spectrum_quantiles.js';
 import { heatmapTriplesMinMax } from './charts/util/heatmap_data.js';
 import { ViewerApi } from './viewer_api.js';
 
@@ -225,6 +227,38 @@ const fetchExperimentResult = (vnode) => {
     })();
 };
 
+// Fire baseline + experiment spectrum fetches in parallel. On both
+// resolving, write into vnode.state._spectrumByKind[kind] and trigger
+// a redraw. On either failing or returning no data, leave the cache
+// empty for that kind and clear the pending flag so the toggle path
+// falls through to FALLBACK (5-percentile split).
+const kickOffSpectrumFetch = (vnode, spec, kind) => {
+    const range = vnode.attrs.experimentQueryRange;
+    const quantiles = quantilesForKind(kind);
+    const plotForFetch = { promql_query: spec.promql_query, opts: spec.opts };
+    Promise.all([
+        fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_BASELINE),
+        fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_EXPERIMENT, range),
+    ])
+        .then(([base, exp]) => {
+            if (!base || !exp) {
+                vnode.state._spectrumPending = null;
+                m.redraw();
+                return;
+            }
+            vnode.state._spectrumByKind = vnode.state._spectrumByKind || {};
+            vnode.state._spectrumByKind[kind] = { baseline: base, experiment: exp };
+            vnode.state._spectrumPending = null;
+            m.redraw();
+        })
+        .catch((err) => {
+            console.error('[compare] spectrum fetch failed', err);
+            vnode.state._spectrumPending = null;
+            vnode.state.error = err?.message || 'spectrum fetch failed';
+            m.redraw();
+        });
+};
+
 const CompareChartWrapper = {
     oninit(vnode) {
         vnode.state.experimentResult = null;
@@ -275,6 +309,45 @@ const CompareChartWrapper = {
         }
         const baselineCap = vnode.state._baselineCap;
         const experimentCap = vnode.state._experimentCap;
+
+        // Compare-mode spectrum fetch: when a percentile chart has a
+        // Full or Tail toggle on, we need the full/tail spectrum data
+        // for both captures. Fetched in parallel, cached on vnode.state
+        // by kind, invalidated when granularity changes (mirrors the
+        // existing experiment refetch path).
+        const chartId = spec?.opts?.id;
+        const chartToggles = chartId && toggles ? toggles[chartId] : null;
+        const spectrumKind = chartToggles?.spectrumKind || null;
+
+        // Invalidate the spectrum cache when granularity changes
+        // (we already track _lastFetchedStep for the experiment fetch;
+        // reuse the same trigger).
+        if (vnode.state._spectrumCachedStep !== vnode.state._lastFetchedStep) {
+            vnode.state._spectrumByKind = {};
+            vnode.state._spectrumPending = null;
+            vnode.state._spectrumCachedStep = vnode.state._lastFetchedStep;
+        }
+
+        if (spectrumKind && resolvedStyle(spec) === 'scatter') {
+            const cached = vnode.state._spectrumByKind?.[spectrumKind];
+            if (!cached && vnode.state._spectrumPending !== spectrumKind) {
+                vnode.state._spectrumPending = spectrumKind;
+                kickOffSpectrumFetch(vnode, spec, spectrumKind);
+                return m('div.chart-loading', 'Loading spectrum\u2026');
+            }
+            if (!cached) {
+                return m('div.chart-loading', 'Loading spectrum\u2026');
+            }
+            // Augment captures with spectrum fields for the strategies.
+            baselineCap.spectrumTimeData = cached.baseline.time_data;
+            baselineCap.spectrumData = cached.baseline.data;
+            baselineCap.spectrumSeriesNames = cached.baseline.series_names;
+            baselineCap.spectrumColorMinAnchor = cached.baseline.color_min_anchor;
+            experimentCap.spectrumTimeData = cached.experiment.time_data;
+            experimentCap.spectrumData = cached.experiment.data;
+            experimentCap.spectrumSeriesNames = cached.experiment.series_names;
+            experimentCap.spectrumColorMinAnchor = cached.experiment.color_min_anchor;
+        }
 
         const result = renderCompareChart({
             spec,

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -236,24 +236,37 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
     const range = vnode.attrs.experimentQueryRange;
     const quantiles = quantilesForKind(kind);
     const plotForFetch = { promql_query: spec.promql_query, opts: spec.opts };
+    // Snapshot the step this fetch was launched at. If the user
+    // changes granularity (which mutates _lastFetchedStep on the next
+    // experiment refetch), we discard this fetch's result so we don't
+    // write stale data into the kind cache after invalidation.
+    const stepAtLaunch = vnode.state._lastFetchedStep;
     Promise.all([
         fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_BASELINE),
         fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_EXPERIMENT, range),
     ])
         .then(([base, exp]) => {
-            if (!base || !exp) {
+            // Discard if granularity has changed since launch (the
+            // cache has already been invalidated for the new step;
+            // a fresh fetch will fire on the next view()).
+            if (vnode.state._spectrumCachedStep !== stepAtLaunch) return;
+            if (vnode.state._spectrumPending === kind) {
                 vnode.state._spectrumPending = null;
+            }
+            if (!base || !exp) {
                 m.redraw();
                 return;
             }
             vnode.state._spectrumByKind = vnode.state._spectrumByKind || {};
             vnode.state._spectrumByKind[kind] = { baseline: base, experiment: exp };
-            vnode.state._spectrumPending = null;
             m.redraw();
         })
         .catch((err) => {
+            if (vnode.state._spectrumCachedStep !== stepAtLaunch) return;
             console.error('[compare] spectrum fetch failed', err);
-            vnode.state._spectrumPending = null;
+            if (vnode.state._spectrumPending === kind) {
+                vnode.state._spectrumPending = null;
+            }
             vnode.state.error = err?.message || 'spectrum fetch failed';
             m.redraw();
         });
@@ -347,6 +360,19 @@ const CompareChartWrapper = {
             experimentCap.spectrumData = cached.experiment.data;
             experimentCap.spectrumSeriesNames = cached.experiment.series_names;
             experimentCap.spectrumColorMinAnchor = cached.experiment.color_min_anchor;
+        } else {
+            // Toggle off (or chart is non-scatter): scrub any spectrum
+            // fields left on the memoized capture objects from a prior
+            // toggled-on render. Otherwise downstream consumers would
+            // see stale truthy fields after the user disables the
+            // spectrum view.
+            for (const cap of [baselineCap, experimentCap]) {
+                if (!cap) continue;
+                cap.spectrumTimeData = undefined;
+                cap.spectrumData = undefined;
+                cap.spectrumSeriesNames = undefined;
+                cap.spectrumColorMinAnchor = undefined;
+            }
         }
 
         const result = renderCompareChart({

--- a/tests/compare_math.test.mjs
+++ b/tests/compare_math.test.mjs
@@ -81,3 +81,21 @@ test('unifyHistogramRange: collapsed range gets a non-zero ceiling', () => {
     assert.equal(r.colorMin, 5);
     assert.ok(r.colorMax > r.colorMin);  // padded so log-scale doesn't collapse
 });
+
+test('unifyHistogramRange: asymmetric anchors — capture without anchor still pulls colorMin via its own scanned min', () => {
+    const a = { ...fakeSpectrum([[10, 20, 30]]), color_min_anchor: 10 };
+    const b = { ...fakeSpectrum([[0.1, 5, 8]]), color_min_anchor: null };
+    const r = unifyHistogramRange(a, b);
+    // B's natural min (0.1) is lower than A's anchor (10); colorMin
+    // must be 0.1 so B's bottom cells aren't clipped on the shared scale.
+    assert.equal(r.colorMin, 0.1);
+    assert.equal(r.colorMax, 30);
+});
+
+test('unifyHistogramRange: asymmetric anchors, reversed — anchor on B, scan on A', () => {
+    const a = { ...fakeSpectrum([[2, 5, 9]]), color_min_anchor: null };
+    const b = { ...fakeSpectrum([[100, 200, 300]]), color_min_anchor: 100 };
+    const r = unifyHistogramRange(a, b);
+    assert.equal(r.colorMin, 2);   // A's natural min
+    assert.equal(r.colorMax, 300); // B's natural max
+});

--- a/tests/compare_math.test.mjs
+++ b/tests/compare_math.test.mjs
@@ -4,6 +4,7 @@ import {
     nullDiff,
     intersectLabels,
     unifyHistogramRange,
+    buildDeltaSpectrum,
 } from '../src/viewer/assets/lib/charts/util/compare_math.js';
 
 test('nullDiff: numbers', () => {
@@ -98,4 +99,57 @@ test('unifyHistogramRange: asymmetric anchors, reversed — anchor on B, scan on
     const r = unifyHistogramRange(a, b);
     assert.equal(r.colorMin, 2);   // A's natural min
     assert.equal(r.colorMax, 300); // B's natural max
+});
+
+const spectrum = (times, qSeries, names) => ({
+    time_data: times,
+    data: [times, ...qSeries],
+    series_names: names,
+});
+
+test('buildDeltaSpectrum: per-cell experiment − baseline', () => {
+    const baseline = spectrum([0, 1], [[1, 2], [3, 4]], ['p50', 'p99']);
+    const experiment = spectrum([0, 1], [[2, 5], [4, 7]], ['p50', 'p99']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.deepEqual(r.data[0], [0, 1]);
+    assert.deepEqual(r.data[1], [1, 3]);   // p50 deltas: 2−1, 5−2
+    assert.deepEqual(r.data[2], [1, 3]);   // p99 deltas: 4−3, 7−4
+    assert.deepEqual(r.series_names, ['p50', 'p99']);
+});
+
+test('buildDeltaSpectrum: dMin/dMax over non-null deltas', () => {
+    const baseline = spectrum([0, 1], [[1, 5]], ['p50']);
+    const experiment = spectrum([0, 1], [[2, 3]], ['p50']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.equal(r.dMin, -2);  // 3 − 5
+    assert.equal(r.dMax, 1);   // 2 − 1
+});
+
+test('buildDeltaSpectrum: null on either side propagates', () => {
+    const baseline = spectrum([0, 1], [[null, 2]], ['p50']);
+    const experiment = spectrum([0, 1], [[5, null]], ['p50']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.deepEqual(r.data[1], [null, null]);
+    assert.equal(r.dMin, null);
+    assert.equal(r.dMax, null);
+});
+
+test('buildDeltaSpectrum: returns matrices keyed by qIdx then tIdx for tooltip lookup', () => {
+    const baseline = spectrum([0, 1], [[1, 2], [3, 4]], ['p50', 'p99']);
+    const experiment = spectrum([0, 1], [[2, 5], [4, 7]], ['p50', 'p99']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.equal(r.matrices.baseline[0][1], 2);    // p50 at t=1 → 2
+    assert.equal(r.matrices.experiment[1][0], 4);  // p99 at t=0 → 4
+});
+
+test('buildDeltaSpectrum: time/series mismatch returns null', () => {
+    const baseline = spectrum([0, 1], [[1, 2]], ['p50']);
+    const experiment = spectrum([0], [[5]], ['p50']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.equal(r, null);
+});
+
+test('buildDeltaSpectrum: empty inputs return null', () => {
+    const r = buildDeltaSpectrum({ data: [[]] }, { data: [[]] });
+    assert.equal(r, null);
 });

--- a/tests/compare_math.test.mjs
+++ b/tests/compare_math.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
     nullDiff,
     intersectLabels,
+    unifyHistogramRange,
 } from '../src/viewer/assets/lib/charts/util/compare_math.js';
 
 test('nullDiff: numbers', () => {
@@ -35,4 +36,48 @@ test('intersectLabels: common subset', () => {
 
 test('intersectLabels: disjoint sets yield empty', () => {
     assert.deepEqual([...intersectLabels(new Set(['x']), new Set(['y']))], []);
+});
+
+const fakeSpectrum = (cols) => ({
+    data: [[/* times unused */ 0, 1, 2], ...cols],
+});
+
+test('unifyHistogramRange: anchors win when present, else natural min', () => {
+    const a = { ...fakeSpectrum([[1, 2, 3], [4, 5, 6]]), color_min_anchor: 0.5 };
+    const b = { ...fakeSpectrum([[2, 3, 4], [5, 6, 7]]), color_min_anchor: 0.7 };
+    const r = unifyHistogramRange(a, b);
+    assert.equal(r.colorMin, 0.5);  // min(0.5, 0.7)
+    assert.equal(r.colorMax, 7);    // max(6, 7)
+});
+
+test('unifyHistogramRange: missing anchor falls back to scanned min', () => {
+    const a = { ...fakeSpectrum([[2, 3, 4]]), color_min_anchor: null };
+    const b = { ...fakeSpectrum([[1, 5, 6]]), color_min_anchor: null };
+    const r = unifyHistogramRange(a, b);
+    assert.equal(r.colorMin, 1);
+    assert.equal(r.colorMax, 6);
+});
+
+test('unifyHistogramRange: skips null/NaN/non-positive cells in scan', () => {
+    const a = { ...fakeSpectrum([[null, 0, -1, 5]]), color_min_anchor: null };
+    const b = { ...fakeSpectrum([[NaN, 2, null, 8]]), color_min_anchor: null };
+    const r = unifyHistogramRange(a, b);
+    assert.equal(r.colorMin, 2);
+    assert.equal(r.colorMax, 8);
+});
+
+test('unifyHistogramRange: empty data falls back to (0, 1)', () => {
+    const a = { data: [[]], color_min_anchor: null };
+    const b = { data: [[]], color_min_anchor: null };
+    const r = unifyHistogramRange(a, b);
+    assert.equal(r.colorMin, 0);
+    assert.equal(r.colorMax, 1);
+});
+
+test('unifyHistogramRange: collapsed range gets a non-zero ceiling', () => {
+    const a = { ...fakeSpectrum([[5, 5, 5]]), color_min_anchor: 5 };
+    const b = { ...fakeSpectrum([[5, 5, 5]]), color_min_anchor: 5 };
+    const r = unifyHistogramRange(a, b);
+    assert.equal(r.colorMin, 5);
+    assert.ok(r.colorMax > r.colorMin);  // padded so log-scale doesn't collapse
 });

--- a/tests/compare_math.test.mjs
+++ b/tests/compare_math.test.mjs
@@ -153,3 +153,15 @@ test('buildDeltaSpectrum: empty inputs return null', () => {
     const r = buildDeltaSpectrum({ data: [[]] }, { data: [[]] });
     assert.equal(r, null);
 });
+
+test('buildDeltaSpectrum: identical captures yield dMin === dMax === 0', () => {
+    const baseline = spectrum([0, 1], [[1, 2], [3, 4]], ['p50', 'p99']);
+    const experiment = spectrum([0, 1], [[1, 2], [3, 4]], ['p50', 'p99']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.deepEqual(r.data[1], [0, 0]);
+    assert.deepEqual(r.data[2], [0, 0]);
+    // Flat-zero is intentionally not padded here — the caller pads
+    // before handing off to a diverging palette renderer.
+    assert.equal(r.dMin, 0);
+    assert.equal(r.dMax, 0);
+});

--- a/tests/data_spectrum_capture.test.mjs
+++ b/tests/data_spectrum_capture.test.mjs
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createDataApi, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from '../src/viewer/assets/lib/data.js';
+
+// Minimal mock: returns a successful PromQL matrix result with one
+// series so fetchQuantileSpectrumForPlot's parsing path completes.
+// Records call args on `calls` for assertions.
+function makeApi(calls, opts = {}) {
+    return createDataApi({
+        getMetadata: async () => ({
+            status: 'success',
+            data: { minTime: opts.minTime ?? 1000, maxTime: opts.maxTime ?? 2000 },
+        }),
+        queryRange: async (query, start, end, step, captureId = 'baseline') => {
+            calls.push({ query, start, end, step, captureId });
+            return {
+                status: 'success',
+                data: {
+                    resultType: 'matrix',
+                    result: [
+                        // p0 series — anchors color_min, then gets stripped
+                        { metric: { __name__: 'm', quantile: '0' }, values: [[start, '1'], [end, '2']] },
+                        // p50 series
+                        { metric: { __name__: 'm', quantile: '0.5' }, values: [[start, '5'], [end, '10']] },
+                    ],
+                },
+            };
+        },
+        logHeatmapErrors: false,
+    });
+}
+
+const plot = {
+    promql_query: 'tcp_packet_latency',
+    opts: { type: 'histogram' },
+};
+
+test('fetchQuantileSpectrumForPlot: defaults to baseline capture', async () => {
+    const calls = [];
+    const api = makeApi(calls);
+    const r = await api.fetchQuantileSpectrumForPlot(plot, [0.5]);
+    assert.ok(r);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].captureId, CAPTURE_BASELINE);
+});
+
+test('fetchQuantileSpectrumForPlot: routes to experiment capture when captureId set', async () => {
+    const calls = [];
+    const api = makeApi(calls);
+    const r = await api.fetchQuantileSpectrumForPlot(plot, [0.5], CAPTURE_EXPERIMENT);
+    assert.ok(r);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].captureId, CAPTURE_EXPERIMENT);
+});
+
+test('fetchQuantileSpectrumForPlot: passes caller-supplied range to experiment query', async () => {
+    const calls = [];
+    const api = makeApi(calls);
+    const range = { start: 5000, end: 6000, step: 5 };
+    const r = await api.fetchQuantileSpectrumForPlot(plot, [0.5], CAPTURE_EXPERIMENT, range);
+    assert.ok(r);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].start, 5000);
+    assert.equal(calls[0].end, 6000);
+    assert.equal(calls[0].step, 5);
+    assert.equal(calls[0].captureId, CAPTURE_EXPERIMENT);
+});
+
+test('fetchQuantileSpectrumForPlot: experiment without range falls back to baseline metadata', async () => {
+    const calls = [];
+    const api = makeApi(calls, { minTime: 100, maxTime: 200 });
+    const r = await api.fetchQuantileSpectrumForPlot(plot, [0.5], CAPTURE_EXPERIMENT);
+    assert.ok(r);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].captureId, CAPTURE_EXPERIMENT);
+    // Range should derive from baseline meta: end = maxTime (200),
+    // start = max(minTime, maxTime - 3600) = 100 (since duration < 3600).
+    assert.equal(calls[0].end, 200);
+    assert.equal(calls[0].start, 100);
+});
+
+test('fetchQuantileSpectrumForPlot: prepends q=0 to the queried quantiles', async () => {
+    const calls = [];
+    const api = makeApi(calls);
+    await api.fetchQuantileSpectrumForPlot(plot, [0.5, 0.99]);
+    // Query should reference [0, 0.5, 0.99] inside histogram_quantiles(...).
+    const query = calls[0].query;
+    assert.match(query, /histogram_quantiles\(\[\s*0\s*,\s*0\.5\s*,\s*0\.99\s*\]/);
+});

--- a/tests/spectrum_quantiles.test.mjs
+++ b/tests/spectrum_quantiles.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { quantilesForKind } from '../src/viewer/assets/lib/charts/util/spectrum_quantiles.js';
+
+test('quantilesForKind: full produces 100 quantiles from 0.01 to 1.00', () => {
+    const qs = quantilesForKind('full');
+    assert.equal(qs.length, 100);
+    assert.equal(qs[0], 0.01);
+    assert.equal(qs[99], 1.0);
+});
+
+test('quantilesForKind: tail produces 100 quantiles from 0.9901 to 1.0000', () => {
+    const qs = quantilesForKind('tail');
+    assert.equal(qs.length, 100);
+    assert.equal(qs[0], 0.9901);
+    assert.equal(qs[99], 1.0);
+});
+
+test('quantilesForKind: full quantiles are uniform 0.01 apart', () => {
+    const qs = quantilesForKind('full');
+    for (let i = 1; i < qs.length; i++) {
+        // Float-tolerant equality at 1e-9; quantilesForKind uses integer math,
+        // so the produced values are exact divisions of 100.
+        assert.ok(Math.abs((qs[i] - qs[i - 1]) - 0.01) < 1e-9);
+    }
+});
+
+test('quantilesForKind: tail quantiles are uniform 0.0001 apart', () => {
+    const qs = quantilesForKind('tail');
+    for (let i = 1; i < qs.length; i++) {
+        assert.ok(Math.abs((qs[i] - qs[i - 1]) - 0.0001) < 1e-9);
+    }
+});
+
+test('quantilesForKind: unknown kind defaults to full', () => {
+    assert.deepEqual(quantilesForKind('unknown'), quantilesForKind('full'));
+    assert.deepEqual(quantilesForKind(null), quantilesForKind('full'));
+});


### PR DESCRIPTION
## Summary

Brings the Full / Tail quantile-heatmap view into compare (A/B) mode for percentile metrics. When the user toggles **Full** or **Tail** on a percentile chart in compare mode, the existing 5-percentile split is replaced with a side-by-side pair of quantile heatmaps sharing a unified color scale. A **Diff** toggle collapses the pair into a single experiment-minus-baseline heatmap with a diverging palette.

- **Side-by-side mode** — baseline + experiment as stacked heatmaps with a unified `[p0_min, p100_max]` color scale. Hovering either heatmap shows a synced crosshair on the other and a single tooltip with `baseline | experiment | Δ` values for the matching cell.
- **Diff mode** — single heatmap of `experiment − baseline`. Diverging blue→neutral→green palette resampled so neutral lands on zero. Tooltip shows the original baseline + experiment values plus the delta. Theme-aware null-cell color for cells where one capture is missing data.
- **Full / Tail / Diff toggles** live in the chart header next to the existing heatmap diff toggle. State persists per-chart via `selectionStore.chartToggles[chartId]` (same channel as the existing heatmap diff).
- **Lazy parallel fetch** — spectrum data for both captures is fetched in parallel only when the toggle is on. Cached per kind, invalidated on granularity change. Loading placeholder during fetch; falls back to the 5-percentile split if either side has no data.

## Architecture

State and dispatch:
- New per-chart toggle field `spectrumKind: null | 'full' | 'tail'` on `selectionStore.chartToggles[chartId]`. The existing `setChartToggle` is the writer.
- `compare.js`'s `renderCompareChart` `'scatter'` case reads the toggle and routes to `sideBySideQuantileHeatmap` (default) or `renderDiffQuantileHeatmap` (when diff is on); falls through to existing `splitScatterToSubgroup` when toggle is null.

Renderer extensions to `quantile_heatmap.js` (additive — single-capture path byte-for-byte preserved):
- `color_max_anchor` (mirrors existing `color_min_anchor`).
- `colormap` (custom palette, e.g. resampled diverging).
- `nullCellColor` (paint vs skip null cells).
- `diffMatrices` + `diffCaptureLabels` + `diffLegendLabels` (diff variant tooltip + legend captions).
- `compareCounterpartData` + `compareCaptureLabels` + `compareSelfRole` (side-by-side dual-value tooltip).
- `compareGroupId` (publishes hover events; subscribes to sibling events; renders crosshair overlay).
- Top-level `isDiff` branching: linear color mapping for signed deltas, signed anchor support, no negative-cell skip in diff mode (single-capture and side-by-side paths keep the existing log10 mapping unchanged).

Cross-chart cursor sync via a tiny pub/sub on `ChartsState` keyed by parent spec id, with self-filter through a `fn._chartId` tag.

Pure helpers (TDD with tests):
- `unifyHistogramRange(a, b)` — unified color scale across two captures, anchor-aware, handles asymmetric anchor presence.
- `buildDeltaSpectrum(baseline, experiment)` — columnar delta + per-cell baseline/experiment matrices for the diff tooltip.
- `quantilesForKind(kind)` — extracted to a shared util so both single-capture scatter and compare strategies issue the same quantile set.

## Files Touched

- `src/viewer/assets/lib/charts/compare.js` — new strategies + dispatch update.
- `src/viewer/assets/lib/charts/quantile_heatmap.js` — additive spec field support + cross-chart cursor wiring + diff-mode color path.
- `src/viewer/assets/lib/charts/chart.js` — new `subscribeCompareCursor` / `publishCompareCursor` pub/sub on ChartsState.
- `src/viewer/assets/lib/charts/util/compare_math.js` — `unifyHistogramRange`, `buildDeltaSpectrum` helpers.
- `src/viewer/assets/lib/charts/util/spectrum_quantiles.js` (new) — `quantilesForKind` shared util.
- `src/viewer/assets/lib/charts/scatter.js` — replace local `quantilesForKind` with shared import.
- `src/viewer/assets/lib/charts/chart_controls.js` — Full/Tail/Diff compare toggles for scatter charts.
- `src/viewer/assets/lib/data.js` — `fetchQuantileSpectrumForPlot` accepts optional `captureId` + `range`.
- `src/viewer/assets/lib/viewer_core.js` — `CompareChartWrapper` parallel spectrum fetch + per-kind cache.
- `tests/spectrum_quantiles.test.mjs` (new), `tests/compare_math.test.mjs`, `tests/data_spectrum_capture.test.mjs` (new) — 24 new tests (38 → 62 total).
- `site/viewer/lib/charts/util/spectrum_quantiles.js` (new symlink).
- `Cargo.toml` / `Cargo.lock` — `5.11.1-alpha.21 → -alpha.22`.

## Spec deviation

State is stored on `selectionStore.chartToggles[chartId]` (with `setChartToggle`) — the same channel the existing heatmap diff toggle uses — instead of on a new `chartsState.compareToggles` map as the design doc described. The chosen channel is strictly better (auto-persists, survives reload, already wired to redraws), and the design doc text was not updated. Behavior matches the spec's intent.

## Test plan

- [x] All 62 JS viewer tests pass (`node --test tests/*.mjs`).
- [x] WASM viewer rebuilt to incorporate any underlying viewer changes.
- [x] Toggle Full / Tail on a percentile chart in compare mode. Verify side-by-side pair renders with consistent colors across both halves.
- [x] Hover either side. Verify synced crosshair on the other side at the same (time, quantile) cell, and tooltip shows baseline / experiment / delta with correct values.
- [x] Toggle Diff on. Verify single diff heatmap with diverging palette, neutral cells near zero, captions oriented correctly. Confirm both negative and positive deltas are rendered.
- [x] Switch granularity. Verify spectrum cache invalidates and refetches.
- [ ] Metric missing on one capture. Verify graceful fallback to 5-percentile split.
- [x] Theme swap (light ↔ dark). Verify diff palette and null-cell color update.