### PR TITLE
ci(release): pin wasm-pack to ^0.14 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --version ^0.14 --locked
 
       - name: build wasm viewer
         run: ./crates/viewer/build.sh


### PR DESCRIPTION
## Summary

The 5.13.0 release build failed in `build-viewer-static` with:

```
error: the argument '--release' cannot be used with '--profile <PROFILE-NAME>'
full command: cargo build --lib --release --target wasm32-unknown-unknown --profile wasm-release
```

`release.yml` installed wasm-pack via `curl https://rustwasm.github.io/wasm-pack/installer/init.sh | sh`, which delivered a 0.13.x build. In that version, `--profile` is not a first-class wasm-pack flag — it gets forwarded as a trailing arg to cargo while wasm-pack still emits its default `--release`, producing the conflict above.

`cargo.yml` and `pages.yml` already install wasm-pack via `cargo install wasm-pack --version ^0.14 --locked`, which has native `--profile` support. This PR aligns `release.yml` with that pattern so `./crates/viewer/build.sh` succeeds during release.

## Test plan

- [ ] Re-run the release workflow (or tag a fresh `v*`) and confirm `build-viewer-static` completes and produces the viewer tarball.
- [ ] Spot-check that `cargo.yml` / `pages.yml` continue to pass on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_