### PR TITLE
ci(release): publish static viewer bundle alongside packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,84 @@ jobs:
           path: target/generate-rpm/*
           name: rpm_${{ matrix.distro }}_${{ matrix.version }}_${{ matrix.arch }}
 
+  build-viewer-static:
+    if: github.repository == 'iopsystems/rezolus'
+    name: build static viewer bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: build wasm viewer
+        run: ./crates/viewer/build.sh
+
+      - name: stage viewer bundle
+        run: |
+          TAG="${{ github.ref_name }}"
+          STAGE="target/viewer-static/rezolus-viewer-${TAG}"
+          mkdir -p "$STAGE"
+          # Dereference symlinks (site/viewer/lib/* points back into
+          # src/viewer/assets/lib) so the tarball is self-contained.
+          # Skip data/ — demo parquets aren't part of the package.
+          rsync -aL --exclude='data' site/viewer/ "$STAGE/"
+          cp LICENSE-MIT LICENSE-APACHE "$STAGE/" 2>/dev/null || true
+          cat > "$STAGE/README.md" << 'EOF'
+          # Rezolus Viewer (static bundle)
+
+          This bundle is a self-contained Rezolus parquet viewer that runs
+          entirely in the browser via WebAssembly. Drop the directory on
+          any static webserver (nginx, caddy, S3 + CloudFront, GitHub
+          Pages, `python -m http.server`, …) and visit `/viewer/`.
+
+          ## Loading recordings
+
+          The viewer accepts parquet recordings via:
+
+          - **Drag-and-drop / file picker** on the landing page.
+          - **`?capture=label=path/to/file.parquet`** in the URL — relative
+            paths are fetched from the same origin.
+          - **`?capture=label=https://...`** for absolute URLs — requires
+            either CORS headers on the source, or the local proxy
+            (see "Loading from arbitrary URLs" below).
+
+          Two `?capture=` params (separated by `&`) put the viewer in
+          A/B compare mode.
+
+          ## Loading from arbitrary URLs
+
+          Cross-origin parquet URLs (e.g. another team's S3 bucket, a
+          colleague's webserver) only work when the source serves CORS
+          headers — most don't. To bypass that, run the full `rezolus`
+          binary with `rezolus view --proxy-allow=<glob>`; the local
+          proxy fetches the URL server-side and streams it to the
+          browser.
+
+          ## Customising
+
+          - Demo parquets go in `data/` (not shipped in this bundle).
+          - Service-extension templates live under `templates/`.
+          - Frontend overrides go in `lib/` — the layout mirrors the
+            in-tree `src/viewer/assets/lib/` so existing patches apply.
+          EOF
+
+      - name: tarball viewer bundle
+        run: |
+          TAG="${{ github.ref_name }}"
+          cd target/viewer-static
+          tar -czf "rezolus-viewer-${TAG}.tar.gz" "rezolus-viewer-${TAG}"
+          ls -l "rezolus-viewer-${TAG}.tar.gz"
+
+      - uses: actions/upload-artifact@v5
+        with:
+          path: target/viewer-static/rezolus-viewer-*.tar.gz
+          name: viewer-static
+
   publish:
     if: github.repository == 'iopsystems/rezolus'
     name: Publish release artifacts
@@ -235,6 +313,7 @@ jobs:
     needs:
       - build-deb
       - build-rpm
+      - build-viewer-static
     steps:
       - uses: actions/checkout@v5
 
@@ -263,6 +342,12 @@ jobs:
         with:
           path: target/rpm/
           pattern: rpm_*
+
+      # Download static viewer bundle
+      - uses: actions/download-artifact@v5
+        with:
+          path: target/viewer-static/
+          pattern: viewer-static
 
       # Upload debs to systemslab registry
       - uses: google-github-actions/auth@v2
@@ -381,6 +466,12 @@ jobs:
             version="$(echo "$directory" | cut -d _ -f 3)"
             arch="$(echo "$directory" | cut -d _ -f 4)"
             mv "$artifact" "target/release-artifacts/${distro}_${version}_${arch}_${name}"
+          done
+
+          # Collect static viewer bundle
+          for artifact in target/viewer-static/viewer-static/*.tar.gz; do
+            [ -f "$artifact" ] || continue
+            mv "$artifact" "target/release-artifacts/$(basename "$artifact")"
           done
 
       - name: generate checksums and sign release artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.12.2-alpha.0"
+version = "5.12.2-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.2-alpha.0"
+version = "5.12.2-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Summary
Part **A** of the "viewer-as-package + URL loading + proxy" sequence we discussed. Adds a release artifact that lets anyone host the viewer themselves on their own domain — useful for serving parquets that live in S3 buckets they don't want to make CORS-friendly publicly.

- New \`build-viewer-static\` job runs \`./crates/viewer/build.sh\` to produce the WASM, then tarballs \`site/viewer/{index.html,lib,pkg,templates}\` into \`rezolus-viewer-vX.Y.Z.tar.gz\` with symlinks dereferenced so the bundle is self-contained. Demo parquets under \`site/viewer/data/\` are excluded.
- The \`publish\` job now also depends on \`build-viewer-static\` and copies the tarball into the GitHub release artifacts directory so it ends up in \`gh release create\` alongside the .deb/.rpm.
- Tarball includes a short README pointing users at \`?capture=label=path\` for relative URLs and noting that cross-origin URLs need either CORS on the source or the upcoming local \`--proxy-allow\` flag.

## Follow-ups (separate PRs)
- **C** — Browser-side URL loading: detect \`https?://\` in \`?capture=\` paths, fetch directly, surface a CORS hint on failure. Add URL input on the landing page.
- **B** — \`rezolus view --proxy-allow=<glob>\` server-side proxy that bypasses CORS for whitelisted hosts.

## Test plan
- [x] YAML parses (\`yq eval '.jobs | keys'\` lists all four jobs)
- [ ] Push a release tag (or trigger via workflow_dispatch on a fork) and confirm \`rezolus-viewer-v*.tar.gz\` appears in the release assets
- [ ] Untar locally, serve with \`python -m http.server\`, drop a parquet next to it, load with \`?capture=label=file.parquet\` — confirm it renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)