### PR TITLE
fix(viewer): keep cgroup section's per-cgroup charts on initial load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.22"
+version = "5.11.1-alpha.23"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.22"
+version = "5.11.1-alpha.23"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -435,14 +435,25 @@ const createDataApi = ({
 
         // Surface no-data plots at the bottom (mirrors service KPI UX)
         // instead of leaving silent empty chart cards mid-section.
+        // Plots whose original query carries the `__SELECTED_CGROUPS__`
+        // placeholder are deferred — they intentionally have no data
+        // until the user picks a cgroup, at which point cgroup_selector
+        // refetches them in place. Stripping them here would remove the
+        // right-side "Individual Cgroups" group entirely on first load
+        // and the cgroup selector would have nothing to repopulate.
         const unavailable = [];
         const plotHasData = (plot) =>
             Array.isArray(plot.data) && plot.data.some((s) => Array.isArray(s) && s.length > 0);
+        const isDeferredCgroupPlot = (plot) =>
+            typeof plot.promql_query === 'string'
+            && plot.promql_query.includes('__SELECTED_CGROUPS__');
         for (const group of data.groups || []) {
             for (const sg of group.subgroups || []) {
                 const surviving = [];
                 for (const plot of (sg.plots || [])) {
-                    if (!plot.promql_query || plotHasData(plot)) {
+                    if (!plot.promql_query
+                        || plotHasData(plot)
+                        || isDeferredCgroupPlot(plot)) {
                         surviving.push(plot);
                     } else {
                         unavailable.push({


### PR DESCRIPTION
## Summary

Regression from #859: the cgroup section's right-side "Individual Cgroups" group disappeared on initial load, leaving the aggregate charts to stretch the full row.

PR #859 added a "drop plots with no data, surface as unavailable" pass in `processDashboardData`. That pass was indiscriminately stripping plots whose query returned empty — including the cgroup section's right-side plots, which carry a `__SELECTED_CGROUPS__` placeholder query and are intentionally empty until the user picks a cgroup. With those plots stripped, the entire right group (and its parent) collapsed out of `data.groups`, and the cgroup selector had nothing to repopulate when a cgroup was eventually selected.

Fix: exempt plots whose query contains `__SELECTED_CGROUPS__` from the unavailable-charts filter. They're deferred, not unavailable.

## Test plan

- [x] `node --test tests/*.mjs` passes (62/62).
- [x] Open a parquet with cgroup data, navigate to `/cgroups`. Verify both columns render: left aggregate charts and right per-cgroup charts (initially empty until a cgroup is picked).
- [x] Pick a cgroup in the selector. Verify the right column populates with one line per selected cgroup.
- [x] Pick multiple cgroups. Verify each gets its own colored line.
- [x] Other sections (CPU, GPU, etc.) still list genuinely-empty plots in the "Charts with no data" footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)