### PR TITLE
feat(viewer): --proxy-allow flag exposes /api/v1/load_url for URL fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,14 +2750,12 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -3826,19 +3824,6 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,10 +741,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -772,6 +819,16 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -980,6 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1163,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,8 +1281,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1223,9 +1294,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1413,6 +1486,21 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1689,6 +1777,50 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1986,6 +2118,12 @@ dependencies = [
  "sparsevec",
  "vob",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -2315,6 +2453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,6 +2700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2794,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2869,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -2743,13 +2981,19 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2830,6 +3074,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +3111,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -2891,6 +3155,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,10 +3260,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3136,6 +3507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3717,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3757,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3627,6 +4029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,6 +4257,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3962,11 +4389,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3980,20 +4425,63 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4003,9 +4491,33 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4015,9 +4527,27 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4027,15 +4557,51 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4233,6 +4799,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,18 +2750,20 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
 [[package]]
 name = "rezolus"
-version = "5.12.2-alpha.2"
+version = "5.12.2-alpha.3"
 dependencies = [
  "allan",
  "anyhow",
@@ -3824,6 +3826,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ rayon = "1.12"
 regex = "1"
 reqwest = { version = "0.13.3", default-features = false, features = [
     "blocking",
-    "stream",
 ] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.2-alpha.2"
+version = "5.12.2-alpha.3"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true
@@ -76,6 +76,7 @@ rayon = "1.12"
 regex = "1"
 reqwest = { version = "0.13.3", default-features = false, features = [
     "blocking",
+    "stream",
 ] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ rayon = "1.12"
 regex = "1"
 reqwest = { version = "0.13.3", default-features = false, features = [
     "blocking",
+    "rustls",
 ] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -418,10 +418,9 @@ const Root = {
                     loadCapture(source, alias);
                 }
             },
-            // Static-site bundle has no local proxy. The CORS hint
-            // surfaces as a fetch failure error, not a permanent
-            // banner — keep this false.
-            proxyEnabled: false,
+            // Static-site bundle has no local proxy; URL loading goes
+            // direct from the browser, so CORS on the source matters.
+            urlLoading: 'direct',
             demoSections,
             loading: false,
             error: landingError,

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -3,7 +3,7 @@
 // Delegates all UI/routing to app.js via initDashboard().
 
 import { ViewerApi } from './viewer_api.js';
-import { FileUpload } from './landing.js';
+import { FileUpload, splitAlias } from './landing.js';
 import { setStorageScope } from './selection.js';
 import { initDashboard, bootstrapSharedSections } from './app.js';
 
@@ -12,19 +12,6 @@ import { initDashboard, bootstrapSharedSections } from './app.js';
 let splashLabel = null;   // non-null = show splash, null = show landing
 let splashProgress = -1;  // -1 = indeterminate, 0–1 = determinate
 let landingError = null;
-
-// Split a "alias=path" string into [alias, path]. Mirrors the Rust
-// split_alias in src/viewer/mod.rs: alias must be non-empty, free of
-// path separators, ':' (URL-scheme guard), and whitespace. Anything
-// else parses as a bare path with alias=null.
-const splitAlias = (raw) => {
-    const eq = raw.indexOf('=');
-    if (eq <= 0) return [null, raw];
-    const lhs = raw.slice(0, eq);
-    const rhs = raw.slice(eq + 1);
-    if (/[\/\\:\s]/.test(lhs)) return [null, raw];
-    return [lhs, rhs];
-};
 
 const demoSections = [
     {

--- a/src/viewer/assets/lib/landing.js
+++ b/src/viewer/assets/lib/landing.js
@@ -16,6 +16,21 @@
 let connectUrl = '';
 let parquetUrl = '';
 
+// Split an `alias=value` string into [alias, value]. Mirrors the Rust
+// split_alias in src/viewer/mod.rs: the alias must be non-empty and
+// free of path separators, ':' (URL-scheme guard), and whitespace.
+// Anything else parses as a bare value with alias=null. Exported so
+// the binary viewer's onLoadUrl handler and the static-site bootstrap
+// share one parser instead of re-implementing the grammar.
+export const splitAlias = (raw) => {
+    const eq = raw.indexOf('=');
+    if (eq <= 0) return [null, raw];
+    const lhs = raw.slice(0, eq);
+    const rhs = raw.slice(eq + 1);
+    if (/[\/\\:\s]/.test(lhs)) return [null, raw];
+    return [lhs, rhs];
+};
+
 // Small reusable dropzone for a single parquet slot. Used by the
 // compare-mode dual landing and available for other single-slot callers.
 // Props: { label, disabled, onDrop(file), onChoose(file) }

--- a/src/viewer/assets/lib/landing.js
+++ b/src/viewer/assets/lib/landing.js
@@ -5,7 +5,10 @@
 //   onFile(file: File)        — called when user selects or drops a .parquet file
 //   onConnect(url: str)       — called when user enters a live agent URL (optional; hidden if absent)
 //   onLoadUrl(raw: str)       — called with `[alias=]url` to load a parquet from a URL (optional; hidden if absent)
-//   proxyEnabled: bool        — when false (default), the URL section warns about CORS for cross-origin loads
+//   urlLoading                — 'direct' | 'proxy' | 'disabled'. Drives the URL input's enabled state and hint text:
+//                               'direct'   — browser fetches directly; CORS on the source matters (static-site default).
+//                               'proxy'    — server fetches via --proxy-allow; CORS irrelevant (binary viewer with allowlist).
+//                               'disabled' — input greyed out; hint explains how to enable (binary viewer without allowlist).
 //   onDemo()                  — called when user clicks "Try Demo" (optional; hidden if absent)
 //   loading: boolean          — show "Loading..." indicator
 //   error: string|null        — show error message
@@ -222,17 +225,26 @@ const FileUpload = {
             }, 'Connect'),
         ]);
 
+        const urlMode = attrs.urlLoading || 'direct';
+        const urlDisabled = urlMode === 'disabled';
+        const urlHint = ({
+            disabled: 'URL loading is off. Restart the viewer with `rezolus view --proxy-allow=<host>` to enable it.',
+            proxy:    'Cross-origin URLs are fetched server-side via the local proxy.',
+            direct:   'Cross-origin URLs require CORS on the source. To bypass, host this viewer with `rezolus view --proxy-allow=<host>`.',
+        })[urlMode];
+
         const urlGroup = attrs.onLoadUrl && m('div.upload-connect', [
             m('p.upload-connect-label', 'Load a parquet from URL'),
             m('textarea.connect-input.connect-textarea', {
                 rows: 4,
                 placeholder: 'https://example.com/recording.parquet\n— or —\nalias=URL, alias=URL\n(comma-separate two for A/B compare mode)',
                 value: parquetUrl,
-                disabled: loading,
+                disabled: loading || urlDisabled,
                 oninput: (e) => { parquetUrl = e.target.value; },
                 onkeydown: (e) => {
                     // Enter submits; Shift+Enter inserts a newline for
                     // users who really want to paste multi-line input.
+                    if (urlDisabled) return;
                     if (e.key === 'Enter' && !e.shiftKey && parquetUrl.trim()) {
                         e.preventDefault();
                         attrs.onLoadUrl(parquetUrl.trim());
@@ -240,12 +252,10 @@ const FileUpload = {
                 },
             }),
             m('button.upload-btn.connect-btn', {
-                disabled: loading || !parquetUrl.trim(),
+                disabled: loading || urlDisabled || !parquetUrl.trim(),
                 onclick: () => attrs.onLoadUrl(parquetUrl.trim()),
             }, 'Load'),
-            m('p.upload-hint', attrs.proxyEnabled
-                ? 'Cross-origin URLs are fetched server-side via the local proxy.'
-                : 'Cross-origin URLs require CORS on the source. To bypass, host this viewer with `rezolus view --proxy-allow=<host>`.'),
+            m('p.upload-hint', { class: urlDisabled ? 'upload-hint-disabled' : '' }, urlHint),
         ]);
 
         const exploreSection = hasExplore && m('section.upload-section', [

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -258,7 +258,7 @@ const showLanding = () => {
                     m.redraw();
                 }
             },
-            proxyEnabled: landingState.proxyEnabled,
+            urlLoading: landingState.proxyEnabled ? 'proxy' : 'disabled',
             loading: landingState.loading,
             error: landingState.error,
         }),

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -178,7 +178,21 @@ let landingState = {
     baselineFilename: null,
     experimentAttached: false,
     experimentFilename: null,
+    proxyEnabled: false,
 };
+
+// Best-effort probe of the proxy state so the landing's "Load from URL"
+// hint can swap to "fetched server-side" when the user started rezolus
+// view with --proxy-allow. A failed probe just leaves it at false.
+ViewerApi.getMode()
+    .then((res) => {
+        const flag = res?.data?.proxy_enabled ?? res?.proxy_enabled ?? false;
+        if (flag) {
+            landingState.proxyEnabled = true;
+            m.redraw();
+        }
+    })
+    .catch(() => { /* default false */ });
 
 const isCompareRequested = () =>
     new URLSearchParams(window.location.search).get('compare') === '1';
@@ -216,6 +230,27 @@ const showLanding = () => {
                     m.redraw();
                 }
             },
+            onLoadUrl: async (raw) => {
+                // Single URL only on the binary-viewer landing — A/B
+                // ingestion goes through the experiment-attach flow
+                // after the baseline lands, not via the URL field.
+                landingState.loading = true;
+                landingState.error = null;
+                m.redraw();
+                try {
+                    const eq = raw.indexOf('=');
+                    const looksAliased = eq > 0
+                        && !/[\/\\:\s]/.test(raw.slice(0, eq));
+                    const url = looksAliased ? raw.slice(eq + 1).trim() : raw.trim();
+                    await ViewerApi.loadFromUrl(url);
+                    window.location.reload();
+                } catch (e) {
+                    landingState.loading = false;
+                    landingState.error = `Failed to load URL: ${e?.message ?? e ?? 'unknown error'}`;
+                    m.redraw();
+                }
+            },
+            proxyEnabled: landingState.proxyEnabled,
             loading: landingState.loading,
             error: landingState.error,
         }),

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -242,7 +242,15 @@ const showLanding = () => {
                     const looksAliased = eq > 0
                         && !/[\/\\:\s]/.test(raw.slice(0, eq));
                     const url = looksAliased ? raw.slice(eq + 1).trim() : raw.trim();
-                    await ViewerApi.loadFromUrl(url);
+                    const res = await ViewerApi.loadFromUrl(url);
+                    // Backend wraps both success and recoverable errors
+                    // (invalid parquet, upstream 404, allowlist deny) in
+                    // an ApiResponse envelope, so check status before
+                    // reloading — otherwise an error gets lost in the
+                    // page refresh.
+                    if (res?.status === 'error') {
+                        throw new Error(res.error || 'unknown error');
+                    }
                     window.location.reload();
                 } catch (e) {
                     landingState.loading = false;

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -3,7 +3,7 @@
 // Delegates all UI/routing to app.js via initDashboard().
 
 import { ViewerApi } from './viewer_api.js';
-import { FileUpload, CompareLanding } from './landing.js';
+import { FileUpload, CompareLanding, splitAlias } from './landing.js';
 import { notify, showSaveModal } from './overlays.js';
 import { setStorageScope, loadPayloadIntoStore, reportStore, clearStore } from './selection.js';
 import { clearMetadataCache, processDashboardData, CAPTURE_EXPERIMENT } from './data.js';
@@ -178,21 +178,21 @@ let landingState = {
     baselineFilename: null,
     experimentAttached: false,
     experimentFilename: null,
-    proxyEnabled: false,
+    urlLoading: 'disabled',
 };
 
-// Best-effort probe of the proxy state so the landing's "Load from URL"
-// hint can swap to "fetched server-side" when the user started rezolus
-// view with --proxy-allow. A failed probe just leaves it at false.
+// Best-effort probe of the URL-loading mode the backend exposes via
+// /api/v1/mode. Drives the landing's "Load from URL" hint and disabled
+// state. A failed probe leaves it 'disabled' (input greyed out).
 ViewerApi.getMode()
     .then((res) => {
-        const flag = res?.data?.proxy_enabled ?? res?.proxy_enabled ?? false;
-        if (flag) {
-            landingState.proxyEnabled = true;
+        const mode = res?.data?.url_loading ?? res?.url_loading;
+        if (mode) {
+            landingState.urlLoading = mode;
             m.redraw();
         }
     })
-    .catch(() => { /* default false */ });
+    .catch(() => { /* default 'disabled' */ });
 
 const isCompareRequested = () =>
     new URLSearchParams(window.location.search).get('compare') === '1';
@@ -238,11 +238,8 @@ const showLanding = () => {
                 landingState.error = null;
                 m.redraw();
                 try {
-                    const eq = raw.indexOf('=');
-                    const looksAliased = eq > 0
-                        && !/[\/\\:\s]/.test(raw.slice(0, eq));
-                    const url = looksAliased ? raw.slice(eq + 1).trim() : raw.trim();
-                    const res = await ViewerApi.loadFromUrl(url);
+                    const [, source] = splitAlias(raw.trim());
+                    const res = await ViewerApi.loadFromUrl(source.trim());
                     // Backend wraps both success and recoverable errors
                     // (invalid parquet, upstream 404, allowlist deny) in
                     // an ApiResponse envelope, so check status before
@@ -258,7 +255,7 @@ const showLanding = () => {
                     m.redraw();
                 }
             },
-            urlLoading: landingState.proxyEnabled ? 'proxy' : 'disabled',
+            urlLoading: landingState.urlLoading,
             loading: landingState.loading,
             error: landingState.error,
         }),

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -3197,6 +3197,11 @@ main {
     margin: 0.5rem 0 0;
 }
 
+.upload-hint-disabled {
+    color: var(--fg);
+    font-style: italic;
+}
+
 .upload-section {
     margin-top: 1.5rem;
     padding-top: 1rem;

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -82,39 +82,16 @@ const ViewerApi = {
         });
     },
 
-    /// Fetch a remote parquet through the local /api/v1/proxy endpoint
-    /// (which respects --proxy-allow on the server) and ingest it into
-    /// the backend TSDB via the existing upload path. The two-hop
-    /// round-trip is wasteful but keeps the feature additive — no new
-    /// ingest endpoint, just composition of /proxy + /upload.
+    /// Ask the local server to fetch + ingest a remote parquet in one
+    /// hop. The bytes never traverse the browser. The server validates
+    /// the URL against its --proxy-allow list and 403s if disallowed.
     async loadFromUrl(url, filename = null) {
-        const proxied = await fetch(`/api/v1/proxy?url=${encodeURIComponent(url)}`);
-        if (!proxied.ok) {
-            const detail = await proxied.text().catch(() => '');
-            throw new Error(`proxy fetch ${proxied.status}: ${detail || proxied.statusText}`);
-        }
-        const data = await proxied.arrayBuffer();
-        if (data.byteLength > MAX_UPLOAD_BYTES) {
-            throw new Error(
-                `Fetched parquet is too large (${formatMB(data.byteLength)} MB). Max upload is ${formatMB(MAX_UPLOAD_BYTES)} MB.`,
-            );
-        }
-        const name = filename || (() => {
-            try {
-                const u = new URL(url);
-                return u.pathname.split('/').filter(Boolean).pop() || 'remote.parquet';
-            } catch (_) {
-                return 'remote.parquet';
-            }
-        })();
         return backendRequest({
             method: 'POST',
-            url: '/api/v1/upload',
-            body: data,
-            serialize: (v) => v,
+            url: '/api/v1/load_url',
+            body: { url, filename },
             headers: {
-                'Content-Type': 'application/octet-stream',
-                'x-rezolus-filename': name,
+                'Content-Type': 'application/json',
             },
         });
     },

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -82,6 +82,43 @@ const ViewerApi = {
         });
     },
 
