### PR TITLE
cargo: drop brotli, trim parquet codecs to zstd-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
- "zlib-rs",
 ]
 
 [[package]]
@@ -1981,15 +1980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,17 +2385,14 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
- "flate2",
  "half",
  "hashbrown 0.17.1",
- "lz4_flex",
  "num-bigint",
  "num-integer",
  "num-traits",
  "paste",
  "seq-macro",
  "simdutf8",
- "snap",
  "thrift",
  "twox-hash",
  "zstd",
@@ -3196,12 +3183,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -4487,12 +4468,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,21 +56,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,27 +501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,7 +693,6 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
- "brotli",
  "compression-core",
  "flate2",
  "memchr",
@@ -2095,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1a586456ded17d177121d843c2d9e31388731f4384280e99f70bf9a3e4296a"
+checksum = "01819b48e04904d3116bda74c380de43c3593d8c38fb870361b4d219ba61440d"
 dependencies = [
  "arrow",
  "chrono",
@@ -2110,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b0fec1e93a38ec9970a55a3bf8c9b87a08fcadb79910cd0df89de501fa4f30"
+checksum = "a2b0678fc7aff2da892a0fac28bce992ca023548e05ccf4c0e2301a93fff551d"
 dependencies = [
  "arrow",
  "bytes",
@@ -2430,7 +2393,6 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "base64",
- "brotli",
  "bytes",
  "chrono",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,18 +63,14 @@ linkme = "0.3.36"
 memmap2 = "0.9.10"
 metriken.workspace = true
 metriken-exposition.workspace = true
-metriken-query = { workspace = true, features = ["ingest", "lz4"] }
+metriken-query = { workspace = true, features = ["ingest"] }
 notify = "8.2.0"
 open = "5.3.4"
 ouroboros = "0.18.5"
 parking_lot = "0.12.5"
 parquet = { version = "58.2.0", default-features = false, features = [
     "arrow",
-    "base64",
-    "flate2-zlib-rs",
-    "lz4",
     "simdutf8",
-    "snap",
     "zstd",
 ] }
 prometheus-parse = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,15 @@ notify = "8.2.0"
 open = "5.3.4"
 ouroboros = "0.18.5"
 parking_lot = "0.12.5"
-parquet = "58.2.0"
+parquet = { version = "58.2.0", default-features = false, features = [
+    "arrow",
+    "base64",
+    "flate2-zlib-rs",
+    "lz4",
+    "simdutf8",
+    "snap",
+    "zstd",
+] }
 prometheus-parse = "0.2.5"
 plain = "0.2.3"
 rayon = "1.12"
@@ -109,8 +117,10 @@ tokio = { version = "1.52.2", features = [
 toml = "1.1.2"
 tower = { version = "0.5.3", features = ["tokio"] }
 tower-http = { version = "0.6.8", features = [
-    "compression-full",
-    "decompression-full",
+    "compression-gzip",
+    "compression-zstd",
+    "decompression-gzip",
+    "decompression-zstd",
     "fs",
 ] }
 tower-livereload = "0.10.3"


### PR DESCRIPTION
## Summary

Removes the `brotli` crate from the dependency graph and trims `parquet`'s codec set to just what we use.

### Changes

- **`tower-http`** — replace `compression-full`/`decompression-full` with `compression-{gzip,zstd}` + `decompression-{gzip,zstd}`. HTTP content-encoding negotiation now offers zstd to clients that advertise it (modern browsers, Chrome 123+/Firefox 126+/Safari 18.4+) and falls back to gzip otherwise. The only regression is a small transfer-size increase for clients that supported `br` but not `zstd` — mostly older Safari and a few headless tools. No correctness impact.
- **`parquet`** — switch to `default-features = false`, enable only `arrow`, `simdutf8`, `zstd`. We control both the write path (`rezolus record`, `hindsight`, `parquet combine` — all use `Compression::ZSTD`) and the read path, and never produce or consume `snap`/`lz4`/`flate2`/`brotli`-compressed parquet.
- **`metriken-query`** — drop the `lz4` feature; nothing references it.
- Picks up `metriken-exposition 0.16.1` and `metriken-query 0.10.3`, which dropped their parquet/brotli features upstream so `cargo tree -i brotli` returns no matches.

### Why bother

`brotli` is a pure-Rust port (~30k LOC across `brotli` + `brotli-decompressor` + `alloc-{std,no-std}lib`) carrying a ~120KB embedded static dictionary, plus the codec is included transitively through both `tower-http` and `parquet`. `zstd` is a thin FFI wrapper over the upstream C lib, so the brotli removal pays for itself in compile time and binary size with no functional loss for our usage pattern.

### Measurements (serialized clean builds, this machine, x86_64)

| Profile | Metric | main | PR | Δ |
|---|---|---|---|---|
| **debug** | wall | 137.3 s | 137.9 s | +0.7 s (noise) |
| | user CPU | 377.7 s | 375.8 s | −1.9 s (noise) |
| | binary | 393.4 MB | 383.1 MB | **−10.3 MB (−2.6%)** |
| | `target/` | 2690 MB | 2640 MB | **−50 MB (−1.9%)** |
| **release** (LTO) | wall | 696.5 s | 641.4 s | **−55.1 s (−7.9%)** |
| | user CPU | 1250.5 s | 1188.9 s | **−61.7 s (−4.9%)** |
| | binary (unstripped) | 240.4 MB | 231.0 MB | **−9.4 MB (−3.9%)** |
| | `target/` | 2011 MB | 1971 MB | **−40 MB (−2.0%)** |
| | stripped binary¹ | 22.2 MB | 20.6 MB | **−1.6 MB (−7.2%)** |

¹ what actually ships in deb/rpm — `dh_strip` and `rpmbuild`'s default `__os_install_post` strip the binary before packaging. The deb path also produces a separate `-dbgsym.ddeb` containing the debug symbols.

### Test plan

- [x] `cargo tree -i brotli` → no matches
- [x] `cargo check` succeeds
- [x] Clean release build succeeds on Linux
- [x] CI green
- [ ] Spot-check viewer/exporter HTTP responses still negotiate compression correctly