### PR TITLE
chore: begin next development iteration (5.13.1-alpha.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.0"
+version = "5.13.1-alpha.0"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.0"
+version = "5.13.1-alpha.0"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Summary

Standard post-release version bump. v5.13.0 has shipped, so `main` moves to `5.13.1-alpha.0` to keep the development trajectory going (matches the pattern from `0ed9251` after the original v5.13.0 prep, before the redo cycle reverted it).

Touches `Cargo.toml` and `Cargo.lock` only.

## Test plan

- [ ] CI green on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD42w778EpqJ3Fuz13j79y)_