### PR TITLE
fix(viewer): selection section bug fixes — empty histograms, lost state, missing context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.12.1-alpha.1"
+version = "5.12.1-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.1-alpha.1"
+version = "5.12.1-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/chart_controls.js
+++ b/src/viewer/assets/lib/chart_controls.js
@@ -110,7 +110,7 @@ export const expandLink = (spec, sectionRoute) => {
     );
 };
 
-export const selectButton = (spec, sectionRoute, sectionName) => {
+export const selectButton = (spec, sectionRoute, sectionName, groupName) => {
     if (!spec.promql_query) return null;
     const sectionKey = sectionRoute.replace(/^\//, '');
     const selected = isSelected(spec.opts.id);
@@ -118,7 +118,7 @@ export const selectButton = (spec, sectionRoute, sectionName) => {
         class: selected ? 'chart-selected' : '',
         onclick: (e) => {
             e.stopPropagation();
-            toggleSelection(spec, sectionKey, sectionName);
+            toggleSelection(spec, sectionKey, sectionName, groupName);
             m.redraw();
         },
         title: selected ? 'Remove from selection' : 'Add to selection',

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -483,8 +483,13 @@ function positionControlsAtGridLeft(chart, container) {
     try {
         const grid = chart.echart.getModel().getComponent('grid');
         const rect = grid?.coordinateSystem?.getRect();
-        const chartWidth = chart.echart.getDom?.()?.clientWidth ?? 0;
-        const narrow = chartWidth > 0 && chartWidth < SPECTRUM_CONTROLS_NARROW_WIDTH;
+        const dom = chart.echart.getDom?.();
+        const chartWidth = dom?.clientWidth ?? 0;
+        // Selection cards put notes alongside the chart, so the
+        // histogram is structurally narrow regardless of viewport width.
+        const inSelectionCard = !!dom?.closest?.('.selection-card-chart');
+        const narrow = inSelectionCard
+            || (chartWidth > 0 && chartWidth < SPECTRUM_CONTROLS_NARROW_WIDTH);
         if (narrow) {
             // Narrow chart: stack above the legend on its own line and
             // align to the right edge so it visually anchors to the

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -112,6 +112,7 @@ const persistStore = (key, store) => {
                 chartId: e.chartId,
                 section: e.section,
                 sectionName: e.sectionName,
+                groupName: e.groupName || '',
                 promql_query: e.promql_query,
                 note: e.note,
                 chartOpts: e.chartOpts,
@@ -148,6 +149,7 @@ const restoreStore = (key, store) => {
             chartId: e.chartId,
             section: e.section,
             sectionName: e.sectionName,
+            groupName: e.groupName || '',
             promql_query: e.promql_query,
             note: e.note || '',
             chartOpts: e.chartOpts,
@@ -194,9 +196,22 @@ const setChartToggle = (chartId, key, value) => {
 restoreStore(REPORT_STORAGE_KEY, reportStore);
 restoreStore(SELECTION_STORAGE_KEY, selectionStore);
 
+// Build the displayed chart title for a selection card. The dashboard
+// gives charts visual context via section/group breadcrumbs ("CPU >
+// TLB Flush > Total Flushes"); the selection cards are flat-listed,
+// so we restore that context inline. De-dups when group equals
+// section (e.g. /scheduler has a single "Scheduler" group).
+const selectionCardTitle = (entry, spec) => {
+    const parts = [];
+    if (entry.sectionName) parts.push(entry.sectionName);
+    if (entry.groupName && entry.groupName !== entry.sectionName) parts.push(entry.groupName);
+    parts.push(spec.opts.title);
+    return parts.join(': ');
+};
+
 // ── Selection API (write mode) ───────────────────────────────────
 
-const toggleSelection = (spec, sectionKey, sectionName) => {
+const toggleSelection = (spec, sectionKey, sectionName, groupName) => {
     const idx = selectionStore.entries.findIndex(e => e.chartId === spec.opts.id);
     if (idx >= 0) {
         selectionStore.entries.splice(idx, 1);
@@ -208,6 +223,7 @@ const toggleSelection = (spec, sectionKey, sectionName) => {
         chartId: spec.opts.id,
         section: sectionKey,
         sectionName,
+        groupName: groupName || '',
         promql_query: spec.promql_query,
         note: '',
         chartOpts: JSON.parse(JSON.stringify(spec.opts)),
@@ -271,6 +287,7 @@ const buildPayload = (store, attrs) => ({
         chartId: e.chartId,
         section: e.section,
         sectionName: e.sectionName,
+        groupName: e.groupName || '',
         promql_query: e.promql_query,
         note: e.note,
         chartOpts: e.chartOpts,
@@ -308,6 +325,7 @@ const loadPayloadIntoStore = (store, payload) => {
         chartId: e.chartId,
         section: e.section,
         sectionName: e.sectionName,
+        groupName: e.groupName || '',
         promql_query: e.promql_query,
         note: e.note || '',
         chartOpts: e.chartOpts,
@@ -555,7 +573,7 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                             }, 'X'),
                             m('div.chart-wrapper', [
                                 m('div.chart-header', [
-                                    m('span.chart-title', spec.opts.title),
+                                    m('span.chart-title', selectionCardTitle(entry, spec)),
                                     spec.opts.description && m('span.chart-subtitle', spec.opts.description),
                                 ]),
                                 m(Chart, { spec, chartsState: attrs.chartsState, interval }),
@@ -647,7 +665,7 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
                         m('div.selection-card-chart', [
                             m('div.chart-wrapper', [
                                 m('div.chart-header', [
-                                    m('span.chart-title', spec.opts.title),
+                                    m('span.chart-title', selectionCardTitle(entry, spec)),
                                     spec.opts.description && m('span.chart-subtitle', spec.opts.description),
                                 ]),
                                 m(Chart, { spec, chartsState: attrs.chartsState, interval }),

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -85,9 +85,11 @@ const setStorageScope = (info) => {
         .toString(36);
     REPORT_STORAGE_KEY = `rezolus_report_${suffix}`;
     SELECTION_STORAGE_KEY = `rezolus_selection_${suffix}`;
-    // Restore from the scoped keys
-    clearStore(selectionStore);
-    clearStore(reportStore);
+    // In-memory reset only — must NOT purge localStorage at the
+    // (just-set) scoped key, otherwise we wipe the file's persisted
+    // selection on every page load before restoring it.
+    resetStoreState(selectionStore);
+    resetStoreState(reportStore);
     restoreStore(REPORT_STORAGE_KEY, reportStore);
     restoreStore(SELECTION_STORAGE_KEY, selectionStore);
 };
@@ -243,7 +245,9 @@ const removeEntry = (store, id) => {
     }
 };
 
-const clearStore = (store) => {
+// In-memory only — leaves localStorage alone. Used during scope
+// re-binding where the next step is restoring from the scoped key.
+const resetStoreState = (store) => {
     store.entries.length = 0;
     store.tagline = '';
     store.zoom = null;
@@ -258,6 +262,13 @@ const clearStore = (store) => {
         store.fileChecksum = null;
         store.timeRange = null;
         store.rezolusVersion = null;
+    }
+};
+
+// Full purge: in-memory + localStorage. Used by the "Clear All" UI.
+const clearStore = (store) => {
+    resetStoreState(store);
+    if (store === reportStore) {
         localStorage.removeItem(REPORT_STORAGE_KEY);
     } else if (store === selectionStore) {
         localStorage.removeItem(SELECTION_STORAGE_KEY);

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -3,7 +3,7 @@
 // Report: loaded from JSON import or parquet metadata (read-only mode).
 
 import { ChartsState, Chart } from './charts/chart.js';
-import { executePromQLRangeQuery, applyResultToPlot, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from './data.js';
+import { executePromQLRangeQuery, applyResultToPlot, buildEffectiveQuery, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from './data.js';
 import { notify, showSaveModal } from './overlays.js';
 import { isHistogramPlot } from './charts/metric_types.js';
 import { migrateSelection, SELECTION_SCHEMA_VERSION } from './selection_migration.js';
@@ -441,7 +441,12 @@ const chartLoaderMixin = (store, component) => ({
                     promql_query: entry.promql_query,
                     data: [],
                 };
-                const result = await executePromQLRangeQuery(entry.promql_query);
+                // Histogram metrics need histogram_quantiles / heatmap
+                // wrapping; the dashboard pipeline does this via
+                // buildEffectiveQuery, but the stored entry only has
+                // the raw metric name.
+                const effective = buildEffectiveQuery(spec) || entry.promql_query;
+                const result = await executePromQLRangeQuery(effective);
                 if (result) {
                     applyResultToPlot(spec, result);
                 }

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -549,7 +549,7 @@ export function createGroupComponent(getState) {
                     chartHeader(renderSpec.opts, renderSpec),
                     chartBody(renderSpec, spec),
                     expandLink(spec, sectionRoute),
-                    selectButton(spec, sectionRoute, sectionName),
+                    selectButton(spec, sectionRoute, sectionName, attrs.name),
                 ]);
             };
 


### PR DESCRIPTION
## Summary
A grab-bag of fixes for the Selection (and Report) section, all noticed while pinning histogram charts on rezolus.com.

### 1. Pinned histograms render empty
Selection's chart loader called `executePromQLRangeQuery(entry.promql_query)` with the raw stored query, skipping the `histogram_quantiles(...)` / `histogram_heatmap(...)` wrapping that `buildEffectiveQuery` normally applies for `opts.type === 'histogram'`. The scatter renderer got bucket data instead of percentile columns and rendered an empty card. Route stored entries through `buildEffectiveQuery` before fetching; fall back to the raw query when wrapping returns `null` (e.g. `__SELECTED_CGROUPS__` without an active cgroup).

### 2. Spectrum controls overlap legend in selection cards
Selection cards put notes alongside the chart, so the histogram is structurally narrow regardless of viewport width. Detect the `.selection-card-chart` ancestor and force the same narrow layout used on small viewports — controls stack above the legend at `top:28, right:12` instead of crowding from the left gutter.

### 3. Selection card titles dropped section/group context
Pinned charts showed just `opts.title` (e.g. "Total Flushes") with no indication of where they came from. Capture `groupName` at pin time alongside `sectionName`, then prefix the displayed title as `Section: Group: Title` (e.g. "CPU: TLB Flush: Total Flushes"). De-dups when group equals section (e.g. `/scheduler` → "Scheduler: Runqueue Latency").

### 4. Selection + notes lost on every page refresh
`setStorageScope` reassigned `SELECTION_STORAGE_KEY` to the file-scoped value, then called `clearStore()` — which does `localStorage.removeItem(SELECTION_STORAGE_KEY)` using the just-set scoped key. The next `restoreStore()` then read an empty key. Net effect: pinned charts and notes vanished on every refresh of a file's viewer URL. Split `clearStore` into `resetStoreState` (in-memory only, used by the scope re-bind) and `clearStore` (in-memory + localStorage purge, kept for the user-facing Clear All button).

## Known limitation (not in this PR)
Per-chart viz toggles (Full/Tail/Diff on percentile heatmaps, Raw count on histogram heatmaps) are still not preserved across pin/reload — pinned charts always render in their default mode. Tracked separately.

## Test plan
- [x] \`node --test tests/*.mjs\` (65/65 pass)
- [x] \`cargo build --bin rezolus\` clean
- [ ] On https://rezolus.com/viewer/?capture=vllm%3Dvllm_gemma3.parquet&capture=sglang%3Dsglang_gemma3.parquet — pin a histogram percentile chart from /scheduler and verify it renders in /selection (was empty before).
- [x] Pin a chart from /cpu and verify the title shows "CPU: TLB Flush: Total Flushes" (or similar).
- [x] Pin a chart, refresh the page, navigate to /selection — verify the chart and any notes are still there.
- [x] On a narrow chart in /selection, confirm Full/Tail checkboxes sit at top-right above the legend, not in the left gutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)