### PR TITLE
release: prepare v5.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+## [5.12.1] - 2026-05-10
+
+### Fixed
+
+- Viewer: align compare-mode spectrum fetches with a shared step so the
+  diff path on quantile heatmaps actually renders, instead of falling
+  back to the baseline percentile scatter when the two captures have
+  different durations. (#881)
+- Viewer: pinned histogram (percentile-scatter) charts in the Selection
+  section now wrap their stored query through `buildEffectiveQuery`,
+  fixing the empty-card regression where the raw metric name was being
+  fetched without the `histogram_quantiles(...)` wrapping. (#882)
+- Viewer: persisted selection + notes now actually survive a page
+  refresh — `setStorageScope` was wiping the just-bound file-scoped
+  localStorage key on every load. (#882)
+- Viewer: selection cards now show "Section: Group: Title" so pinned
+  charts carry the same context the dashboard headers provide; spectrum
+  controls use the narrow layout when rendered inside a selection card
+  so they don't crowd the legend. (#882)
+- CI: Homebrew formula bump on release no longer fails on permissions.
+  (#880)
+
 ## [5.12.0] - 2026-05-09
 
 ### Added
@@ -706,7 +728,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.12.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.12.1...HEAD
+[5.12.1]: https://github.com/iopsystems/rezolus/compare/v5.12.0...v5.12.1
 [5.12.0]: https://github.com/iopsystems/rezolus/compare/v5.11.0...v5.12.0
 [5.11.0]: https://github.com/iopsystems/rezolus/compare/v5.10.0...v5.11.0
 [5.10.0]: https://github.com/iopsystems/rezolus/compare/v5.9.1...v5.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.12.1-alpha.2"
+version = "5.12.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.1-alpha.2"
+version = "5.12.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Release v5.12.1

Patch release rolling up viewer + CI fixes.

### Fixed
- Viewer: compare-mode quantile-heatmap diff now actually renders when captures have different durations (#881).
- Viewer: pinned histogram (percentile-scatter) charts in /selection no longer render empty (#882).
- Viewer: persisted selection + notes survive page refresh — `setStorageScope` was wiping the just-bound file-scoped key (#882).
- Viewer: selection cards show "Section: Group: Title" breadcrumb; spectrum controls use narrow layout inside selection cards (#882).
- CI: Homebrew formula bump on release no longer fails on permissions (#880).

### Changes
- Version bump in Cargo.toml (5.12.1-alpha.2 → 5.12.1)
- CHANGELOG.md updated

### After Merge
The release workflows will automatically:
1. Create git tag `v5.12.1` and bump to next dev version
2. Build and publish packages (deb, rpm, Homebrew)
3. Create GitHub release with all artifacts
4. Publish to crates.io

---
See CHANGELOG.md for details.