+    /// Fetch a remote parquet through the local /api/v1/proxy endpoint
+    /// (which respects --proxy-allow on the server) and ingest it into
+    /// the backend TSDB via the existing upload path. The two-hop
+    /// round-trip is wasteful but keeps the feature additive — no new
+    /// ingest endpoint, just composition of /proxy + /upload.
+    async loadFromUrl(url, filename = null) {
+        const proxied = await fetch(`/api/v1/proxy?url=${encodeURIComponent(url)}`);
+        if (!proxied.ok) {
+            const detail = await proxied.text().catch(() => '');
+            throw new Error(`proxy fetch ${proxied.status}: ${detail || proxied.statusText}`);
+        }
+        const data = await proxied.arrayBuffer();
+        if (data.byteLength > MAX_UPLOAD_BYTES) {
+            throw new Error(
+                `Fetched parquet is too large (${formatMB(data.byteLength)} MB). Max upload is ${formatMB(MAX_UPLOAD_BYTES)} MB.`,
+            );
+        }
+        const name = filename || (() => {
+            try {
+                const u = new URL(url);
+                return u.pathname.split('/').filter(Boolean).pop() || 'remote.parquet';
+            } catch (_) {
+                return 'remote.parquet';
+            }
+        })();
+        return backendRequest({
+            method: 'POST',
+            url: '/api/v1/upload',
+            body: data,
+            serialize: (v) => v,
+            headers: {
+                'Content-Type': 'application/octet-stream',
+                'x-rezolus-filename': name,
+            },
+        });
+    },
+
     saveUrl() {
         return '/api/v1/save';
     },

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1558,12 +1558,21 @@ async fn mode(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
 ) -> axum::response::Json<serde_json::Value> {
     let loaded = !state.sections.read().is_empty();
+    // The static-site bundle reports "direct" for its own URL input
+    // (browser fetches the URL itself, CORS applies). The binary viewer
+    // never reports "direct" — the only way to load a URL here is
+    // through the local proxy.
+    let url_loading = if state.proxy.enabled() {
+        "proxy"
+    } else {
+        "disabled"
+    };
     axum::response::Json(serde_json::json!({
         "live": state.live.load(Ordering::Relaxed),
         "loaded": loaded,
         "compare_mode": state.captures.experiment_attached(),
         "category": state.category_name.read().clone(),
-        "proxy_enabled": state.proxy.enabled(),
+        "url_loading": url_loading,
     }))
 }
 

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -67,6 +67,7 @@ use promql::QueryEngine;
 use tsdb::*;
 
 pub mod capture_registry;
