### PR TITLE
debian: narrow clang override to TARGET_CC only

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,7 @@ override_dh_auto_configure:
 	bash debian/cargo/create-config.sh > debian/cargo_home/config.toml
 
 override_dh_auto_build:
-	HOST_CC=clang HOST_CXX=clang++ TARGET_CC=clang TARGET_CXX=clang++ CC_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang CXX_$(subst -,_,$(DEB_HOST_RUST_TYPE))=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
+	TARGET_CC=clang TARGET_CXX=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
 
 override_dh_auto_install:
 	@mkdir -p debian/tmp/bin


### PR DESCRIPTION
## Summary

#901 got the deb build past `aws-lc-sys` on focal/bullseye x86_64 by routing everything (`HOST_CC`, `TARGET_CC`, `CC_<triple>`) through clang. That broke bullseye **arm64**'s host-side build:

```
/usr/bin/ld: cargo_target/release/deps/libvsprintf-*.rlib:
  error adding symbols: file format not recognized
```

Bullseye's GNU ld can't index the rlib produced when clang is the host C compiler.

The gcc 95189 memcmp bug only manifests on x86_64 — arm64 was building fine with plain gcc-10 from the start. And per the aws-lc-sys log:

```
Environment Variable found 'TARGET_CC': 'x86_64-linux-gnu-gcc'
Setting CC_x86_64_unknown_linux_gnu: x86_64-linux-gnu-gcc
```

aws-lc-sys reads `TARGET_CC` and uses it to clobber `CC_<triple>` for its own cc-rs lookup. So `TARGET_CC=clang` alone gets aws-lc-sys onto clang, while leaving cc-rs's normal host-side chain on the distro's default gcc — so `vsprintf` etc. archive correctly on bullseye arm64.

## Test plan

- [ ] CI green.
- [ ] After merge, retag `v5.13.0` and watch *all* deb matrix cells finish — both the previously-failing x86_64 jobs (focal, bullseye) **and** the newly-failing bullseye arm64 job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_