### PR TITLE
fix(viewer): align compare-mode spectrum fetches so diff heatmap renders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.12.1-alpha.0"
+version = "5.12.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.1-alpha.0"
+version = "5.12.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -105,28 +105,43 @@ function positiveOr(v, fallback) {
  * Uses nullDiff so undefined/NaN propagate cleanly.
  *
  * Caller responsibilities:
- *   - Time axes must be VALUE-aligned, not just length-matched. This
- *     function only verifies length; matching cadence is the upstream
- *     fetch's job.
+ *   - Compare-mode anchors each capture to its own first sample
+ *     (relative t=0). When the captures share the same step, the i-th
+ *     index represents the same relative offset on both sides — this
+ *     function pairs by index and truncates to the common prefix when
+ *     timestamp counts differ. Step mismatch returns null instead of
+ *     producing a misleading diff.
  *   - When dMin === dMax (flat captures), pad before passing to a
  *     diverging palette renderer (see renderDiffHeatmap in compare.js
  *     for the canonical pad recipe).
  *   - Do not mutate the returned `time_data` / `data[0]` in place;
- *     they alias baseline.time_data.
+ *     they alias baseline.time_data when no truncation was needed.
  */
 export function buildDeltaSpectrum(baseline, experiment) {
     const baseTimes = baseline?.time_data;
     const expTimes = experiment?.time_data;
     if (!Array.isArray(baseTimes) || !Array.isArray(expTimes)) return null;
-    if (baseTimes.length === 0 || baseTimes.length !== expTimes.length) return null;
+    if (baseTimes.length === 0 || expTimes.length === 0) return null;
 
     const baseData = baseline.data;
     const expData = experiment.data;
     if (!Array.isArray(baseData) || baseData.length < 2) return null;
+    // qCount must match across captures (same set of percentiles).
     if (!Array.isArray(expData) || expData.length !== baseData.length) return null;
 
+    // Reject when either side has too few samples to determine step,
+    // or when steps disagree — pairing by index would be meaningless.
+    if (baseTimes.length < 2 || expTimes.length < 2) return null;
+    const baseStep = baseTimes[1] - baseTimes[0];
+    const expStep = expTimes[1] - expTimes[0];
+    if (!(baseStep > 0) || !(expStep > 0)) return null;
+    if (Math.abs(baseStep - expStep) > 1e-9) return null;
+
     const qCount = baseData.length - 1;
-    const tCount = baseTimes.length;
+    const tCount = Math.min(baseTimes.length, expTimes.length);
+    const truncatedBaseTimes = baseTimes.length === tCount
+        ? baseTimes
+        : baseTimes.slice(0, tCount);
 
     const deltaCols = [];
     const baseMatrix = [];
@@ -158,8 +173,8 @@ export function buildDeltaSpectrum(baseline, experiment) {
     }
 
     return {
-        time_data: baseTimes,
-        data: [baseTimes, ...deltaCols],
+        time_data: truncatedBaseTimes,
+        data: [truncatedBaseTimes, ...deltaCols],
         series_names: baseline.series_names || [],
         dMin: Number.isFinite(dMin) ? dMin : null,
         dMax: Number.isFinite(dMax) ? dMax : null,

--- a/src/viewer/assets/lib/charts/util/compare_math.js
+++ b/src/viewer/assets/lib/charts/util/compare_math.js
@@ -105,12 +105,9 @@ function positiveOr(v, fallback) {
  * Uses nullDiff so undefined/NaN propagate cleanly.
  *
  * Caller responsibilities:
- *   - Compare-mode anchors each capture to its own first sample
- *     (relative t=0). When the captures share the same step, the i-th
- *     index represents the same relative offset on both sides — this
- *     function pairs by index and truncates to the common prefix when
- *     timestamp counts differ. Step mismatch returns null instead of
- *     producing a misleading diff.
+ *   - Pairs by index after compare-mode anchors each capture to its
+ *     own first sample (relative t=0); requires matching step.
+ *     Mismatched steps return null instead of misleading the user.
  *   - When dMin === dMax (flat captures), pad before passing to a
  *     diverging palette renderer (see renderDiffHeatmap in compare.js
  *     for the canonical pad recipe).
@@ -126,11 +123,8 @@ export function buildDeltaSpectrum(baseline, experiment) {
     const baseData = baseline.data;
     const expData = experiment.data;
     if (!Array.isArray(baseData) || baseData.length < 2) return null;
-    // qCount must match across captures (same set of percentiles).
     if (!Array.isArray(expData) || expData.length !== baseData.length) return null;
 
-    // Reject when either side has too few samples to determine step,
-    // or when steps disagree — pairing by index would be meaningless.
     if (baseTimes.length < 2 || expTimes.length < 2) return null;
     const baseStep = baseTimes[1] - baseTimes[0];
     const expStep = expTimes[1] - expTimes[0];

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -227,9 +227,8 @@ const fetchExperimentResult = (vnode) => {
     })();
 };
 
-// Resolve baseline's full [start, end] time range from server metadata.
-// Returns null when metadata isn't available; callers fall back to
-// data.js's natural baseline range (3600 s window cap).
+// Returns null on metadata failure; callers then fall back to data.js's
+// 3600 s-capped baseline range — fine outside the diff path.
 const fetchBaselineRange = async () => {
     try {
         const meta = await ViewerApi.getMetadata(CAPTURE_BASELINE);
@@ -248,28 +247,16 @@ const fetchBaselineRange = async () => {
     }
 };
 
-// Fire baseline + experiment spectrum fetches in parallel. On both
-// resolving, write into vnode.state._spectrumByKind[kind] and trigger
-// a redraw. On either failing or returning no data, leave the cache
-// empty for that kind and clear the pending flag so the toggle path
-// falls through to FALLBACK (5-percentile split).
-//
-// Both captures fetch over their full duration with a SHARED step so
-// the diff path (renderDiffQuantileHeatmap → buildDeltaSpectrum) can
-// pair samples by index after rebasing each side to its own first
-// sample. Without a shared step, baseline (3600 s cap, step=window/500)
-// and experiment (full duration, step=duration/500) end up on
-// incompatible grids whenever the durations differ — buildDeltaSpectrum
-// then refuses to diff and the user sees the baseline scatter instead
-// of a heatmap.
+// Both captures fetch with a SHARED step so buildDeltaSpectrum can pair
+// samples by index. Without it, baseline (3600 s cap) and experiment
+// (full duration) land on incompatible grids whenever durations differ
+// and the diff path silently falls back to the baseline scatter.
 const kickOffSpectrumFetch = (vnode, spec, kind) => {
     const expRange = vnode.attrs.experimentQueryRange;
     const quantiles = quantilesForKind(kind);
     const plotForFetch = { promql_query: spec.promql_query, opts: spec.opts };
-    // Snapshot the step this fetch was launched at. If the user
-    // changes granularity (which mutates _lastFetchedStep on the next
-    // experiment refetch), we discard this fetch's result so we don't
-    // write stale data into the kind cache after invalidation.
+    // Snapshot _lastFetchedStep: if granularity changes mid-fetch we
+    // discard this result to avoid writing stale data into the cache.
     const stepAtLaunch = vnode.state._lastFetchedStep;
 
     (async () => {
@@ -278,8 +265,7 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
             let baseRange = null;
             let expRangeOut = expRange || null;
             if (baseRangeBare && expRange?.step) {
-                // Coarsest step keeps both grids aligned without
-                // oversampling either capture.
+                // Coarsest step avoids oversampling either capture.
                 const baseStep = Math.max(1, Math.floor((baseRangeBare.end - baseRangeBare.start) / 500));
                 const sharedStep = Math.max(baseStep, expRange.step);
                 baseRange = { ...baseRangeBare, step: sharedStep };
@@ -291,9 +277,6 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
                 fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_EXPERIMENT, expRangeOut),
             ]);
 
-            // Discard if granularity has changed since launch (the
-            // cache has already been invalidated for the new step;
-            // a fresh fetch will fire on the next view()).
             if (vnode.state._spectrumCachedStep !== stepAtLaunch) return;
             if (vnode.state._spectrumPending === kind) {
                 vnode.state._spectrumPending = null;

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -227,13 +227,43 @@ const fetchExperimentResult = (vnode) => {
     })();
 };
 
+// Resolve baseline's full [start, end] time range from server metadata.
+// Returns null when metadata isn't available; callers fall back to
+// data.js's natural baseline range (3600 s window cap).
+const fetchBaselineRange = async () => {
+    try {
+        const meta = await ViewerApi.getMetadata(CAPTURE_BASELINE);
+        const data = meta?.data ?? meta;
+        const minT = data?.minTime ?? data?.min_time ?? data?.start_time;
+        const maxT = data?.maxTime ?? data?.max_time ?? data?.end_time;
+        if (minT == null || maxT == null) return null;
+        const start = Number(minT);
+        const end = Number(maxT);
+        if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+            return null;
+        }
+        return { start, end };
+    } catch (_) {
+        return null;
+    }
+};
+
 // Fire baseline + experiment spectrum fetches in parallel. On both
 // resolving, write into vnode.state._spectrumByKind[kind] and trigger
 // a redraw. On either failing or returning no data, leave the cache
 // empty for that kind and clear the pending flag so the toggle path
 // falls through to FALLBACK (5-percentile split).
+//
+// Both captures fetch over their full duration with a SHARED step so
+// the diff path (renderDiffQuantileHeatmap → buildDeltaSpectrum) can
+// pair samples by index after rebasing each side to its own first
+// sample. Without a shared step, baseline (3600 s cap, step=window/500)
+// and experiment (full duration, step=duration/500) end up on
+// incompatible grids whenever the durations differ — buildDeltaSpectrum
+// then refuses to diff and the user sees the baseline scatter instead
+// of a heatmap.
 const kickOffSpectrumFetch = (vnode, spec, kind) => {
-    const range = vnode.attrs.experimentQueryRange;
+    const expRange = vnode.attrs.experimentQueryRange;
     const quantiles = quantilesForKind(kind);
     const plotForFetch = { promql_query: spec.promql_query, opts: spec.opts };
     // Snapshot the step this fetch was launched at. If the user
@@ -241,11 +271,26 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
     // experiment refetch), we discard this fetch's result so we don't
     // write stale data into the kind cache after invalidation.
     const stepAtLaunch = vnode.state._lastFetchedStep;
-    Promise.all([
-        fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_BASELINE),
-        fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_EXPERIMENT, range),
-    ])
-        .then(([base, exp]) => {
+
+    (async () => {
+        try {
+            const baseRangeBare = await fetchBaselineRange();
+            let baseRange = null;
+            let expRangeOut = expRange || null;
+            if (baseRangeBare && expRange?.step) {
+                // Coarsest step keeps both grids aligned without
+                // oversampling either capture.
+                const baseStep = Math.max(1, Math.floor((baseRangeBare.end - baseRangeBare.start) / 500));
+                const sharedStep = Math.max(baseStep, expRange.step);
+                baseRange = { ...baseRangeBare, step: sharedStep };
+                expRangeOut = { ...expRange, step: sharedStep };
+            }
+
+            const [base, exp] = await Promise.all([
+                fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_BASELINE, baseRange),
+                fetchQuantileSpectrumForPlot(plotForFetch, quantiles, CAPTURE_EXPERIMENT, expRangeOut),
+            ]);
+
             // Discard if granularity has changed since launch (the
             // cache has already been invalidated for the new step;
             // a fresh fetch will fire on the next view()).
@@ -260,8 +305,7 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
             vnode.state._spectrumByKind = vnode.state._spectrumByKind || {};
             vnode.state._spectrumByKind[kind] = { baseline: base, experiment: exp };
             m.redraw();
-        })
-        .catch((err) => {
+        } catch (err) {
             if (vnode.state._spectrumCachedStep !== stepAtLaunch) return;
             console.error('[compare] spectrum fetch failed', err);
             if (vnode.state._spectrumPending === kind) {
@@ -269,7 +313,8 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
             }
             vnode.state.error = err?.message || 'spectrum fetch failed';
             m.redraw();
-        });
+        }
+    })();
 };
 
 const CompareChartWrapper = {

--- a/tests/compare_math.test.mjs
+++ b/tests/compare_math.test.mjs
@@ -142,9 +142,45 @@ test('buildDeltaSpectrum: returns matrices keyed by qIdx then tIdx for tooltip l
     assert.equal(r.matrices.experiment[1][0], 4);  // p99 at t=0 → 4
 });
 
