### PR TITLE
debian: use clang for cargo build to skirt aws-lc-sys gcc check

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,7 @@ override_dh_auto_configure:
 	bash debian/cargo/create-config.sh > debian/cargo_home/config.toml
 
 override_dh_auto_build:
-	$(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
+	CC=clang CXX=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
 
 override_dh_auto_install:
 	@mkdir -p debian/tmp/bin


### PR DESCRIPTION
## Summary

The 5.13.0 release deb build fails on older distros (Ubuntu Focal, Debian Bullseye) with:

```
### COMPILER BUG DETECTED ###
Your compiler (x86_64-linux-gnu-gcc) is not supported due to a memcmp related bug
reported in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189.
```

`aws-lc-sys 0.40.0` (pulled in transitively via `reqwest → rustls → aws-lc-rs`) added an unconditional panic when it detects a gcc affected by that bug (fixed upstream in gcc 11.3). Focal ships gcc 9.4 and Bullseye ships gcc 10.2, so both trip the check.

`clang` is already in `debian/control` as a build dependency (it's used for BPF compilation), so it's installed in every container. Pointing `CC`/`CXX` at it for the cargo build routes cc-rs based C compilation (aws-lc-sys, libbpf-sys, etc.) through clang, which doesn't have this bug and isn't blocked by the check. Modern distros are unaffected — they already had a working compiler and just swap to clang.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, move `v5.13.0` tag to the merge commit, push, and watch `release.yml` produce all deb artifacts (especially `build-ubuntu-focal-x86_64`, `build-debian-bullseye-x86_64`, `build-debian-bullseye-arm64`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_