### PR TITLE
debian: override TARGET_CC/HOST_CC too — aws-lc-sys ignores CC_&lt;triple&gt;

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,7 @@ override_dh_auto_configure:
 	bash debian/cargo/create-config.sh > debian/cargo_home/config.toml
 
 override_dh_auto_build:
-	CC_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang CXX_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
+	HOST_CC=clang HOST_CXX=clang++ TARGET_CC=clang TARGET_CXX=clang++ CC_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang CXX_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
 
 override_dh_auto_install:
 	@mkdir -p debian/tmp/bin


### PR DESCRIPTION
## Summary

#900 set `CC_$(triple)=clang` (cc-rs's top-priority env var) but the deb build still tripped the gcc 95189 panic. The aws-lc-sys build script log explains why — it doesn't follow cc-rs's precedence:

```
warning: aws-lc-sys@0.40.0: Environment Variable found 'TARGET_CC': 'x86_64-linux-gnu-gcc'
warning: aws-lc-sys@0.40.0: Environment Variable found 'CC_x86_64_unknown_linux_gnu': 'clang'
warning: aws-lc-sys@0.40.0: Setting CC_x86_64_unknown_linux_gnu: x86_64-linux-gnu-gcc
```

It finds both variables, then **clobbers** `CC_<triple>` with `TARGET_CC`'s value. `debian/cargo/cross-compile.mk:14` exports `TARGET_CC := $(CC)` (= `x86_64-linux-gnu-gcc`), so it lands back on the buggy gcc.

This PR also overrides `TARGET_CC` and `HOST_CC` (the latter because cc-rs prefers `HOST_CC` over `CC` when host == target) in the same recipe. With every plausible compiler env var pointing at clang, neither cc-rs nor aws-lc-sys's hand-rolled precedence can fall back to gcc.

## Test plan

- [ ] CI green.
- [ ] After merge, retag `v5.13.0` and watch the focal x86_64 / bullseye x86_64+arm64 deb jobs get past aws-lc-sys.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_