### PR TITLE
test(viewer): end-to-end smoke test + viewer-smoke skill

### DIFF
--- a/.claude/skills/viewer-smoke/SKILL.md
+++ b/.claude/skills/viewer-smoke/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: viewer-smoke
+description: Run the end-to-end viewer smoke test (`tests/viewer_smoke.sh`). Spawns `rezolus view` in upload-only, file, A/B, and proxy modes, exercises the API endpoints, and verifies experiment attach/detach. Use after any change touching `src/viewer/` or before opening a viewer-related PR.
+---
+
+# Viewer smoke test
+
+Runs the viewer in four configurations against checked-in demo
+parquets and asserts the public API endpoints behave correctly.
+Designed to be invoked from a PR/commit hook so behavior regressions
+in `src/viewer/` show up before review.
+
+## Steps
+
+1. **Run the script:**
+
+   ```bash
+   bash tests/viewer_smoke.sh
+   ```
+
+2. **Interpret the result:**
+
+   - **Exit 0** → all assertions passed; viewer behaves correctly across
+     upload-only, file mode, A/B compare mode, and proxy mode, including
+     experiment attach/detach via the HTTP API.
+   - **Exit 1** → first failed assertion is printed, plus the failing
+     viewer's startup log. Read both before guessing — the log usually
+     says exactly what blew up (port collision, missing parquet, panic,
+     etc.).
+
+3. **If the script fails, do *not* paper over by editing the assertions.**
+   The script is the contract. If a behavioral change is intentional
+   (e.g. a renamed JSON field), update the assertion in the same commit
+   that changes the behavior, and call it out in the PR description.
+
+## What it covers
+
+- `/api/v1/mode` — `loaded`, `compare_mode`, `url_loading` flags across
+  the four startup configs
+- `/api/v1/sections` — navigation list non-empty
+- `/data/<section>.json` — at least one group in the lazy-section payload
+- `/api/v1/query_range` — PromQL execution returns `status:"success"`
+- `/api/v1/load_url` — 403 envelope when proxy disabled, `invalid_parquet`
+  envelope when fetching non-parquet bytes from an allowed host
+- `POST /api/v1/captures/experiment` — flips `compare_mode:true`
+- `DELETE /api/v1/captures/experiment` — flips `compare_mode:false`
+- Static assets — `/`, `/about`, `/lib/style.css` all return 200
+
+## What it does *not* cover
+
+- **Live mode** (`rezolus view <agent-url>`) — needs an actual rezolus
+  agent listening, not reproducible without one.
+- **Browser-rendered UI** — the script only asserts on backend payload
+  shape. Visual regressions in the dashboard need eyeball verification.
+- **Compare-mode UI rendering** — the experiment attach/detach assertion
+  only checks the API flag flip; the rendered side-by-side view isn't
+  exercised.
+
+## Requirements
+
+- `cargo` — builds the binary if it isn't already built
+- `bash` 4+, `curl`, `jq` — assertions
+- Ports 18500-18503 free
+- Internet access to `httpbin.org` for the proxy assertion (skipped
+  with a warning if unreachable)
+
+## Triggering it from a hook
+
+A typical wiring:
+
+- **Per-PR (CI)** — add a job to `.github/workflows/cargo.yml` that runs
+  `bash tests/viewer_smoke.sh` after `cargo build`.
+- **Per-commit (local)** — `.git/hooks/pre-push` calling the same
+  script. Slow (cold builds take ~60 s + 8 s of viewer warmup), so
+  prefer the CI route unless the dev wants the early signal.
+- **Per Claude Code session** — invoke this skill via `/viewer-smoke`
+  or have the agent call it from a SessionStart / PostToolUse hook
+  that watches `src/viewer/**`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.12.2-alpha.4"
+version = "5.12.2-alpha.5"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.2-alpha.4"
+version = "5.12.2-alpha.5"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# tests/viewer_smoke.sh — end-to-end smoke test for `rezolus view`.
+#
+# Spawns the viewer in four configurations (upload-only, file mode, A/B
+# file mode, proxy enabled) on adjacent ports, hits the public API
+# endpoints, and asserts the expected mode + payload shape. Also covers
+# experiment attach / detach via /api/v1/captures/experiment.
+#
+# Live mode is intentionally skipped — it requires a running rezolus
+# agent and isn't reproducible from a dev/CI machine without one.
+#
+# Requirements: cargo, bash 4+, curl, jq. Listens on 18500-18503.
+# Exits 0 on full pass, 1 on first failed assertion (with the failing
+# server's log printed for context).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PORT_UPLOAD=18500
+PORT_FILE=18501
+PORT_AB=18502
+PORT_PROXY=18503
+
+PARQUET_FILE=site/viewer/data/cachecannon.parquet
+PARQUET_AB_A=site/viewer/data/AB_base.parquet
+PARQUET_AB_B=site/viewer/data/AB_base_pin.parquet
+
+LOGDIR=$(mktemp -d -t rezolus-smoke-XXXXXX)
+echo "logs: $LOGDIR"
+
+# Build before launching anything so a compile failure surfaces early.
+cargo build --bin rezolus 2>&1 | tail -3
+
+# Launch all four. Each writes its log to $LOGDIR so failures can be
+# triaged without re-running.
+./target/debug/rezolus view \
+    --listen 127.0.0.1:$PORT_UPLOAD \
+    > "$LOGDIR/upload.log" 2>&1 &
+PID_UPLOAD=$!
+
+./target/debug/rezolus view "$PARQUET_FILE" \
+    --listen 127.0.0.1:$PORT_FILE \
+    > "$LOGDIR/file.log" 2>&1 &
+PID_FILE=$!
+
+./target/debug/rezolus view "$PARQUET_AB_A" "$PARQUET_AB_B" \
+    --listen 127.0.0.1:$PORT_AB \
+    > "$LOGDIR/ab.log" 2>&1 &
+PID_AB=$!
+
+./target/debug/rezolus view \
+    --proxy-allow=httpbin.org \
+    --listen 127.0.0.1:$PORT_PROXY \
+    > "$LOGDIR/proxy.log" 2>&1 &
+PID_PROXY=$!
+
+cleanup() {
+    kill "$PID_UPLOAD" "$PID_FILE" "$PID_AB" "$PID_PROXY" 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait for each port to accept connections (up to 30 s). Bash's
+# /dev/tcp is built-in and works on both macOS and Linux.
+wait_for_port() {
+    local port=$1 tries=30
+    while ! (echo > /dev/tcp/127.0.0.1/"$port") 2>/dev/null; do
+        sleep 1
+        tries=$((tries - 1))
+        if [ "$tries" -le 0 ]; then
+            echo "FAIL: port $port did not open within 30 s"
+            return 1
+        fi
+    done
+}
+
+for port in $PORT_UPLOAD $PORT_FILE $PORT_AB $PORT_PROXY; do
+    wait_for_port "$port" || {
+        echo "--- log for port $port ---"
+        case $port in
+            $PORT_UPLOAD) cat "$LOGDIR/upload.log" ;;
+            $PORT_FILE)   cat "$LOGDIR/file.log" ;;
+            $PORT_AB)     cat "$LOGDIR/ab.log" ;;
+            $PORT_PROXY)  cat "$LOGDIR/proxy.log" ;;
+        esac
+        exit 1
+    }
+done
+
+# Failure surfaces: print the failing assertion + the most relevant
+# server log so triage doesn't need a re-run.
+fail() {
+    local label=$1 got=$2 want=$3 logfile=$4
+    echo "FAIL: $label"
+    echo "  got:  $got"
+    echo "  want: $want"
+    if [ -n "$logfile" ] && [ -s "$logfile" ]; then
+        echo "--- $logfile ---"
+        cat "$logfile"
+    fi
+    exit 1
+}
+
+eq() {
+    local label=$1 got=$2 want=$3 logfile=${4:-}
+    if [ "$got" != "$want" ]; then
+        fail "$label" "$got" "$want" "$logfile"
+    fi
+}
+
+mode_at() { curl -fsS "http://127.0.0.1:$1/api/v1/mode"; }
+
+echo "==> /api/v1/mode (all four)"
+mode=$(mode_at $PORT_UPLOAD)
+eq "upload mode loaded"      "$(echo "$mode" | jq -r .loaded)"       "false"    "$LOGDIR/upload.log"
+eq "upload mode url_loading" "$(echo "$mode" | jq -r .url_loading)"  "disabled" "$LOGDIR/upload.log"
+
+mode=$(mode_at $PORT_FILE)
+eq "file mode loaded"        "$(echo "$mode" | jq -r .loaded)"       "true"     "$LOGDIR/file.log"
+
+mode=$(mode_at $PORT_AB)
+eq "A/B compare_mode"        "$(echo "$mode" | jq -r .compare_mode)" "true"     "$LOGDIR/ab.log"
+
+mode=$(mode_at $PORT_PROXY)
+eq "proxy url_loading"       "$(echo "$mode" | jq -r .url_loading)"  "proxy"    "$LOGDIR/proxy.log"
+
+echo "==> /api/v1/sections returns navigation"
+sections=$(curl -fsS "http://127.0.0.1:$PORT_FILE/api/v1/sections")
+echo "$sections" | jq -e '.data.sections | length > 0' >/dev/null \
+    || fail "sections payload empty" "$sections" "non-empty .data.sections" "$LOGDIR/file.log"
+
+echo "==> /data/<section>.json returns groups"
+overview=$(curl -fsS "http://127.0.0.1:$PORT_FILE/data/overview.json")
+echo "$overview" | jq -e '.groups | length > 0' >/dev/null \
+    || fail "overview payload empty" "$(echo "$overview" | head -c 200)" "non-empty .groups" "$LOGDIR/file.log"
+
+echo "==> /api/v1/query_range returns matrix"
+rq=$(curl -fsS "http://127.0.0.1:$PORT_FILE/api/v1/query_range?query=cpu_cores&start=0&end=10000000000&step=60")
+eq "range query status" "$(echo "$rq" | jq -r .status)" "success" "$LOGDIR/file.log"
+
+echo "==> /api/v1/load_url forbidden when proxy disabled"
+lu=$(curl -fsS -X POST -H 'content-type: application/json' \
+     -d '{"url":"https://httpbin.org/bytes/100"}' \
+     "http://127.0.0.1:$PORT_UPLOAD/api/v1/load_url")
+eq "load_url forbidden envelope" "$(echo "$lu" | jq -r .errorType)" "forbidden" "$LOGDIR/upload.log"
+
+echo "==> /api/v1/load_url proxies when allowed (httpbin returns non-parquet → invalid_parquet)"
+# Network test: tolerate a transient httpbin outage by warning rather
+# than failing. The response shape (envelope with errorType) is what
+# we're really verifying.
+if lu=$(curl -fsS --max-time 10 -X POST -H 'content-type: application/json' \
+        -d '{"url":"https://httpbin.org/bytes/100"}' \
+        "http://127.0.0.1:$PORT_PROXY/api/v1/load_url"); then
+    eq "load_url proxied errorType" "$(echo "$lu" | jq -r .errorType)" "invalid_parquet" "$LOGDIR/proxy.log"
+else
+    echo "    (skipped: httpbin.org unreachable)"
+fi
+
+echo "==> POST /api/v1/captures/experiment attaches experiment"
+curl -fsS -X POST --data-binary @"$PARQUET_AB_B" \
+    -H 'Content-Type: application/octet-stream' \
+    -H "x-rezolus-filename: $(basename "$PARQUET_AB_B")" \
+    "http://127.0.0.1:$PORT_FILE/api/v1/captures/experiment" >/dev/null
+sleep 1
+mode=$(mode_at $PORT_FILE)
+eq "experiment attached → compare_mode" "$(echo "$mode" | jq -r .compare_mode)" "true" "$LOGDIR/file.log"
+
+echo "==> DELETE /api/v1/captures/experiment detaches"
+curl -fsS -X DELETE "http://127.0.0.1:$PORT_FILE/api/v1/captures/experiment" >/dev/null
+sleep 1
+mode=$(mode_at $PORT_FILE)
+eq "experiment detached → compare_mode" "$(echo "$mode" | jq -r .compare_mode)" "false" "$LOGDIR/file.log"
+
+echo "==> static assets respond 200"
+for path in / /about /lib/style.css; do
+    status=$(curl -fsS -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT_UPLOAD$path" || true)
+    eq "static $path" "$status" "200" "$LOGDIR/upload.log"
+done
+
+echo
+echo "ALL VIEWER SMOKE TESTS PASSED"


### PR DESCRIPTION
## Summary
Automates the manual smoke test we ran on PR #892. Spawns \`rezolus view\` in four configurations (upload-only, file, A/B file, proxy) against checked-in demo parquets, hits the public API endpoints, asserts the expected payload shapes, and exercises experiment attach/detach.

Adds:
- \`tests/viewer_smoke.sh\` — the runner.
- \`.claude/skills/viewer-smoke/SKILL.md\` — Claude Code skill so the agent can invoke + triage from inside a session via \`/viewer-smoke\`.

## What it covers
| Endpoint | Assertion |
|---|---|
| \`GET /api/v1/mode\` (×4) | \`loaded\` / \`compare_mode\` / \`url_loading\` flags match the startup config |
| \`GET /api/v1/sections\` | non-empty navigation list |
| \`GET /data/<section>.json\` | non-empty \`.groups\` (lazy-section payload) |
| \`GET /api/v1/query_range\` | \`status:"success"\` for a basic PromQL query |
| \`POST /api/v1/load_url\` (proxy off) | 403-equivalent envelope (\`errorType: "forbidden"\`) |
| \`POST /api/v1/load_url\` (proxy on) | non-parquet bytes → \`errorType: "invalid_parquet"\` |
| \`POST /api/v1/captures/experiment\` | flips \`compare_mode:true\` |
| \`DELETE /api/v1/captures/experiment\` | flips \`compare_mode:false\` |
| \`GET /\`, \`/about\`, \`/lib/style.css\` | all 200 |

## Out of scope
- Live mode (\`rezolus view <agent-url>\`) — needs an agent listener.
- Browser-rendered UI / compare-mode side-by-side rendering — payload-shape only here; visual regressions still need eyeball verification.

## Wiring (left for a follow-up so reviewers can decide)
Three options described in the skill body:
- **Per-PR CI**: add a job to \`.github/workflows/cargo.yml\` calling \`bash tests/viewer_smoke.sh\` after the build.
- **Per-commit local**: \`.git/hooks/pre-push\` calling the same script.
- **Per Claude Code session**: invoke \`/viewer-smoke\` directly, or wire a SessionStart / PostToolUse hook that watches \`src/viewer/**\`.

## Test plan
- [x] \`bash tests/viewer_smoke.sh\` passes locally on the rebuilt PR-892 binary
- [x] Script tolerates a transient httpbin.org outage (the proxy assertion warns and continues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)