### PR TITLE
debian: override CC per-target so aws-lc-sys actually sees clang

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,7 @@ override_dh_auto_configure:
 	bash debian/cargo/create-config.sh > debian/cargo_home/config.toml
 
 override_dh_auto_build:
-	CC=clang CXX=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
+	CC_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang CXX_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
 
 override_dh_auto_install:
 	@mkdir -p debian/tmp/bin


### PR DESCRIPTION
## Summary

#899 set `CC=clang` in `override_dh_auto_build`, but the deb build for v5.13.0 still tripped the aws-lc-sys gcc 95189 panic on Focal/Bullseye. Root cause: cc-rs's compiler env-var precedence is

1. `CC_<target>` — e.g. `CC_x86_64-unknown-linux-gnu`
2. `CC_<target_underscore>` — e.g. `CC_x86_64_unknown_linux_gnu`
3. `HOST_CC` / `TARGET_CC`
4. `CC`

`debian/cargo/cross-compile.mk:18` exports `HOST_CC=$(CC_FOR_BUILD)` (gcc), which outranks our recipe-local `CC=clang`. So cc-rs kept resolving to `x86_64-linux-gnu-gcc` and aws-lc-sys's runtime memcmp check still panicked.

Set the per-target form `CC_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang` (and `CXX`) instead. That's at the top of cc-rs's lookup chain and isn't shadowed by `HOST_CC`. For the amd64 build the var name is `CC_x86_64_unknown_linux_gnu`; for arm64 it's `CC_aarch64_unknown_linux_gnu`.

## Test plan

- [ ] CI green.
- [ ] After merge, retag `v5.13.0` and re-run release. Watch the previously-failing matrix cells (Ubuntu Focal x86_64, Debian Bullseye x86_64/arm64) get past the aws-lc-sys compile step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_