### PR TITLE
feat(dashboard): per-CPU runqueue wait and context switches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.22"
+version = "5.11.1-alpha.23"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.22"
+version = "5.11.1-alpha.23"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/crates/dashboard/src/dashboard/scheduler.rs
+++ b/crates/dashboard/src/dashboard/scheduler.rs
@@ -1,8 +1,17 @@
 use crate::Tsdb;
 use crate::plot::*;
 
+/// True iff the recording has more than one CPU. Per-core charts are
+/// suppressed when this is false because they degenerate to the aggregate.
+fn has_multiple_cpus(data: &Tsdb) -> bool {
+    ["scheduler_runqueue_wait", "scheduler_context_switch"]
+        .iter()
+        .any(|m| metric_unique_label_count(data, m, "id") > 1)
+}
+
 pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
+    let multi_cpu = has_multiple_cpus(data);
 
     /*
      * Scheduler
@@ -18,6 +27,35 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
             .with_unit_system("time"),
         "scheduler_runqueue_latency".to_string(),
     );
+
+    let wait = scheduler.subgroup("Runqueue Wait");
+    wait.describe(
+        "Accumulated runqueue wait time, averaged across CPUs and broken out per-CPU. \
+         A value of 1s/s means one task was waiting for the entire interval; values above \
+         1s/s mean multiple tasks were queued concurrently — an indicator of scheduler pressure.",
+    );
+    if multi_cpu {
+        wait.plot_promql(
+            PlotOpts::counter("Wait", "scheduler-runqueue-wait", Unit::Time)
+                .with_unit_system("time"),
+            "sum(irate(scheduler_runqueue_wait[5m])) / cpu_cores".to_string(),
+        );
+        wait.plot_promql(
+            PlotOpts::counter(
+                "Wait (Per-CPU)",
+                "scheduler-runqueue-wait-per-cpu",
+                Unit::Time,
+            )
+            .with_unit_system("time"),
+            "sum by (id) (irate(scheduler_runqueue_wait[5m]))".to_string(),
+        );
+    } else {
+        wait.plot_promql_full(
+            PlotOpts::counter("Wait", "scheduler-runqueue-wait", Unit::Time)
+                .with_unit_system("time"),
+            "sum(irate(scheduler_runqueue_wait[5m])) / cpu_cores".to_string(),
+        );
+    }
 
     let timing = scheduler.subgroup("Task Timing");
     timing.describe("Time tasks spent off-CPU (blocked, waiting) and on-CPU (running).");
@@ -35,11 +73,22 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     );
 
     let switches = scheduler.subgroup("Context Switches");
-    switches.describe("Overall context-switch rate across all cores.");
-    switches.plot_promql_full(
-        PlotOpts::counter("Context Switch", "cswitch", Unit::Rate),
-        "sum(irate(scheduler_context_switch[5m]))".to_string(),
-    );
+    switches.describe("Involuntary context-switch rate, aggregate and per-core.");
+    if multi_cpu {
+        switches.plot_promql(
+            PlotOpts::counter("Context Switch", "cswitch", Unit::Rate),
+            "sum(irate(scheduler_context_switch[5m]))".to_string(),
+        );
+        switches.plot_promql(
+            PlotOpts::counter("Context Switch (Per-CPU)", "cswitch-per-cpu", Unit::Rate),
+            "sum by (id) (irate(scheduler_context_switch[5m]))".to_string(),
+        );
+    } else {
+        switches.plot_promql_full(
+            PlotOpts::counter("Context Switch", "cswitch", Unit::Rate),
+            "sum(irate(scheduler_context_switch[5m]))".to_string(),
+        );
+    }
 
     view.group(scheduler);
 


### PR DESCRIPTION
## Summary
- Adds a **Runqueue Wait** subgroup to the viewer's scheduler dashboard, exposing `scheduler_runqueue_wait` (already collected, previously not plotted) as an averaged-across-CPUs rate plus a per-CPU breakdown.
- Adds a per-CPU breakdown to the existing **Context Switches** subgroup so scheduler imbalance is visible per core.
- Values are emitted as raw ns/s with the `time` unit system, letting the viewer's formatter pick µs/ms/s automatically (matches the `CPU Time / Throughput` precedent in `overview.rs`).

## Test plan
- [x] `cargo build -p dashboard`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p dashboard`
- [x] `cargo test -p dashboard`
- [ ] Visually verify the new charts in the viewer against a multi-CPU recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)