### PR TITLE
refactor(viewer): split mod.rs into focused submodules

### DIFF
--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -1,0 +1,633 @@
+//! Action handlers — endpoints that mutate `AppState` (uploads, attach
+//! and detach, live agent connect, parquet save) plus the live-mode
+//! ingest loop.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::body::{Body, Bytes};
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Json, Response};
+use http::{header, StatusCode};
+use parking_lot::{Mutex, RwLock};
+use reqwest::{Client, Url};
+use tracing::{debug, error, info, warn};
+
+use super::capture_registry::CaptureId;
+use super::metadata::{
+    build_multinode_systeminfo, compute_file_checksum, extract_parquet_metadata,
+    extract_service_extension_metadata, regenerate_dashboards, validate_service_extensions,
+};
+use super::state::{ApiResponse, AppState, LazySectionStore};
+use super::tsdb::Tsdb;
+use ::dashboard;
+
+// ── Snapshot ingest (live mode) ───────────────────────────────────────
+
+/// Background task that polls a live agent and ingests snapshots.
+pub async fn ingest_loop(
+    url: Url,
+    tsdb: Arc<RwLock<Tsdb>>,
+    snapshots: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    source: String,
+    version: String,
+) {
+    let client = match Client::builder().http1_only().build() {
+        Ok(c) => c,
+        Err(e) => {
+            error!("failed to create http client: {e}");
+            return;
+        }
+    };
+
+    {
+        let mut tsdb = tsdb.write();
+        tsdb.set_sampling_interval_ms(1000);
+        tsdb.set_source(source);
+        tsdb.set_version(version);
+        tsdb.set_filename(url.to_string());
+    }
+
+    let interval_duration = Duration::from_secs(1);
+    let mut interval = crate::common::aligned_interval(interval_duration);
+    let mut sample_count: u64 = 0;
+
+    loop {
+        interval.tick().await;
+
+        let start = Instant::now();
+        let response = match client.get(url.clone()).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("failed to fetch metrics: {e}");
+                continue;
+            }
+        };
+        let body = match response.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("failed to read response body: {e}");
+                continue;
+            }
+        };
+
+        debug!("sampling latency: {} us", start.elapsed().as_micros());
+
+        let snapshot: metriken_exposition::Snapshot = match rmp_serde::from_slice(&body) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("failed to deserialize snapshot: {e}");
+                continue;
+            }
+        };
+
+        let mut tsdb = tsdb.write();
+        tsdb.ingest(snapshot);
+        sample_count += 1;
+
+        snapshots.lock().push_back(body.to_vec());
+
+        if sample_count <= 5 || sample_count.is_multiple_of(60) {
+            debug!(
+                "ingested {} samples, counters: {}, gauges: {}, histograms: {}",
+                sample_count,
+                tsdb.counter_names().len(),
+                tsdb.gauge_names().len(),
+                tsdb.histogram_names().len(),
+            );
+        }
+    }
+}
+
+/// Fetch the agent banner (`source version`) and `/systeminfo`. Used by
+/// CLI startup and the runtime `/api/v1/connect` handler.
+pub async fn fetch_agent_info(client: &Client, url: &Url) -> Result<AgentInfo, String> {
+    let resp = client
+        .get(url.clone())
+        .send()
+        .await
+        .map_err(|e| format!("failed to connect to agent at {url}: {e}"))?;
+    let banner = resp.text().await.unwrap_or_default();
+    let first_line = banner.lines().next().unwrap_or("");
+    let parts: Vec<&str> = first_line.split_whitespace().collect();
+    let (source, version) = match parts.as_slice() {
+        [name, ver, ..] => (name.to_string(), ver.to_string()),
+        _ => {
+            warn!("unexpected agent banner: {first_line:?}");
+            ("rezolus".to_string(), String::new())
+        }
+    };
+
+    let mut info_url = url.clone();
+    info_url.set_path("/systeminfo");
+    let sysinfo = match client.get(info_url).send().await {
+        Ok(r) if r.status().is_success() => r.text().await.ok(),
+        _ => None,
+    };
+
+    Ok(AgentInfo {
+        source,
+        version,
+        sysinfo,
+    })
+}
+
+pub struct AgentInfo {
+    pub source: String,
+    pub version: String,
+    pub sysinfo: Option<String>,
+}
+
+// ── Upload / load_url ─────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+pub struct LoadUrlBody {
+    url: String,
+    #[serde(default)]
+    filename: Option<String>,
+}
+
+/// Fetch a remote parquet on the browser's behalf and ingest it. Refuses
+/// every request when `--proxy-allow` was not set or when the host
+/// doesn't match any allowlist pattern.
+pub async fn load_url(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<LoadUrlBody>,
+) -> Json<ApiResponse<serde_json::Value>> {
+    if state.live.load(Ordering::Relaxed) {
+        return ApiResponse::err("load_url is only available in file mode", "bad_request");
+    }
+    let Some(client) = state.proxy.client.as_ref() else {
+        return ApiResponse::err("url loading is disabled", "forbidden");
+    };
+
+    let target = match Url::parse(&body.url) {
+        Ok(u) => u,
+        Err(e) => return ApiResponse::err(format!("invalid url: {e}"), "bad_request"),
+    };
+    if !matches!(target.scheme(), "http" | "https") {
+        return ApiResponse::err("url scheme must be http or https", "bad_request");
+    }
+    let Some(host) = target.host_str().map(str::to_string) else {
+        return ApiResponse::err("url is missing a host", "bad_request");
+    };
+    if !state.proxy.allow.allows(&host) {
+        return ApiResponse::err(
+            format!("host {host} not in --proxy-allow list"),
+            "forbidden",
+        );
+    }
+
+    let upstream = match client.get(target.clone()).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("load_url fetch failed for {target}: {e}");
+            return ApiResponse::err(format!("upstream fetch failed: {e}"), "upstream_error");
+        }
+    };
+    if !upstream.status().is_success() {
+        return ApiResponse::err(
+            format!("upstream returned {}", upstream.status()),
+            "upstream_error",
+        );
+    }
+    let bytes = match upstream.bytes().await {
+        Ok(b) => b,
+        Err(e) => return ApiResponse::err(format!("upstream read failed: {e}"), "upstream_error"),
+    };
+
+    let temp_path = baseline_temp_path();
+    if let Err(e) = std::fs::write(&temp_path, &bytes) {
+        return ApiResponse::err(format!("failed to stage upstream bytes: {e}"), "io_error");
+    }
+
+    let filename = body.filename.unwrap_or_else(|| {
+        target
+            .path_segments()
+            .and_then(|mut s| s.rfind(|seg| !seg.is_empty()))
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "remote.parquet".to_string())
+    });
+    ingest_baseline_from_path(&state, temp_path, filename)
+}
+
+/// Upload and load a parquet file into file-mode viewer state.
+pub async fn upload_parquet(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Json<ApiResponse<serde_json::Value>> {
+    if state.live.load(Ordering::Relaxed) {
+        return ApiResponse::err("upload is only available in file mode", "bad_request");
+    }
+    if body.is_empty() {
+        return ApiResponse::err("missing parquet bytes", "bad_request");
+    }
+
+    let filename = filename_header(&headers).unwrap_or_else(|| "upload.parquet".to_string());
+    let temp_path = baseline_temp_path();
+    if let Err(e) = std::fs::write(&temp_path, &body) {
+        return ApiResponse::err(format!("failed to store upload: {e}"), "io_error");
+    }
+    ingest_baseline_from_path(&state, temp_path, filename)
+}
+
+/// Shared baseline-ingest path used by upload and load_url. Takes
+/// ownership of `temp_path`; the file is deleted on parquet-load
+/// failure and retained on success (AppState references it).
+pub fn ingest_baseline_from_path(
+    state: &AppState,
+    temp_path: PathBuf,
+    filename: String,
+) -> Json<ApiResponse<serde_json::Value>> {
+    let mut data = match Tsdb::load(&temp_path) {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp_path);
+            return ApiResponse::err(format!("failed to load parquet: {e}"), "invalid_parquet");
+        }
+    };
+    let filesize = std::fs::metadata(&temp_path).map(|m| m.len()).ok();
+    data.set_filename(filename.clone());
+
+    let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
+    validate_service_extensions(&data, &mut service_exts);
+    let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
+    let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None);
+    let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
+    let file_checksum = compute_file_checksum(&temp_path);
+
+    {
+        let tsdb_handle = state.baseline_tsdb();
+        let mut tsdb = tsdb_handle.write();
+        *tsdb = data;
+    }
+    *state.sections.write() = LazySectionStore::new(context);
+    let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
+    *state.parquet_path.write() = Some(temp_path);
+    state
+        .captures
+        .set_baseline_systeminfo(multinode_sysinfo.or(systeminfo));
+    *state.selection.write() = selection;
+    *state.file_checksum.write() = file_checksum;
+    state.captures.set_baseline_file_metadata(file_meta);
+
+    ApiResponse::ok(serde_json::json!({ "filename": filename }))
+}
+
+pub fn baseline_temp_path() -> PathBuf {
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!("rezolus-viewer-{}-{}", std::process::id(), suffix))
+}
+
+fn filename_header(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-rezolus-filename")
+        .and_then(|v| v.to_str().ok())
+        .map(ToString::to_string)
+}
+
+// ── Experiment attach / detach ────────────────────────────────────────
+
+/// Attach an experiment parquet for A/B comparison. Body is raw parquet
+/// bytes. Returns 409 if an experiment is already attached.
+pub async fn attach_experiment(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if state.captures.experiment_attached() {
+        return (
+            StatusCode::CONFLICT,
+            "experiment already attached; DELETE first",
+        )
+            .into_response();
+    }
+    if body.is_empty() {
+        return (StatusCode::BAD_REQUEST, "missing parquet bytes").into_response();
+    }
+
+    let filename = filename_header(&headers).unwrap_or_else(|| "experiment.parquet".to_string());
+    let temp_path =
+        std::env::temp_dir().join(format!("rezolus-experiment-{}.parquet", std::process::id()));
+    if let Err(e) = std::fs::write(&temp_path, &body) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to store upload: {e}"),
+        )
+            .into_response();
+    }
+
+    let mut tsdb = match Tsdb::load(&temp_path) {
+        Ok(t) => t,
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp_path);
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("failed to load parquet: {e}"),
+            )
+                .into_response();
+        }
+    };
+    tsdb.set_filename(filename);
+
+    let (sysinfo, _selection, file_meta) = extract_parquet_metadata(&temp_path);
+    // HTTP-attached experiments don't carry an alias today; the
+    // parameter is here so a future `x-rezolus-alias` header can thread
+    // one through without further signature changes.
+    state
+        .captures
+        .attach_experiment(tsdb, sysinfo.clone(), file_meta, None);
+    *state.experiment_parquet_path.write() = Some(temp_path);
+
+    regenerate_dashboards(&state);
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        sysinfo.unwrap_or_else(|| "{}".into()),
+    )
+        .into_response()
+}
+
+/// Detach the currently attached experiment (if any) and clean up its temp file.
+pub async fn detach_experiment(State(state): State<Arc<AppState>>) -> Response {
+    state.captures.detach_experiment();
+    if let Some(path) = state.experiment_parquet_path.write().take() {
+        let _ = std::fs::remove_file(&path);
+    }
+    // Clear the CLI-supplied experiment path too so regen below doesn't
+    // rebuild against a detached capture. Only the path reference is
+    // dropped — the user's parquet on disk is left alone.
+    state.cli_experiment_path.write().take();
+    regenerate_dashboards(&state);
+    StatusCode::OK.into_response()
+}
+
+// ── Live agent connect / reset ────────────────────────────────────────
+
+/// Connect to a live Rezolus agent at runtime.
+pub async fn connect_agent(
+    State(state): State<Arc<AppState>>,
+    body: Bytes,
+) -> Json<ApiResponse<serde_json::Value>> {
+    if state.live.load(Ordering::Relaxed) {
+        return ApiResponse::err("already connected to a live agent", "bad_request");
+    }
+
+    let url_str = match std::str::from_utf8(&body) {
+        Ok(s) => s.trim().to_string(),
+        Err(_) => return ApiResponse::err("invalid UTF-8 in URL", "bad_request"),
+    };
+    let url: Url = match url_str.parse() {
+        Ok(u) => u,
+        Err(e) => return ApiResponse::err(format!("invalid URL: {e}"), "bad_request"),
+    };
+
+    let client = match Client::builder().http1_only().build() {
+        Ok(c) => c,
+        Err(e) => {
+            return ApiResponse::err(
+                format!("failed to create HTTP client: {e}"),
+                "internal_error",
+            );
+        }
+    };
+
+    let info = match fetch_agent_info(&client, &url).await {
+        Ok(i) => i,
+        Err(e) => return ApiResponse::err(e, "connection_error"),
+    };
+
+    let mut tsdb = Tsdb::default();
+    tsdb.set_sampling_interval_ms(1000);
+    tsdb.set_source(info.source.clone());
+    tsdb.set_version(info.version.clone());
+    tsdb.set_filename(url.to_string());
+    let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
+
+    {
+        let tsdb_handle = state.baseline_tsdb();
+        let mut db = tsdb_handle.write();
+        *db = tsdb;
+    }
+    *state.sections.write() = LazySectionStore::new(context);
+    state.captures.set_baseline_systeminfo(info.sysinfo);
+    state.live.store(true, Ordering::Relaxed);
+
+    let ingest_tsdb = state.baseline_tsdb();
+    let ingest_snapshots = state.snapshots.clone();
+    let mut ingest_url = url.clone();
+    ingest_url.set_path("/metrics/binary");
+
+    tokio::spawn(ingest_loop(
+        ingest_url,
+        ingest_tsdb,
+        ingest_snapshots,
+        info.source.clone(),
+        info.version.clone(),
+    ));
+
+    info!(
+        "Connected to {source} {version} at {url}",
+        source = info.source,
+        version = info.version
+    );
+
+    ApiResponse::ok(serde_json::json!({
+        "source": info.source,
+        "version": info.version,
+        "url": url.to_string(),
+    }))
+}
+
+/// Reset the TSDB — clears all data and buffered snapshots.
+pub async fn reset_tsdb(
+    State(state): State<Arc<AppState>>,
+) -> Json<ApiResponse<serde_json::Value>> {
+    if !state.live.load(Ordering::Relaxed) {
+        return ApiResponse::err("reset is only available in live mode", "bad_request");
+    }
+
+    let tsdb_handle = state.baseline_tsdb();
+    let (source, version, filename) = {
+        let tsdb = tsdb_handle.read();
+        (
+            tsdb.source().to_string(),
+            tsdb.version().to_string(),
+            tsdb.filename().to_string(),
+        )
+    };
+    {
+        let mut tsdb = tsdb_handle.write();
+        *tsdb = Tsdb::default();
+        tsdb.set_sampling_interval_ms(1000);
+        tsdb.set_source(source);
+        tsdb.set_version(version);
+        tsdb.set_filename(filename);
+    }
+    state.snapshots.lock().clear();
+    info!("TSDB reset by user");
+    ApiResponse::ok(serde_json::json!({ "ok": true }))
+}
+
+// ── Save parquet ──────────────────────────────────────────────────────
+
+/// Convert buffered live-mode snapshots to a parquet byte vec, stamped
+/// with `sampling_interval_ms`, optional `systeminfo`, and an optional
+/// `selection` JSON.
+fn snapshots_to_parquet(
+    snapshot_data: Vec<Vec<u8>>,
+    sysinfo_json: Option<String>,
+    selection_json: Option<String>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    use std::io::Cursor;
+
+    let total_size: usize = snapshot_data.iter().map(|s| s.len()).sum();
+    let mut raw = Vec::with_capacity(total_size);
+    for snapshot_bytes in &snapshot_data {
+        raw.extend_from_slice(snapshot_bytes);
+    }
+
+    let reader = Cursor::new(raw);
+    let mut output = Vec::new();
+    let mut converter = metriken_exposition::MsgpackToParquet::with_options(
+        metriken_exposition::ParquetOptions::new(),
+    )
+    .metadata("sampling_interval_ms".to_string(), "1000".to_string());
+
+    if let Some(json) = sysinfo_json {
+        converter = converter.metadata("systeminfo".to_string(), json);
+    }
+    if let Some(selection) = selection_json {
+        converter = converter.metadata("selection".to_string(), selection);
+    }
+
+    converter
+        .convert_file_handle(reader, Cursor::new(&mut output))
+        .map(|rows| {
+            info!("saved parquet with {rows} rows");
+            output
+        })
+        .map_err(Into::into)
+}
+
+fn parquet_attachment(filename: &str, body: Vec<u8>) -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/octet-stream")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .body(Body::from(body))
+        .unwrap()
+}
+
+fn server_error(msg: impl Into<String>) -> Response {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from(msg.into()))
+        .unwrap()
+}
+
+/// Save buffered live-mode snapshots as a parquet file download.
+pub async fn save_parquet(State(state): State<Arc<AppState>>) -> Response {
+    let snapshot_data: Vec<Vec<u8>> = state.snapshots.lock().iter().cloned().collect();
+    if snapshot_data.is_empty() {
+        return Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(Body::empty())
+            .unwrap();
+    }
+
+    let sysinfo_json = state.captures.systeminfo(CaptureId::Baseline);
+    let result = tokio::task::spawn_blocking(move || {
+        snapshots_to_parquet(snapshot_data, sysinfo_json, None)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(output)) => parquet_attachment("rezolus-capture.parquet", output),
+        Ok(Err(e)) => {
+            error!("failed to convert to parquet: {e}");
+            server_error(format!("parquet conversion failed: {e}"))
+        }
+        Err(e) => {
+            error!("parquet conversion task panicked: {e}");
+            server_error("internal error")
+        }
+    }
+}
+
+/// In file mode, stamp the source parquet's footer with the supplied
+/// selection JSON and stream it back. In live mode, convert buffered
+/// snapshots and stamp the same selection at the same time.
+pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: String) -> Response {
+    let parquet_path = state.parquet_path.read().clone();
+    let selection_json = body;
+
+    if let Some(path) = parquet_path {
+        let result = tokio::task::spawn_blocking(move || {
+            use parquet::file::metadata::KeyValue;
+            let mut kv_meta =
+                crate::parquet_tools::read_file_metadata(&path).map_err(|e| e.to_string())?;
+            kv_meta.retain(|kv| kv.key != "selection");
+            kv_meta.push(KeyValue {
+                key: "selection".to_string(),
+                value: Some(selection_json),
+            });
+            let output = crate::parquet_tools::rewrite_parquet(&path, kv_meta, None)
+                .map_err(|e| e.to_string())?;
+            info!("saved annotated parquet ({} bytes)", output.len());
+            Ok::<Vec<u8>, String>(output)
+        })
+        .await;
+
+        return match result {
+            Ok(Ok(output)) => parquet_attachment("rezolus-capture-annotated.parquet", output),
+            Ok(Err(e)) => {
+                error!("failed to annotate parquet: {e}");
+                server_error(format!("parquet annotation failed: {e}"))
+            }
+            Err(e) => {
+                error!("parquet annotation task panicked: {e}");
+                server_error("internal error")
+            }
+        };
+    }
+
+    // Live mode: convert snapshots with the selection metadata.
+    let snapshot_data: Vec<Vec<u8>> = state.snapshots.lock().iter().cloned().collect();
+    if snapshot_data.is_empty() {
+        return Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(Body::empty())
+            .unwrap();
+    }
+
+    let sysinfo_json = state.captures.systeminfo(CaptureId::Baseline);
+    let result = tokio::task::spawn_blocking(move || {
+        snapshots_to_parquet(snapshot_data, sysinfo_json, Some(selection_json))
+    })
+    .await;
+
+    match result {
+        Ok(Ok(output)) => parquet_attachment("rezolus-capture-annotated.parquet", output),
+        Ok(Err(e)) => {
+            error!("failed to convert to parquet: {e}");
+            server_error(format!("parquet conversion failed: {e}"))
+        }
+        Err(e) => {
+            error!("parquet conversion task panicked: {e}");
+            server_error("internal error")
+        }
+    }
+}