+mod proxy_allow;
 
 use capture_registry::{CaptureId, CaptureRegistry};
 
@@ -140,6 +141,19 @@ pub fn command() -> Command {
                 )
                 .action(clap::ArgAction::Set),
         )
+        .arg(
+            clap::Arg::new("PROXY_ALLOW")
+                .long("proxy-allow")
+                .value_name("HOST_PATTERN")
+                .help(
+                    "Enable the URL proxy and whitelist a host pattern \
+                     (repeatable). Patterns are shell-style with `*` matching \
+                     a single DNS label — e.g. `*.s3.amazonaws.com`, \
+                     `bucket.example.internal`. Without this flag the proxy \
+                     stays disabled and the browser must fetch URLs directly.",
+                )
+                .action(clap::ArgAction::Append),
+        )
 }
 
 pub struct Config {
@@ -151,6 +165,7 @@ pub struct Config {
     verbose: u8,
     listen: SocketAddr,
     templates_dir: Option<PathBuf>,
+    proxy_allow: proxy_allow::Allowlist,
 }
 
 /// Split a positional input into an optional alias and the remaining
@@ -209,6 +224,12 @@ impl TryFrom<ArgMatches> for Config {
             None => (None, None),
         };
 
+        let proxy_allow = proxy_allow::Allowlist::new(
+            args.get_many::<String>("PROXY_ALLOW")
+                .unwrap_or_default()
+                .cloned(),
+        );
+
         Ok(Config {
             source,
             experiment_path,
@@ -220,6 +241,7 @@ impl TryFrom<ArgMatches> for Config {
                 .get_one::<SocketAddr>("LISTEN")
                 .unwrap_or(&"127.0.0.1:0".to_socket_addrs().unwrap().next().unwrap()),
             templates_dir: args.get_one::<PathBuf>("templates").cloned(),
+            proxy_allow,
         })
     }
 }
