### PR TITLE
release: re-prep v5.13.0 (revert alpha bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.0"
+version = "5.13.0"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.0"
+version = "5.13.0"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Summary

The original v5.13.0 release tagged `7e69d4b`, but `build-viewer-static` in `release.yml` failed (`--release cannot be used with --profile`). #896 fixed that on main. Between the original tag and the fix, the version was already bumped to `5.13.1-alpha.0` (commit `0ed9251`).

This PR reverts the alpha bump so the tree sits at version `5.13.0` again, **on a commit that includes the wasm-pack fix**. Once merged, the `v5.13.0` tag is moved to the merge commit and the release workflow re-runs from a green state.

## Follow-up after release

Re-bump to `5.13.1-alpha.0` (single revert of this PR's revert, or run the usual post-release bump tool) so `main` resumes its development trajectory.

## Test plan

- [x] CI green on this PR (build/clippy/wasm-viewer pass).
- [x] Confirm `Cargo.toml`/`Cargo.lock` show `5.13.0` on the merge commit.
- [ ] After merge: move `v5.13.0` tag to the merge commit, push, and watch `release.yml` complete (especially `build-viewer-static`).
- [ ] Open follow-up PR re-bumping to `5.13.1-alpha.0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_