### PR TITLE
feat(viewer): load parquet from arbitrary URL on the static site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.12.2-alpha.1"
+version = "5.12.2-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.2-alpha.1"
+version = "5.12.2-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -401,11 +401,22 @@ const Root = {
                 }
             },
             onLoadUrl: (raw) => {
-                // Reuse the same alias=URL grammar as the URL params so
-                // users can paste `vllm=https://…/file.parquet` to seed
-                // both the legend and the source.
-                const [alias, source] = splitAlias(raw);
-                loadCapture(source, alias);
+                // Comma separates A/B for compare mode. Each entry uses
+                // the same alias=URL grammar as the URL params, so a
+                // paste like `vllm=https://…/a.parquet, sglang=https://…/b.parquet`
+                // seeds legends and routes to compare mode automatically.
+                const entries = raw.split(',').map((s) => s.trim()).filter(Boolean);
+                if (entries.length >= 2) {
+                    const [labelA, fileA] = splitAlias(entries[0]);
+                    const [labelB, fileB] = splitAlias(entries[1]);
+                    const legends = (labelA || labelB)
+                        ? { baseline: labelA, experiment: labelB }
+                        : null;
+                    loadCompareDemo(fileA, fileB, legends, null);
+                } else if (entries.length === 1) {
+                    const [alias, source] = splitAlias(entries[0]);
+                    loadCapture(source, alias);
+                }
             },
             // Static-site bundle has no local proxy. The CORS hint
             // surfaces as a fetch failure error, not a permanent

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -137,11 +137,14 @@ async function loadParquet(data, filename) {
 
 // ── Load demo parquet (with download progress) ──────────────────────
 
-// Fetch a demo parquet from `data/<filename>` with optional progress
-// reporting. Returns the raw bytes as a Uint8Array.
-async function fetchDemoBytes(filename, onProgress) {
-    const resp = await fetch('data/' + filename);
-    if (!resp.ok) throw new Error(`Failed to fetch ${filename}: ${resp.status}`);
+// Fetch a parquet by URL or relative path. Relative paths resolve under
+// `data/` (the static-site convention for bundled demos); anything
+// matching `^https?://` is fetched as-is. Returns the raw bytes as a
+// Uint8Array.
+async function fetchParquetBytes(source, onProgress) {
+    const url = /^https?:\/\//i.test(source) ? source : 'data/' + source;
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`Failed to fetch ${source}: ${resp.status}`);
 
     const contentLength = resp.headers.get('Content-Length');
     if (contentLength && resp.body) {
@@ -174,7 +177,7 @@ async function loadDemo(filename = 'demo.parquet') {
     m.redraw();
 
     try {
-        const data = await fetchDemoBytes(filename, (p) => {
+        const data = await fetchParquetBytes(filename, (p) => {
             splashProgress = p;
             m.redraw();
         });
@@ -200,6 +203,63 @@ async function loadDemo(filename = 'demo.parquet') {
     }
 }
 
+// Filename surfaced in the splash + URL bar. URL paths get their basename
+// (or the explicit alias); relative-path entries stay as-is.
+const captureLabel = (alias, source) => {
+    if (alias) return alias;
+    try {
+        const u = new URL(source);
+        return u.pathname.split('/').filter(Boolean).pop() || source;
+    } catch (_) {
+        return source;
+    }
+};
+
+// Load a single capture from either a relative path (resolved under
+// `data/`) or an absolute http(s) URL. Mirrors loadDemo's lifecycle but
+// canonicalizes the address bar to ?capture=… instead of ?demo=… so
+// URL pins survive a refresh.
+async function loadCapture(source, alias = null) {
+    const display = captureLabel(alias, source);
+    splashLabel = display;
+    splashProgress = -1;
+    landingError = null;
+    m.redraw();
+
+    try {
+        const data = await fetchParquetBytes(source, (p) => {
+            splashProgress = p;
+            m.redraw();
+        });
+
+        splashLabel = 'Initializing';
+        splashProgress = -1;
+        m.redraw();
+
+        await loadParquet(data, display);
+
+        // Canonicalize address bar to ?capture=[alias=]source so the
+        // URL is shareable and bookmarkable.
+        const url = new URL(window.location);
+        url.searchParams.delete('demo');
+        url.searchParams.delete('demoA');
+        url.searchParams.delete('demoB');
+        url.searchParams.delete('capture');
+        url.searchParams.append('capture', alias ? `${alias}=${source}` : source);
+        window.history.replaceState(null, '', url);
+    } catch (e) {
+        splashLabel = null;
+        const msg = e?.message ?? e ?? 'unknown error';
+        // Cross-origin fetch failures usually surface as opaque "Failed
+        // to fetch" — point users at the proxy workaround.
+        const isUrl = /^https?:\/\//i.test(source);
+        landingError = isUrl
+            ? `Failed to load ${display}: ${msg}. If this is a cross-origin URL, the source may be missing CORS headers — host the viewer with \`rezolus view --proxy-allow=<host>\` to bypass.`
+            : `Failed to load ${display}: ${msg}`;
+        m.redraw();
+    }
+}
+
 // Load a pair of demo parquets as baseline + experiment and launch the
 // viewer in compare mode. Triggered by ?demoA=<file>&demoB=<file>.
 async function loadCompareDemo(fileA, fileB, legends = null, category = null) {
@@ -214,12 +274,12 @@ async function loadCompareDemo(fileA, fileB, legends = null, category = null) {
         let aDone = 0;
         let bDone = 0;
         const [dataA, dataB] = await Promise.all([
-            fetchDemoBytes(fileA, (p) => {
+            fetchParquetBytes(fileA, (p) => {
                 aDone = p;
                 splashProgress = (aDone + bDone) / 2;
                 m.redraw();
             }),
-            fetchDemoBytes(fileB, (p) => {
+            fetchParquetBytes(fileB, (p) => {
                 bDone = p;
                 splashProgress = (aDone + bDone) / 2;
                 m.redraw();
@@ -340,6 +400,17 @@ const Root = {
                     loadDemo(demo.file);
                 }
             },
+            onLoadUrl: (raw) => {
+                // Reuse the same alias=URL grammar as the URL params so
+                // users can paste `vllm=https://…/file.parquet` to seed
+                // both the legend and the source.
+                const [alias, source] = splitAlias(raw);
+                loadCapture(source, alias);
+            },
+            // Static-site bundle has no local proxy. The CORS hint
+            // surfaces as a fetch failure error, not a permanent
+            // banner — keep this false.
+            proxyEnabled: false,
             demoSections,
             loading: false,
             error: landingError,
@@ -377,6 +448,11 @@ if (_captureRaw.length >= 2) {
     splashLabel = `${legends?.baseline || fileA} vs ${legends?.experiment || fileB}`;
     m.mount(document.body, Root);
     loadCompareDemo(fileA, fileB, legends, _category);
+} else if (_captureRaw.length === 1) {
+    const [alias, source] = splitAlias(_captureRaw[0]);
+    splashLabel = alias || source;
+    m.mount(document.body, Root);
+    loadCapture(source, alias);
 } else if (_demoA && _demoB) {
     // Legacy A/B compare URL — parsed for one release, rewritten to
     // canonical `?capture=…&capture=…` on load by loadCompareDemo.

--- a/src/viewer/assets/lib/landing.js
+++ b/src/viewer/assets/lib/landing.js
@@ -2,13 +2,16 @@
 // Used by both the binary viewer (src/viewer) and the static site (site/viewer).
 //
 // Props:
-//   onFile(file: File)  — called when user selects or drops a .parquet file
-//   onConnect(url: str) — called when user enters a live agent URL (optional; hidden if absent)
-//   onDemo()            — called when user clicks "Try Demo" (optional; hidden if absent)
-//   loading: boolean    — show "Loading..." indicator
-//   error: string|null  — show error message
+//   onFile(file: File)        — called when user selects or drops a .parquet file
+//   onConnect(url: str)       — called when user enters a live agent URL (optional; hidden if absent)
+//   onLoadUrl(raw: str)       — called with `[alias=]url` to load a parquet from a URL (optional; hidden if absent)
+//   proxyEnabled: bool        — when false (default), the URL section warns about CORS for cross-origin loads
+//   onDemo()                  — called when user clicks "Try Demo" (optional; hidden if absent)
+//   loading: boolean          — show "Loading..." indicator
+//   error: string|null        — show error message
 
 let connectUrl = '';
+let parquetUrl = '';
 
 // Small reusable dropzone for a single parquet slot. Used by the
 // compare-mode dual landing and available for other single-slot callers.
@@ -187,6 +190,28 @@ const FileUpload = {
                         disabled: loading || !connectUrl.trim(),
                         onclick: () => onConnect(connectUrl.trim()),
                     }, 'Connect'),
+                ]),
+                attrs.onLoadUrl && m('div.upload-connect', [
+                    m('p.upload-connect-label', 'or load a parquet from URL'),
+                    m('input.connect-input', {
+                        type: 'text',
+                        placeholder: 'https://example.com/recording.parquet (or alias=URL)',
+                        value: parquetUrl,
+                        disabled: loading,
+                        oninput: (e) => { parquetUrl = e.target.value; },
+                        onkeydown: (e) => {
+                            if (e.key === 'Enter' && parquetUrl.trim()) {
+                                attrs.onLoadUrl(parquetUrl.trim());
+                            }
+                        },
+                    }),
+                    m('button.upload-btn.connect-btn', {
+                        disabled: loading || !parquetUrl.trim(),
+                        onclick: () => attrs.onLoadUrl(parquetUrl.trim()),
+                    }, 'Load'),
+                    m('p.upload-hint', attrs.proxyEnabled
+                        ? 'Cross-origin URLs are fetched server-side via the local proxy.'
+                        : 'Cross-origin URLs require CORS on the source. To bypass, host this viewer with `rezolus view --proxy-allow=<host>`.'),
                 ]),
                 // Demo area — either grouped by section (demoSections)
                 // or a flat row (demos). A demo entry may carry either a

--- a/src/viewer/assets/lib/landing.js
+++ b/src/viewer/assets/lib/landing.js
@@ -129,121 +129,140 @@ const CompareLanding = {
 const FileUpload = {
     view({ attrs }) {
         const { onFile, onConnect, onDemo, loading, error } = attrs;
+
+        const hasDemos = !!(attrs.demoSections || attrs.demos || onDemo);
+        const hasExplore = !!(onFile || onConnect || attrs.onLoadUrl);
+
+        const demosSection = hasDemos && m('section.upload-section', [
+            m('h2.upload-section-title', 'Demos'),
+            // Either grouped by section (demoSections) or a flat row
+            // (demos). A demo entry may carry either a single `file`
+            // string or a `files` array (for compare demos); onDemo
+            // receives the whole entry so the caller can route single
+            // vs compare appropriately.
+            m('div.upload-demo-area',
+                attrs.demoSections
+                    ? attrs.demoSections.map(section => m('div.upload-demo-section', [
+                        m('p.upload-section-label', section.label),
+                        m('div.upload-demo-row',
+                            (section.demos || []).map(demo =>
+                                m('button.upload-btn', {
+                                    onclick: () => onDemo(demo),
+                                    disabled: loading,
+                                }, demo.label),
+                            ),
+                        ),
+                    ]))
+                    : m('div.upload-demo-row',
+                        (attrs.demos || [{ label: 'Try Demo' }]).map(demo =>
+                            m('button.upload-btn', {
+                                onclick: () => onDemo(demo),
+                                disabled: loading,
+                            }, demo.label),
+                        ),
+                    ),
+            ),
+        ]);
+
+        const dropzone = onFile && m('div.upload-dropzone', {
+            ondragover: (e) => {
+                e.preventDefault();
+                e.currentTarget.classList.add('dragover');
+            },
+            ondragleave: (e) => {
+                e.currentTarget.classList.remove('dragover');
+            },
+            ondrop: (e) => {
+                e.preventDefault();
+                e.currentTarget.classList.remove('dragover');
+                const file = e.dataTransfer.files[0];
+                if (file) onFile(file);
+            },
+        }, [
+            m('svg.upload-icon', {
+                width: 48, height: 48, viewBox: '0 0 24 24',
+                fill: 'none', stroke: 'currentColor', 'stroke-width': 1.5,
+            }, [
+                m('path', { d: 'M12 16V4m0 0L8 8m4-4l4 4', 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }),
+                m('path', { d: 'M2 17l.621 2.485A2 2 0 004.561 21h14.878a2 2 0 001.94-1.515L22 17', 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }),
+            ]),
+            m('p', 'Drag & drop a .parquet file here'),
+            m('p.upload-or', 'or'),
+            m('label.upload-btn', [
+                'Choose File',
+                m('input', {
+                    type: 'file',
+                    accept: '.parquet',
+                    style: 'display:none',
+                    onchange: (e) => {
+                        const file = e.target.files[0];
+                        if (file) onFile(file);
+                    },
+                }),
+            ]),
+        ]);
+
+        const connectGroup = onConnect && m('div.upload-connect', [
+            m('p.upload-connect-label', 'Connect to a live agent'),
+            m('input.connect-input', {
+                type: 'text',
+                placeholder: 'http://localhost:4241',
+                value: connectUrl,
+                disabled: loading,
+                oninput: (e) => { connectUrl = e.target.value; },
+                onkeydown: (e) => {
+                    if (e.key === 'Enter' && connectUrl.trim()) {
+                        onConnect(connectUrl.trim());
+                    }
+                },
+            }),
+            m('button.upload-btn.connect-btn', {
+                disabled: loading || !connectUrl.trim(),
+                onclick: () => onConnect(connectUrl.trim()),
+            }, 'Connect'),
+        ]);
+
+        const urlGroup = attrs.onLoadUrl && m('div.upload-connect', [
+            m('p.upload-connect-label', 'Load a parquet from URL'),
+            m('textarea.connect-input.connect-textarea', {
+                rows: 4,
+                placeholder: 'https://example.com/recording.parquet\n— or —\nalias=URL, alias=URL\n(comma-separate two for A/B compare mode)',
+                value: parquetUrl,
+                disabled: loading,
+                oninput: (e) => { parquetUrl = e.target.value; },
+                onkeydown: (e) => {
+                    // Enter submits; Shift+Enter inserts a newline for
+                    // users who really want to paste multi-line input.
+                    if (e.key === 'Enter' && !e.shiftKey && parquetUrl.trim()) {
+                        e.preventDefault();
+                        attrs.onLoadUrl(parquetUrl.trim());
+                    }
+                },
+            }),
+            m('button.upload-btn.connect-btn', {
+                disabled: loading || !parquetUrl.trim(),
+                onclick: () => attrs.onLoadUrl(parquetUrl.trim()),
+            }, 'Load'),
+            m('p.upload-hint', attrs.proxyEnabled
+                ? 'Cross-origin URLs are fetched server-side via the local proxy.'
+                : 'Cross-origin URLs require CORS on the source. To bypass, host this viewer with `rezolus view --proxy-allow=<host>`.'),
+        ]);
+
+        const exploreSection = hasExplore && m('section.upload-section', [
+            m('h2.upload-section-title', 'Explore'),
+            dropzone,
+            connectGroup,
+            urlGroup,
+        ]);
+
         return m('div.upload-container', [
             m('div.upload-card', [
                 m('h1.upload-title', 'Rezolus Viewer'),
                 m('p.upload-subtitle', onFile
-                    ? 'Drop a parquet file to explore system performance metrics.'
-                    : 'Explore system performance metrics.'),
-                onFile && m('div.upload-dropzone', {
-                    ondragover: (e) => {
-                        e.preventDefault();
-                        e.currentTarget.classList.add('dragover');
-                    },
-                    ondragleave: (e) => {
-                        e.currentTarget.classList.remove('dragover');
-                    },
-                    ondrop: (e) => {
-                        e.preventDefault();
-                        e.currentTarget.classList.remove('dragover');
-                        const file = e.dataTransfer.files[0];
-                        if (file) onFile(file);
-                    },
-                }, [
-                    m('svg.upload-icon', {
-                        width: 48, height: 48, viewBox: '0 0 24 24',
-                        fill: 'none', stroke: 'currentColor', 'stroke-width': 1.5,
-                    }, [
-                        m('path', { d: 'M12 16V4m0 0L8 8m4-4l4 4', 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }),
-                        m('path', { d: 'M2 17l.621 2.485A2 2 0 004.561 21h14.878a2 2 0 001.94-1.515L22 17', 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }),
-                    ]),
-                    m('p', 'Drag & drop a .parquet file here'),
-                    m('p.upload-or', 'or'),
-                    m('label.upload-btn', [
-                        'Choose File',
-                        m('input', {
-                            type: 'file',
-                            accept: '.parquet',
-                            style: 'display:none',
-                            onchange: (e) => {
-                                const file = e.target.files[0];
-                                if (file) onFile(file);
-                            },
-                        }),
-                    ]),
-                ]),
-                onConnect && m('div.upload-connect', [
-                    m('p.upload-connect-label', 'or connect to a live agent'),
-                    m('input.connect-input', {
-                        type: 'text',
-                        placeholder: 'http://localhost:4241',
-                        value: connectUrl,
-                        disabled: loading,
-                        oninput: (e) => { connectUrl = e.target.value; },
-                        onkeydown: (e) => {
-                            if (e.key === 'Enter' && connectUrl.trim()) {
-                                onConnect(connectUrl.trim());
-                            }
-                        },
-                    }),
-                    m('button.upload-btn.connect-btn', {
-                        disabled: loading || !connectUrl.trim(),
-                        onclick: () => onConnect(connectUrl.trim()),
-                    }, 'Connect'),
-                ]),
-                attrs.onLoadUrl && m('div.upload-connect', [
-                    m('p.upload-connect-label', 'or load a parquet from URL (comma-separated for A/B compare)'),
-                    m('input.connect-input', {
-                        type: 'text',
-                        placeholder: 'https://example.com/recording.parquet  —  or  alias=URL, alias=URL',
-                        value: parquetUrl,
-                        disabled: loading,
-                        oninput: (e) => { parquetUrl = e.target.value; },
-                        onkeydown: (e) => {
-                            if (e.key === 'Enter' && parquetUrl.trim()) {
-                                attrs.onLoadUrl(parquetUrl.trim());
-                            }
-                        },
-                    }),
-                    m('button.upload-btn.connect-btn', {
-                        disabled: loading || !parquetUrl.trim(),
-                        onclick: () => attrs.onLoadUrl(parquetUrl.trim()),
-                    }, 'Load'),
-                    m('p.upload-hint', attrs.proxyEnabled
-                        ? 'Cross-origin URLs are fetched server-side via the local proxy.'
-                        : 'Cross-origin URLs require CORS on the source. To bypass, host this viewer with `rezolus view --proxy-allow=<host>`.'),
-                ]),
-                // Demo area — either grouped by section (demoSections)
-                // or a flat row (demos). A demo entry may carry either a
-                // single `file` string or a `files` array (for compare
-                // demos); onDemo receives the whole entry so the caller
-                // can route single vs compare appropriately.
-                (attrs.demoSections || attrs.demos || (onDemo ? [{ label: 'Try Demo' }] : [])).length > 0 &&
-                    m('div.upload-demo-area', [
-                        onFile && m('p.upload-or', 'or'),
-                        ...(attrs.demoSections
-                            ? attrs.demoSections.map(section => m('div.upload-demo-section', [
-                                m('p.upload-section-label', section.label),
-                                m('div.upload-demo-row',
-                                    (section.demos || []).map(demo =>
-                                        m('button.upload-btn', {
-                                            onclick: () => onDemo(demo),
-                                            disabled: loading,
-                                        }, demo.label),
-                                    ),
-                                ),
-                            ]))
-                            : [
-                                m('div.upload-demo-row',
-                                    (attrs.demos || [{ label: 'Try Demo' }]).map(demo =>
-                                        m('button.upload-btn', {
-                                            onclick: () => onDemo(demo),
-                                            disabled: loading,
-                                        }, demo.label),
-                                    ),
-                                ),
-                            ]),
-                    ]),
+                    ? 'Drop a rezolus-recorded parquet file for no-code charts.'
+                    : 'Explore system metrics and service KPIs.'),
+                demosSection,
+                exploreSection,
                 error && m('p.upload-error', error),
                 loading && m('p.upload-loading', 'Loading...'),
             ]),

--- a/src/viewer/assets/lib/landing.js
+++ b/src/viewer/assets/lib/landing.js
@@ -192,10 +192,10 @@ const FileUpload = {
                     }, 'Connect'),
                 ]),
                 attrs.onLoadUrl && m('div.upload-connect', [
-                    m('p.upload-connect-label', 'or load a parquet from URL'),
+                    m('p.upload-connect-label', 'or load a parquet from URL (comma-separated for A/B compare)'),
                     m('input.connect-input', {
                         type: 'text',
-                        placeholder: 'https://example.com/recording.parquet (or alias=URL)',
+                        placeholder: 'https://example.com/recording.parquet  —  or  alias=URL, alias=URL',
                         value: parquetUrl,
                         disabled: loading,
                         oninput: (e) => { parquetUrl = e.target.value; },

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -3190,6 +3190,13 @@ main {
     margin: 0 0 0.25rem;
 }
 
+.upload-hint {
+    color: var(--fg-muted);
+    font-size: 0.78rem;
+    line-height: 1.4;
+    margin: 0.5rem 0 0;
+}
+
 .connect-input {
     display: block;
     width: 100%;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -3197,6 +3197,36 @@ main {
     margin: 0.5rem 0 0;
 }
 
+.upload-section {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-default);
+}
+
+.upload-section:first-of-type {
+    margin-top: 1rem;
+    padding-top: 0;
+    border-top: none;
+}
+
+.upload-section-title {
+    color: var(--accent);
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.connect-textarea {
+    resize: vertical;
+    min-height: 7rem;
+    text-align: left;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-y: auto;
+}
+
 .connect-input {
     display: block;
     width: 100%;


### PR DESCRIPTION
## Summary
Part **C** of the viewer-as-package + URL loading + proxy sequence (after [#885](https://github.com/iopsystems/rezolus/pull/885), before the local proxy in part B).

- The existing \`?capture=alias=path\` grammar now accepts absolute \`http(s)\` URLs in the path slot. Single \`?capture=…\` (previously unhandled — only two-or-more matched for compare mode) routes through a new \`loadCapture()\` lifecycle that mirrors \`loadDemo()\` but canonicalizes the address bar to \`?capture=…\`.
- Landing page gains a "Load from URL" input + button via a new \`onLoadUrl\` prop on the shared \`FileUpload\` component. Same \`alias=URL\` grammar so a paste like \`vllm=https://…/file.parquet\` seeds both the legend and the source.
- Cross-origin failures surface a CORS-aware error message that points users at \`rezolus view --proxy-allow=<host>\` (the upcoming part B). A persistent hint under the input says the same thing in lighter terms; once part B lands, setting \`proxyEnabled: true\` flips it to "fetched server-side via local proxy".
- Compare mode (\`?capture=A&capture=B\`) gets URL support for free since both sides go through the same \`fetchParquetBytes\` helper.

## Out of scope (follow-ups)
- **B** — \`rezolus view --proxy-allow=<glob>\` server-side proxy that bypasses CORS for whitelisted hosts. The hint text and \`proxyEnabled\` prop are already in place; B just needs to flip the prop and route the fetch through \`/api/v1/proxy?url=\`.
- Server-side viewer (the binary) doesn't pass \`onLoadUrl\` yet — the input only renders for the static site. The binary needs the proxy first to load arbitrary URLs.

## Test plan
- [x] \`node --test tests/*.mjs\` (65/65)
- [x] \`cargo build --bin rezolus\` clean
- [x] Serve \`site/viewer/\` locally (\`python -m http.server\`), paste a CORS-friendly parquet URL into the new input — confirm it renders and the URL bar updates to \`?capture=…\`
- [x] Try a CORS-hostile URL (e.g. plain S3 without CORS) — confirm the error mentions \`--proxy-allow\`
- [x] Open \`?capture=alias=https://…/file.parquet\` directly — confirm it loads on first navigation
- [ ] Open \`?capture=…&capture=…\` with two URLs — confirm compare mode works

🤖 Generated with [Claude Code](https://claude.com/claude-code)