### PR TITLE
debian: install non-buggy gcc on bullseye/focal

### DIFF
--- a/debian/package.sh
+++ b/debian/package.sh
@@ -119,6 +119,35 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get -q update
 apt-get -q install -y build-essential curl jq lsb-release unzip gpg
 
+# aws-lc-sys 0.40 hard-panics on gcc < 11.3 (gcc bug 95189: memcmp). Debian
+# bullseye ships gcc 10 and Ubuntu focal ships gcc 9, so pull a newer gcc on
+# those releases and point `gcc`/`g++`/`<triple>-gcc`/`<triple>-g++` at it
+# via update-alternatives. Everywhere else, the distro's default gcc is fine.
+TRIPLE=$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)
+upgrade_gcc() {
+    local v="$1"
+    update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-$v" 100
+    update-alternatives --install /usr/bin/g++ g++ "/usr/bin/g++-$v" 100
+    update-alternatives --install "/usr/bin/$TRIPLE-gcc" "$TRIPLE-gcc" "/usr/bin/gcc-$v" 100
+    update-alternatives --install "/usr/bin/$TRIPLE-g++" "$TRIPLE-g++" "/usr/bin/g++-$v" 100
+}
+case "$(lsb_release -cs)" in
+    bullseye)
+        echo "deb http://deb.debian.org/debian bullseye-backports main" \
+            > /etc/apt/sources.list.d/backports.list
+        apt-get -q update
+        apt-get -q install -y -t bullseye-backports gcc-12 g++-12
+        upgrade_gcc 12
+        ;;
+    focal)
+        apt-get -q install -y software-properties-common
+        add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        apt-get -q update
+        apt-get -q install -y gcc-11 g++-11
+        upgrade_gcc 11
+        ;;
+esac
+
 nextgroup install rust
 curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
 . "$HOME/.cargo/env"

--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,7 @@ override_dh_auto_configure:
 	bash debian/cargo/create-config.sh > debian/cargo_home/config.toml
 
 override_dh_auto_build:
-	TARGET_CC=clang TARGET_CXX=clang++ $(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
+	$(CARGO) build --target $(DEB_HOST_RUST_TYPE) --profile $(PROFILE) --bins $(CARGOFLAGS)
 
 override_dh_auto_install:
 	@mkdir -p debian/tmp/bin


### PR DESCRIPTION
## Summary

aws-lc-sys 0.40 runs a memcmp test program at build time and panics on any gcc affected by [gcc 95189](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189) (fixed in gcc 11.3). Bullseye ships gcc 10.2 and focal ships gcc 9.4, so both trip the check.

#899–#902 tried to route those builds through clang via `CC` env vars. That ended up splitting the toolchain — clang compiles C, GNU `ar` archives, GNU `ld` links — and downstream rlib reads kept choking on the result (`libvsprintf` rejected on bullseye arm64 under #901, `libaws_lc_sys` rejected on jammy under #902, both with `error adding symbols: file format not recognized`).

Going around the bug instead of trying to use a buggy compiler:

- Reverts `TARGET_CC=clang` in `debian/rules` — the toolchain is uniform gcc again.
- `debian/package.sh` installs a non-buggy gcc on the two affected releases:
  - **bullseye** → enable `bullseye-backports`, install `gcc-12`/`g++-12`.
  - **focal** → add `ppa:ubuntu-toolchain-r/test`, install `gcc-11`/`g++-11`.
- `update-alternatives` points `gcc`, `g++`, `<triple>-gcc`, and `<triple>-g++` at the new version, so both `create-config.sh`'s `-Clinker=<triple>-gcc` and cc-rs's defaults resolve to the patched gcc with no further env-var fiddling.

Other distros (bookworm, jammy, noble, trixie) already ship gcc ≥ 11.3 and aren't touched.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, retag `v5.13.0` and watch the full deb matrix complete — especially the three jobs that have been failing across attempts: focal x86_64, bullseye x86_64/arm64, and jammy x86_64/arm64.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_