--- a/src/viewer/metadata.rs
+++ b/src/viewer/metadata.rs
@@ -1,0 +1,420 @@
+//! Parquet metadata extraction and dashboard regeneration.
+//!
+//! All file-level inspection (systeminfo, selection, multi-node info,
+//! service-extension lookup, file checksum) lives here, plus the
+//! `regenerate_dashboards` orchestrator that re-derives the section map
+//! whenever a capture is attached/detached.
+
+use std::path::Path;
+
+use parquet::file::reader::FileReader;
+use parquet::file::serialized_reader::SerializedFileReader;
+use tracing::warn;
+
+use super::capture_registry::CaptureId;
+use super::promql::{self, QueryEngine};
+use super::state::{AppState, LazySectionStore};
+use super::tsdb::Tsdb;
+use ::dashboard::{self, CategoryExtension, ServiceExtension, TemplateRegistry};
+
+/// Read systeminfo, selection, and the full key-value map (with
+/// pre-computed multi-node enrichment) from a parquet file's metadata.
+pub fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>, Option<String>) {
+    std::fs::File::open(path)
+        .ok()
+        .and_then(|f| {
+            let reader = SerializedFileReader::new(f).ok()?;
+            let kv = reader.metadata().file_metadata().key_value_metadata()?;
+            let sysinfo = kv
+                .iter()
+                .find(|kv| kv.key == "systeminfo")
+                .and_then(|kv| kv.value.clone());
+            let sel = kv
+                .iter()
+                .find(|kv| kv.key == "selection")
+                .and_then(|kv| kv.value.clone());
+
+            let mut map = serde_json::Map::new();
+            for pair in kv {
+                if let Some(ref val) = pair.value {
+                    let json_val = serde_json::from_str(val)
+                        .unwrap_or_else(|_| serde_json::Value::String(val.clone()));
+                    map.insert(pair.key.clone(), json_val);
+                }
+            }
+            enrich_with_multi_node_info(&mut map);
+            let file_meta = serde_json::to_string(&serde_json::Value::Object(map)).ok();
+
+            Some((sysinfo, sel, file_meta))
+        })
+        .unwrap_or((None, None, None))
+}
+
+/// Pre-compute multi-node info (nodes list, version map, service
+/// instances) from `per_source_metadata` so the JS frontend doesn't
+/// re-parse it.
+fn enrich_with_multi_node_info(map: &mut serde_json::Map<String, serde_json::Value>) {
+    let psm = match map.get("per_source_metadata").and_then(|v| v.as_object()) {
+        Some(psm) => psm.clone(),
+        None => return,
+    };
+
+    let mut nodes = Vec::new();
+    let mut node_versions = serde_json::Map::new();
+    if let Some(rez_group) = psm.get("rezolus").and_then(|v| v.as_object()) {
+        for (sub_key, entry) in rez_group {
+            let Some(obj) = entry.as_object() else {
+                continue;
+            };
+            let node_name = obj.get("node").and_then(|v| v.as_str()).unwrap_or(sub_key);
+            if !nodes.contains(&node_name.to_string()) {
+                nodes.push(node_name.to_string());
+            }
+            if let Some(version) = obj.get("version").and_then(|v| v.as_str()) {
+                node_versions.insert(
+                    node_name.to_string(),
+                    serde_json::Value::String(version.to_string()),
+                );
+            }
+        }
+    }
+
+    let mut service_instances = serde_json::Map::new();
+    for (source, group) in &psm {
+        if source == "rezolus" {
+            continue;
+        }
+        let Some(group_obj) = group.as_object() else {
+            continue;
+        };
+        let mut instances = Vec::new();
+        for (sub_key, entry) in group_obj {
+            let Some(obj) = entry.as_object() else {
+                continue;
+            };
+            let instance_id = obj
+                .get("instance")
+                .and_then(|v| v.as_str())
+                .unwrap_or(sub_key);
+            let node = obj.get("node").and_then(|v| v.as_str());
+            let mut inst = serde_json::Map::new();
+            inst.insert(
+                "id".into(),
+                serde_json::Value::String(instance_id.to_string()),
+            );
+            inst.insert(
+                "node".into(),
+                node.map(|n| serde_json::Value::String(n.to_string()))
+                    .unwrap_or(serde_json::Value::Null),
+            );
+            instances.push(serde_json::Value::Object(inst));
+        }
+        if !instances.is_empty() {
+            service_instances.insert(source.clone(), serde_json::Value::Array(instances));
+        }
+    }
+
+    map.insert(
+        "nodes".into(),
+        serde_json::Value::Array(nodes.into_iter().map(serde_json::Value::String).collect()),
+    );
+    if !node_versions.is_empty() {
+        map.insert(
+            "node_versions".into(),
+            serde_json::Value::Object(node_versions),
+        );
+    }
+    if !service_instances.is_empty() {
+        map.insert(
+            "service_instances".into(),
+            serde_json::Value::Object(service_instances),
+        );
+    }
+}
+
+/// When the parquet has multi-node systeminfo (>1 rezolus node), assemble
+/// it into a JSON object keyed by node name. Returns `None` for
+/// single-node files; the caller falls back to the flat top-level
+/// `systeminfo` key.
+pub fn build_multinode_systeminfo(path: &Path) -> Option<String> {
+    use crate::parquet_metadata::KEY_PER_SOURCE_METADATA;
+
+    let f = std::fs::File::open(path).ok()?;
+    let reader = SerializedFileReader::new(f).ok()?;
+    let kv = reader.metadata().file_metadata().key_value_metadata()?;
+
+    let psm_json = kv
+        .iter()
+        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
+        .and_then(|kv| kv.value.as_ref())?;
+
+    let psm: serde_json::Map<String, serde_json::Value> = serde_json::from_str(psm_json).ok()?;
+
+    let mut nodes = serde_json::Map::new();
+    if let Some(rez_group) = psm.get("rezolus").and_then(|v| v.as_object()) {
+        for (node_key, entry) in rez_group {
+            let Some(obj) = entry.as_object() else {
+                continue;
+            };
+            let Some(sysinfo_val) = obj.get("systeminfo") else {
+                continue;
+            };
+            let node_name = obj
+                .get("node")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .unwrap_or_else(|| node_key.clone());
+            nodes.insert(node_name, sysinfo_val.clone());
+        }
+    }
+
+    if nodes.len() > 1 {
+        serde_json::to_string(&serde_json::Value::Object(nodes)).ok()
+    } else {
+        None
+    }
+}
+
+/// SHA-256 of the parquet file body, excluding footer metadata so the
+/// digest is stable across selection annotations. Layout:
+/// `[magic 4B] [row groups] [footer] [footer_len 4B] [magic 4B]`. We
+/// hash `[0, file_len - 8 - footer_len)`.
+pub fn compute_file_checksum(path: &Path) -> Option<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::{Read, Seek, SeekFrom};
+    (|| -> Option<String> {
+        let mut f = std::fs::File::open(path).ok()?;
+        let file_len = f.metadata().ok()?.len();
+        if file_len < 12 {
+            return None;
+        }
+        f.seek(SeekFrom::End(-8)).ok()?;
+        let mut tail = [0u8; 4];
+        f.read_exact(&mut tail).ok()?;
+        let footer_len = u32::from_le_bytes(tail) as u64;
+        let data_end = file_len.checked_sub(8 + footer_len)?;
+        f.seek(SeekFrom::Start(0)).ok()?;
+        let mut hasher = Sha256::new();
+        let mut buf = [0u8; 64 * 1024];
+        let mut remaining = data_end;
+        while remaining > 0 {
+            let to_read = (remaining as usize).min(buf.len());
+            match f.read(&mut buf[..to_read]) {
+                Ok(0) => break,
+                Ok(n) => {
+                    hasher.update(&buf[..n]);
+                    remaining -= n as u64;
+                }
+                Err(e) => {
+                    warn!("failed to read file for checksum: {e}");
+                    return None;
+                }
+            }
+        }
+        Some(
+            hasher
+                .finalize()
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect(),
+        )
+    })()
+}
+
+/// Service-extension lookup: by precedence,
+/// (1) top-level `service_queries`,
+/// (2) `per_source_metadata.<source>.service_queries`,
+/// (3) built-in template for known sources.
+///
+/// The returned source keys come purely from the parquet's metadata —
+/// CLI legend labels are display-only and don't influence template
+/// binding.
+pub fn extract_service_extension_metadata(
+    path: &Path,
+    registry: &TemplateRegistry,
+) -> Vec<(String, ServiceExtension)> {
+    use crate::parquet_metadata::{
+        KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, NESTED_SERVICE_QUERIES,
+    };
+
+    let mut results = Vec::new();
+
+    let Ok(f) = std::fs::File::open(path) else {
+        return results;
+    };
+    let Ok(reader) = SerializedFileReader::new(f) else {
+        return results;
+    };
+    let Some(kv) = reader.metadata().file_metadata().key_value_metadata() else {
+        return results;
+    };
+
+    // 1. Top-level service_queries (written by `parquet annotate`).
+    if let Some(sq_json) = kv
+        .iter()
+        .find(|kv| kv.key == KEY_SERVICE_QUERIES)
+        .and_then(|kv| kv.value.as_deref())
+    {
+        if let Ok(ext) = serde_json::from_str::<ServiceExtension>(sq_json) {
+            let source = kv
+                .iter()
+                .find(|kv| kv.key == KEY_SOURCE)
+                .and_then(|kv| kv.value.as_deref())
+                .unwrap_or(&ext.service_name);
+            results.push((source.to_string(), ext));
+        }
+    }
+
+    // 2. Nested under per_source_metadata (combined files).
+    if let Some(metadata_json) = kv
+        .iter()
+        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
+        .and_then(|kv| kv.value.as_deref())
+    {
+        if let Ok(metadata_map) =
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(metadata_json)
+        {
+            for (source, group_val) in &metadata_map {
+                if results.iter().any(|(s, _)| s == source) {
+                    continue;
+                }
+                if let Some(group) = group_val.as_object() {
+                    for (_sub_key, entry) in group {
+                        if let Some(sq) = entry.get(NESTED_SERVICE_QUERIES) {
+                            if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone())
+                            {
+                                results.push((source.clone(), ext));
+                                break; // one extension per source
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 3a. No service_queries — fall back to built-in templates.
+            for source in metadata_map.keys() {
+                if results.iter().any(|(s, _)| s == source) {
+                    continue;
+                }
+                if let Some(ext) = registry.get(source) {
+                    results.push((source.clone(), ext.clone()));
+                }
+            }
+        }
+    }
+
+    // 3b. No per_source_metadata — check the top-level source key.
+    if results.is_empty() {
+        if let Some(source) = kv
+            .iter()
+            .find(|kv| kv.key == KEY_SOURCE)
+            .and_then(|kv| kv.value.as_deref())
+        {
+            if let Some(ext) = registry.get(source) {
+                results.push((source.to_string(), ext.clone()));
+            }
+        }
+    }
+
+    results
+}
+
+/// Run each KPI's PromQL against the loaded TSDB so the dashboard can
+/// hide KPIs whose queries return no data (e.g. zero-traffic histograms).
+pub fn validate_service_extensions(tsdb: &Tsdb, exts: &mut [(String, ServiceExtension)]) {
+    let engine = QueryEngine::new(tsdb);
+    let (start, end) = engine.get_time_range();
+
+    for (_source, ext) in exts.iter_mut() {
+        for kpi in &mut ext.kpis {
+            let query = kpi.effective_query();
+            let has_data = match engine.query_range(&query, start, end, 1.0) {
+                Ok(result) => match &result {
+                    promql::QueryResult::Vector { result } => !result.is_empty(),
+                    promql::QueryResult::Matrix { result } => !result.is_empty(),
+                    promql::QueryResult::Scalar { .. } => true,
+                    promql::QueryResult::HistogramHeatmap { result } => !result.data.is_empty(),
+                },
+                Err(_) => false,
+            };
+            kpi.available = has_data;
+        }
+    }
+}
+
+/// Resolve the active category for a regen pass. Activation requires
+/// `state.category_name` to be Some, two service refs attached, and each
+/// ref's source name to appear in the category's `members`. Returns
+/// None when any of those fail — the caller falls back to per-member
+/// rendering. CLI startup ran stricter checks; silent fall-back here
+/// only happens at runtime (e.g. mid-session detach).
+pub fn lookup_category<'a>(
+    state: &AppState,
+    registry: &'a TemplateRegistry,
+    service_refs: &[(&str, &ServiceExtension)],
+) -> Option<(&'a str, &'a CategoryExtension)> {
+    let cat_name = state.category_name.read().clone()?;
+    if service_refs.len() != 2 {
+        return None;
+    }
+    let category = registry.get_category(&cat_name)?;
+    for (source, _) in service_refs {
+        if !category.members.iter().any(|m| m == source) {
+            return None;
+        }
+    }
+    Some((category.service_name.as_str(), category))
+}
+
+/// Regenerate the section map from the currently attached captures.
+/// Called at CLI startup after the experiment attaches, and on every
+/// HTTP attach/detach so the section list stays in sync.
+pub fn regenerate_dashboards(state: &AppState) {
+    let registry = &state.templates;
+    let baseline_path = state.parquet_path.read().clone();
+    // Prefer the HTTP-owned temp path; fall back to the CLI-supplied
+    // user path. Stored in separate fields so `detach_experiment` can
+    // safely delete only server-owned temp files.
+    let experiment_path = state
+        .experiment_parquet_path
+        .read()
+        .clone()
+        .or_else(|| state.cli_experiment_path.read().clone());
+
+    // Validate baseline exts against the baseline tsdb and experiment
+    // exts against the experiment tsdb so a KPI present only in one
+    // recording isn't wrongly marked unavailable.
+    let mut baseline_exts: Vec<(String, ServiceExtension)> = baseline_path
+        .as_ref()
+        .map(|p| extract_service_extension_metadata(p, registry))
+        .unwrap_or_default();
+    let mut experiment_exts: Vec<(String, ServiceExtension)> = experiment_path
+        .as_ref()
+        .map(|p| extract_service_extension_metadata(p, registry))
+        .unwrap_or_default();
+
+    {
+        let baseline_handle = state.baseline_tsdb();
+        let baseline_data = baseline_handle.read();
+        validate_service_extensions(&baseline_data, &mut baseline_exts);
+    }
+    if !experiment_exts.is_empty() {
+        if let Some(experiment_handle) = state.captures.get(CaptureId::Experiment) {
+            let experiment_data = experiment_handle.read();
+            validate_service_extensions(&experiment_data, &mut experiment_exts);
+        }
+    }
+
+    let mut service_exts = baseline_exts;
+    service_exts.extend(experiment_exts);
+
+    let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
+    let category = lookup_category(state, registry, &service_refs);
+
+    let filesize = baseline_path
+        .as_ref()
+        .and_then(|p| std::fs::metadata(p).ok().map(|m| m.len()));
+
+    let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, category);
+    *state.sections.write() = LazySectionStore::new(context);
+}

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1,43 +1,57 @@
+//! Viewer subcommand: serves a web dashboard backed by parquet files,
+//! a live agent connection, or upload-only mode.
+//!
+//! Submodules:
+//! - [`state`] — `AppState`, `LazySectionStore`, `CaptureParam`, API
+//!   envelope types
+//! - [`metadata`] — parquet metadata extraction + dashboard regeneration
+//! - [`routes`] — HTTP routing and read-side handlers
+//! - [`actions`] — mutating handlers (upload, attach, save, connect, …)
+//!   and the live-mode ingest loop
+//! - [`capture_registry`] — baseline/experiment slot registry
+//! - [`proxy_allow`] — host-pattern allowlist for `--proxy-allow`
+
 use super::*;
 
-#[cfg(not(feature = "developer-mode"))]
-use axum::response::IntoResponse;
-use axum::routing::get;
 use axum::Router;
 use clap::ArgMatches;
-use http::header;
-use http::StatusCode;
-#[cfg(not(feature = "developer-mode"))]
-use http::Uri;
-#[cfg(not(feature = "developer-mode"))]
-use include_dir::{include_dir, Dir};
 use tokio::net::TcpListener;
-use tower::ServiceBuilder;
-use tower_http::compression::CompressionLayer;
-use tower_http::decompression::RequestDecompressionLayer;
 use tower_livereload::LiveReloadLayer;
 
-use std::collections::{HashMap, VecDeque};
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 
 #[cfg(feature = "developer-mode")]
 use notify::Watcher;
 
-#[cfg(feature = "developer-mode")]
-use tower_http::services::{ServeDir, ServeFile};
+#[cfg(test)]
+pub use dashboard::Kpi;
+pub use dashboard::{ServiceExtension, TemplateRegistry};
 
-#[cfg(not(feature = "developer-mode"))]
-static ASSETS: Dir<'_> = include_dir!("src/viewer/assets");
+pub use metriken_query::promql;
+pub use metriken_query::tsdb;
+
+use tsdb::*;
+
+pub mod capture_registry;
+mod proxy_allow;
+
+mod actions;
+mod metadata;
+mod routes;
+mod state;
+
+use capture_registry::CaptureId;
+use state::AppState;
 
 /// Shared entry point for loading the template registry. Both the
 /// viewer (`rezolus view`) and `rezolus parquet annotate/filter` call
 /// this. Precedence: explicit `--templates <path>` > env var /
 /// `config/templates/` default (developer-mode or explicit path only).
 /// Release builds fall back to templates baked into the binary via
-/// `include_dir!`; developer-mode continues to read from disk so
-/// template edits don't require a rebuild.
+/// `include_dir!`; developer-mode reads from disk so template edits
+/// don't require a rebuild.
 pub fn load_template_registry(cli_path: Option<&Path>) -> TemplateRegistry {
     if cli_path.is_some() {
         return TemplateRegistry::resolve_and_load(cli_path);
@@ -54,22 +68,6 @@ pub fn load_template_registry(cli_path: Option<&Path>) -> TemplateRegistry {
         TemplateRegistry::resolve_and_load(None)
     }
 }
-
-#[cfg(test)]
-pub use dashboard::Kpi;
-pub use dashboard::{CategoryExtension, ServiceExtension, TemplateRegistry};
-
-// Re-export from metriken-query crate
-pub use metriken_query::promql;
-pub use metriken_query::tsdb;
-
-use promql::QueryEngine;
-use tsdb::*;
-
-pub mod capture_registry;
-mod proxy_allow;
-
-use capture_registry::{CaptureId, CaptureRegistry};
 
 /// The input source for the viewer.
 enum Source {
@@ -180,19 +178,17 @@ pub struct Config {
 }
 
 /// Split a positional input into an optional alias and the remaining
-/// path-or-url. The alias prefix must look "identifier-like" — no
-/// path separators, no colon (which would collide with URL schemes),
-/// no whitespace. Anything else parses as a bare path.
+/// path-or-url. The alias prefix must look "identifier-like" — no path
+/// separators, no colon (would collide with URL schemes), no whitespace.
 ///
-/// Examples:
-///   "redis=./a.parquet"          → (Some("redis"), "./a.parquet")
-///   "./a.parquet"                → (None,          "./a.parquet")
-///   "http://localhost:4241"      → (None,          "http://localhost:4241")  (colon guard)
-///   "/abs/path=weird.parquet"    → (None,          "/abs/path=weird.parquet") (slash guard)
+/// `redis=./a.parquet`         → (Some("redis"), "./a.parquet")
+/// `./a.parquet`               → (None,          "./a.parquet")
+/// `http://localhost:4241`     → (None,          "http://localhost:4241")
+/// `/abs/path=weird.parquet`   → (None,          "/abs/path=weird.parquet")
 fn split_alias(raw: &str) -> (Option<String>, &str) {
     if let Some(eq) = raw.find('=') {
         let (lhs, rest) = raw.split_at(eq);
-        let rhs = &rest[1..]; // skip the '=' itself
+        let rhs = &rest[1..];
         let lhs_ok = !lhs.is_empty()
             && !lhs.contains('/')
             && !lhs.contains('\\')
@@ -208,9 +204,7 @@ fn split_alias(raw: &str) -> (Option<String>, &str) {
 impl TryFrom<ArgMatches> for Config {
     type Error = String;
 
-    fn try_from(
-        args: ArgMatches,
-    ) -> Result<Self, <Self as std::convert::TryFrom<clap::ArgMatches>>::Error> {
+    fn try_from(args: ArgMatches) -> Result<Self, Self::Error> {
         let (baseline_alias, source) = match args.get_one::<String>("INPUT") {
             Some(raw) => {
                 let (alias, body) = split_alias(raw);
@@ -263,7 +257,6 @@ impl TryFrom<ArgMatches> for Config {
 
 pub fn run(config: Config) {
     let config: Arc<Config> = config.into();
-
     let _log_drain = configure_logging(verbosity_to_level(config.verbose));
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -273,257 +266,13 @@ pub fn run(config: Config) {
         .build()
         .expect("failed to launch async runtime");
 
-    ctrlc::set_handler(move || {
-        std::process::exit(2);
-    })
-    .expect("failed to set ctrl-c handler");
+    ctrlc::set_handler(move || std::process::exit(2)).expect("failed to set ctrl-c handler");
 
     let registry = load_template_registry(config.templates_dir.as_deref());
 
     let mut state = match &config.source {
-        Source::File(path) => {
-            info!("Loading data from parquet file...");
-            let data = Tsdb::load(path)
-                .map_err(|e| {
-                    eprintln!("failed to load data from parquet: {e}");
-                    std::process::exit(1);
-                })
-                .unwrap();
-
-            let (systeminfo, selection, file_meta) = extract_parquet_metadata(path);
-            // CLI startup log only — the canonical extraction happens
-            // inside `regenerate_dashboards` below.
-            let mut service_exts = extract_service_extension_metadata(path, &registry);
-
-            // Validate KPI availability against the loaded data so that
-            // template-derived dashboards hide KPIs with no data. The
-            // `service_exts` here is consumed only for the startup log
-            // below; `regenerate_dashboards` re-extracts and re-validates
-            // per-capture once the experiment (if any) has been attached.
-            validate_service_extensions(&data, &mut service_exts);
-
-            // Compute SHA-256 checksum of the parquet data (excluding footer metadata).
-            // Parquet layout: [magic 4B] [row groups...] [footer] [footer_len 4B] [magic 4B]
-            // We hash only [0, file_size - 8 - footer_len) so the checksum is stable
-            // regardless of key-value metadata changes (e.g. selection annotations).
-            info!("Computing file checksum...");
-            let file_checksum = compute_file_checksum(path);
-
-            if service_exts.is_empty() && config.category_name.is_some() {
-                warn!("no service extension matched the baseline parquet's source metadata");
-            }
-            for (source, ext) in &service_exts {
-                let available = ext.kpis.iter().filter(|k| k.available).count();
-                info!(
-                    "Found service extension for {:?} from source {:?} ({}/{} KPIs available) — baseline",
-                    ext.service_name,
-                    source,
-                    available,
-                    ext.kpis.len()
-                );
-            }
-
-            let state = AppState::new(data, registry.clone());
-            *state.parquet_path.write() = Some(path.clone());
-            let multinode_sysinfo = build_multinode_systeminfo(path);
-            state
-                .captures
-                .set_baseline_systeminfo(multinode_sysinfo.or(systeminfo));
-            *state.selection.write() = selection;
-            *state.file_checksum.write() = file_checksum;
-            state.captures.set_baseline_file_metadata(file_meta);
-            state
-                .captures
-                .set_baseline_alias(config.baseline_alias.clone());
-
-            // --category requires the active category template to exist
-            // and for both captures' detected sources to appear in its
-            // `members` list. Detection comes from each capture's
-            // parquet metadata (CLI legend labels are display-only and
-            // never influence membership). Refuse to launch on
-            // misconfiguration; silently falling back hides user intent
-            // and produces a confusing dashboard.
-            if let Some(ref cat_name) = config.category_name {
-                let category = registry.get_category(cat_name).unwrap_or_else(|| {
-                    eprintln!("no category template named {cat_name:?} found in the registry");
-                    std::process::exit(1);
-                });
-                let baseline_sources: Vec<String> =
-                    service_exts.iter().map(|(s, _)| s.clone()).collect();
-                let experiment_path = config.experiment_path.as_ref().unwrap_or_else(|| {
-                    eprintln!(
-                        "--category {cat_name:?} requires both a baseline and an experiment capture"
-                    );
-                    std::process::exit(1);
-                });
-                let mut experiment_exts =
-                    extract_service_extension_metadata(experiment_path, &registry);
-                if let Ok(exp_data) = Tsdb::load(experiment_path) {
-                    validate_service_extensions(&exp_data, &mut experiment_exts);
-                }
-                let experiment_sources: Vec<String> =
-                    experiment_exts.iter().map(|(s, _)| s.clone()).collect();
-                for source in baseline_sources.iter().chain(experiment_sources.iter()) {
-                    if !category.members.iter().any(|m| m == source) {
-                        eprintln!(
-                            "source {source:?} is not a member of category {cat_name:?} (members: {:?})",
-                            category.members
-                        );
-                        std::process::exit(1);
-                    }
-                }
-                info!(
-                    "Activated category {:?} (members: {:?}) — baseline sources {:?}, experiment sources {:?}",
-                    cat_name, category.members, baseline_sources, experiment_sources,
-                );
-                *state.category_name.write() = Some(cat_name.clone());
-            }
-
-            // Attach the optional experiment capture for A/B comparison.
-            // The experiment path is recorded in `cli_experiment_path`
-            // (NOT `experiment_parquet_path`). That separation
-            // matters: `experiment_parquet_path` is for server-owned
-            // temp files written by the HTTP attach handler so they
-            // can be cleaned up on detach. The CLI path is the user's
-            // own file on disk — detaching must not delete it.
-            // `regenerate_dashboards` consults both fields.
-            if let Some(exp_path) = &config.experiment_path {
-                info!("Loading experiment from parquet file...");
-                let (exp_sysinfo, _exp_selection, exp_file_meta) =
-                    extract_parquet_metadata(exp_path);
-                match Tsdb::load(exp_path) {
-                    Ok(mut exp_tsdb) => {
-                        // Stamp the Tsdb with its filename (basename) so
-                        // the viewer can surface it in the compare badge.
-                        let base = exp_path
-                            .file_name()
-                            .and_then(|s| s.to_str())
-                            .unwrap_or("experiment.parquet")
-                            .to_string();
-                        exp_tsdb.set_filename(base);
-                        state.captures.attach_experiment(
-                            exp_tsdb,
-                            exp_sysinfo,
-                            exp_file_meta,
-                            config.experiment_alias.clone(),
-                        );
-                        *state.cli_experiment_path.write() = Some(exp_path.clone());
-                        info!("Attached experiment capture: {}", exp_path.display());
-
-                        // Mirror the baseline log line for the
-                        // experiment so the user can see whether
-                        // template detection picked anything up.
-                        let mut exp_exts = extract_service_extension_metadata(exp_path, &registry);
-                        if let Some(handle) = state.captures.get(CaptureId::Experiment) {
-                            let exp_data = handle.read();
-                            validate_service_extensions(&exp_data, &mut exp_exts);
-                        }
-                        if exp_exts.is_empty() {
-                            warn!(
-                                "no service extension matched the experiment parquet's source metadata"
-                            );
-                        }
-                        for (source, ext) in &exp_exts {
-                            let available = ext.kpis.iter().filter(|k| k.available).count();
-                            info!(
-                                "Found service extension for {:?} from source {:?} ({}/{} KPIs available) — experiment",
-                                ext.service_name,
-                                source,
-                                available,
-                                ext.kpis.len()
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        warn!(
-                            "failed to load experiment '{}': {e}. Starting in single-capture mode.",
-                            exp_path.display(),
-                        );
-                    }
-                }
-            }
-
-            // Now that BOTH captures (baseline + optional experiment)
-            // are attached, generate the dashboard once. This is the
-            // single place that picks up a category when the registry
-            // has one whose members match the two service extensions.
-            info!("Generating dashboards...");
-            regenerate_dashboards(&state);
-
-            state
-        }
-        Source::Live(url) => {
-            info!("Connecting to live agent at {url}...");
-
-            let (source, version, agent_systeminfo) = rt.block_on(async {
-                let client = Client::builder()
-                    .http1_only()
-                    .build()
-                    .expect("failed to create http client");
-
-                let (source, version) = match client.get(url.clone()).send().await {
-                    Ok(response) => match response.text().await {
-                        Ok(body) => {
-                            let first_line = body.lines().next().unwrap_or("");
-                            let parts: Vec<&str> = first_line.split_whitespace().collect();
-                            match parts.as_slice() {
-                                [name, ver, ..] => (name.to_string(), ver.to_string()),
-                                _ => {
-                                    warn!("unexpected agent banner: {first_line:?}");
-                                    ("rezolus".to_string(), String::new())
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            warn!("failed to read agent banner: {e}");
-                            ("rezolus".to_string(), String::new())
-                        }
-                    },
-                    Err(e) => {
-                        eprintln!("failed to connect to agent at {url}: {e}");
-                        std::process::exit(1);
-                    }
-                };
-
-                let mut info_url = url.clone();
-                info_url.set_path("/systeminfo");
-                let sysinfo = match client.get(info_url).send().await {
-                    Ok(response) if response.status().is_success() => response.text().await.ok(),
-                    _ => None,
-                };
-
-                (source, version, sysinfo)
-            });
-
-            info!("Connected to {source} {version} at {url}");
-
-            let mut tsdb = Tsdb::default();
-            tsdb.set_sampling_interval_ms(1000);
-            tsdb.set_source(source.clone());
-            tsdb.set_version(version.clone());
-            tsdb.set_filename(url.to_string());
-            let state = AppState::new(tsdb, registry.clone());
-            let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
-            *state.sections.write() = LazySectionStore::new(context);
-            state.live.store(true, Ordering::Relaxed);
-
-            state.captures.set_baseline_systeminfo(agent_systeminfo);
-
-            let ingest_tsdb = state.baseline_tsdb();
-            let ingest_snapshots = state.snapshots.clone();
-            let mut ingest_url = url.clone();
-            ingest_url.set_path("/metrics/binary");
-
-            rt.spawn(ingest_loop(
-                ingest_url,
-                ingest_tsdb,
-                ingest_snapshots,
-                source,
-                version,
-            ));
-
-            state
-        }
+        Source::File(path) => init_file_mode(&config, path, &registry),
+        Source::Live(url) => init_live_mode(&rt, url, &registry),
         Source::Empty => {
             info!("No input file — starting in upload-only mode");
             AppState::new(Tsdb::default(), registry.clone())
@@ -542,9 +291,9 @@ pub fn run(config: Config) {
         }
     }
 
-    // The experiment CLI arg is only honored when the baseline is a parquet
-    // file. Live and upload-only modes manage the experiment slot via the
-    // HTTP attach endpoint instead.
+    // The experiment CLI arg is only honored when the baseline is a
+    // parquet file. Live and upload-only modes use the HTTP attach
+    // endpoint instead.
     if config.experiment_path.is_some() && !matches!(config.source, Source::File(_)) {
         warn!(
             "--experiment ignored outside of file mode (v1 compare requires a baseline parquet file)"
@@ -556,7 +305,6 @@ pub fn run(config: Config) {
 
     rt.spawn(async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
-
         if open::that(format!("http://{addr}")).is_err() {
             info!("Use your browser to view: http://{addr}");
         } else {
@@ -565,88 +313,206 @@ pub fn run(config: Config) {
     });
 
     rt.block_on(async move { serve(listener, state).await });
-
     std::thread::sleep(Duration::from_millis(200));
 }
 
-/// Background task that polls a live agent and ingests snapshots into the TSDB.
-async fn ingest_loop(
-    url: Url,
-    tsdb: Arc<parking_lot::RwLock<Tsdb>>,
-    snapshots: Arc<parking_lot::Mutex<VecDeque<Vec<u8>>>>,
-    source: String,
-    version: String,
+/// Build initial AppState for a parquet file source, including the
+/// optional experiment attach and category validation.
+fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> AppState {
+    info!("Loading data from parquet file...");
+    let data = Tsdb::load(path).unwrap_or_else(|e| {
+        eprintln!("failed to load data from parquet: {e}");
+        std::process::exit(1);
+    });
+
+    let (systeminfo, selection, file_meta) = metadata::extract_parquet_metadata(path);
+    // CLI-startup log only; the canonical extraction happens inside
+    // `regenerate_dashboards` below.
+    let mut service_exts = metadata::extract_service_extension_metadata(path, registry);
+    metadata::validate_service_extensions(&data, &mut service_exts);
+
+    info!("Computing file checksum...");
+    let file_checksum = metadata::compute_file_checksum(path);
+
+    if service_exts.is_empty() && config.category_name.is_some() {
+        warn!("no service extension matched the baseline parquet's source metadata");
+    }
+    log_service_exts(&service_exts, "baseline");
+
+    let state = AppState::new(data, registry.clone());
+    *state.parquet_path.write() = Some(path.to_path_buf());
+    let multinode_sysinfo = metadata::build_multinode_systeminfo(path);
+    state
+        .captures
+        .set_baseline_systeminfo(multinode_sysinfo.or(systeminfo));
+    *state.selection.write() = selection;
+    *state.file_checksum.write() = file_checksum;
+    state.captures.set_baseline_file_metadata(file_meta);
+    state
+        .captures
+        .set_baseline_alias(config.baseline_alias.clone());
+
+    if let Some(ref cat_name) = config.category_name {
+        validate_category_at_startup(&state, registry, cat_name, &service_exts, config);
+    }
+
+    if let Some(exp_path) = &config.experiment_path {
+        attach_cli_experiment(&state, exp_path, registry, config.experiment_alias.clone());
+    }
+
+    info!("Generating dashboards...");
+    metadata::regenerate_dashboards(&state);
+    state
+}
+
+/// Validate `--category`: the named category must exist, both captures'
+/// detected sources must appear in its `members`. Refuses to launch on
+/// misconfiguration; silent fall-back hides user intent.
+fn validate_category_at_startup(
+    state: &AppState,
+    registry: &TemplateRegistry,
+    cat_name: &str,
+    baseline_exts: &[(String, ServiceExtension)],
+    config: &Config,
 ) {
-    let client = match Client::builder().http1_only().build() {
-        Ok(c) => c,
+    let category = registry.get_category(cat_name).unwrap_or_else(|| {
+        eprintln!("no category template named {cat_name:?} found in the registry");
+        std::process::exit(1);
+    });
+    let baseline_sources: Vec<String> = baseline_exts.iter().map(|(s, _)| s.clone()).collect();
+    let experiment_path = config.experiment_path.as_ref().unwrap_or_else(|| {
+        eprintln!("--category {cat_name:?} requires both a baseline and an experiment capture");
+        std::process::exit(1);
+    });
+    let mut experiment_exts =
+        metadata::extract_service_extension_metadata(experiment_path, registry);
+    if let Ok(exp_data) = Tsdb::load(experiment_path) {
+        metadata::validate_service_extensions(&exp_data, &mut experiment_exts);
+    }
+    let experiment_sources: Vec<String> = experiment_exts.iter().map(|(s, _)| s.clone()).collect();
+    for source in baseline_sources.iter().chain(experiment_sources.iter()) {
+        if !category.members.iter().any(|m| m == source) {
+            eprintln!(
+                "source {source:?} is not a member of category {cat_name:?} (members: {:?})",
+                category.members
+            );
+            std::process::exit(1);
+        }
+    }
+    info!(
+        "Activated category {:?} (members: {:?}) — baseline sources {:?}, experiment sources {:?}",
+        cat_name, category.members, baseline_sources, experiment_sources,
+    );
+    *state.category_name.write() = Some(cat_name.to_string());
+}
+
+/// Attach the optional experiment capture supplied via the CLI. Records
+/// the user-supplied path in `cli_experiment_path` (NOT
+/// `experiment_parquet_path`) so detach never deletes the user's file.
+fn attach_cli_experiment(
+    state: &AppState,
+    exp_path: &Path,
+    registry: &TemplateRegistry,
+    alias: Option<String>,
+) {
+    info!("Loading experiment from parquet file...");
+    let (exp_sysinfo, _exp_selection, exp_file_meta) = metadata::extract_parquet_metadata(exp_path);
+    let mut exp_tsdb = match Tsdb::load(exp_path) {
+        Ok(t) => t,
         Err(e) => {
-            error!("failed to create http client: {e}");
+            warn!(
+                "failed to load experiment '{}': {e}. Starting in single-capture mode.",
+                exp_path.display(),
+            );
             return;
         }
     };
+    let base = exp_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("experiment.parquet")
+        .to_string();
+    exp_tsdb.set_filename(base);
+    state
+        .captures
+        .attach_experiment(exp_tsdb, exp_sysinfo, exp_file_meta, alias);
+    *state.cli_experiment_path.write() = Some(exp_path.to_path_buf());
+    info!("Attached experiment capture: {}", exp_path.display());
 
-    {
-        let mut tsdb = tsdb.write();
-        tsdb.set_sampling_interval_ms(1000);
-        tsdb.set_source(source);
-        tsdb.set_version(version);
-        tsdb.set_filename(url.to_string());
+    let mut exp_exts = metadata::extract_service_extension_metadata(exp_path, registry);
+    if let Some(handle) = state.captures.get(CaptureId::Experiment) {
+        let exp_data = handle.read();
+        metadata::validate_service_extensions(&exp_data, &mut exp_exts);
     }
+    if exp_exts.is_empty() {
+        warn!("no service extension matched the experiment parquet's source metadata");
+    }
+    log_service_exts(&exp_exts, "experiment");
+}
 
-    let interval_duration = Duration::from_secs(1);
-    let mut interval = crate::common::aligned_interval(interval_duration);
+fn log_service_exts(exts: &[(String, ServiceExtension)], capture: &str) {
+    for (source, ext) in exts {
+        let available = ext.kpis.iter().filter(|k| k.available).count();
+        info!(
+            "Found service extension for {:?} from source {:?} ({}/{} KPIs available) — {capture}",
+            ext.service_name,
+            source,
+            available,
+            ext.kpis.len()
+        );
+    }
+}
 
-    let mut sample_count: u64 = 0;
-
-    loop {
-        interval.tick().await;
-
-        let start = Instant::now();
-
-        let response = match client.get(url.clone()).send().await {
-            Ok(r) => r,
+fn init_live_mode(
+    rt: &tokio::runtime::Runtime,
+    url: &Url,
+    registry: &TemplateRegistry,
+) -> AppState {
+    info!("Connecting to live agent at {url}...");
+    let info = rt.block_on(async {
+        let client = Client::builder()
+            .http1_only()
+            .build()
+            .expect("failed to create http client");
+        match actions::fetch_agent_info(&client, url).await {
+            Ok(i) => i,
             Err(e) => {
-                warn!("failed to fetch metrics: {e}");
-                continue;
+                eprintln!("{e}");
+                std::process::exit(1);
             }
-        };
-
-        let body = match response.bytes().await {
-            Ok(b) => b,
-            Err(e) => {
-                warn!("failed to read response body: {e}");
-                continue;
-            }
-        };
-
-        let latency = start.elapsed();
-        debug!("sampling latency: {} us", latency.as_micros());
-
-        let snapshot: metriken_exposition::Snapshot = match rmp_serde::from_slice(&body) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("failed to deserialize snapshot: {e}");
-                continue;
-            }
-        };
-
-        let mut tsdb = tsdb.write();
-        tsdb.ingest(snapshot);
-        sample_count += 1;
-
-        // Buffer raw bytes for parquet export
-        snapshots.lock().push_back(body.to_vec());
-
-        if sample_count <= 5 || sample_count.is_multiple_of(60) {
-            debug!(
-                "ingested {} samples, counters: {}, gauges: {}, histograms: {}",
-                sample_count,
-                tsdb.counter_names().len(),
-                tsdb.gauge_names().len(),
-                tsdb.histogram_names().len(),
-            );
         }
-    }
+    });
+    info!(
+        "Connected to {source} {version} at {url}",
+        source = info.source,
+        version = info.version
+    );
+
+    let mut tsdb = Tsdb::default();
+    tsdb.set_sampling_interval_ms(1000);
+    tsdb.set_source(info.source.clone());
+    tsdb.set_version(info.version.clone());
+    tsdb.set_filename(url.to_string());
+    let state = AppState::new(tsdb, registry.clone());
+    let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
+    *state.sections.write() = state::LazySectionStore::new(context);
+    state.live.store(true, Ordering::Relaxed);
+    state.captures.set_baseline_systeminfo(info.sysinfo);
+
+    let ingest_tsdb = state.baseline_tsdb();
+    let ingest_snapshots = state.snapshots.clone();
+    let mut ingest_url = url.clone();
+    ingest_url.set_path("/metrics/binary");
+
+    rt.spawn(actions::ingest_loop(
+        ingest_url,
+        ingest_tsdb,
+        ingest_snapshots,
+        info.source,
+        info.version,
+    ));
+
+    state
 }
 
 async fn serve(listener: std::net::TcpListener, state: AppState) {
@@ -655,17 +521,14 @@ async fn serve(listener: std::net::TcpListener, state: AppState) {
     #[cfg(feature = "developer-mode")]
     {
         let reloader = livereload.reloader();
-
         let mut watcher = notify::recommended_watcher(move |res: Result<notify::Event, _>| {
             if let Ok(event) = res {
-                // Reload, unless it's just a read.
                 if !matches!(event.kind, notify::EventKind::Access(_)) {
                     reloader.reload();
                 }
             }
         })
         .expect("failed to initialize watcher");
-
         watcher
             .watch(
                 Path::new("src/viewer/assets"),
@@ -674,1867 +537,21 @@ async fn serve(listener: std::net::TcpListener, state: AppState) {
             .expect("failed to watch assets folder");
     }
 
-    let app = app(livereload, state);
+    let app: Router = routes::app(livereload, state);
 
     listener.set_nonblocking(true).unwrap();
     let listener = TcpListener::from_std(listener).unwrap();
-
     axum::serve(listener, app)
         .await
         .expect("failed to run http server");
 }
 
-/// Caches the navigation list (via the owned `DashboardContext`) and
-/// memoizes per-section JSON bodies, so the `/api/v1/sections` route
-/// reads the nav list without materializing any section body, and
-/// `/data/<section>.json` generates a body on first request and serves
-/// the cached value thereafter.
-struct LazySectionStore {
-    context: dashboard::dashboard::DashboardContext,
-    /// Memoized rendered bodies keyed by the route key the frontend
-    /// requests, e.g. `cpu.json`, `service/vllm.json`. Filesize is
-    /// already applied uniformly across all routes — Phase 2 dropped
-    /// the shim's old "filesize on stock routes only" carve-out.
-    cached_bodies: HashMap<String, serde_json::Value>,
-}
-
-impl LazySectionStore {
-    fn new(context: dashboard::dashboard::DashboardContext) -> Self {
-        Self {
-            context,
-            cached_bodies: HashMap::new(),
-        }
-    }
-
-    /// The navigation list. Borrowed directly from the context.
-    fn sections(&self) -> &[dashboard::Section] {
-        &self.context.sections
-    }
-
-    /// True when no context has been loaded — used by the `mode`
-    /// endpoint to advertise the not-yet-loaded state.
-    fn is_empty(&self) -> bool {
-        self.context.sections.is_empty()
-    }
-
-    /// Read-only access to the context (for `sections_metadata` to read
-    /// filesize and other shared params).
-    fn context(&self) -> &dashboard::dashboard::DashboardContext {
-        &self.context
-    }
-
-    /// Generate (or return the cached body for) `route`. Looks up
-    /// `route` of the form `/<route>` (e.g. `/cpu`, `/service/vllm`,
-    /// `/overview`). Returns `None` if the route is unknown OR the
-    /// section has no data. Applies `context.filesize` uniformly to
-    /// every rendered View.
-    fn get_or_generate(&mut self, route: &str, data: &Tsdb) -> Option<&serde_json::Value> {
-        // route always starts with '/', so &route[1..] is the stem.
-        let key = format!("{}.json", &route[1..]);
-        if !self.cached_bodies.contains_key(&key) {
-            let mut view = dashboard::dashboard::generate_section(data, route, &self.context)?;
-            if let Some(size) = self.context.filesize {
-                view.set_filesize(size);
-            }
-            let value = serde_json::to_value(&view).ok()?;
-            self.cached_bodies.insert(key.clone(), value);
-        }
-        self.cached_bodies.get(&key)
-    }
-}
-
-impl Default for LazySectionStore {
-    fn default() -> Self {
-        Self::new(dashboard::dashboard::DashboardContext::default())
-    }
-}
-
-/// Proxy state for the optional URL-fetch endpoint. When the CLI is
-/// invoked without `--proxy-allow`, both fields stay empty/None and the
-/// endpoint refuses every request.
-#[derive(Default)]
-struct ProxyState {
-    allow: proxy_allow::Allowlist,
-    client: Option<Client>,
-}
-
-impl ProxyState {
-    fn enabled(&self) -> bool {
-        !self.allow.is_empty() && self.client.is_some()
-    }
-}
-
-struct AppState {
-    sections: parking_lot::RwLock<LazySectionStore>,
-    /// Per-capture TSDB + metadata. Single-capture callers always target
-    /// `CaptureId::Baseline`; the experiment slot is empty unless a compare
-    /// mode hand-off has attached one.
-    captures: Arc<CaptureRegistry>,
-    templates: TemplateRegistry,
-    /// Raw msgpack snapshot bytes for parquet export (live mode only).
-    snapshots: Arc<parking_lot::Mutex<VecDeque<Vec<u8>>>>,
-    live: AtomicBool,
-    /// Original parquet file path (file mode only).
-    parquet_path: parking_lot::RwLock<Option<std::path::PathBuf>>,
-    /// Temp parquet path for the attached experiment capture (cleared on detach).
-    /// Populated by the HTTP attach handler, which owns the temp file and
-    /// deletes it on detach. The CLI startup path uses `cli_experiment_path`
-    /// instead so detach never touches the user's own file.
-    experiment_parquet_path: parking_lot::RwLock<Option<std::path::PathBuf>>,
-    /// User-supplied experiment parquet path from the CLI (e.g.
-    /// `rezolus view a.parquet b.parquet`). Read-only — not deleted on
-    /// detach. Detach only clears `experiment_parquet_path`. Kept
-    /// separate from that field so `regenerate_dashboards` can find
-    /// the experiment metadata without risking the user's file.
-    cli_experiment_path: parking_lot::RwLock<Option<std::path::PathBuf>>,
-    /// Active category template name (when `--category` was supplied at
-    /// startup). `regenerate_dashboards` resolves this against the
-    /// registry on every regen and validates the attached aliases
-    /// against the category's `members` list. None = no category mode.
-    category_name: parking_lot::RwLock<Option<String>>,
-    /// Serialized selection JSON from parquet metadata.
-    selection: parking_lot::RwLock<Option<String>>,
-    /// SHA-256 hex digest of the source parquet file (file mode only).
-    file_checksum: parking_lot::RwLock<Option<String>>,
-    /// Optional URL-fetch proxy. Disabled (empty allowlist + no client)
-    /// unless the CLI was invoked with one or more `--proxy-allow`.
-    proxy: ProxyState,
-}
-
-impl AppState {
-    pub fn new(tsdb: Tsdb, templates: TemplateRegistry) -> Self {
-        Self {
-            sections: Default::default(),
-            captures: Arc::new(CaptureRegistry::new(tsdb, None, None, None)),
-            templates,
-            snapshots: Arc::new(parking_lot::Mutex::new(VecDeque::new())),
-            live: AtomicBool::new(false),
-            parquet_path: parking_lot::RwLock::new(None),
-            experiment_parquet_path: parking_lot::RwLock::new(None),
-            cli_experiment_path: parking_lot::RwLock::new(None),
-            category_name: parking_lot::RwLock::new(None),
-            selection: parking_lot::RwLock::new(None),
-            file_checksum: parking_lot::RwLock::new(None),
-            proxy: ProxyState::default(),
-        }
-    }
-
-    /// Enable the URL proxy with the given hostname allowlist. Builds a
-    /// dedicated reqwest client (so the proxy traffic is isolated from
-    /// the live-mode scrape client). No-op when the allowlist is empty.
-    fn set_proxy(&mut self, allow: proxy_allow::Allowlist) {
-        if allow.is_empty() {
-            return;
-        }
-        match Client::builder().build() {
-            Ok(client) => {
-                self.proxy = ProxyState {
-                    allow,
-                    client: Some(client),
-                };
-            }
-            Err(e) => {
-                error!("failed to build proxy http client: {e}");
-            }
-        }
-    }
-
-    /// Shorthand for the baseline TSDB handle. Every existing caller that
-    /// used to dereference `state.tsdb` directly lands on baseline — the
-    /// registry guarantees the baseline slot is always present.
-    fn baseline_tsdb(&self) -> Arc<parking_lot::RwLock<Tsdb>> {
-        self.captures
-            .get(CaptureId::Baseline)
-            .expect("baseline capture is always present")
-    }
-
-    /// Build the navigation + global params payload for the
-    /// `/api/v1/sections` endpoint. The navigation list comes from the
-    /// `LazySectionStore`'s `DashboardContext`; the global params come
-    /// from the TSDB itself (filesize from the context). When no
-    /// context has been loaded yet — e.g. live mode before the first
-    /// refresh, or upload-only mode pre-upload — returns a minimal
-    /// payload with an empty sections array and zeroed numeric fields
-    /// so the frontend never sees a 5xx for the "we just don't have
-    /// data yet" case.
-    ///
-    /// The `capture` argument is currently advisory: the same nav list
-    /// applies to both baseline and experiment, so we ignore the id
-    /// rather than silently 404 on `?capture=experiment`.
-    fn sections_metadata(&self, _capture: CaptureId) -> serde_json::Value {
-        let store = self.sections.read();
-        let sections_array: Vec<serde_json::Value> = store
-            .sections()
-            .iter()
-            .map(|s| serde_json::to_value(s).unwrap_or_default())
-            .collect();
-        let filesize = store.context().filesize.unwrap_or(0);
-        drop(store);
-
-        let tsdb_handle = self.baseline_tsdb();
-        let data = tsdb_handle.read();
-        let interval = data.interval();
-        let source = data.source().to_string();
-        let version = data.version().to_string();
-        let filename = data.filename().to_string();
-        // Tsdb time_range is in nanoseconds; convert to milliseconds to
-        // match the View's convention.
-        let (start_time, end_time) = data
-            .time_range()
-            .map(|(min, max)| (min / 1_000_000, max / 1_000_000))
-            .unwrap_or((0, 0));
-        let num_series = {
-            let mut count = 0usize;
-            for name in data.counter_names() {
-                count += data.counter_labels(name).map_or(0, |l| l.len());
-            }
-            for name in data.gauge_names() {
-                count += data.gauge_labels(name).map_or(0, |l| l.len());
-            }
-            for name in data.histogram_names() {
-                count += data.histogram_labels(name).map_or(0, |l| l.len());
-            }
-            count
-        };
-
-        build_sections_metadata_payload(
-            sections_array,
-            &source,
-            &version,
-            &filename,
-            interval,
-            filesize,
-            start_time,
-            end_time,
-            num_series,
-        )
-    }
-}
-
-fn extract_parquet_metadata(path: &Path) -> (Option<String>, Option<String>, Option<String>) {
-    use parquet::file::reader::FileReader;
-    use parquet::file::serialized_reader::SerializedFileReader;
-    std::fs::File::open(path)
-        .ok()
-        .and_then(|f| {
-            let reader = SerializedFileReader::new(f).ok()?;
-            let kv = reader.metadata().file_metadata().key_value_metadata()?;
-            let sysinfo = kv
-                .iter()
-                .find(|kv| kv.key == "systeminfo")
-                .and_then(|kv| kv.value.clone());
-            let sel = kv
-                .iter()
-                .find(|kv| kv.key == "selection")
-                .and_then(|kv| kv.value.clone());
-
-            // Build a JSON object from all key-value pairs.
-            let mut map = serde_json::Map::new();
-            for pair in kv {
-                if let Some(ref val) = pair.value {
-                    // Try to parse value as JSON; fall back to plain string.
-                    let json_val = serde_json::from_str(val)
-                        .unwrap_or_else(|_| serde_json::Value::String(val.clone()));
-                    map.insert(pair.key.clone(), json_val);
-                }
-            }
-
-            // Pre-compute multi-node info so the frontend doesn't have to
-            // re-parse per_source_metadata itself.
-            enrich_with_multi_node_info(&mut map);
-
-            let file_meta = serde_json::to_string(&serde_json::Value::Object(map)).ok();
-
-            Some((sysinfo, sel, file_meta))
-        })
-        .unwrap_or((None, None, None))
-}
-
-/// Enrich a file-metadata JSON map with pre-computed multi-node info.
-///
-/// Parses `per_source_metadata` and adds:
-/// - `nodes`: ordered list of node names
-/// - `service_instances`: `{ service: [{id, node}, ...] }` for non-rezolus sources
-/// - `node_versions`: `{ node_name: version }` for the TopNav version display
-///
-/// This consolidates parsing that was previously duplicated in the JS frontend.
-fn enrich_with_multi_node_info(map: &mut serde_json::Map<String, serde_json::Value>) {
-    let psm = match map.get("per_source_metadata").and_then(|v| v.as_object()) {
-        Some(psm) => psm.clone(),
-        None => return,
-    };
-
-    // Extract node list from rezolus group
-    let mut nodes = Vec::new();
-    let mut node_versions = serde_json::Map::new();
-    if let Some(rez_group) = psm.get("rezolus").and_then(|v| v.as_object()) {
-        for (sub_key, entry) in rez_group {
-            let obj = match entry.as_object() {
-                Some(o) => o,
-                None => continue,
-            };
-            let node_name = obj.get("node").and_then(|v| v.as_str()).unwrap_or(sub_key);
-            if !nodes.contains(&node_name.to_string()) {
-                nodes.push(node_name.to_string());
-            }
-            if let Some(version) = obj.get("version").and_then(|v| v.as_str()) {
-                node_versions.insert(
-                    node_name.to_string(),
-                    serde_json::Value::String(version.to_string()),
-                );
-            }
-        }
-    }
-
-    // Extract service instances from non-rezolus groups
-    let mut service_instances = serde_json::Map::new();
-    for (source, group) in &psm {
-        if source == "rezolus" {
-            continue;
-        }
-        let group_obj = match group.as_object() {
-            Some(o) => o,
-            None => continue,
-        };
-        let mut instances = Vec::new();
-        for (sub_key, entry) in group_obj {
-            let obj = match entry.as_object() {
-                Some(o) => o,
-                None => continue,
-            };
-            let instance_id = obj
-                .get("instance")
-                .and_then(|v| v.as_str())
-                .unwrap_or(sub_key);
-            let node = obj.get("node").and_then(|v| v.as_str());
-            let mut inst = serde_json::Map::new();
-            inst.insert(
-                "id".into(),
-                serde_json::Value::String(instance_id.to_string()),
-            );
-            inst.insert(
-                "node".into(),
-                node.map(|n| serde_json::Value::String(n.to_string()))
-                    .unwrap_or(serde_json::Value::Null),
-            );
-            instances.push(serde_json::Value::Object(inst));
-        }
-        if !instances.is_empty() {
-            service_instances.insert(source.clone(), serde_json::Value::Array(instances));
-        }
-    }
-
-    map.insert(
-        "nodes".into(),
-        serde_json::Value::Array(nodes.into_iter().map(serde_json::Value::String).collect()),
-    );
-    if !node_versions.is_empty() {
-        map.insert(
-            "node_versions".into(),
-            serde_json::Value::Object(node_versions),
-        );
-    }
-    if !service_instances.is_empty() {
-        map.insert(
-            "service_instances".into(),
-            serde_json::Value::Object(service_instances),
-        );
-    }
-}
-
-/// Build a multi-node systeminfo JSON object from `per_source_metadata`.
-///
-/// Returns `Some(json_string)` when there are multiple nodes (>1), where the
-/// JSON is an object keyed by node name with the systeminfo object as value.
-/// Returns `None` for single-node files (the caller falls back to flat format).
-fn build_multinode_systeminfo(path: &Path) -> Option<String> {
-    use crate::parquet_metadata::KEY_PER_SOURCE_METADATA;
-    use parquet::file::reader::FileReader;
-    use parquet::file::serialized_reader::SerializedFileReader;
-
-    let f = std::fs::File::open(path).ok()?;
-    let reader = SerializedFileReader::new(f).ok()?;
-    let kv = reader.metadata().file_metadata().key_value_metadata()?;
-
-    let psm_json = kv
-        .iter()
-        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
-        .and_then(|kv| kv.value.as_ref())?;
-
-    let psm: serde_json::Map<String, serde_json::Value> = serde_json::from_str(psm_json).ok()?;
-
-    let mut nodes = serde_json::Map::new();
-
-    // per_source_metadata is nested: { "rezolus": { "node1": {...}, "node2": {...} }, ... }
-    // Extract systeminfo from each rezolus node entry.
-    if let Some(rez_group) = psm.get("rezolus").and_then(|v| v.as_object()) {
-        for (node_key, entry) in rez_group {
-            let obj = match entry.as_object() {
-                Some(o) => o,
-                None => continue,
-            };
-            let sysinfo_val = match obj.get("systeminfo") {
-                Some(v) => v,
-                None => continue,
-            };
-            let node_name = obj
-                .get("node")
-                .and_then(|v| v.as_str())
-                .map(String::from)
-                .unwrap_or_else(|| node_key.clone());
-
-            nodes.insert(node_name, sysinfo_val.clone());
-        }
-    }
-
-    // Only return multi-node format when there are actually multiple nodes
-    if nodes.len() > 1 {
-        serde_json::to_string(&serde_json::Value::Object(nodes)).ok()
-    } else {
-        None
-    }
-}
-
-/// Resolve the active category for a regen pass. Activation requires:
-/// `state.category_name` is Some, the named category exists in the
-/// registry, exactly two service refs are attached, and each ref's
-/// source name (detected from the parquet) appears in the category's
-/// `members` list. Returns None when any of those fail — the caller
-/// falls back to per-member rendering. CLI startup ran stricter
-/// checks, so silent fall-back here only happens at runtime (e.g.
-/// mid-session experiment detach) and that's the correct UX.
-fn lookup_category<'a>(
-    state: &AppState,
-    registry: &'a TemplateRegistry,
-    service_refs: &[(&str, &ServiceExtension)],
-) -> Option<(&'a str, &'a CategoryExtension)> {
-    let cat_name = state.category_name.read().clone()?;
-    if service_refs.len() != 2 {
-        return None;
-    }
-    let category = registry.get_category(&cat_name)?;
-    for (source, _) in service_refs {
-        if !category.members.iter().any(|m| m == source) {
-            return None;
-        }
-    }
-    Some((category.service_name.as_str(), category))
-}
-
-/// Regenerate the dashboard sections from the currently attached
-/// captures. Pulls service extensions from each capture's parquet
-/// metadata, validates them against the live tsdb data, looks up a
-/// category in the registry when both captures are present, and renders
-/// the resulting section map into `state.sections`. Called at CLI
-/// startup after the experiment attaches, and on every HTTP attach /
-/// detach so the section list stays in sync with which captures are
-/// loaded.
-fn regenerate_dashboards(state: &AppState) {
-    let registry = &state.templates;
-    let baseline_path = state.parquet_path.read().clone();
-    // Prefer the HTTP-owned temp path; fall back to the CLI-supplied
-    // user path. The two are stored in separate fields so that
-    // `detach_experiment` can safely delete only server-owned temp
-    // files — see `cli_experiment_path` for the rationale.
-    let experiment_path = state
-        .experiment_parquet_path
-        .read()
-        .clone()
-        .or_else(|| state.cli_experiment_path.read().clone());
-
-    // Extract service extensions per-capture; baseline-source exts
-    // validate against the baseline tsdb, experiment-source exts
-    // against the experiment tsdb, so a KPI present only in one
-    // recording isn't wrongly marked unavailable.
-    //
-    // Template selection is driven entirely by each capture's parquet
-    // metadata. CLI legend labels are display-only (plumbed to the
-    // viewer's compare badge) and never affect template lookup or
-    // category membership.
-    let mut baseline_exts: Vec<(String, ServiceExtension)> = baseline_path
-        .as_ref()
-        .map(|p| extract_service_extension_metadata(p, registry))
-        .unwrap_or_default();
-    let mut experiment_exts: Vec<(String, ServiceExtension)> = experiment_path
-        .as_ref()
-        .map(|p| extract_service_extension_metadata(p, registry))
-        .unwrap_or_default();
-
-    {
-        let baseline_handle = state.baseline_tsdb();
-        let baseline_data = baseline_handle.read();
-        validate_service_extensions(&baseline_data, &mut baseline_exts);
-    }
-    if !experiment_exts.is_empty() {
-        if let Some(experiment_handle) = state.captures.get(CaptureId::Experiment) {
-            let experiment_data = experiment_handle.read();
-            validate_service_extensions(&experiment_data, &mut experiment_exts);
-        }
-    }
-
-    let mut service_exts = baseline_exts;
-    service_exts.extend(experiment_exts);
-
-    let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
-    let category = lookup_category(state, registry, &service_refs);
-
-    let filesize = baseline_path
-        .as_ref()
-        .and_then(|p| std::fs::metadata(p).ok().map(|m| m.len()));
-
-    let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, category);
-    *state.sections.write() = LazySectionStore::new(context);
-}
-
-/// Extract service extension metadata from a parquet file.
-///
-/// Checks in order:
-/// 1. Top-level `service_queries` key (single-source annotated files)
-/// 2. `per_source_metadata.<source>.service_queries` (combined files)
-/// 3. Built-in template for known sources (fallback)
-///
-/// Template selection and the returned source keys come purely from
-/// the parquet's own metadata. CLI legend labels (the `label=path`
-/// prefix) never influence which template a capture binds to; they
-/// are display-only and plumbed separately via `set_baseline_alias`
-/// / `attach_experiment`.
-fn extract_service_extension_metadata(
-    path: &Path,
-    registry: &TemplateRegistry,
-) -> Vec<(String, ServiceExtension)> {
-    use crate::parquet_metadata::{
-        KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, NESTED_SERVICE_QUERIES,
-    };
-    use parquet::file::reader::FileReader;
-    use parquet::file::serialized_reader::SerializedFileReader;
-
-    let mut results = Vec::new();
-
-    let f = match std::fs::File::open(path) {
-        Ok(f) => f,
-        Err(_) => return results,
-    };
-    let reader = match SerializedFileReader::new(f) {
-        Ok(r) => r,
-        Err(_) => return results,
-    };
-    let kv = match reader.metadata().file_metadata().key_value_metadata() {
-        Some(kv) => kv,
-        None => return results,
-    };
-
-    // 1. Top-level service_queries (written by `parquet annotate`).
-    if let Some(sq_json) = kv
-        .iter()
-        .find(|kv| kv.key == KEY_SERVICE_QUERIES)
-        .and_then(|kv| kv.value.as_deref())
-    {
-        if let Ok(ext) = serde_json::from_str::<ServiceExtension>(sq_json) {
-            let source = kv
-                .iter()
-                .find(|kv| kv.key == KEY_SOURCE)
-                .and_then(|kv| kv.value.as_deref())
-                .unwrap_or(&ext.service_name);
-            results.push((source.to_string(), ext));
-        }
-    }
-
-    // 2. Nested under per_source_metadata (combined files).
-    if let Some(metadata_json) = kv
-        .iter()
-        .find(|kv| kv.key == KEY_PER_SOURCE_METADATA)
-        .and_then(|kv| kv.value.as_deref())
-    {
-        if let Ok(metadata_map) =
-            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(metadata_json)
-        {
-            // per_source_metadata is nested: { "source": { "id": { ... }, ... }, ... }
-            // Check each source group's entries for service_queries.
-            for (source, group_val) in &metadata_map {
-                // Skip sources already found via top-level service_queries.
-                if results.iter().any(|(s, _)| s == source) {
-                    continue;
-                }
-                if let Some(group) = group_val.as_object() {
-                    for (_sub_key, entry) in group {
-                        if let Some(sq) = entry.get(NESTED_SERVICE_QUERIES) {
-                            if let Ok(ext) = serde_json::from_value::<ServiceExtension>(sq.clone())
-                            {
-                                results.push((source.clone(), ext));
-                                break; // one extension per source
-                            }
-                        }
-                    }
-                }
-            }
-
-            // 3a. No service_queries found for a source — check built-in templates.
-            for source in metadata_map.keys() {
-                if results.iter().any(|(s, _)| s == source) {
-                    continue;
-                }
-                if let Some(ext) = registry.get(source) {
-                    results.push((source.clone(), ext.clone()));
-                }
-            }
-        }
-    }
-
-    // 3b. No per_source_metadata — check the top-level source key for a template.
-    if results.is_empty() {
-        if let Some(source) = kv
-            .iter()
-            .find(|kv| kv.key == KEY_SOURCE)
-            .and_then(|kv| kv.value.as_deref())
-        {
-            if let Some(ext) = registry.get(source) {
-                results.push((source.to_string(), ext.clone()));
-            }
-        }
-    }
-
-    results
-}
-
-/// Validate KPI availability for service extensions by running each KPI's
-/// PromQL query against the loaded TSDB. Sets `available = false` on KPIs
-/// whose queries return empty results (e.g. zero-traffic histograms).
-fn validate_service_extensions(tsdb: &Tsdb, exts: &mut [(String, ServiceExtension)]) {
-    let engine = QueryEngine::new(tsdb);
-    let (start, end) = engine.get_time_range();
-
-    for (_source, ext) in exts.iter_mut() {
-        for kpi in &mut ext.kpis {
-            let query = kpi.effective_query();
-            let has_data = match engine.query_range(&query, start, end, 1.0) {
-                Ok(result) => match &result {
-                    promql::QueryResult::Vector { result } => !result.is_empty(),
-                    promql::QueryResult::Matrix { result } => !result.is_empty(),
-                    promql::QueryResult::Scalar { .. } => true,
-                    promql::QueryResult::HistogramHeatmap { result } => !result.data.is_empty(),
-                },
-                Err(_) => false,
-            };
-            kpi.available = has_data;
-        }
-    }
-}
-
-/// Assemble the JSON payload returned by `/api/v1/sections`.
-///
-/// The viewer frontend wants the navigation list and the global capture
-/// params (source, version, filename, interval, filesize, time bounds,
-/// num_series) without any of the per-section group/plot bodies. Keeping
-/// this as a pure helper makes it trivial to unit-test the shape — the
-/// route handler does the I/O of pulling values out of the cached
-/// section bodies.
-#[allow(clippy::too_many_arguments)]
-fn build_sections_metadata_payload(
-    sections: Vec<serde_json::Value>,
-    source: &str,
-    version: &str,
-    filename: &str,
-    interval: f64,
-    filesize: u64,
-    start_time: u64,
-    end_time: u64,
-    num_series: usize,
-) -> serde_json::Value {
-    serde_json::json!({
-        "sections": sections,
-        "source": source,
-        "version": version,
-        "filename": filename,
-        "interval": interval,
-        "filesize": filesize,
-        "start_time": start_time,
-        "end_time": end_time,
-        "num_series": num_series,
-    })
-}
-
-/// Strip the navigation `sections` array from a section payload before
-/// sending it to the frontend.  Each cached section body embeds the full
-/// nav list so that `sections_metadata` can extract it, but the frontend
-/// does not need that redundant data in per-section responses.
-fn strip_sections_from_section_payload(value: &mut serde_json::Value) {
-    if let Some(obj) = value.as_object_mut() {
-        obj.remove("sections");
-    }
-}
-
-fn compute_file_checksum(path: &Path) -> Option<String> {
-    use sha2::{Digest, Sha256};
-    use std::io::{Read, Seek, SeekFrom};
-    (|| -> Option<String> {
-        let mut f = std::fs::File::open(path).ok()?;
-        let file_len = f.metadata().ok()?.len();
-        if file_len < 12 {
-            return None;
-        }
-        f.seek(SeekFrom::End(-8)).ok()?;
-        let mut tail = [0u8; 4];
-        f.read_exact(&mut tail).ok()?;
-        let footer_len = u32::from_le_bytes(tail) as u64;
-        let data_end = file_len.checked_sub(8 + footer_len)?;
-        f.seek(SeekFrom::Start(0)).ok()?;
-        let mut hasher = Sha256::new();
-        let mut buf = [0u8; 64 * 1024];
-        let mut remaining = data_end;
-        while remaining > 0 {
-            let to_read = (remaining as usize).min(buf.len());
-            match f.read(&mut buf[..to_read]) {
-                Ok(0) => break,
-                Ok(n) => {
-                    hasher.update(&buf[..n]);
-                    remaining -= n as u64;
-                }
-                Err(e) => {
-                    warn!("failed to read file for checksum: {e}");
-                    return None;
-                }
-            }
-        }
-        Some(
-            hasher
-                .finalize()
-                .iter()
-                .map(|b| format!("{b:02x}"))
-                .collect::<String>(),
-        )
-    })()
-}
-
-fn app(livereload: LiveReloadLayer, state: AppState) -> Router {
-    let state = Arc::new(state);
-
-    // API routes get Cache-Control: no-store to prevent browsers from
-    // returning stale data during live mode polling.
-    let api_routes = Router::new()
-        .route("/query", get(instant_query))
-        .route("/query_range", get(range_query))
-        .route("/labels", get(label_names))
-        .route("/label/{name}/values", get(label_values))
-        .route("/metadata", get(metadata))
-        .route("/mode", get(mode))
-        .route("/reset", axum::routing::post(reset_tsdb))
-        .route("/save", get(save_parquet))
-        .route("/systeminfo", get(systeminfo_handler))
-        .route("/selection", get(selection_handler))
-        .route("/sections", get(sections_handler))
-        .route("/file_metadata", get(file_metadata_handler))
-        .route(
-            "/upload",
-            axum::routing::post(upload_parquet)
-                .layer(axum::extract::DefaultBodyLimit::max(50 * 1024 * 1024)),
-        )
-        .route(
-            "/captures/experiment",
-            axum::routing::post(attach_experiment)
-                .delete(detach_experiment)
-                .layer(axum::extract::DefaultBodyLimit::max(50 * 1024 * 1024)),
-        )
-        .route("/connect", axum::routing::post(connect_agent))
-        .route(
-            "/save_with_selection",
-            axum::routing::post(save_with_selection),
-        )
-        .route("/load_url", axum::routing::post(load_url))
-        .layer(axum::middleware::map_response(
-            |mut response: axum::response::Response| async move {
-                response.headers_mut().insert(
-                    header::CACHE_CONTROL,
-                    header::HeaderValue::from_static("no-store"),
-                );
-                response
-            },
-        ));
-
-    let router = Router::new()
-        .route("/about", get(about))
-        .route("/data/{*path}", get(data))
-        .nest("/api/v1", api_routes)
-        .with_state(state.clone());
-
-    #[cfg(feature = "developer-mode")]
-    let router = {
-        warn!("running in developer mode. Rezolus Viewer must be run from within project folder");
-        router
-            .route_service("/", ServeFile::new("src/viewer/assets/index.html"))
-            .nest_service("/lib", ServeDir::new(Path::new("src/viewer/assets/lib")))
-            .fallback_service(ServeFile::new("src/viewer/assets/index.html"))
-    };
-
-    #[cfg(not(feature = "developer-mode"))]
-    let router = {
-        router
-            .route_service("/", get(index))
-            .nest_service("/lib", get(lib))
-            .fallback_service(get(index))
-    };
-
-    router.layer(
-        ServiceBuilder::new()
-            .layer(RequestDecompressionLayer::new())
-            .layer(CompressionLayer::new())
-            .layer(livereload),
-    )
-}
-
-/// Shared HTML head for standalone pages — reuses the main viewer stylesheet
-/// and applies the saved theme before first paint.
-const STANDALONE_HEAD: &str = r#"<meta charset="utf-8"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script>!function(){var t=localStorage.getItem('rezolus-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t)}()</script>
-<link rel="stylesheet" href="/lib/style.css"/>
-<style>body{display:flex;align-items:center;justify-content:center;padding:2rem}</style>"#;
-
-async fn about() -> axum::response::Html<String> {
-    let version = env!("CARGO_PKG_VERSION");
-    axum::response::Html(format!(
-        r#"<!DOCTYPE html>
-<html lang="en">
-<head><title>Rezolus — About</title>
-{STANDALONE_HEAD}
-</head>
-<body>
-<div class="card">
-  <h1>Rezolus</h1>
-  <div class="version">v{version}</div>
-  <p class="subtitle">High-resolution systems performance telemetry agent.</p>
-  <div class="link-row">
-    <a href="https://rezolus.com">Website</a>
-    <a href="https://github.com/iopsystems/rezolus">GitHub</a>
-    <a href="/">Dashboard</a>
-  </div>
-</div>
-</body>
-</html>"#
-    ))
-}
-
-async fn data(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Path(path): axum::extract::Path<String>,
-) -> axum::response::Response {
-    use axum::response::IntoResponse;
-
-    // path comes in as e.g. "cpu.json" or "service/vllm.json". Convert
-    // to the route form generate_section expects (e.g. "/cpu",
-    // "/service/vllm"). Tolerate a missing ".json" suffix gracefully.
-    let stem = path.strip_suffix(".json").unwrap_or(&path);
-    let route = format!("/{stem}");
-
-    let value = {
-        let tsdb_handle = state.baseline_tsdb();
-        let tsdb = tsdb_handle.read();
-        let mut store = state.sections.write();
-        store.get_or_generate(&route, &tsdb).cloned()
-    };
-
-    let Some(mut value) = value else {
-        return StatusCode::NOT_FOUND.into_response();
-    };
-
-    // The lazy generator already produces lean bodies, but keep the
-    // strip as cheap insurance against accidental re-introduction.
-    strip_sections_from_section_payload(&mut value);
-    match serde_json::to_string(&value) {
-        Ok(body) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            body,
-        )
-            .into_response(),
-        Err(e) => {
-            warn!("section response serialization failed for {path}: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        }
-    }
-}
-
-/// Returns whether the viewer is in live or file mode.
-async fn mode(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Json<serde_json::Value> {
-    let loaded = !state.sections.read().is_empty();
-    // The static-site bundle reports "direct" for its own URL input
-    // (browser fetches the URL itself, CORS applies). The binary viewer
-    // never reports "direct" — the only way to load a URL here is
-    // through the local proxy.
-    let url_loading = if state.proxy.enabled() {
-        "proxy"
-    } else {
-        "disabled"
-    };
-    axum::response::Json(serde_json::json!({
-        "live": state.live.load(Ordering::Relaxed),
-        "loaded": loaded,
-        "compare_mode": state.captures.experiment_attached(),
-        "category": state.category_name.read().clone(),
-        "url_loading": url_loading,
-    }))
-}
-
-#[derive(serde::Deserialize)]
-struct LoadUrlBody {
-    url: String,
-    #[serde(default)]
-    filename: Option<String>,
-}
-
-/// Fetch a remote parquet on behalf of the browser and ingest it into
-/// the baseline TSDB in one server-side hop. Refuses every request when
-/// `--proxy-allow` was not set or when the requested host doesn't match
-/// any allowlist pattern. The browser only sends the URL; the bytes
-/// never traverse it — no double round-trip, no ArrayBuffer pressure.
-async fn load_url(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Json(body): axum::extract::Json<LoadUrlBody>,
-) -> axum::response::Json<ApiResponse<serde_json::Value>> {
-    // Every branch returns Json(ApiResponse) — never raw text — so the
-    // Mithril frontend's JSON-parsing default doesn't choke on non-2xx
-    // bodies and bury the real error as `null`.
-    let err =
-        |msg: String, kind: &str| axum::response::Json(ApiResponse::error(msg, kind.to_string()));
-
-    if state.live.load(Ordering::Relaxed) {
-        return err(
-            "load_url is only available in file mode".to_string(),
-            "bad_request",
-        );
-    }
-
-    let Some(client) = state.proxy.client.as_ref() else {
-        return err("url loading is disabled".to_string(), "forbidden");
-    };
-
-    let target = match Url::parse(&body.url) {
-        Ok(u) => u,
-        Err(e) => return err(format!("invalid url: {e}"), "bad_request"),
-    };
-
-    if !matches!(target.scheme(), "http" | "https") {
-        return err(
-            "url scheme must be http or https".to_string(),
-            "bad_request",
-        );
-    }
-
-    let host = match target.host_str() {
-        Some(h) => h.to_string(),
-        None => return err("url is missing a host".to_string(), "bad_request"),
-    };
-
-    if !state.proxy.allow.allows(&host) {
-        return err(
-            format!("host {host} not in --proxy-allow list"),
-            "forbidden",
-        );
-    }
-
-    let upstream = match client.get(target.clone()).send().await {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("load_url fetch failed for {target}: {e}");
-            return err(format!("upstream fetch failed: {e}"), "upstream_error");
-        }
-    };
-    if !upstream.status().is_success() {
-        return err(
-            format!("upstream returned {}", upstream.status()),
-            "upstream_error",
-        );
-    }
-
-    let bytes = match upstream.bytes().await {
-        Ok(b) => b,
-        Err(e) => return err(format!("upstream read failed: {e}"), "upstream_error"),
-    };
-
-    let temp_path = baseline_temp_path();
-    if let Err(e) = std::fs::write(&temp_path, &bytes) {
-        return err(format!("failed to stage upstream bytes: {e}"), "io_error");
-    }
-
-    let filename = body.filename.unwrap_or_else(|| {
-        target
-            .path_segments()
-            .and_then(|mut s| s.rfind(|seg| !seg.is_empty()))
-            .map(ToString::to_string)
-            .unwrap_or_else(|| "remote.parquet".to_string())
-    });
-
-    ingest_baseline_from_path(&state, temp_path, filename)
-}
-
-/// Query param for endpoints that select between baseline and experiment.
-#[derive(serde::Deserialize)]
-struct CaptureParam {
-    #[serde(default)]
-    capture: Option<String>,
-}
-
-impl CaptureParam {
-    fn capture_id(&self) -> CaptureId {
-        CaptureId::parse_opt(self.capture.as_deref())
-    }
-}
-
-/// Returns the system hardware summary from parquet metadata or the live system.
-async fn systeminfo_handler(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Query(p): axum::extract::Query<CaptureParam>,
-) -> axum::response::Response {
-    use axum::response::IntoResponse;
-
-    match state.captures.systeminfo(p.capture_id()) {
-        Some(json) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            json,
-        )
-            .into_response(),
-        None => StatusCode::NOT_FOUND.into_response(),
-    }
-}
-
-async fn selection_handler(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Response {
-    use axum::response::IntoResponse;
-
-    match &*state.selection.read() {
-        Some(json) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            json.clone(),
-        )
-            .into_response(),
-        None => StatusCode::NOT_FOUND.into_response(),
-    }
-}
-
-/// Returns the navigation list plus global capture params (no section
-/// bodies). Used by the frontend to build the side nav and headline
-/// metadata without paying the cost of fetching every section JSON
-/// upfront.
-async fn sections_handler(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Query(p): axum::extract::Query<CaptureParam>,
-) -> axum::response::Json<serde_json::Value> {
-    axum::response::Json(serde_json::json!({
-        "status": "success",
-        "data": state.sections_metadata(p.capture_id()),
-    }))
-}
-
-async fn file_metadata_handler(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Query(p): axum::extract::Query<CaptureParam>,
-) -> axum::response::Response {
-    use axum::response::IntoResponse;
-    match state.captures.file_metadata(p.capture_id()) {
-        Some(json) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            json,
-        )
-            .into_response(),
-        None => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/json")],
-            "{}".to_string(),
-        )
-            .into_response(),
-    }
-}
-
-// PromQL API handlers that delegate to the swappable QueryEngine
-
-#[derive(serde::Deserialize)]
-struct QueryParams {
-    query: String,
-    time: Option<f64>,
-    #[serde(default)]
-    capture: Option<String>,
-}
-
-#[derive(serde::Deserialize)]
-struct RangeQueryParams {
-    query: String,
-    start: f64,
-    end: f64,
-    step: f64,
-    #[serde(default)]
-    capture: Option<String>,
-}
-
-#[derive(serde::Serialize)]
-struct ApiResponse<T: serde::Serialize> {
-    status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<T>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "errorType")]
-    error_type: Option<String>,
-}
-
-impl<T: serde::Serialize> ApiResponse<T> {
-    fn success(data: T) -> Self {
-        Self {
-            status: "success".to_string(),
-            data: Some(data),
-            error: None,
-            error_type: None,
-        }
-    }
-
-    fn error(error: String, error_type: String) -> Self {
-        Self {
-            status: "error".to_string(),
-            data: None,
-            error: Some(error),
-            error_type: Some(error_type),
-        }
-    }
-}
-
-fn error_type(e: &promql::QueryError) -> &'static str {
-    match e {
-        promql::QueryError::ParseError(_) => "bad_data",
-        promql::QueryError::EvaluationError(_) => "execution",
-        promql::QueryError::Unsupported(_) => "unsupported",
-        promql::QueryError::MetricNotFound(_) => "not_found",
-    }
-}
-
-async fn instant_query(
-    axum::extract::Query(params): axum::extract::Query<QueryParams>,
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Json<ApiResponse<promql::QueryResult>> {
-    let capture = CaptureId::parse_opt(params.capture.as_deref());
-    let tsdb_handle = match state.captures.get(capture) {
-        Some(t) => t,
-        None => {
-            return axum::response::Json(ApiResponse::error(
-                format!("capture '{:?}' not attached", capture),
-                "capture_not_found".to_string(),
-            ));
-        }
-    };
-    let tsdb = tsdb_handle.read();
-    let engine = QueryEngine::new(&*tsdb);
-    match engine.query(&params.query, params.time) {
-        Ok(result) => axum::response::Json(ApiResponse::success(result)),
-        Err(e) => axum::response::Json(ApiResponse::error(
-            e.to_string(),
-            error_type(&e).to_string(),
-        )),
-    }
-}
-
-async fn range_query(
-    axum::extract::Query(params): axum::extract::Query<RangeQueryParams>,
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Json<ApiResponse<promql::QueryResult>> {
-    let capture = CaptureId::parse_opt(params.capture.as_deref());
-    let tsdb_handle = match state.captures.get(capture) {
-        Some(t) => t,
-        None => {
-            return axum::response::Json(ApiResponse::error(
-                format!("capture '{:?}' not attached", capture),
-                "capture_not_found".to_string(),
-            ));
-        }
-    };
-    let tsdb = tsdb_handle.read();
-    let engine = QueryEngine::new(&*tsdb);
-    match engine.query_range(&params.query, params.start, params.end, params.step) {
-        Ok(result) => axum::response::Json(ApiResponse::success(result)),
-        Err(e) => axum::response::Json(ApiResponse::error(
-            e.to_string(),
-            error_type(&e).to_string(),
-        )),
-    }
-}
-
-async fn label_names(
-    axum::extract::State(_state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Json<ApiResponse<Vec<String>>> {
-    let labels = vec![
-        "__name__".to_string(),
-        "direction".to_string(),
-        "op".to_string(),
-        "state".to_string(),
-        "reason".to_string(),
-        "id".to_string(),
-        "name".to_string(),
-        "sampler".to_string(),
-    ];
-    axum::response::Json(ApiResponse::success(labels))
-}
-
-async fn label_values(
-    axum::extract::Path(name): axum::extract::Path<String>,
-    axum::extract::State(_state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Json<ApiResponse<Vec<String>>> {
-    let values = match name.as_str() {
-        "direction" => vec![
-            "transmit".to_string(),
-            "receive".to_string(),
-            "to".to_string(),
-            "from".to_string(),
-        ],
-        "op" => vec!["read".to_string(), "write".to_string()],
-        "state" => vec!["user".to_string(), "system".to_string()],
-        _ => vec![],
-    };
-    axum::response::Json(ApiResponse::success(values))
-}
-
-async fn metadata(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Query(p): axum::extract::Query<CaptureParam>,
-) -> axum::response::Json<ApiResponse<serde_json::Value>> {
-    let capture = p.capture_id();
-    let tsdb_handle = match state.captures.get(capture) {
-        Some(t) => t,
-        None => {
-            return axum::response::Json(ApiResponse::error(
-                format!("capture {:?} not attached", capture),
-                "capture_not_found".to_string(),
-            ));
-        }
-    };
-    let tsdb = tsdb_handle.read();
-    let engine = QueryEngine::new(&*tsdb);
-    let time_range = engine.get_time_range();
-    let mut metadata = serde_json::json!({
-        "minTime": time_range.0,
-        "maxTime": time_range.1,
-        "filename": tsdb.filename(),
-    });
-    // Display alias, when the CLI provided one (e.g. `redis=./a.parquet`).
-    // Present to the frontend as `alias` alongside `filename`; absent
-    // when no alias was set, so the UI falls back to the capture id.
-    if let Some(alias) = state.captures.alias(capture) {
-        metadata["alias"] = serde_json::json!(alias);
-    }
-    // File checksum is only tracked for the baseline capture today.
-    if matches!(capture, capture_registry::CaptureId::Baseline) {
-        if let Some(checksum) = &*state.file_checksum.read() {
-            metadata["fileChecksum"] = serde_json::json!(checksum);
-        }
-    }
-    axum::response::Json(ApiResponse::success(metadata))
-}
-
-/// Upload and load a parquet file into file-mode viewer state.
-async fn upload_parquet(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
-) -> axum::response::Json<ApiResponse<serde_json::Value>> {
-    if state.live.load(Ordering::Relaxed) {
-        return axum::response::Json(ApiResponse::error(
-            "upload is only available in file mode".to_string(),
-            "bad_request".to_string(),
-        ));
-    }
-
-    if body.is_empty() {
-        return axum::response::Json(ApiResponse::error(
-            "missing parquet bytes".to_string(),
-            "bad_request".to_string(),
-        ));
-    }
-
-    let filename = headers
-        .get("x-rezolus-filename")
-        .and_then(|v| v.to_str().ok())
-        .map(ToString::to_string)
-        .unwrap_or_else(|| "upload.parquet".to_string());
-
-    let temp_path = baseline_temp_path();
-    if let Err(e) = std::fs::write(&temp_path, &body) {
-        return axum::response::Json(ApiResponse::error(
-            format!("failed to store upload: {e}"),
-            "io_error".to_string(),
-        ));
-    }
-
-    ingest_baseline_from_path(&state, temp_path, filename)
-}
-
-/// Shared baseline-ingest path used by `/api/v1/upload` and
-/// `/api/v1/load_url`. Takes ownership of `temp_path` (file is deleted
-/// on parquet-load failure, retained on success since the AppState
-/// references it for re-reads). The caller is responsible for
-/// populating the file at `temp_path` before calling.
-fn ingest_baseline_from_path(
-    state: &AppState,
-    temp_path: PathBuf,
-    filename: String,
-) -> axum::response::Json<ApiResponse<serde_json::Value>> {
-    let loaded = Tsdb::load(&temp_path);
-    let mut data = match loaded {
-        Ok(d) => d,
-        Err(e) => {
-            let _ = std::fs::remove_file(&temp_path);
-            return axum::response::Json(ApiResponse::error(
-                format!("failed to load parquet: {e}"),
-                "invalid_parquet".to_string(),
-            ));
-        }
-    };
-
-    let filesize = std::fs::metadata(&temp_path).map(|m| m.len()).ok();
-
-    // Set the real filename before generating dashboards so the section JSON
-    // embeds the original name instead of the temp path.
-    data.set_filename(filename.clone());
-
-    // Template lookup is driven by the parquet's source metadata.
-    let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
-    validate_service_extensions(&data, &mut service_exts);
-    let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
-    let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None);
-    let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
-    let file_checksum = compute_file_checksum(&temp_path);
-
-    {
-        let tsdb_handle = state.baseline_tsdb();
-        let mut tsdb = tsdb_handle.write();
-        *tsdb = data;
-    }
-    *state.sections.write() = LazySectionStore::new(context);
-    let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
-    *state.parquet_path.write() = Some(temp_path);
-    state
-        .captures
-        .set_baseline_systeminfo(multinode_sysinfo.or(systeminfo));
-    *state.selection.write() = selection;
-    *state.file_checksum.write() = file_checksum;
-    state.captures.set_baseline_file_metadata(file_meta);
-
-    axum::response::Json(ApiResponse::success(serde_json::json!({
-        "filename": filename,
-    })))
-}
-
-fn baseline_temp_path() -> PathBuf {
-    let suffix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or_default();
-    std::env::temp_dir().join(format!("rezolus-viewer-{}-{}", std::process::id(), suffix))
-}
-
-/// Attach an experiment parquet for A/B comparison. Body is raw parquet bytes.
-/// Returns 409 if an experiment is already attached (caller must DELETE first).
-async fn attach_experiment(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
-) -> axum::response::Response {
-    use axum::response::IntoResponse;
-
-    if state.captures.experiment_attached() {
-        return (
-            StatusCode::CONFLICT,
-            "experiment already attached; DELETE first",
-        )
-            .into_response();
-    }
-
-    if body.is_empty() {
-        return (StatusCode::BAD_REQUEST, "missing parquet bytes").into_response();
-    }
-
-    let filename = headers
-        .get("x-rezolus-filename")
-        .and_then(|v| v.to_str().ok())
-        .map(ToString::to_string)
-        .unwrap_or_else(|| "experiment.parquet".to_string());
-
-    let temp_path =
-        std::env::temp_dir().join(format!("rezolus-experiment-{}.parquet", std::process::id(),));
-    if let Err(e) = std::fs::write(&temp_path, &body) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to store upload: {e}"),
-        )
-            .into_response();
-    }
-
-    let mut tsdb = match Tsdb::load(&temp_path) {
-        Ok(t) => t,
-        Err(e) => {
-            let _ = std::fs::remove_file(&temp_path);
-            return (
-                StatusCode::BAD_REQUEST,
-                format!("failed to load parquet: {e}"),
-            )
-                .into_response();
-        }
-    };
-    // Stamp with the uploader's filename so the viewer can display it
-    // in the compare badge.
-    tsdb.set_filename(filename);
-
-    let (sysinfo, _selection, file_meta) = extract_parquet_metadata(&temp_path);
-    // HTTP-attached experiments don't carry an alias — aliases only
-    // come in via the CLI today. Keep None for now; this parameter is
-    // here so a future `x-rezolus-alias` upload header can thread one
-    // through without further signature changes.
-    state
-        .captures
-        .attach_experiment(tsdb, sysinfo.clone(), file_meta, None);
-    *state.experiment_parquet_path.write() = Some(temp_path);
-
-    // Rebuild the section map now that both captures are present.
-    // Picks up a category when the registry has one whose members match
-    // the two service extensions.
-    regenerate_dashboards(&state);
-
-    (
-        StatusCode::OK,
-        [(header::CONTENT_TYPE, "application/json")],
-        sysinfo.unwrap_or_else(|| "{}".into()),
-    )
-        .into_response()
-}
-
-/// Detach the currently attached experiment (if any) and clean up its temp file.
-async fn detach_experiment(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Response {
-    use axum::response::IntoResponse;
-
-    state.captures.detach_experiment();
-    if let Some(path) = state.experiment_parquet_path.write().take() {
-        let _ = std::fs::remove_file(&path);
-    }
-    // Also clear the CLI-supplied experiment path so the section
-    // regeneration below doesn't rebuild the category against a
-    // detached capture. Note: we only clear the path reference, not
-    // the file itself — the user's parquet on disk is left alone.
-    state.cli_experiment_path.write().take();
-
-    // Rebuild the section map back to baseline-only (drops category /
-    // experiment service section).
-    regenerate_dashboards(&state);
-
-    StatusCode::OK.into_response()
-}
-
-/// Connect to a live Rezolus agent at runtime.
-/// Fetches agent metadata, generates dashboards, spawns the ingest loop,
-/// and flips the viewer into live mode.
-async fn connect_agent(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    body: axum::body::Bytes,
-) -> axum::response::Json<ApiResponse<serde_json::Value>> {
-    if state.live.load(Ordering::Relaxed) {
-        return axum::response::Json(ApiResponse::error(
-            "already connected to a live agent".to_string(),
-            "bad_request".to_string(),
-        ));
-    }
-
-    let url_str = match std::str::from_utf8(&body) {
-        Ok(s) => s.trim().to_string(),
-        Err(_) => {
-            return axum::response::Json(ApiResponse::error(
-                "invalid UTF-8 in URL".to_string(),
-                "bad_request".to_string(),
-            ));
-        }
-    };
-
-    let url: Url = match url_str.parse() {
-        Ok(u) => u,
-        Err(e) => {
-            return axum::response::Json(ApiResponse::error(
-                format!("invalid URL: {e}"),
-                "bad_request".to_string(),
-            ));
-        }
-    };
-
-    let client = match Client::builder().http1_only().build() {
-        Ok(c) => c,
-        Err(e) => {
-            return axum::response::Json(ApiResponse::error(
-                format!("failed to create HTTP client: {e}"),
-                "internal_error".to_string(),
-            ));
-        }
-    };
-
-    let (source, version) = match client.get(url.clone()).send().await {
-        Ok(response) => match response.text().await {
-            Ok(body) => {
-                let first_line = body.lines().next().unwrap_or("");
-                let parts: Vec<&str> = first_line.split_whitespace().collect();
-                match parts.as_slice() {
-                    [name, ver, ..] => (name.to_string(), ver.to_string()),
-                    _ => ("rezolus".to_string(), String::new()),
-                }
-            }
-            Err(_) => ("rezolus".to_string(), String::new()),
-        },
-        Err(e) => {
-            return axum::response::Json(ApiResponse::error(
-                format!("failed to connect to agent at {url}: {e}"),
-                "connection_error".to_string(),
-            ));
-        }
-    };
-
-    let mut info_url = url.clone();
-    info_url.set_path("/systeminfo");
-    let agent_systeminfo = match client.get(info_url).send().await {
-        Ok(response) if response.status().is_success() => response.text().await.ok(),
-        _ => None,
-    };
-
-    let mut tsdb = Tsdb::default();
-    tsdb.set_sampling_interval_ms(1000);
-    tsdb.set_source(source.clone());
-    tsdb.set_version(version.clone());
-    tsdb.set_filename(url.to_string());
-    let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
-
-    {
-        let tsdb_handle = state.baseline_tsdb();
-        let mut db = tsdb_handle.write();
-        *db = tsdb;
-    }
-    *state.sections.write() = LazySectionStore::new(context);
-    state.captures.set_baseline_systeminfo(agent_systeminfo);
-    state.live.store(true, Ordering::Relaxed);
-
-    let ingest_tsdb = state.baseline_tsdb();
-    let ingest_snapshots = state.snapshots.clone();
-    let mut ingest_url = url.clone();
-    ingest_url.set_path("/metrics/binary");
-
-    tokio::spawn(ingest_loop(
-        ingest_url,
-        ingest_tsdb,
-        ingest_snapshots,
-        source.clone(),
-        version.clone(),
-    ));
-
-    info!("Connected to {source} {version} at {url}");
-
-    axum::response::Json(ApiResponse::success(serde_json::json!({
-        "source": source,
-        "version": version,
-        "url": url.to_string(),
-    })))
-}
-
-/// Reset the TSDB — clears all data and buffered snapshots.
-async fn reset_tsdb(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Json<ApiResponse<serde_json::Value>> {
-    if !state.live.load(Ordering::Relaxed) {
-        return axum::response::Json(ApiResponse::error(
-            "reset is only available in live mode".to_string(),
-            "bad_request".to_string(),
-        ));
-    }
-
-    // Preserve metadata across reset
-    let tsdb_handle = state.baseline_tsdb();
-    let (source, version, filename) = {
-        let tsdb = tsdb_handle.read();
-        (
-            tsdb.source().to_string(),
-            tsdb.version().to_string(),
-            tsdb.filename().to_string(),
-        )
-    };
-
-    {
-        let mut tsdb = tsdb_handle.write();
-        *tsdb = Tsdb::default();
-        tsdb.set_sampling_interval_ms(1000);
-        tsdb.set_source(source);
-        tsdb.set_version(version);
-        tsdb.set_filename(filename);
-    }
-
-    state.snapshots.lock().clear();
-    info!("TSDB reset by user");
-
-    axum::response::Json(ApiResponse::success(serde_json::json!({ "ok": true })))
-}
-
-/// Save buffered snapshots as a parquet file download.
-async fn save_parquet(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-) -> axum::response::Response {
-    use axum::body::Body;
-    use std::io::Cursor;
-
-    let snapshot_data: Vec<Vec<u8>> = state.snapshots.lock().iter().cloned().collect();
-
-    if snapshot_data.is_empty() {
-        return axum::response::Response::builder()
-            .status(StatusCode::NO_CONTENT)
-            .body(Body::empty())
-            .unwrap();
-    }
-
-    // Grab the stored systeminfo (from agent or local) for parquet metadata
-    let sysinfo_json = state.captures.systeminfo(CaptureId::Baseline);
-
-    // Run the synchronous parquet conversion off the async runtime
-    let result = tokio::task::spawn_blocking(move || {
-        let total_size: usize = snapshot_data.iter().map(|s| s.len()).sum();
-        let mut raw = Vec::with_capacity(total_size);
-        for snapshot_bytes in &snapshot_data {
-            raw.extend_from_slice(snapshot_bytes);
-        }
-
-        let reader = Cursor::new(raw);
-        let mut output = Vec::new();
-
-        let mut converter = metriken_exposition::MsgpackToParquet::with_options(
-            metriken_exposition::ParquetOptions::new(),
-        )
-        .metadata("sampling_interval_ms".to_string(), "1000".to_string());
-
-        if let Some(json) = sysinfo_json {
-            converter = converter.metadata("systeminfo".to_string(), json);
-        }
-
-        converter
-            .convert_file_handle(reader, Cursor::new(&mut output))
-            .map(|rows| {
-                info!("saved parquet with {rows} rows");
-                output
-            })
-    })
-    .await;
-
-    match result {
-        Ok(Ok(output)) => axum::response::Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, "application/octet-stream")
-            .header(
-                header::CONTENT_DISPOSITION,
-                "attachment; filename=\"rezolus-capture.parquet\"",
-            )
-            .body(Body::from(output))
-            .unwrap(),
-        Ok(Err(e)) => {
-            error!("failed to convert to parquet: {e}");
-            axum::response::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from(format!("parquet conversion failed: {e}")))
-                .unwrap()
-        }
-        Err(e) => {
-            error!("parquet conversion task panicked: {e}");
-            axum::response::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from("internal error"))
-                .unwrap()
-        }
-    }
-}
-
-async fn save_with_selection(
-    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    body: String,
-) -> axum::response::Response {
-    use axum::body::Body;
-    use std::io::Cursor;
-
-    let parquet_path = state.parquet_path.read().clone();
-    let selection_json = body;
-
-    // File mode: copy original parquet with selection metadata added
-    if let Some(path) = parquet_path {
-        let result = tokio::task::spawn_blocking(move || {
-            use parquet::file::metadata::KeyValue;
-
-            let mut kv_meta =
-                crate::parquet_tools::read_file_metadata(&path).map_err(|e| e.to_string())?;
-            kv_meta.retain(|kv| kv.key != "selection");
-            kv_meta.push(KeyValue {
-                key: "selection".to_string(),
-                value: Some(selection_json),
-            });
-
-            let output = crate::parquet_tools::rewrite_parquet(&path, kv_meta, None)
-                .map_err(|e| e.to_string())?;
-            info!("saved annotated parquet ({} bytes)", output.len());
-            Ok::<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>(output)
-        })
-        .await;
-
-        return match result {
-            Ok(Ok(output)) => axum::response::Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, "application/octet-stream")
-                .header(
-                    header::CONTENT_DISPOSITION,
-                    "attachment; filename=\"rezolus-capture-annotated.parquet\"",
-                )
-                .body(Body::from(output))
-                .unwrap(),
-            Ok(Err(e)) => {
-                error!("failed to annotate parquet: {e}");
-                axum::response::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(Body::from(format!("parquet annotation failed: {e}")))
-                    .unwrap()
-            }
-            Err(e) => {
-                error!("parquet annotation task panicked: {e}");
-                axum::response::Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(Body::from("internal error"))
-                    .unwrap()
-            }
-        };
-    }
-
-    // Live mode: convert snapshots to parquet with selection metadata
-    let snapshot_data: Vec<Vec<u8>> = state.snapshots.lock().iter().cloned().collect();
-
-    if snapshot_data.is_empty() {
-        return axum::response::Response::builder()
-            .status(StatusCode::NO_CONTENT)
-            .body(Body::empty())
-            .unwrap();
-    }
-
-    let sysinfo_json = state.captures.systeminfo(CaptureId::Baseline);
-
-    let result = tokio::task::spawn_blocking(move || {
-        let total_size: usize = snapshot_data.iter().map(|s| s.len()).sum();
-        let mut raw = Vec::with_capacity(total_size);
-        for snapshot_bytes in &snapshot_data {
-            raw.extend_from_slice(snapshot_bytes);
-        }
-
-        let reader = Cursor::new(raw);
-        let mut output = Vec::new();
-
-        let mut converter = metriken_exposition::MsgpackToParquet::with_options(
-            metriken_exposition::ParquetOptions::new(),
-        )
-        .metadata("sampling_interval_ms".to_string(), "1000".to_string());
-
-        if let Some(json) = sysinfo_json {
-            converter = converter.metadata("systeminfo".to_string(), json);
-        }
-
-        converter = converter.metadata("selection".to_string(), selection_json);
-
-        converter
-            .convert_file_handle(reader, Cursor::new(&mut output))
-            .map(|rows| {
-                info!("saved annotated parquet with {rows} rows");
-                output
-            })
-    })
-    .await;
-
-    match result {
-        Ok(Ok(output)) => axum::response::Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, "application/octet-stream")
-            .header(
-                header::CONTENT_DISPOSITION,
-                "attachment; filename=\"rezolus-capture-annotated.parquet\"",
-            )
-            .body(Body::from(output))
-            .unwrap(),
-        Ok(Err(e)) => {
-            error!("failed to convert to parquet: {e}");
-            axum::response::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from(format!("parquet conversion failed: {e}")))
-                .unwrap()
-        }
-        Err(e) => {
-            error!("parquet conversion task panicked: {e}");
-            axum::response::Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from("internal error"))
-                .unwrap()
-        }
-    }
-}
-
-#[cfg(not(feature = "developer-mode"))]
-async fn index() -> impl IntoResponse {
-    if let Some(asset) = ASSETS.get_file("index.html") {
-        let body = asset.contents_utf8().unwrap();
-        let content_type = "text/html";
-
-        (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, content_type)],
-            body.to_string(),
-        )
-    } else {
-        error!("index.html missing from build");
-        (
-            StatusCode::from_u16(404).unwrap(),
-            [(header::CONTENT_TYPE, "text/plain")],
-            "404 Not Found".to_string(),
-        )
-    }
-}
-
-#[cfg(not(feature = "developer-mode"))]
-async fn lib(uri: Uri) -> impl IntoResponse {
-    let path = uri.path();
-
-    if let Some(asset) = ASSETS.get_file(format!("lib{path}")) {
-        let body = asset.contents_utf8().unwrap();
-        let content_type = if path.ends_with(".js") {
-            "text/javascript"
-        } else if path.ends_with(".css") {
-            "text/css"
-        } else if path.ends_with(".html") {
-            "text/html"
-        } else if path.ends_with(".json") {
-            "application/json"
-        } else {
-            "text/plain"
-        };
-
-        (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, content_type)],
-            body.to_string(),
-        )
-    } else {
-        error!("path: {path} does not map to a static resource");
-        (
-            StatusCode::from_u16(404).unwrap(),
-            [(header::CONTENT_TYPE, "text/plain")],
-            "404 Not Found".to_string(),
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::routes::strip_sections_from_section_payload;
+    use super::state::{build_sections_metadata_payload, LazySectionStore};
+    use ::dashboard::dashboard::DashboardContext;
+    use ::dashboard::Section;
 
     #[test]
     fn lean_section_payload_does_not_repeat_sections() {
@@ -2565,7 +582,6 @@ mod tests {
             2000,
             99,
         );
-
         assert_eq!(payload["sections"], serde_json::Value::Array(sections));
         assert!(payload.get("groups").is_none());
         assert_eq!(payload["source"], serde_json::json!("rezolus"));
@@ -2580,9 +596,6 @@ mod tests {
 
     #[test]
     fn lazy_section_store_exposes_context_sections() {
-        use dashboard::dashboard::DashboardContext;
-        use dashboard::Section;
-
         let context = DashboardContext {
             sections: vec![
                 Section {

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -1,0 +1,437 @@
+//! HTTP routing and read-side handlers.
+//!
+//! Action handlers (upload, attach, save, connect, ingest, …) live in
+//! `super::actions` and are wired in here.
+
+use std::sync::Arc;
+
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::response::{IntoResponse, Json, Response};
+use axum::routing::get;
+use axum::Router;
+use http::{header, StatusCode};
+use tower::ServiceBuilder;
+use tower_http::compression::CompressionLayer;
+use tower_http::decompression::RequestDecompressionLayer;
+use tower_livereload::LiveReloadLayer;
+use tracing::warn;
+
+#[cfg(not(feature = "developer-mode"))]
+use http::Uri;
+#[cfg(not(feature = "developer-mode"))]
+use include_dir::{include_dir, Dir};
+
+#[cfg(feature = "developer-mode")]
+use std::path::Path;
+#[cfg(feature = "developer-mode")]
+use tower_http::services::{ServeDir, ServeFile};
+
+use std::sync::atomic::Ordering;
+
+use super::actions;
+use super::capture_registry::{self, CaptureId};
+use super::promql::{self, QueryEngine};
+use super::state::{self, ApiResponse, AppState, CaptureParam};
+use super::tsdb::Tsdb;
+
+#[cfg(not(feature = "developer-mode"))]
+static ASSETS: Dir<'_> = include_dir!("src/viewer/assets");
+
+pub fn app(livereload: LiveReloadLayer, app_state: AppState) -> Router {
+    let app_state = Arc::new(app_state);
+
+    // API routes get Cache-Control: no-store to prevent browsers from
+    // returning stale data during live mode polling.
+    let api_routes = Router::new()
+        .route("/query", get(instant_query))
+        .route("/query_range", get(range_query))
+        .route("/labels", get(label_names))
+        .route("/label/{name}/values", get(label_values))
+        .route("/metadata", get(metadata))
+        .route("/mode", get(mode))
+        .route("/reset", axum::routing::post(actions::reset_tsdb))
+        .route("/save", get(actions::save_parquet))
+        .route("/systeminfo", get(systeminfo_handler))
+        .route("/selection", get(selection_handler))
+        .route("/sections", get(sections_handler))
+        .route("/file_metadata", get(file_metadata_handler))
+        .route(
+            "/upload",
+            axum::routing::post(actions::upload_parquet)
+                .layer(axum::extract::DefaultBodyLimit::max(50 * 1024 * 1024)),
+        )
+        .route(
+            "/captures/experiment",
+            axum::routing::post(actions::attach_experiment)
+                .delete(actions::detach_experiment)
+                .layer(axum::extract::DefaultBodyLimit::max(50 * 1024 * 1024)),
+        )
+        .route("/connect", axum::routing::post(actions::connect_agent))
+        .route(
+            "/save_with_selection",
+            axum::routing::post(actions::save_with_selection),
+        )
+        .route("/load_url", axum::routing::post(actions::load_url))
+        .layer(axum::middleware::map_response(
+            |mut response: Response| async move {
+                response.headers_mut().insert(
+                    header::CACHE_CONTROL,
+                    header::HeaderValue::from_static("no-store"),
+                );
+                response
+            },
+        ));
+
+    let router = Router::new()
+        .route("/about", get(about))
+        .route("/data/{*path}", get(data))
+        .nest("/api/v1", api_routes)
+        .with_state(app_state.clone());
+
+    #[cfg(feature = "developer-mode")]
+    let router = {
+        warn!("running in developer mode. Rezolus Viewer must be run from within project folder");
+        router
+            .route_service("/", ServeFile::new("src/viewer/assets/index.html"))
+            .nest_service("/lib", ServeDir::new(Path::new("src/viewer/assets/lib")))
+            .fallback_service(ServeFile::new("src/viewer/assets/index.html"))
+    };
+
+    #[cfg(not(feature = "developer-mode"))]
+    let router = {
+        router
+            .route_service("/", get(index))
+            .nest_service("/lib", get(lib))
+            .fallback_service(get(index))
+    };
+
+    router.layer(
+        ServiceBuilder::new()
+            .layer(RequestDecompressionLayer::new())
+            .layer(CompressionLayer::new())
+            .layer(livereload),
+    )
+}
+
+/// Shared HTML head for standalone pages. Reuses the main viewer
+/// stylesheet and applies the saved theme before first paint.
+const STANDALONE_HEAD: &str = r#"<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<script>!function(){var t=localStorage.getItem('rezolus-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t)}()</script>
+<link rel="stylesheet" href="/lib/style.css"/>
+<style>body{display:flex;align-items:center;justify-content:center;padding:2rem}</style>"#;
+
+async fn about() -> axum::response::Html<String> {
+    let version = env!("CARGO_PKG_VERSION");
+    axum::response::Html(format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head><title>Rezolus — About</title>
+{STANDALONE_HEAD}
+</head>
+<body>
+<div class="card">
+  <h1>Rezolus</h1>
+  <div class="version">v{version}</div>
+  <p class="subtitle">High-resolution systems performance telemetry agent.</p>
+  <div class="link-row">
+    <a href="https://rezolus.com">Website</a>
+    <a href="https://github.com/iopsystems/rezolus">GitHub</a>
+    <a href="/">Dashboard</a>
+  </div>
+</div>
+</body>
+</html>"#
+    ))
+}
+
+/// Per-section dashboard JSON, generated lazily and memoized.
+async fn data(State(state): State<Arc<AppState>>, AxumPath(path): AxumPath<String>) -> Response {
+    // Path arrives as "cpu.json" or "service/vllm.json"; LazySectionStore
+    // expects "/cpu", "/service/vllm".
+    let stem = path.strip_suffix(".json").unwrap_or(&path);
+    let route = format!("/{stem}");
+
+    let value = {
+        let tsdb_handle = state.baseline_tsdb();
+        let tsdb = tsdb_handle.read();
+        let mut store = state.sections.write();
+        store.get_or_generate(&route, &tsdb).cloned()
+    };
+
+    let Some(mut value) = value else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    // The lazy generator already produces lean bodies, but keep the
+    // strip as cheap insurance against accidental re-introduction.
+    strip_sections_from_section_payload(&mut value);
+    match serde_json::to_string(&value) {
+        Ok(body) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            body,
+        )
+            .into_response(),
+        Err(e) => {
+            warn!("section response serialization failed for {path}: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+/// Drop the navigation `sections` array from a section payload before
+/// returning it. Each cached section body embeds the full nav list so
+/// that `sections_metadata` can extract it; per-section responses don't
+/// need that redundancy.
+pub fn strip_sections_from_section_payload(value: &mut serde_json::Value) {
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("sections");
+    }
+}
+
+/// Reports viewer mode (live/file/upload-only, compare attached, etc.).
+async fn mode(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
+    let loaded = !state.sections.read().is_empty();
+    // The static-site bundle reports "direct" for its own URL input;
+    // the binary viewer never reports "direct" — URL loads always go
+    // through the local proxy.
+    let url_loading = if state.proxy.enabled() {
+        "proxy"
+    } else {
+        "disabled"
+    };
+    Json(serde_json::json!({
+        "live": state.live.load(Ordering::Relaxed),
+        "loaded": loaded,
+        "compare_mode": state.captures.experiment_attached(),
+        "category": state.category_name.read().clone(),
+        "url_loading": url_loading,
+    }))
+}
+
+async fn systeminfo_handler(
+    State(state): State<Arc<AppState>>,
+    Query(p): Query<CaptureParam>,
+) -> Response {
+    match state.captures.systeminfo(p.capture_id()) {
+        Some(json) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            json,
+        )
+            .into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+async fn selection_handler(State(state): State<Arc<AppState>>) -> Response {
+    match &*state.selection.read() {
+        Some(json) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            json.clone(),
+        )
+            .into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// Navigation list + global capture params; no section bodies.
+async fn sections_handler(
+    State(state): State<Arc<AppState>>,
+    Query(p): Query<CaptureParam>,
+) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "status": "success",
+        "data": state.sections_metadata(p.capture_id()),
+    }))
+}
+
+async fn file_metadata_handler(
+    State(state): State<Arc<AppState>>,
+    Query(p): Query<CaptureParam>,
+) -> Response {
+    let body = state
+        .captures
+        .file_metadata(p.capture_id())
+        .unwrap_or_else(|| "{}".to_string());
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        body,
+    )
+        .into_response()
+}
+
+// ── PromQL handlers ───────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct QueryParams {
+    query: String,
+    time: Option<f64>,
+    #[serde(default)]
+    capture: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct RangeQueryParams {
+    query: String,
+    start: f64,
+    end: f64,
+    step: f64,
+    #[serde(default)]
+    capture: Option<String>,
+}
+
+/// Run `f` against the resolved capture's `QueryEngine`; on a missing
+/// capture, return a `capture_not_found` ApiResponse.
+fn run_query<F>(
+    state: &AppState,
+    capture: Option<&str>,
+    f: F,
+) -> Json<ApiResponse<promql::QueryResult>>
+where
+    F: FnOnce(&QueryEngine<&Tsdb>) -> Result<promql::QueryResult, promql::QueryError>,
+{
+    let capture = CaptureId::parse_opt(capture);
+    let Some(tsdb_handle) = state.captures.get(capture) else {
+        return ApiResponse::err(
+            format!("capture '{capture:?}' not attached"),
+            "capture_not_found",
+        );
+    };
+    let tsdb = tsdb_handle.read();
+    let engine = QueryEngine::new(&*tsdb);
+    match f(&engine) {
+        Ok(result) => ApiResponse::ok(result),
+        Err(e) => ApiResponse::err(e.to_string(), state::promql_error_type(&e)),
+    }
+}
+
+async fn instant_query(
+    Query(params): Query<QueryParams>,
+    State(state): State<Arc<AppState>>,
+) -> Json<ApiResponse<promql::QueryResult>> {
+    run_query(&state, params.capture.as_deref(), |engine| {
+        engine.query(&params.query, params.time)
+    })
+}
+
+async fn range_query(
+    Query(params): Query<RangeQueryParams>,
+    State(state): State<Arc<AppState>>,
+) -> Json<ApiResponse<promql::QueryResult>> {
+    run_query(&state, params.capture.as_deref(), |engine| {
+        engine.query_range(&params.query, params.start, params.end, params.step)
+    })
+}
+
+async fn label_names(State(_state): State<Arc<AppState>>) -> Json<ApiResponse<Vec<String>>> {
+    let labels = [
+        "__name__",
+        "direction",
+        "op",
+        "state",
+        "reason",
+        "id",
+        "name",
+        "sampler",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    ApiResponse::ok(labels)
+}
+
+async fn label_values(
+    AxumPath(name): AxumPath<String>,
+    State(_state): State<Arc<AppState>>,
+) -> Json<ApiResponse<Vec<String>>> {
+    let values: Vec<String> = match name.as_str() {
+        "direction" => ["transmit", "receive", "to", "from"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        "op" => vec!["read".to_string(), "write".to_string()],
+        "state" => vec!["user".to_string(), "system".to_string()],
+        _ => vec![],
+    };
+    ApiResponse::ok(values)
+}
+
+async fn metadata(
+    State(state): State<Arc<AppState>>,
+    Query(p): Query<CaptureParam>,
+) -> Json<ApiResponse<serde_json::Value>> {
+    let capture = p.capture_id();
+    let Some(tsdb_handle) = state.captures.get(capture) else {
+        return ApiResponse::err(
+            format!("capture {capture:?} not attached"),
+            "capture_not_found",
+        );
+    };
+    let tsdb = tsdb_handle.read();
+    let engine = QueryEngine::new(&*tsdb);
+    let (min_time, max_time) = engine.get_time_range();
+    let mut meta = serde_json::json!({
+        "minTime": min_time,
+        "maxTime": max_time,
+        "filename": tsdb.filename(),
+    });
+    if let Some(alias) = state.captures.alias(capture) {
+        meta["alias"] = serde_json::json!(alias);
+    }
+    if matches!(capture, capture_registry::CaptureId::Baseline) {
+        if let Some(checksum) = &*state.file_checksum.read() {
+            meta["fileChecksum"] = serde_json::json!(checksum);
+        }
+    }
+    ApiResponse::ok(meta)
+}
+
+// ── Static asset serving (release builds) ─────────────────────────────
+
+#[cfg(not(feature = "developer-mode"))]
+async fn index() -> impl IntoResponse {
+    if let Some(asset) = ASSETS.get_file("index.html") {
+        let body = asset.contents_utf8().unwrap();
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/html")],
+            body.to_string(),
+        )
+    } else {
+        tracing::error!("index.html missing from build");
+        (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "text/plain")],
+            "404 Not Found".to_string(),
+        )
+    }
+}
+
+#[cfg(not(feature = "developer-mode"))]
+async fn lib(uri: Uri) -> impl IntoResponse {
+    let path = uri.path();
+    let Some(asset) = ASSETS.get_file(format!("lib{path}")) else {
+        tracing::error!("path: {path} does not map to a static resource");
+        return (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "text/plain")],
+            "404 Not Found".to_string(),
+        );
+    };
+    let body = asset.contents_utf8().unwrap();
+    let content_type = match path.rsplit('.').next() {
+        Some("js") => "text/javascript",
+        Some("css") => "text/css",
+        Some("html") => "text/html",
+        Some("json") => "application/json",
+        _ => "text/plain",
+    };
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, content_type)],
+        body.to_string(),
+    )
+}

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -1,0 +1,313 @@
+//! Viewer server state and shared types.
+//!
+//! `AppState` is the single Arc-shared handle threaded into every axum
+//! handler. The ancillary types (`LazySectionStore`, `ProxyState`,
+//! `ApiResponse`, `CaptureParam`) live here too because they're the
+//! HTTP-level scaffolding the handlers all touch.
+
+use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use parking_lot::{Mutex, RwLock};
+use reqwest::Client;
+use tracing::error;
+
+use super::capture_registry::{CaptureId, CaptureRegistry};
+use super::proxy_allow;
+use super::tsdb::Tsdb;
+use ::dashboard::{self, TemplateRegistry};
+
+/// Caches the navigation list (via the owned `DashboardContext`) and
+/// memoizes per-section JSON bodies. `/api/v1/sections` reads the nav
+/// without materializing any body; `/data/<section>.json` generates a
+/// body on first request and serves the cached value thereafter.
+pub struct LazySectionStore {
+    context: dashboard::dashboard::DashboardContext,
+    cached_bodies: HashMap<String, serde_json::Value>,
+}
+
+impl LazySectionStore {
+    pub fn new(context: dashboard::dashboard::DashboardContext) -> Self {
+        Self {
+            context,
+            cached_bodies: HashMap::new(),
+        }
+    }
+
+    pub fn sections(&self) -> &[dashboard::Section] {
+        &self.context.sections
+    }
+
+    /// True when no context has been loaded — used by the `mode` endpoint.
+    pub fn is_empty(&self) -> bool {
+        self.context.sections.is_empty()
+    }
+
+    pub fn context(&self) -> &dashboard::dashboard::DashboardContext {
+        &self.context
+    }
+
+    /// Generate (or return the cached body for) `route` (`/cpu`,
+    /// `/service/vllm`, …). Returns `None` when the route is unknown or
+    /// the section has no data. Applies `context.filesize` uniformly.
+    pub fn get_or_generate(&mut self, route: &str, data: &Tsdb) -> Option<&serde_json::Value> {
+        let key = format!("{}.json", &route[1..]);
+        if !self.cached_bodies.contains_key(&key) {
+            let mut view = dashboard::dashboard::generate_section(data, route, &self.context)?;
+            if let Some(size) = self.context.filesize {
+                view.set_filesize(size);
+            }
+            let value = serde_json::to_value(&view).ok()?;
+            self.cached_bodies.insert(key.clone(), value);
+        }
+        self.cached_bodies.get(&key)
+    }
+}
+
+impl Default for LazySectionStore {
+    fn default() -> Self {
+        Self::new(dashboard::dashboard::DashboardContext::default())
+    }
+}
+
+/// Optional URL-fetch proxy. Disabled (no client) unless the CLI was
+/// invoked with `--proxy-allow`/`--proxy-allow-any`.
+#[derive(Default)]
+pub struct ProxyState {
+    pub allow: proxy_allow::Allowlist,
+    pub client: Option<Client>,
+}
+
+impl ProxyState {
+    pub fn enabled(&self) -> bool {
+        !self.allow.is_empty() && self.client.is_some()
+    }
+}
+
+pub struct AppState {
+    pub sections: RwLock<LazySectionStore>,
+    /// Per-capture TSDB + metadata. Single-capture callers always target
+    /// `CaptureId::Baseline`; the experiment slot is empty unless a
+    /// compare-mode hand-off has attached one.
+    pub captures: Arc<CaptureRegistry>,
+    pub templates: TemplateRegistry,
+    /// Raw msgpack snapshot bytes for parquet export (live mode only).
+    pub snapshots: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    pub live: AtomicBool,
+    /// Original parquet file path (file mode only).
+    pub parquet_path: RwLock<Option<PathBuf>>,
+    /// Temp parquet path for the HTTP-attached experiment capture.
+    /// Owned by the attach handler — deleted on detach. The CLI startup
+    /// path uses `cli_experiment_path` instead so detach never touches
+    /// the user's own file.
+    pub experiment_parquet_path: RwLock<Option<PathBuf>>,
+    /// User-supplied experiment parquet path from the CLI. Read-only —
+    /// never deleted on detach. Kept separate from
+    /// `experiment_parquet_path` so `regenerate_dashboards` can find
+    /// the experiment metadata without risking the user's file.
+    pub cli_experiment_path: RwLock<Option<PathBuf>>,
+    /// Active category template name (when `--category` was supplied).
+    pub category_name: RwLock<Option<String>>,
+    /// Serialized selection JSON from parquet metadata.
+    pub selection: RwLock<Option<String>>,
+    /// SHA-256 hex digest of the source parquet file (file mode only).
+    pub file_checksum: RwLock<Option<String>>,
+    pub proxy: ProxyState,
+}
+
+impl AppState {
+    pub fn new(tsdb: Tsdb, templates: TemplateRegistry) -> Self {
+        Self {
+            sections: Default::default(),
+            captures: Arc::new(CaptureRegistry::new(tsdb, None, None, None)),
+            templates,
+            snapshots: Arc::new(Mutex::new(VecDeque::new())),
+            live: AtomicBool::new(false),
+            parquet_path: RwLock::new(None),
+            experiment_parquet_path: RwLock::new(None),
+            cli_experiment_path: RwLock::new(None),
+            category_name: RwLock::new(None),
+            selection: RwLock::new(None),
+            file_checksum: RwLock::new(None),
+            proxy: ProxyState::default(),
+        }
+    }
+
+    /// Enable the URL proxy with the given hostname allowlist. Builds a
+    /// dedicated reqwest client so proxy traffic is isolated from the
+    /// live-mode scrape client. No-op when the allowlist is empty.
+    pub fn set_proxy(&mut self, allow: proxy_allow::Allowlist) {
+        if allow.is_empty() {
+            return;
+        }
+        match Client::builder().build() {
+            Ok(client) => {
+                self.proxy = ProxyState {
+                    allow,
+                    client: Some(client),
+                };
+            }
+            Err(e) => error!("failed to build proxy http client: {e}"),
+        }
+    }
+
+    /// Shorthand for the baseline TSDB handle. The registry guarantees
+    /// the baseline slot is always present.
+    pub fn baseline_tsdb(&self) -> Arc<RwLock<Tsdb>> {
+        self.captures
+            .get(CaptureId::Baseline)
+            .expect("baseline capture is always present")
+    }
+
+    /// Build the navigation + global params payload for `/api/v1/sections`.
+    /// When no context has been loaded yet (live mode pre-refresh,
+    /// upload-only mode pre-upload) returns a minimal payload with empty
+    /// sections and zeroed numerics. The `_capture` argument is advisory:
+    /// the same nav list applies to both baseline and experiment.
+    pub fn sections_metadata(&self, _capture: CaptureId) -> serde_json::Value {
+        let store = self.sections.read();
+        let sections_array: Vec<serde_json::Value> = store
+            .sections()
+            .iter()
+            .map(|s| serde_json::to_value(s).unwrap_or_default())
+            .collect();
+        let filesize = store.context().filesize.unwrap_or(0);
+        drop(store);
+
+        let tsdb_handle = self.baseline_tsdb();
+        let data = tsdb_handle.read();
+        let interval = data.interval();
+        let source = data.source().to_string();
+        let version = data.version().to_string();
+        let filename = data.filename().to_string();
+        // Tsdb time_range is in nanoseconds; convert to milliseconds to
+        // match the View's convention.
+        let (start_time, end_time) = data
+            .time_range()
+            .map(|(min, max)| (min / 1_000_000, max / 1_000_000))
+            .unwrap_or((0, 0));
+        let num_series = {
+            let mut count = 0usize;
+            for name in data.counter_names() {
+                count += data.counter_labels(name).map_or(0, |l| l.len());
+            }
+            for name in data.gauge_names() {
+                count += data.gauge_labels(name).map_or(0, |l| l.len());
+            }
+            for name in data.histogram_names() {
+                count += data.histogram_labels(name).map_or(0, |l| l.len());
+            }
+            count
+        };
+
+        build_sections_metadata_payload(
+            sections_array,
+            &source,
+            &version,
+            &filename,
+            interval,
+            filesize,
+            start_time,
+            end_time,
+            num_series,
+        )
+    }
+}
+
+/// Pure helper for `/api/v1/sections` — kept separate so the JSON shape
+/// is trivially unit-testable.
+#[allow(clippy::too_many_arguments)]
+pub fn build_sections_metadata_payload(
+    sections: Vec<serde_json::Value>,
+    source: &str,
+    version: &str,
+    filename: &str,
+    interval: f64,
+    filesize: u64,
+    start_time: u64,
+    end_time: u64,
+    num_series: usize,
+) -> serde_json::Value {
+    serde_json::json!({
+        "sections": sections,
+        "source": source,
+        "version": version,
+        "filename": filename,
+        "interval": interval,
+        "filesize": filesize,
+        "start_time": start_time,
+        "end_time": end_time,
+        "num_series": num_series,
+    })
+}
+
+/// Query param for endpoints that select between baseline and experiment.
+#[derive(serde::Deserialize)]
+pub struct CaptureParam {
+    #[serde(default)]
+    pub capture: Option<String>,
+}
+
+impl CaptureParam {
+    pub fn capture_id(&self) -> CaptureId {
+        CaptureId::parse_opt(self.capture.as_deref())
+    }
+}
+
+/// Standard JSON envelope for API endpoints. Matches Prometheus's
+/// `{ status, data?, error?, errorType? }` shape.
+#[derive(serde::Serialize)]
+pub struct ApiResponse<T: serde::Serialize> {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "errorType")]
+    error_type: Option<String>,
+}
+
+impl<T: serde::Serialize> ApiResponse<T> {
+    pub fn success(data: T) -> Self {
+        Self {
+            status: "success".to_string(),
+            data: Some(data),
+            error: None,
+            error_type: None,
+        }
+    }
+
+    pub fn error(error: impl Into<String>, error_type: impl Into<String>) -> Self {
+        Self {
+            status: "error".to_string(),
+            data: None,
+            error: Some(error.into()),
+            error_type: Some(error_type.into()),
+        }
+    }
+
+    /// Convenience: build an error response already wrapped in `Json`.
+    pub fn err(
+        error: impl Into<String>,
+        error_type: impl Into<String>,
+    ) -> axum::response::Json<Self> {
+        axum::response::Json(Self::error(error, error_type))
+    }
+
+    pub fn ok(data: T) -> axum::response::Json<Self> {
+        axum::response::Json(Self::success(data))
+    }
+}
+
+pub fn promql_error_type(e: &super::promql::QueryError) -> &'static str {
+    use super::promql::QueryError::*;
+    match e {
+        ParseError(_) => "bad_data",
+        EvaluationError(_) => "execution",
+        Unsupported(_) => "unsupported",
+        MetricNotFound(_) => "not_found",
+    }
+}


### PR DESCRIPTION
## Summary

`src/viewer/mod.rs` had grown to 2610 lines mixing CLI parsing, server state, parquet metadata, HTTP routing, and a dozen action handlers. This splits it along those seams without behavior changes.

| File | Lines | Contents |
| --- | --- | --- |
| `mod.rs` | ~620 | Entry point, `command()`, `Config`, `run()`, `serve()`, mode-init helpers, tests |
| `state.rs` | ~310 | `AppState`, `LazySectionStore`, `ProxyState`, `ApiResponse`, `CaptureParam`, `promql_error_type` |
| `metadata.rs` | ~420 | Parquet metadata extraction, multi-node info, file checksum, service-extension lookup, dashboard regen |
| `routes.rs` | ~430 | `app()` router + read-side handlers (about, data, mode, sections, file_metadata, systeminfo, selection, query, query_range, labels, metadata, static assets) |
| `actions.rs` | ~630 | Mutating handlers (upload, load_url, attach/detach experiment, connect, reset, save_parquet, save_with_selection) and the live-mode `ingest_loop` |

### Code-reuse improvements folded into the split

- `run_query` helper consolidates capture lookup + `QueryEngine` for the two PromQL handlers
- `snapshots_to_parquet` centralizes the live-mode parquet conversion shared by `save_parquet` and `save_with_selection`
- `fetch_agent_info` shared between CLI live-mode startup and the runtime `/api/v1/connect` handler
- `parquet_attachment` / `server_error` helpers cut response-builder boilerplate
- `ApiResponse::err` / `ApiResponse::ok` return pre-wrapped `Json`, removing ~30 verbose call sites
- `run()` decomposed into `init_file_mode`, `init_live_mode`, `validate_category_at_startup`, `attach_cli_experiment`, `log_service_exts`

Comments were tightened where they were redundant; the genuinely informative ones (the WHY behind `experiment_parquet_path` vs `cli_experiment_path`, the QueryEngine generic, the file-checksum layout) are kept.

## Test plan

- [x] `cargo check --bin rezolus`
- [x] `cargo clippy --bin rezolus` — no new warnings in `src/viewer/`
- [x] `cargo test --bin rezolus` — all 116 unit tests pass, including the four `viewer::tests::*` that exercise `LazySectionStore`, `build_sections_metadata_payload`, `strip_sections_from_section_payload`
- [x] `cargo fmt`
- [x] Manual smoke: `rezolus view <parquet>` (parquet mode), `rezolus view <agent-url>` (live mode), `rezolus view` (upload-only mode), experiment attach/detach


---
_Generated by [Claude Code](https://claude.ai/code/session_012EcjgH4mKf5nXteANS3Qdt)_