### PR TITLE
cargo: switch rustls crypto provider from aws-lc-rs to ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,28 +410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,15 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,12 +995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,12 +1114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,10 +1226,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1282,11 +1237,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2065,12 +2018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "lz4_flex"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,15 +2592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2739,62 +2677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,35 +2696,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "rayon"
@@ -2923,7 +2776,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2988,6 +2840,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "rustfft",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -3048,12 +2901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,8 +2942,9 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3121,7 +2969,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -3158,7 +3005,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3650,21 +3496,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4183,16 +4014,6 @@ name = "web-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,13 @@ rayon = "1.12"
 regex = "1"
 reqwest = { version = "0.13.3", default-features = false, features = [
     "blocking",
-    "rustls",
+    "rustls-no-provider",
+] }
+rustls = { version = "0.23", default-features = false, features = [
+    "logging",
+    "ring",
+    "std",
+    "tls12",
 ] }
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/debian/package.sh
+++ b/debian/package.sh
@@ -119,35 +119,6 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get -q update
 apt-get -q install -y build-essential curl jq lsb-release unzip gpg
 
-# aws-lc-sys 0.40 hard-panics on gcc < 11.3 (gcc bug 95189: memcmp). Debian
-# bullseye ships gcc 10 and Ubuntu focal ships gcc 9, so pull a newer gcc on
-# those releases and point `gcc`/`g++`/`<triple>-gcc`/`<triple>-g++` at it
-# via update-alternatives. Everywhere else, the distro's default gcc is fine.
-TRIPLE=$(dpkg-architecture -qDEB_BUILD_GNU_TYPE)
-upgrade_gcc() {
-    local v="$1"
-    update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-$v" 100
-    update-alternatives --install /usr/bin/g++ g++ "/usr/bin/g++-$v" 100
-    update-alternatives --install "/usr/bin/$TRIPLE-gcc" "$TRIPLE-gcc" "/usr/bin/gcc-$v" 100
-    update-alternatives --install "/usr/bin/$TRIPLE-g++" "$TRIPLE-g++" "/usr/bin/g++-$v" 100
-}
-case "$(lsb_release -cs)" in
-    bullseye)
-        echo "deb http://deb.debian.org/debian bullseye-backports main" \
-            > /etc/apt/sources.list.d/backports.list
-        apt-get -q update
-        apt-get -q install -y -t bullseye-backports gcc-12 g++-12
-        upgrade_gcc 12
-        ;;
-    focal)
-        apt-get -q install -y software-properties-common
-        add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        apt-get -q update
-        apt-get -q install -y gcc-11 g++-11
-        upgrade_gcc 11
-        ;;
-esac
-
 nextgroup install rust
 curl -sSf https://sh.rustup.rs | sh /dev/stdin -y
 . "$HOME/.cargo/env"

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,10 @@ fn main() {
         std::process::exit(101);
     }));
 
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls ring crypto provider");
+
     let cli = Command::new(env!("CARGO_BIN_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .long_about("Rezolus provides high-resolution systems performance telemetry.")


### PR DESCRIPTION
## Summary

Switches the rustls crypto provider from `aws-lc-rs` to `ring`. Drops `aws-lc-sys` / `aws-lc-rs` from the dependency tree entirely, along with `quinn-proto`, `quinn-udp`, and ~15 other crates that came in via the aws-lc-rs / quinn-rustls path. Net result: ~150 fewer entries in `Cargo.lock` and a smaller, faster, less-fragile build.

### Motivation

- **#899–#903 chronicled the cost of carrying aws-lc-sys.** Its 0.40 release added a runtime memcmp self-test that hard-panics on gcc affected by [gcc 95189](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189) (fixed in gcc 11.3), which broke deb builds on bullseye + focal. Routing those builds through clang split the toolchain and produced unreadable rlibs; #903 installed newer gcc from bullseye-backports / `ubuntu-toolchain-r`, but **bullseye-backports has stopped serving a Release file** ("does not have a Release file" from `deb.debian.org`) so #903's workaround was already broken. (Backports for Debian oldstable migrate to `archive.debian.org` as the release winds down.)
- **We don't need aws-lc-rs's tradeoffs.** It exists to enable FIPS 140-3 certification and squeeze a few percent of perf out of x86_64 AES-NI. Rezolus is an observability agent; its TLS client doesn't ship into FedRAMP environments and isn't on a TLS-throughput hot path.
- **ring is the historically dominant Rust crypto provider.** Used by rustls for years before the 0.23 default flip, by Cloudflare's stack, by hyper, by quinn deployments, by deno, etc. Pure Rust + targeted asm, no large C codebase, no symbol-prefix post-processing, no compiler self-tests.

### Changes

- `Cargo.toml`: switch reqwest's `rustls` feature to `rustls-no-provider` (the `rustls` feature is hardwired to enable `__rustls-aws-lc-rs`), and add a direct `rustls = { default-features = false, features = ["ring", "logging", "std", "tls12"] }` dep.
- `src/main.rs`: install `rustls::crypto::ring::default_provider()` as the default before any TLS handshake.
- `debian/package.sh`: revert #903's gcc upgrade — bullseye's gcc 10.2 and focal's gcc 9.4 are perfectly capable now that there's no aws-lc-sys to compile.
- `Cargo.lock`: −182/+3 lines; ~16 crates removed.

### Verification

- `cargo tree -i aws-lc-rs` → empty.
- `grep aws-lc Cargo.lock` → 0 hits.
- `cargo check --bins` → clean.
- `cargo clippy --bins` → no new warnings.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, retag `v5.13.0` and watch the full deb matrix complete, including focal x86_64 and bullseye x86_64/arm64.
- [ ] Smoke test the recorder against an HTTPS Prometheus endpoint (the only path that actually exercises rustls).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_