### PR TITLE
ci(release): find viewer tarball regardless of download nesting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,11 +468,12 @@ jobs:
             mv "$artifact" "target/release-artifacts/${distro}_${version}_${arch}_${name}"
           done
 
-          # Collect static viewer bundle
-          for artifact in target/viewer-static/viewer-static/*.tar.gz; do
-            [ -f "$artifact" ] || continue
-            mv "$artifact" "target/release-artifacts/$(basename "$artifact")"
-          done
+          # Collect static viewer bundle. `actions/download-artifact@v5` with
+          # `pattern:` nests files under `<path>/<artifact_name>/...`, but
+          # `upload-artifact`'s preserved relative path can add extra levels.
+          # `find` locates the tarball regardless of how deep it lands.
+          find target/viewer-static -type f -name 'rezolus-viewer-*.tar.gz' \
+            -exec mv -t target/release-artifacts/ {} +
 
       - name: generate checksums and sign release artifacts
         env:


### PR DESCRIPTION
## Summary

v5.13.0 published 28 deb/rpm/checksum assets but skipped `rezolus-viewer-v5.13.0.tar.gz`. The `build-viewer-static` job ran and uploaded a `viewer-static` artifact successfully (the run shows 16 artifacts = 11 deb + 4 rpm + 1 viewer-static), but the publish job's collection step never moved it into `target/release-artifacts/`.

The offending block:

```bash
for artifact in target/viewer-static/viewer-static/*.tar.gz; do
    [ -f "$artifact" ] || continue
    mv "$artifact" "target/release-artifacts/$(basename "$artifact")"
done
```

This glob assumes `actions/download-artifact@v5` with `pattern: viewer-static` puts the tarball at exactly two levels of nesting (`<path>/<artifact_name>/<file>`), which itself assumes `upload-artifact`'s preserved relative path collapses to just the basename. If either assumption breaks the loop is a silent no-op thanks to the `[ -f ] || continue` guard.

Replaces it with `find target/viewer-static -name 'rezolus-viewer-*.tar.gz' -exec mv ...` so the file gets picked up regardless of where the download action chose to drop it. Deb/rpm collection is unchanged — those happen to match the assumed layout and have been working since #885.

## Test plan

- [ ] CI green on this PR.
- [ ] Cut a fresh patch release (or re-tag), confirm `rezolus-viewer-vX.Y.Z.tar.gz` appears on the GitHub release.
- [ ] Confirm SHA256SUMS includes the viewer tarball line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_