### PR TITLE
Use cargo install for wasm-pack instead of shell script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: cargo install wasm-pack --version ^0.14 --locked
 
       - name: build wasm viewer
         run: ./crates/viewer/build.sh


### PR DESCRIPTION
## Problem

The current release workflow installs `wasm-pack` by downloading and executing a shell script from the internet. This approach has several drawbacks:
- It's less reproducible and harder to pin to a specific version
- Shell script execution can be slower and less reliable
- It doesn't integrate well with Rust tooling conventions

## Solution

Replace the shell script installation method with `cargo install wasm-pack --version ^0.14 --locked`, which:
- Uses Cargo's standard package installation mechanism
- Pins the version to `^0.14` (compatible with 0.14.x releases)
- Uses `--locked` to ensure reproducible builds with locked dependency versions
- Integrates better with the existing Rust toolchain

## Result

The `wasm-pack` installation in the release workflow will be more reliable, reproducible, and maintainable while maintaining compatibility with the 0.14.x version series.

https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y