### PR TITLE
refactor(recorder): auto-label source=rezolus on Msgpack probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.11.1-alpha.23"
+version = "5.11.1-alpha.24"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.11.1-alpha.23"
+version = "5.11.1-alpha.24"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/recorder/config.rs
+++ b/src/recorder/config.rs
@@ -1,4 +1,4 @@
-use super::endpoint::{infer_source_name, EndpointConfig, Protocol};
+use super::endpoint::{EndpointConfig, Protocol};
 use crate::Format;
 
 use clap::ArgMatches;
@@ -159,12 +159,11 @@ impl RecordingConfig {
             .ok_or_else(|| "OUTPUT is required".to_string())?
             .to_path_buf();
 
-        // Extract source from --metadata source=xxx, else infer
+        // Source from --metadata source=xxx; None means probe resolves it.
         let source = metadata
             .iter()
             .find(|(k, _)| k == "source")
-            .map(|(_, v)| v.clone())
-            .unwrap_or_else(|| infer_source_name(&url));
+            .map(|(_, v)| v.clone());
 
         let endpoint = EndpointConfig {
             url,
@@ -228,8 +227,6 @@ pub fn parse_endpoint_str(s: &str) -> Result<EndpointConfig, String> {
         }
     }
 
-    let source = source.unwrap_or_else(|| infer_source_name(&url));
-
     Ok(EndpointConfig {
         url,
         source,
@@ -250,14 +247,14 @@ mod tests {
     #[test]
     fn test_parse_endpoint_str_full() {
         let ep = parse_endpoint_str("http://localhost:4241,source=rezolus,role=agent").unwrap();
-        assert_eq!(ep.source, "rezolus");
+        assert_eq!(ep.source.as_deref(), Some("rezolus"));
         assert_eq!(ep.role.as_deref(), Some("agent"));
     }
 
     #[test]
     fn test_parse_endpoint_str_url_only() {
         let ep = parse_endpoint_str("http://localhost:9090/metrics").unwrap();
-        assert_eq!(ep.source, "localhost-9090"); // inferred
+        assert!(ep.source.is_none()); // probe resolves it
         assert!(ep.role.is_none());
     }
 

--- a/src/recorder/config.rs
+++ b/src/recorder/config.rs
@@ -159,7 +159,6 @@ impl RecordingConfig {
             .ok_or_else(|| "OUTPUT is required".to_string())?
             .to_path_buf();
 
-        // Source from --metadata source=xxx; None means probe resolves it.
         let source = metadata
             .iter()
             .find(|(k, _)| k == "source")

--- a/src/recorder/endpoint.rs
+++ b/src/recorder/endpoint.rs
@@ -20,11 +20,23 @@ where
 pub struct EndpointConfig {
     #[serde(deserialize_with = "deserialize_url")]
     pub url: Url,
-    pub source: String,
+    /// User-supplied source label. None means "let the recorder pick"
+    /// — the probe handler resolves it after the protocol is known
+    /// (Msgpack → "rezolus", Prometheus → URL-derived + warning).
+    #[serde(default)]
+    pub source: Option<String>,
     #[serde(default)]
     pub role: Option<String>,
     #[serde(default)]
     pub protocol: Option<Protocol>,
+}
+
+impl EndpointConfig {
+    /// Source label as `&str`. Returns "?" before probe has resolved
+    /// the source (only Pending endpoints hit this).
+    pub fn source_label(&self) -> &str {
+        self.source.as_deref().unwrap_or("?")
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -74,14 +86,12 @@ impl EndpointState {
     }
 }
 
-/// Derive a source name from a URL when none is configured.
-/// Logs a warning to stderr.
+/// Derive a source name from a URL when none is configured. Silent;
+/// the recorder warns (or upgrades to "rezolus") after protocol probe.
 pub fn infer_source_name(url: &Url) -> String {
     let host = url.host_str().unwrap_or("unknown");
     let port = url.port().map(|p| format!("-{p}")).unwrap_or_default();
-    let name = format!("{host}{port}");
-    eprintln!("warn: no source name specified for {url}, using \"{name}\"");
-    name
+    format!("{host}{port}")
 }
 
 #[cfg(test)]
@@ -106,7 +116,7 @@ mod tests {
     fn test_endpoint_state_new() {
         let config = EndpointConfig {
             url: "http://localhost:4241".parse().unwrap(),
-            source: "rezolus".to_string(),
+            source: Some("rezolus".to_string()),
             role: None,
             protocol: Some(Protocol::Msgpack),
         };
@@ -120,7 +130,7 @@ mod tests {
     fn test_record_success() {
         let config = EndpointConfig {
             url: "http://localhost:4241".parse().unwrap(),
-            source: "rezolus".to_string(),
+            source: Some("rezolus".to_string()),
             role: None,
             protocol: None,
         };

--- a/src/recorder/endpoint.rs
+++ b/src/recorder/endpoint.rs
@@ -20,9 +20,8 @@ where
 pub struct EndpointConfig {
     #[serde(deserialize_with = "deserialize_url")]
     pub url: Url,
-    /// User-supplied source label. None means "let the recorder pick"
-    /// — the probe handler resolves it after the protocol is known
-    /// (Msgpack → "rezolus", Prometheus → URL-derived + warning).
+    /// None until probe resolves it: Msgpack → "rezolus",
+    /// Prometheus → URL-derived (with warning).
     #[serde(default)]
     pub source: Option<String>,
     #[serde(default)]
@@ -32,8 +31,7 @@ pub struct EndpointConfig {
 }
 
 impl EndpointConfig {
-    /// Source label as `&str`. Returns "?" before probe has resolved
-    /// the source (only Pending endpoints hit this).
+    /// "?" only reachable on Pending endpoints (probe hasn't run).
     pub fn source_label(&self) -> &str {
         self.source.as_deref().unwrap_or("?")
     }
@@ -86,8 +84,6 @@ impl EndpointState {
     }
 }
 
-/// Derive a source name from a URL when none is configured. Silent;
-/// the recorder warns (or upgrades to "rezolus") after protocol probe.
 pub fn infer_source_name(url: &Url) -> String {
     let host = url.host_str().unwrap_or("unknown");
     let port = url.port().map(|p| format!("-{p}")).unwrap_or_default();

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -6,7 +6,7 @@ mod prometheus;
 
 use crate::parquet_metadata;
 pub use config::RecordingConfig;
-use endpoint::{EndpointState, EndpointStatus, Protocol};
+use endpoint::{infer_source_name, EndpointState, EndpointStatus, Protocol};
 use std::path::Path;
 
 pub fn command() -> Command {
@@ -306,7 +306,7 @@ fn build_parquet_converter(
     );
 
     // Source metadata
-    converter = converter.metadata("source".to_string(), ep.config.source.clone());
+    converter = converter.metadata("source".to_string(), ep.config.source_label().to_string());
 
     // User-supplied metadata
     for (key, value) in &config.metadata {
@@ -337,7 +337,7 @@ fn build_parquet_converter(
         .iter()
         .find(|(k, _)| k == "source")
         .map(|(_, v)| v.as_str())
-        .unwrap_or(ep.config.source.as_str());
+        .unwrap_or(ep.config.source_label());
 
     if let Some(json) = build_per_source_metadata(
         effective_source,
@@ -460,9 +460,25 @@ pub fn run(config: RecordingConfig) {
         for ep in &mut endpoints {
             match probe_endpoint(&client, &ep.config).await {
                 Some((protocol, url)) => {
+                    // Resolve source by protocol when caller didn't set one.
+                    if ep.config.source.is_none() {
+                        if protocol == Protocol::Msgpack {
+                            ep.config.source = Some("rezolus".to_string());
+                        } else {
+                            let inferred = infer_source_name(&ep.config.url);
+                            eprintln!(
+                                "warn: no source name specified for {}, using \"{inferred}\" \
+                                 (pass --metadata source=NAME to override)",
+                                ep.config.url,
+                            );
+                            ep.config.source = Some(inferred);
+                        }
+                    }
                     info!(
                         "endpoint {} ({}): detected {:?}",
-                        ep.config.source, ep.config.url, protocol
+                        ep.config.source_label(),
+                        ep.config.url,
+                        protocol
                     );
                     if protocol == Protocol::Msgpack {
                         let (si, desc) = fetch_agent_metadata(&client, &ep.config.url).await;
@@ -475,8 +491,8 @@ pub fn run(config: RecordingConfig) {
                 }
                 None => {
                     warn!(
-                        "endpoint {} ({}) not reachable, will retry each tick",
-                        ep.config.source, ep.config.url
+                        "endpoint {} not reachable, will retry each tick",
+                        ep.config.url
                     );
                 }
             }
@@ -505,7 +521,7 @@ pub fn run(config: RecordingConfig) {
                 };
                 let converter = if ep.protocol() == Some(&Protocol::Prometheus) {
                     Some(prometheus::PrometheusConverter::with_provenance(
-                        ep.config.source.clone(),
+                        ep.config.source_label().to_string(),
                         ep.config.url.to_string(),
                     ))
                 } else {
@@ -575,7 +591,7 @@ pub fn run(config: RecordingConfig) {
                                     Err(e) => {
                                         error!(
                                             "serialize error for {}: {e}",
-                                            endpoints[idx].config.source
+                                            endpoints[idx].config.source_label()
                                         );
                                         continue;
                                     }
@@ -587,7 +603,7 @@ pub fn run(config: RecordingConfig) {
                                     Ok(snapshot) => {
                                         let snapshot = inject_provenance(
                                             snapshot,
-                                            &endpoints[idx].config.source,
+                                            endpoints[idx].config.source_label(),
                                             endpoints[idx].config.url.as_str(),
                                         );
                                         match rmp_serde::encode::to_vec(&snapshot) {
@@ -595,7 +611,7 @@ pub fn run(config: RecordingConfig) {
                                             Err(e) => {
                                                 error!(
                                                     "serialize error for {}: {e}",
-                                                    endpoints[idx].config.source
+                                                    endpoints[idx].config.source_label()
                                                 );
                                                 continue;
                                             }
@@ -604,7 +620,7 @@ pub fn run(config: RecordingConfig) {
                                     Err(e) => {
                                         warn!(
                                             "msgpack decode error for {}: {e}",
-                                            endpoints[idx].config.source
+                                            endpoints[idx].config.source_label()
                                         );
                                         continue;
                                     }
@@ -612,14 +628,18 @@ pub fn run(config: RecordingConfig) {
                             };
 
                             if let Err(e) = ew.writer.write_all(&bytes) {
-                                error!("write error for {}: {e}", endpoints[idx].config.source);
+                                error!(
+                                    "write error for {}: {e}",
+                                    endpoints[idx].config.source_label()
+                                );
                             }
                         }
                     }
                     Err(e) => {
                         warn!(
                             "scrape failed for {} ({}): {e}",
-                            endpoints[idx].config.source, endpoints[idx].config.url
+                            endpoints[idx].config.source_label(),
+                            endpoints[idx].config.url
                         );
                     }
                 }
@@ -636,9 +656,23 @@ pub fn run(config: RecordingConfig) {
             for idx in pending_indices {
                 if let Some((protocol, url)) = probe_endpoint(&client, &endpoints[idx].config).await
                 {
+                    if endpoints[idx].config.source.is_none() {
+                        if protocol == Protocol::Msgpack {
+                            endpoints[idx].config.source = Some("rezolus".to_string());
+                        } else {
+                            let inferred = infer_source_name(&endpoints[idx].config.url);
+                            eprintln!(
+                                "warn: no source name specified for {}, using \"{inferred}\" \
+                                 (pass --metadata source=NAME to override)",
+                                endpoints[idx].config.url,
+                            );
+                            endpoints[idx].config.source = Some(inferred);
+                        }
+                    }
                     info!(
                         "endpoint {} ({}) now available, starting capture",
-                        endpoints[idx].config.source, endpoints[idx].config.url
+                        endpoints[idx].config.source_label(),
+                        endpoints[idx].config.url
                     );
                     if protocol == Protocol::Msgpack {
                         let (si, desc) =
@@ -652,7 +686,7 @@ pub fn run(config: RecordingConfig) {
 
                     let converter = if protocol == Protocol::Prometheus {
                         Some(prometheus::PrometheusConverter::with_provenance(
-                            endpoints[idx].config.source.clone(),
+                            endpoints[idx].config.source_label().to_string(),
                             endpoints[idx].config.url.to_string(),
                         ))
                     } else {
@@ -692,7 +726,10 @@ pub fn run(config: RecordingConfig) {
                             continue;
                         }
                         let dest_path = if config.separate || active_count > 1 {
-                            separate_output_path(&config.output, &endpoints[idx].config.source)
+                            separate_output_path(
+                                &config.output,
+                                endpoints[idx].config.source_label(),
+                            )
                         } else {
                             config.output.clone()
                         };
@@ -717,8 +754,10 @@ pub fn run(config: RecordingConfig) {
                         if endpoints[idx].first_success_ns.is_none() {
                             continue;
                         }
-                        let dest_path =
-                            separate_output_path(&config.output, &endpoints[idx].config.source);
+                        let dest_path = separate_output_path(
+                            &config.output,
+                            endpoints[idx].config.source_label(),
+                        );
                         match std::fs::File::create(&dest_path) {
                             Ok(dest) => {
                                 let _ = ew.writer.rewind();
@@ -732,7 +771,7 @@ pub fn run(config: RecordingConfig) {
                                 {
                                     eprintln!(
                                         "error saving parquet for {}: {e}",
-                                        endpoints[idx].config.source
+                                        endpoints[idx].config.source_label()
                                     );
                                 } else {
                                     info!("wrote {}", dest_path.display());
@@ -805,7 +844,7 @@ pub fn run(config: RecordingConfig) {
                                     {
                                         eprintln!(
                                             "error converting {} to parquet: {e}",
-                                            endpoints[idx].config.source
+                                            endpoints[idx].config.source_label()
                                         );
                                         continue;
                                     }

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -460,7 +460,6 @@ pub fn run(config: RecordingConfig) {
         for ep in &mut endpoints {
             match probe_endpoint(&client, &ep.config).await {
                 Some((protocol, url)) => {
-                    // Resolve source by protocol when caller didn't set one.
                     if ep.config.source.is_none() {
                         if protocol == Protocol::Msgpack {
                             ep.config.source = Some("rezolus".to_string());


### PR DESCRIPTION
## Summary
- Collapse the recorder's `source: String` + `source_explicit: bool` pair into a single `source: Option<String>` populated from CLI/TOML.
- Probe handler resolves it after detecting the protocol — Msgpack → `"rezolus"`, Prometheus → URL-inferred name with a one-time warning nudging the user to pass `--metadata source=NAME`.
- Removes the need to type `--metadata source=rezolus` when recording a local Rezolus agent.

## Test plan
- [x] `cargo build` clean
- [x] `cargo clippy --bin rezolus -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --bin rezolus recorder::` (16/16 pass)
- [x] Manually verify: `rezolus record http://localhost:4241 out.parquet` writes `source=rezolus` metadata without explicit flag
- [ ] Manually verify: recording a Prometheus endpoint without `--metadata source=…` prints the inference warning and uses the URL-derived name

🤖 Generated with [Claude Code](https://claude.com/claude-code)