@@ -243,7 +265,7 @@ pub fn run(config: Config) {
 
     let registry = load_template_registry(config.templates_dir.as_deref());
 
-    let state = match &config.source {
+    let mut state = match &config.source {
         Source::File(path) => {
             info!("Loading data from parquet file...");
             let data = Tsdb::load(path)
@@ -493,6 +515,11 @@ pub fn run(config: Config) {
         }
     };
 
+    state.set_proxy(config.proxy_allow.clone());
+    if state.proxy.enabled() {
+        info!("URL proxy enabled at /api/v1/proxy");
+    }
+
     // The experiment CLI arg is only honored when the baseline is a parquet
     // file. Live and upload-only modes manage the experiment slot via the
     // HTTP attach endpoint instead.
@@ -700,6 +727,21 @@ impl Default for LazySectionStore {
     }
 }
 
+/// Proxy state for the optional URL-fetch endpoint. When the CLI is
+/// invoked without `--proxy-allow`, both fields stay empty/None and the
+/// endpoint refuses every request.
+#[derive(Default)]
+struct ProxyState {
+    allow: proxy_allow::Allowlist,
+    client: Option<Client>,
+}
+
+impl ProxyState {
+    fn enabled(&self) -> bool {
+        !self.allow.is_empty() && self.client.is_some()
+    }
+}
+
 struct AppState {
     sections: parking_lot::RwLock<LazySectionStore>,
     /// Per-capture TSDB + metadata. Single-capture callers always target
@@ -732,6 +774,9 @@ struct AppState {
     selection: parking_lot::RwLock<Option<String>>,
     /// SHA-256 hex digest of the source parquet file (file mode only).
     file_checksum: parking_lot::RwLock<Option<String>>,
+    /// Optional URL-fetch proxy. Disabled (empty allowlist + no client)
+    /// unless the CLI was invoked with one or more `--proxy-allow`.
+    proxy: ProxyState,
 }
 
 impl AppState {
@@ -748,6 +793,27 @@ impl AppState {
             category_name: parking_lot::RwLock::new(None),
             selection: parking_lot::RwLock::new(None),
             file_checksum: parking_lot::RwLock::new(None),
+            proxy: ProxyState::default(),
+        }
+    }
+
+    /// Enable the URL proxy with the given hostname allowlist. Builds a
+    /// dedicated reqwest client (so the proxy traffic is isolated from
+    /// the live-mode scrape client). No-op when the allowlist is empty.
+    fn set_proxy(&mut self, allow: proxy_allow::Allowlist) {
+        if allow.is_empty() {
+            return;
+        }
+        match Client::builder().build() {
+            Ok(client) => {
+                self.proxy = ProxyState {
+                    allow,
+                    client: Some(client),
+                };
+            }
+            Err(e) => {
+                error!("failed to build proxy http client: {e}");
+            }
         }
     }
 
@@ -1351,6 +1417,7 @@ fn app(livereload: LiveReloadLayer, state: AppState) -> Router {
             "/save_with_selection",
             axum::routing::post(save_with_selection),
         )
+        .route("/proxy", get(proxy_url))
         .layer(axum::middleware::map_response(
             |mut response: axum::response::Response| async move {
                 response.headers_mut().insert(
@@ -1474,7 +1541,80 @@ async fn mode(
         "loaded": loaded,
         "compare_mode": state.captures.experiment_attached(),
         "category": state.category_name.read().clone(),
+        "proxy_enabled": state.proxy.enabled(),
     }))
+}
+
+#[derive(serde::Deserialize)]
+struct ProxyParam {
+    url: String,
+}
+
+/// Fetch a remote URL on behalf of the browser. Refuses every request
+/// when the proxy is disabled (no `--proxy-allow` patterns) or when the
+/// requested host doesn't match the allowlist. The handler is GET-only
+/// and streams the upstream response body verbatim — no buffering, no
+/// rewriting beyond stripping cookie-setting headers.
+async fn proxy_url(
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    axum::extract::Query(q): axum::extract::Query<ProxyParam>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let Some(client) = state.proxy.client.as_ref() else {
+        return (StatusCode::FORBIDDEN, "proxy is disabled").into_response();
+    };
+
+    let target = match Url::parse(&q.url) {
+        Ok(u) => u,
+        Err(e) => return (StatusCode::BAD_REQUEST, format!("invalid url: {e}")).into_response(),
+    };
+
+    if !matches!(target.scheme(), "http" | "https") {
+        return (StatusCode::BAD_REQUEST, "url scheme must be http or https").into_response();
+    }
+
+    let host = match target.host_str() {
+        Some(h) => h,
+        None => return (StatusCode::BAD_REQUEST, "url is missing a host").into_response(),
+    };
+
+    if !state.proxy.allow.allows(host) {
+        return (
+            StatusCode::FORBIDDEN,
+            format!("host {host} not in --proxy-allow list"),
+        )
+            .into_response();
+    }
+
+    let upstream = match client.get(target.clone()).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("proxy fetch failed for {target}: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("upstream fetch failed: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    let status = upstream.status();
+    let upstream_headers = upstream.headers().clone();
+    let body = axum::body::Body::from_stream(upstream.bytes_stream());
+
+    let mut response = axum::response::Response::builder().status(status);
+    // Forward content type + length. Drop Set-Cookie so the upstream
+    // can't plant cookies on the proxy's origin.
+    for name in [header::CONTENT_TYPE, header::CONTENT_LENGTH] {
+        if let Some(v) = upstream_headers.get(&name) {
+            response = response.header(name, v);
+        }
+    }
+    response.body(body).unwrap_or_else(|e| {
+        error!("failed to assemble proxy response: {e}");
+        (StatusCode::INTERNAL_SERVER_ERROR, "proxy response error").into_response()
+    })
 }
 
 /// Query param for endpoints that select between baseline and experiment.

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1417,7 +1417,7 @@ fn app(livereload: LiveReloadLayer, state: AppState) -> Router {
             "/save_with_selection",
             axum::routing::post(save_with_selection),
         )
-        .route("/proxy", get(proxy_url))
+        .route("/load_url", axum::routing::post(load_url))
         .layer(axum::middleware::map_response(
             |mut response: axum::response::Response| async move {
                 response.headers_mut().insert(
@@ -1546,26 +1546,36 @@ async fn mode(
 }
 
 #[derive(serde::Deserialize)]
-struct ProxyParam {
+struct LoadUrlBody {
     url: String,
+    #[serde(default)]
+    filename: Option<String>,
 }
 
-/// Fetch a remote URL on behalf of the browser. Refuses every request
-/// when the proxy is disabled (no `--proxy-allow` patterns) or when the
-/// requested host doesn't match the allowlist. The handler is GET-only
-/// and streams the upstream response body verbatim — no buffering, no
-/// rewriting beyond stripping cookie-setting headers.
-async fn proxy_url(
+/// Fetch a remote parquet on behalf of the browser and ingest it into
+/// the baseline TSDB in one server-side hop. Refuses every request when
+/// `--proxy-allow` was not set or when the requested host doesn't match
+/// any allowlist pattern. The browser only sends the URL; the bytes
+/// never traverse it — no double round-trip, no ArrayBuffer pressure.
+async fn load_url(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Query(q): axum::extract::Query<ProxyParam>,
+    axum::extract::Json(body): axum::extract::Json<LoadUrlBody>,
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
 
+    if state.live.load(Ordering::Relaxed) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "load_url is only available in file mode",
+        )
+            .into_response();
+    }
+
     let Some(client) = state.proxy.client.as_ref() else {
-        return (StatusCode::FORBIDDEN, "proxy is disabled").into_response();
+        return (StatusCode::FORBIDDEN, "url loading is disabled").into_response();
     };
 
-    let target = match Url::parse(&q.url) {
+    let target = match Url::parse(&body.url) {
         Ok(u) => u,
         Err(e) => return (StatusCode::BAD_REQUEST, format!("invalid url: {e}")).into_response(),
     };
@@ -1575,11 +1585,11 @@ async fn proxy_url(
     }
 
     let host = match target.host_str() {
-        Some(h) => h,
+        Some(h) => h.to_string(),
         None => return (StatusCode::BAD_REQUEST, "url is missing a host").into_response(),
     };
 
-    if !state.proxy.allow.allows(host) {
+    if !state.proxy.allow.allows(&host) {
         return (
             StatusCode::FORBIDDEN,
             format!("host {host} not in --proxy-allow list"),
@@ -1590,7 +1600,7 @@ async fn proxy_url(
     let upstream = match client.get(target.clone()).send().await {
         Ok(r) => r,
         Err(e) => {
-            warn!("proxy fetch failed for {target}: {e}");
+            warn!("load_url fetch failed for {target}: {e}");
             return (
                 StatusCode::BAD_GATEWAY,
                 format!("upstream fetch failed: {e}"),
@@ -1598,23 +1608,43 @@ async fn proxy_url(
                 .into_response();
         }
     };
-
-    let status = upstream.status();
-    let upstream_headers = upstream.headers().clone();
-    let body = axum::body::Body::from_stream(upstream.bytes_stream());
-
-    let mut response = axum::response::Response::builder().status(status);
-    // Forward content type + length. Drop Set-Cookie so the upstream
-    // can't plant cookies on the proxy's origin.
-    for name in [header::CONTENT_TYPE, header::CONTENT_LENGTH] {
-        if let Some(v) = upstream_headers.get(&name) {
-            response = response.header(name, v);
-        }
+    if !upstream.status().is_success() {
+        return (
+            StatusCode::BAD_GATEWAY,
+            format!("upstream returned {}", upstream.status()),
+        )
+            .into_response();
     }
-    response.body(body).unwrap_or_else(|e| {
-        error!("failed to assemble proxy response: {e}");
-        (StatusCode::INTERNAL_SERVER_ERROR, "proxy response error").into_response()
-    })
+
+    let bytes = match upstream.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("upstream read failed: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    let temp_path = baseline_temp_path();
+    if let Err(e) = std::fs::write(&temp_path, &bytes) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to stage upstream bytes: {e}"),
+        )
+            .into_response();
+    }
+
+    let filename = body.filename.unwrap_or_else(|| {
+        target
+            .path_segments()
+            .and_then(|mut s| s.rfind(|seg| !seg.is_empty()))
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "remote.parquet".to_string())
+    });
+
+    ingest_baseline_from_path(&state, temp_path, filename).into_response()
 }
 
 /// Query param for endpoints that select between baseline and experiment.
@@ -1907,15 +1937,7 @@ async fn upload_parquet(
         .map(ToString::to_string)
         .unwrap_or_else(|| "upload.parquet".to_string());
 
-    let temp_suffix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or_default();
-    let temp_path = std::env::temp_dir().join(format!(
-        "rezolus-viewer-{}-{}",
-        std::process::id(),
-        temp_suffix
-    ));
+    let temp_path = baseline_temp_path();
     if let Err(e) = std::fs::write(&temp_path, &body) {
         return axum::response::Json(ApiResponse::error(
             format!("failed to store upload: {e}"),
@@ -1923,6 +1945,19 @@ async fn upload_parquet(
         ));
     }
 
+    ingest_baseline_from_path(&state, temp_path, filename)
+}
+
+/// Shared baseline-ingest path used by `/api/v1/upload` and
+/// `/api/v1/load_url`. Takes ownership of `temp_path` (file is deleted
+/// on parquet-load failure, retained on success since the AppState
+/// references it for re-reads). The caller is responsible for
+/// populating the file at `temp_path` before calling.
+fn ingest_baseline_from_path(
+    state: &AppState,
+    temp_path: PathBuf,
+    filename: String,
+) -> axum::response::Json<ApiResponse<serde_json::Value>> {
     let loaded = Tsdb::load(&temp_path);
     let mut data = match loaded {
         Ok(d) => d,
@@ -1967,6 +2002,14 @@ async fn upload_parquet(
     axum::response::Json(ApiResponse::success(serde_json::json!({
         "filename": filename,
     })))
+}
+
+fn baseline_temp_path() -> PathBuf {
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!("rezolus-viewer-{}-{}", std::process::id(), suffix))
 }
 
 /// Attach an experiment parquet for A/B comparison. Body is raw parquet bytes.

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -517,7 +517,7 @@ pub fn run(config: Config) {
 
     state.set_proxy(config.proxy_allow.clone());
     if state.proxy.enabled() {
-        info!("URL proxy enabled at /api/v1/proxy");
+        info!("URL loading enabled at /api/v1/load_url");
     }
 
     // The experiment CLI arg is only honored when the baseline is a parquet
@@ -1560,80 +1560,70 @@ struct LoadUrlBody {
 async fn load_url(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
     axum::extract::Json(body): axum::extract::Json<LoadUrlBody>,
-) -> axum::response::Response {
-    use axum::response::IntoResponse;
+) -> axum::response::Json<ApiResponse<serde_json::Value>> {
+    // Every branch returns Json(ApiResponse) — never raw text — so the
+    // Mithril frontend's JSON-parsing default doesn't choke on non-2xx
+    // bodies and bury the real error as `null`.
+    let err =
+        |msg: String, kind: &str| axum::response::Json(ApiResponse::error(msg, kind.to_string()));
 
     if state.live.load(Ordering::Relaxed) {
-        return (
-            StatusCode::BAD_REQUEST,
-            "load_url is only available in file mode",
-        )
-            .into_response();
+        return err(
+            "load_url is only available in file mode".to_string(),
+            "bad_request",
+        );
     }
 
     let Some(client) = state.proxy.client.as_ref() else {
-        return (StatusCode::FORBIDDEN, "url loading is disabled").into_response();
+        return err("url loading is disabled".to_string(), "forbidden");
     };
 
     let target = match Url::parse(&body.url) {
         Ok(u) => u,
-        Err(e) => return (StatusCode::BAD_REQUEST, format!("invalid url: {e}")).into_response(),
+        Err(e) => return err(format!("invalid url: {e}"), "bad_request"),
     };
 
     if !matches!(target.scheme(), "http" | "https") {
-        return (StatusCode::BAD_REQUEST, "url scheme must be http or https").into_response();
+        return err(
+            "url scheme must be http or https".to_string(),
+            "bad_request",
+        );
     }
 
     let host = match target.host_str() {
         Some(h) => h.to_string(),
-        None => return (StatusCode::BAD_REQUEST, "url is missing a host").into_response(),
+        None => return err("url is missing a host".to_string(), "bad_request"),
     };
 
     if !state.proxy.allow.allows(&host) {
-        return (
-            StatusCode::FORBIDDEN,
+        return err(
             format!("host {host} not in --proxy-allow list"),
-        )
-            .into_response();
+            "forbidden",
+        );
     }
 
     let upstream = match client.get(target.clone()).send().await {
         Ok(r) => r,
         Err(e) => {
             warn!("load_url fetch failed for {target}: {e}");
-            return (
-                StatusCode::BAD_GATEWAY,
-                format!("upstream fetch failed: {e}"),
-            )
-                .into_response();
+            return err(format!("upstream fetch failed: {e}"), "upstream_error");
         }
     };
     if !upstream.status().is_success() {
-        return (
-            StatusCode::BAD_GATEWAY,
+        return err(
             format!("upstream returned {}", upstream.status()),
-        )
-            .into_response();
+            "upstream_error",
+        );
     }
 
     let bytes = match upstream.bytes().await {
         Ok(b) => b,
-        Err(e) => {
-            return (
-                StatusCode::BAD_GATEWAY,
-                format!("upstream read failed: {e}"),
-            )
-                .into_response();
-        }
+        Err(e) => return err(format!("upstream read failed: {e}"), "upstream_error"),
     };
 
     let temp_path = baseline_temp_path();
     if let Err(e) = std::fs::write(&temp_path, &bytes) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to stage upstream bytes: {e}"),
-        )
-            .into_response();
+        return err(format!("failed to stage upstream bytes: {e}"), "io_error");
     }
 
     let filename = body.filename.unwrap_or_else(|| {
@@ -1644,7 +1634,7 @@ async fn load_url(
             .unwrap_or_else(|| "remote.parquet".to_string())
     });
 
-    ingest_baseline_from_path(&state, temp_path, filename).into_response()
+    ingest_baseline_from_path(&state, temp_path, filename)
 }
 
 /// Query param for endpoints that select between baseline and experiment.

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -154,6 +154,17 @@ pub fn command() -> Command {
                 )
                 .action(clap::ArgAction::Append),
         )
+        .arg(
+            clap::Arg::new("PROXY_ALLOW_ANY")
+                .long("proxy-allow-any")
+                .help(
+                    "Disable the proxy allowlist entirely — every URL is \
+                     fetched. Use only when you trust everyone who can reach \
+                     this viewer (the SSRF risk is on you). Mutually exclusive \
+                     with --proxy-allow; if both are passed, this wins.",
+                )
+                .action(clap::ArgAction::SetTrue),
+        )
 }
 
 pub struct Config {
@@ -224,11 +235,15 @@ impl TryFrom<ArgMatches> for Config {
             None => (None, None),
         };
 
-        let proxy_allow = proxy_allow::Allowlist::new(
-            args.get_many::<String>("PROXY_ALLOW")
-                .unwrap_or_default()
-                .cloned(),
-        );
+        let proxy_allow = if args.get_flag("PROXY_ALLOW_ANY") {
+            proxy_allow::Allowlist::any()
+        } else {
+            proxy_allow::Allowlist::new(
+                args.get_many::<String>("PROXY_ALLOW")
+                    .unwrap_or_default()
+                    .cloned(),
+            )
+        };
 
         Ok(Config {
             source,
@@ -517,7 +532,14 @@ pub fn run(config: Config) {
 
     state.set_proxy(config.proxy_allow.clone());
     if state.proxy.enabled() {
-        info!("URL loading enabled at /api/v1/load_url");
+        if state.proxy.allow.is_any() {
+            warn!(
+                "URL loading enabled at /api/v1/load_url with --proxy-allow-any — \
+                 every URL will be fetched. Don't expose this listen address."
+            );
+        } else {
+            info!("URL loading enabled at /api/v1/load_url");
+        }
     }
 
     // The experiment CLI arg is only honored when the baseline is a parquet

--- a/src/viewer/proxy_allow.rs
+++ b/src/viewer/proxy_allow.rs
@@ -1,0 +1,142 @@
+//! Hostname allowlist for the viewer's URL proxy.
+//!
+//! Patterns are shell-style with `*` matching a single DNS label. So
+//! `*.s3.amazonaws.com` matches `bucket.s3.amazonaws.com` but NOT
+//! `bucket.x.s3.amazonaws.com`. To allow multiple subdomain levels,
+//! list multiple patterns (`*.s3.amazonaws.com`, `*.*.s3.amazonaws.com`).
+//!
+//! The match is case-insensitive (DNS is). An empty pattern list
+//! matches nothing — proxy stays effectively disabled.
+
+#[derive(Debug, Clone, Default)]
+pub struct Allowlist {
+    patterns: Vec<Vec<Label>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Label {
+    Wildcard,
+    Literal(String),
+}
+
+impl Allowlist {
+    pub fn new(patterns: impl IntoIterator<Item = String>) -> Self {
+        let patterns = patterns
+            .into_iter()
+            .filter(|p| !p.is_empty())
+            .map(|p| {
+                p.to_ascii_lowercase()
+                    .split('.')
+                    .map(|label| {
+                        if label == "*" {
+                            Label::Wildcard
+                        } else {
+                            Label::Literal(label.to_string())
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        Self { patterns }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    pub fn allows(&self, host: &str) -> bool {
+        let host = host.to_ascii_lowercase();
+        let host_labels: Vec<&str> = host.split('.').collect();
+        self.patterns.iter().any(|pattern| {
+            pattern.len() == host_labels.len()
+                && pattern
+                    .iter()
+                    .zip(host_labels.iter())
+                    .all(|(p, h)| match p {
+                        Label::Wildcard => true,
+                        Label::Literal(s) => s == h,
+                    })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allow(patterns: &[&str]) -> Allowlist {
+        Allowlist::new(patterns.iter().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn empty_allowlist_blocks_everything() {
+        let a = allow(&[]);
+        assert!(a.is_empty());
+        assert!(!a.allows("anything.com"));
+    }
+
+    #[test]
+    fn exact_host_matches_itself() {
+        let a = allow(&["s3.amazonaws.com"]);
+        assert!(a.allows("s3.amazonaws.com"));
+    }
+
+    #[test]
+    fn exact_host_does_not_match_subdomain() {
+        let a = allow(&["s3.amazonaws.com"]);
+        assert!(!a.allows("bucket.s3.amazonaws.com"));
+    }
+
+    #[test]
+    fn wildcard_matches_single_label_subdomain() {
+        let a = allow(&["*.s3.amazonaws.com"]);
+        assert!(a.allows("bucket.s3.amazonaws.com"));
+    }
+
+    #[test]
+    fn wildcard_does_not_match_apex() {
+        // `*.foo.com` requires a leading label. `foo.com` itself has
+        // one fewer label than the pattern, so it must not match.
+        let a = allow(&["*.s3.amazonaws.com"]);
+        assert!(!a.allows("s3.amazonaws.com"));
+    }
+
+    #[test]
+    fn single_wildcard_does_not_span_multiple_labels() {
+        // Single `*` is one DNS label only — `*.foo.com` does not
+        // match `bar.baz.foo.com`. Users who want multi-level should
+        // list multiple patterns.
+        let a = allow(&["*.s3.amazonaws.com"]);
+        assert!(!a.allows("bucket.x.s3.amazonaws.com"));
+    }
+
+    #[test]
+    fn case_insensitive_match() {
+        // DNS is case-insensitive; the matcher must agree.
+        let a = allow(&["*.S3.AmazonAWS.com"]);
+        assert!(a.allows("Bucket.s3.amazonaws.COM"));
+    }
+
+    #[test]
+    fn multiple_patterns_any_match_passes() {
+        let a = allow(&["s3.amazonaws.com", "*.internal.example.com"]);
+        assert!(a.allows("s3.amazonaws.com"));
+        assert!(a.allows("svc.internal.example.com"));
+        assert!(!a.allows("svc.external.example.com"));
+    }
+
+    #[test]
+    fn empty_pattern_strings_are_dropped() {
+        let a = Allowlist::new(["".to_string(), "s3.amazonaws.com".to_string()]);
+        assert!(!a.is_empty());
+        assert!(a.allows("s3.amazonaws.com"));
+    }
+
+    #[test]
+    fn wildcard_in_middle_position() {
+        let a = allow(&["bucket.*.example.com"]);
+        assert!(a.allows("bucket.us-west.example.com"));
+        assert!(!a.allows("bucket.example.com"));
+        assert!(!a.allows("other.us-west.example.com"));
+    }
+}

--- a/src/viewer/proxy_allow.rs
+++ b/src/viewer/proxy_allow.rs
@@ -10,6 +10,10 @@
 
 #[derive(Debug, Clone, Default)]
 pub struct Allowlist {
+    /// `--proxy-allow-any` short-circuits — every host passes,
+    /// regardless of `patterns`. Deliberate opt-in escape hatch for
+    /// "I'm running this on my own laptop, just let me load anything."
+    any: bool,
     patterns: Vec<Vec<Label>>,
 }
 
@@ -37,14 +41,31 @@ impl Allowlist {
                     .collect()
             })
             .collect();
-        Self { patterns }
+        Self {
+            any: false,
+            patterns,
+        }
+    }
+
+    pub fn any() -> Self {
+        Self {
+            any: true,
+            patterns: Vec::new(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.patterns.is_empty()
+        !self.any && self.patterns.is_empty()
+    }
+
+    pub fn is_any(&self) -> bool {
+        self.any
     }
 
     pub fn allows(&self, host: &str) -> bool {
+        if self.any {
+            return true;
+        }
         let host = host.to_ascii_lowercase();
         let host_labels: Vec<&str> = host.split('.').collect();
         self.patterns.iter().any(|pattern| {
@@ -138,5 +159,18 @@ mod tests {
         assert!(a.allows("bucket.us-west.example.com"));
         assert!(!a.allows("bucket.example.com"));
         assert!(!a.allows("other.us-west.example.com"));
+    }
+
+    #[test]
+    fn any_allows_every_host() {
+        // --proxy-allow-any is the deliberate escape hatch. is_empty
+        // must report false (proxy is enabled), and allows() must
+        // accept arbitrary label counts and shapes.
+        let a = Allowlist::any();
+        assert!(!a.is_empty());
+        assert!(a.allows("example.com"));
+        assert!(a.allows("bucket.s3.amazonaws.com"));
+        assert!(a.allows("a.b.c.d.e.f.g"));
+        assert!(a.allows("localhost"));
     }
 }


### PR DESCRIPTION
## Summary
Part **B** of the viewer-as-package + URL loading + proxy sequence (after [#885](https://github.com/iopsystems/rezolus/pull/885) static bundle and [#886](https://github.com/iopsystems/rezolus/pull/886) browser URL loading). Closes the loop so users can load a parquet from a cross-origin URL the browser can't reach directly — host the parquet wherever it lives (S3 bucket, intranet server, presigned URL), and let the locally-running rezolus binary do the fetch.

### CLI
- New \`--proxy-allow <HOST_PATTERN>\` flag (repeatable). Without it the URL-fetch endpoint stays disabled.
- Patterns are shell-style with \`*\` matching a single DNS label: \`*.s3.amazonaws.com\`, \`bucket.example.internal\`, \`bucket.*.example.com\`. Single \`*\` does not span multiple labels — list multiple patterns or repeat the wildcard for nested subdomains.

### Backend
- \`POST /api/v1/load_url\` accepts \`{ url, filename? }\`, validates URL → checks scheme (http/https) → checks host against the allowlist → fetches via reqwest → stages to a tempfile → ingests through the same \`ingest_baseline_from_path\` helper that \`/api/v1/upload\` uses. The browser only sends the URL string; the bytes never traverse it.
- \`/api/v1/mode\` now exposes \`proxy_enabled\` so the frontend's URL hint flips between \"CORS workaround\" and \"fetched server-side\".
- Hostname matcher lives in [src/viewer/proxy_allow.rs](src/viewer/proxy_allow.rs) with 10 unit tests covering exact match, wildcard semantics, case insensitivity, mid-position wildcards, and edge cases.

### Frontend
- \`ViewerApi.loadFromUrl(url)\` is a single POST \`/api/v1/load_url\` — no manual proxy fetch + re-upload composition.
- The binary viewer's landing page (\`src/viewer/assets/lib/script.js\`) wires the \`onLoadUrl\` handler from PR #886 and probes \`/api/v1/mode\` at startup so the landing's URL hint reflects the live proxy state.
- The static-site WASM viewer is unchanged: it has no backend so the endpoint isn't reachable; the existing CORS hint stays as the user-facing fallback.

## Out of scope (deliberate)
- The endpoint is POST-only with a JSON body; query-string \`?url=…\` would expand the SSRF surface and run into URL-length limits for long S3 paths.
- No IP-resolution check on the host. The allowlist is the user's explicit opt-in — if they whitelist \`*.internal.example.com\` and that resolves to RFC1918, that's a deliberate choice.
- No max-bytes cap inside the load handler; an oversized parquet still trips the existing TSDB ingest path on the way in.

## Test plan
- [x] \`cargo test --bin rezolus viewer::\` (17/17, including 10 new \`proxy_allow\` tests)
- [x] \`cargo clippy --bin rezolus -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`node --test tests/*.mjs\` (65/65)
- [x] Run \`rezolus view --proxy-allow=httpbin.org --listen 127.0.0.1:8765\`, hit \`/api/v1/load_url\` with \`curl -X POST -H 'content-type: application/json' -d '{\"url\":\"https://httpbin.org/bytes/100\"}'\` — confirm \`{ status: \"error\", error: \"failed to load parquet: …\" }\` (httpbin returns random bytes; that's the correct refusal).
- [x] Same setup, hit \`/api/v1/load_url\` with a real parquet URL — confirm 200 OK and the dashboard renders.
- [x] Hit /api/v1/load_url with \`https://example.com/foo\` — confirm 403 \"host example.com not in --proxy-allow list\".
- [x] Without \`--proxy-allow\`, hit /load_url — confirm 403 \"url loading is disabled\".
- [x] Open the binary viewer landing in upload-only mode (\`rezolus view --proxy-allow=...\`), paste a CORS-hostile parquet URL into the \"Load from URL\" input, confirm it loads. Refresh and confirm the URL hint says \"fetched server-side\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)