### PR TITLE
feat(viewer): SelectionView mirrors live compare mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.12.2-alpha.5"
+version = "5.12.2-alpha.6"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.12.2-alpha.5"
+version = "5.12.2-alpha.6"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -513,6 +513,16 @@ const SectionContent = {
                 heatmapLoading,
                 stepOverride: currentGranularity,
                 onToggleHeatmap: toggleGlobalHeatmap,
+                // Compare-mode plumbing — SelectionView mirrors the
+                // current viewer state, so pinning in compare mode and
+                // visiting /selection renders the compare view.
+                compareMode,
+                anchors: selectionStore.anchors || { baseline: 0, experiment: 0 },
+                toggles: selectionStore.chartToggles || {},
+                setChartToggle,
+                experimentQueryRange,
+                baselineAlias,
+                experimentAlias,
             });
         }
 

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -3,6 +3,7 @@
 // Report: loaded from JSON import or parquet metadata (read-only mode).
 
 import { ChartsState, Chart } from './charts/chart.js';
+import { CompareChartWrapper } from './viewer_core.js';
 import { executePromQLRangeQuery, applyResultToPlot, buildEffectiveQuery, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from './data.js';
 import { notify, showSaveModal } from './overlays.js';
 import { isHistogramPlot } from './charts/metric_types.js';
@@ -575,6 +576,28 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
             selectionStore.entries.map((entry) => {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
+                // In compare mode, render through CompareChartWrapper so
+                // pinned charts mirror the live A/B view (side-by-side,
+                // diff, etc.). Service-template charts that lack a
+                // promql_query fall through to the single-capture path.
+                const captureLabels = {
+                    baseline: attrs.baselineAlias || 'baseline',
+                    experiment: attrs.experimentAlias || 'experiment',
+                };
+                const chartBody = (attrs.compareMode && spec.promql_query)
+                    ? m(CompareChartWrapper, {
+                        spec,
+                        chartsState: attrs.chartsState,
+                        interval,
+                        anchors: attrs.anchors,
+                        toggles: attrs.toggles,
+                        setChartToggle: attrs.setChartToggle,
+                        sectionRoute: '/selection',
+                        step: interval,
+                        experimentQueryRange: attrs.experimentQueryRange,
+                        captureLabels,
+                    })
+                    : m(Chart, { spec, chartsState: attrs.chartsState, interval });
                 return m('div.selection-card', [
                     m('div.selection-card-body', [
                         m('div.selection-card-chart', [
@@ -587,7 +610,7 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                                     m('span.chart-title', selectionCardTitle(entry, spec)),
                                     spec.opts.description && m('span.chart-subtitle', spec.opts.description),
                                 ]),
-                                m(Chart, { spec, chartsState: attrs.chartsState, interval }),
+                                chartBody,
                             ]),
                         ]),
                         m('div.selection-card-notes', [

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -300,7 +300,7 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
     })();
 };
 
-const CompareChartWrapper = {
+export const CompareChartWrapper = {
     oninit(vnode) {
         vnode.state.experimentResult = null;
         vnode.state.error = null;


### PR DESCRIPTION
## Summary
Closes the gap surfaced by recent review: pinning a chart in compare mode and visiting \`/selection\` was reverting to baseline-only because \`SelectionView\` always rendered through \`Chart\` directly, never through \`CompareChartWrapper\`. The toggles + anchors were already persisted in \`selectionStore\` — they just weren't being read.

This PR makes \`/selection\` reactive to the current viewer's compare state ("hybrid A" from the design discussion):

- **In compare mode** → pinned charts render side-by-side / overlay / diff, matching the live dashboard.
- **After detaching the experiment** → selection charts revert to baseline.
- **Toggling Diff inside a selection card** → updates \`selectionStore.chartToggles[chartId]\`, every chart with that id picks it up immediately (selection + main dashboard stay in sync).

## Changes
1. \`viewer_core.js\` — export \`CompareChartWrapper\`.
2. \`app.js\` — thread \`compareMode\` + \`anchors\` + \`toggles\` + \`setChartToggle\` + \`experimentQueryRange\` + \`baselineAlias\` + \`experimentAlias\` into the \`SelectionView\` mount, mirroring the props the \`Group\` factory already gets.
3. \`selection.js\` — in the per-entry render, dispatch on \`attrs.compareMode\`: when true and the spec has a \`promql_query\`, route through \`CompareChartWrapper\` with the same attrs the dashboard uses. Falls through to the single-capture \`Chart\` for service-template charts without a query.

No schema changes, no new APIs, no migration. \`SelectionView._loadCharts\` continues to fetch baseline data only — \`CompareChartWrapper\` does its own experiment fetch when mounted.

## Out of scope (PR 2)
\`ReportView\` intentionally stays single-capture. Reports get exported and shared, so a compare-aware report needs to capture an experiment file pointer (filename + checksum) at export time and re-attach on load. That's a schema bump (v3) plus the re-attach UX, big enough for its own PR.

## Test plan
- [x] \`cargo build --bin rezolus\` clean
- [x] \`bash tests/viewer_smoke.sh\` (10/10)
- [x] \`cargo test --bin rezolus\` (116/116)
- [ ] Visual: load baseline parquet → pin a chart → attach experiment → visit /selection → confirm pinned chart renders compare view (side-by-side or diff per the chart style)
- [ ] Visual: toggle \`Diff\` on a heatmap inside a selection card → confirm same chart in /blockio (or wherever pinned from) updates simultaneously
- [ ] Visual: detach experiment → confirm selection chart reverts to baseline rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)