-test('buildDeltaSpectrum: time/series mismatch returns null', () => {
+test('buildDeltaSpectrum: undetermined step (single-sample side) returns null', () => {
     const baseline = spectrum([0, 1], [[1, 2]], ['p50']);
     const experiment = spectrum([0], [[5]], ['p50']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.equal(r, null);
+});
+
+test('buildDeltaSpectrum: timestamp count mismatch with matching step truncates to common prefix', () => {
+    // Compare-mode rebases each capture to its own first sample
+    // (relative t=0). When steps match, the i-th index represents the
+    // same relative offset in both captures, so the diff covers the
+    // common prefix.
+    const baseline = spectrum([100, 101, 102, 103], [[1, 2, 3, 4]], ['p50']);
+    const experiment = spectrum([200, 201, 202, 203, 204, 205], [[10, 12, 14, 16, 18, 20]], ['p50']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.notEqual(r, null);
+    assert.equal(r.data[1].length, 4);
+    assert.deepEqual(r.data[1], [9, 10, 11, 12]);
+    // Truncated baseline times become the diff's time axis.
+    assert.deepEqual(r.time_data, [100, 101, 102, 103]);
+    assert.equal(r.dMin, 9);
+    assert.equal(r.dMax, 12);
+});
+
+test('buildDeltaSpectrum: experiment shorter than baseline truncates to experiment length', () => {
+    const baseline = spectrum([0, 1, 2, 3, 4], [[1, 2, 3, 4, 5]], ['p50']);
+    const experiment = spectrum([0, 1, 2], [[10, 12, 14]], ['p50']);
+    const r = buildDeltaSpectrum(baseline, experiment);
+    assert.notEqual(r, null);
+    assert.equal(r.data[1].length, 3);
+    assert.deepEqual(r.data[1], [9, 10, 11]);
+    assert.deepEqual(r.time_data, [0, 1, 2]);
+});
+
+test('buildDeltaSpectrum: mismatched step refuses to pair samples', () => {
+    // step 1 vs step 2 — same index does not correspond to same
+    // relative time, so refuse the diff rather than mislead.
+    const baseline = spectrum([0, 1, 2, 3], [[1, 2, 3, 4]], ['p50']);
+    const experiment = spectrum([0, 2, 4, 6], [[1, 2, 3, 4]], ['p50']);
     const r = buildDeltaSpectrum(baseline, experiment);
     assert.equal(r, null);
 });

--- a/tests/compare_math.test.mjs
+++ b/tests/compare_math.test.mjs
@@ -150,17 +150,14 @@ test('buildDeltaSpectrum: undetermined step (single-sample side) returns null', 
 });
 
 test('buildDeltaSpectrum: timestamp count mismatch with matching step truncates to common prefix', () => {
-    // Compare-mode rebases each capture to its own first sample
-    // (relative t=0). When steps match, the i-th index represents the
-    // same relative offset in both captures, so the diff covers the
-    // common prefix.
+    // Captures with matching step but different lengths pair by index
+    // after compare-mode rebases each to its own first sample.
     const baseline = spectrum([100, 101, 102, 103], [[1, 2, 3, 4]], ['p50']);
     const experiment = spectrum([200, 201, 202, 203, 204, 205], [[10, 12, 14, 16, 18, 20]], ['p50']);
     const r = buildDeltaSpectrum(baseline, experiment);
     assert.notEqual(r, null);
     assert.equal(r.data[1].length, 4);
     assert.deepEqual(r.data[1], [9, 10, 11, 12]);
-    // Truncated baseline times become the diff's time axis.
     assert.deepEqual(r.time_data, [100, 101, 102, 103]);
     assert.equal(r.dMin, 9);
     assert.equal(r.dMax, 12);
@@ -177,8 +174,8 @@ test('buildDeltaSpectrum: experiment shorter than baseline truncates to experime
 });
 
 test('buildDeltaSpectrum: mismatched step refuses to pair samples', () => {
-    // step 1 vs step 2 — same index does not correspond to same
-    // relative time, so refuse the diff rather than mislead.
+    // Same index → different relative time when steps differ; refuse
+    // rather than produce a nonsense diff.
     const baseline = spectrum([0, 1, 2, 3], [[1, 2, 3, 4]], ['p50']);
     const experiment = spectrum([0, 2, 4, 6], [[1, 2, 3, 4]], ['p50']);
     const r = buildDeltaSpectrum(baseline, experiment);


### PR DESCRIPTION
## Summary
- Compare-mode quantile-heatmap diff was falling back to the baseline percentile scatter when the two captures had different durations. Root cause: baseline + experiment fetched their spectrum data with independent (mismatched) steps, and `buildDeltaSpectrum` rejected the resulting unaligned grids.
- `kickOffSpectrumFetch` now resolves baseline metadata, picks `sharedStep = max(baseStep, expStep)`, and passes explicit ranges with that shared step to both fetches. Side-by-side baseline panels also show full duration in compare mode now (previously 3600 s capped) — symmetric with experiment.
- `buildDeltaSpectrum` now tolerates timestamp-count mismatch when steps match — pairs by index (each capture is rebased to its own first sample at relative t=0) and truncates to the common prefix. Step mismatch still returns `null`.

## Test plan
- [x] `node --test tests/*.mjs` (65/65 pass, including 3 new `buildDeltaSpectrum` cases)
- [x] `cargo build --bin rezolus` clean
- [x] `cargo clippy --bin rezolus -- -D warnings` clean
- [x] Manually verify on https://rezolus.com/viewer/?capture=vllm%3Dvllm_gemma3.parquet&capture=sglang%3Dsglang_gemma3.parquet#/scheduler that toggling Diff while Full or Tail is selected renders the diff heatmap (not the original scatter)
- [ ] Manually spot-check a same-duration A/B pair to confirm the side-by-side heatmap still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)