### PR TITLE
feat(viewer): SelectionView mirrors live compare mode (resolves #894)

### DIFF
--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -513,6 +513,16 @@ const SectionContent = {
                 heatmapLoading,
                 stepOverride: currentGranularity,
                 onToggleHeatmap: toggleGlobalHeatmap,
+                // Compare-mode plumbing — SelectionView mirrors the
+                // current viewer state, so pinning in compare mode and
+                // visiting /selection renders the compare view.
+                compareMode,
+                anchors: selectionStore.anchors || { baseline: 0, experiment: 0 },
+                toggles: selectionStore.chartToggles || {},
+                setChartToggle,
+                experimentQueryRange,
+                baselineAlias,
+                experimentAlias,
             });
         }
 

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -3,6 +3,7 @@
 // Report: loaded from JSON import or parquet metadata (read-only mode).
 
 import { ChartsState, Chart } from './charts/chart.js';
+import { CompareChartWrapper } from './viewer_core.js';
 import { executePromQLRangeQuery, applyResultToPlot, buildEffectiveQuery, CAPTURE_BASELINE, CAPTURE_EXPERIMENT } from './data.js';
 import { notify, showSaveModal } from './overlays.js';
 import { isHistogramPlot } from './charts/metric_types.js';
@@ -575,6 +576,28 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
             selectionStore.entries.map((entry) => {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
+                // In compare mode, render through CompareChartWrapper so
+                // pinned charts mirror the live A/B view (side-by-side,
+                // diff, etc.). Service-template charts that lack a
+                // promql_query fall through to the single-capture path.
+                const captureLabels = {
+                    baseline: attrs.baselineAlias || 'baseline',
+                    experiment: attrs.experimentAlias || 'experiment',
+                };
+                const chartBody = (attrs.compareMode && spec.promql_query)
+                    ? m(CompareChartWrapper, {
+                        spec,
+                        chartsState: attrs.chartsState,
+                        interval,
+                        anchors: attrs.anchors,
+                        toggles: attrs.toggles,
+                        setChartToggle: attrs.setChartToggle,
+                        sectionRoute: '/selection',
+                        step: interval,
+                        experimentQueryRange: attrs.experimentQueryRange,
+                        captureLabels,
+                    })
+                    : m(Chart, { spec, chartsState: attrs.chartsState, interval });
                 return m('div.selection-card', [
                     m('div.selection-card-body', [
                         m('div.selection-card-chart', [
@@ -587,7 +610,7 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                                     m('span.chart-title', selectionCardTitle(entry, spec)),
                                     spec.opts.description && m('span.chart-subtitle', spec.opts.description),
                                 ]),
-                                m(Chart, { spec, chartsState: attrs.chartsState, interval }),
+                                chartBody,
                             ]),
                         ]),
                         m('div.selection-card-notes', [

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -300,7 +300,7 @@ const kickOffSpectrumFetch = (vnode, spec, kind) => {
     })();
 };
 
-const CompareChartWrapper = {
+export const CompareChartWrapper = {
     oninit(vnode) {
         vnode.state.experimentResult = null;
         vnode.state.error = null;


### PR DESCRIPTION
Supersedes #894 with the merge conflict resolved against current `main`.

## Conflict resolution
The original PR bumped `version` in `Cargo.toml`/`Cargo.lock` from `5.12.2-alpha.5` → `5.12.2-alpha.6`. Since then the crate has been bumped on `main` to `5.13.1-alpha.0` via the release cycle, so the version-bump portion of #894 is now stale. Resolution: keep `main`'s `5.13.1-alpha.0` and drop the alpha.6 bump.

The remaining viewer changes (`app.js`, `selection.js`, `viewer_core.js`) auto-merged cleanly and were verified to still match the current code shape:

- `app.js`: the `SectionContent` mount point still threads the same `compareMode` / `anchors` / `toggles` / `setChartToggle` / `experimentQueryRange` / `baselineAlias` / `experimentAlias` props in `app.js:443-447` and `app.js:110-117` — adding them at the `SelectionView` call site (`app.js:519-525`) keeps `/selection` reactive.
- `selection.js`: still imports `Chart` from `./charts/chart.js`; adding `CompareChartWrapper` from `./viewer_core.js` and dispatching on `attrs.compareMode && spec.promql_query` matches the same wrapper signature used by the dashboard section render (`viewer_core.js:513-527`).
- `viewer_core.js`: `CompareChartWrapper` now `export`ed.

## Verification
- `node --check` on all three modified JS files passes.
- `node --test tests/*.mjs` — 64/65 pass; the one failure (`wasm_viewer_histogram_kpis`) needs `./crates/viewer/build.sh` to run first and is unrelated to this change.
- Full Rust build was not exercised in this environment (libelf headers missing), but the patch touches only JS viewer assets, not Rust sources.

Original PR description follows for visual-testing context:

---

## Summary
Closes the gap surfaced by recent review: pinning a chart in compare mode and visiting `/selection` was reverting to baseline-only because `SelectionView` always rendered through `Chart` directly, never through `CompareChartWrapper`. The toggles + anchors were already persisted in `selectionStore` — they just weren't being read.

This PR makes `/selection` reactive to the current viewer's compare state ("hybrid A" from the design discussion):

- **In compare mode** → pinned charts render side-by-side / overlay / diff, matching the live dashboard.
- **After detaching the experiment** → selection charts revert to baseline.
- **Toggling Diff inside a selection card** → updates `selectionStore.chartToggles[chartId]`, every chart with that id picks it up immediately (selection + main dashboard stay in sync).

## Changes
1. `viewer_core.js` — export `CompareChartWrapper`.
2. `app.js` — thread `compareMode` + `anchors` + `toggles` + `setChartToggle` + `experimentQueryRange` + `baselineAlias` + `experimentAlias` into the `SelectionView` mount, mirroring the props the `Group` factory already gets.
3. `selection.js` — in the per-entry render, dispatch on `attrs.compareMode`: when true and the spec has a `promql_query`, route through `CompareChartWrapper` with the same attrs the dashboard uses. Falls through to the single-capture `Chart` for service-template charts without a query.

No schema changes, no new APIs, no migration. `SelectionView._loadCharts` continues to fetch baseline data only — `CompareChartWrapper` does its own experiment fetch when mounted.

## Test plan
- [ ] Visual: load baseline parquet → pin a chart → attach experiment → visit /selection → confirm pinned chart renders compare view (side-by-side or diff per the chart style)
- [ ] Visual: toggle `Diff` on a heatmap inside a selection card → confirm same chart in /blockio (or wherever pinned from) updates simultaneously
- [ ] Visual: detach experiment → confirm selection chart reverts to baseline rendering


---
_Generated by [Claude Code](https://claude.ai/code/session_018dHYBT2CquT1CBJ8nKtrjV)_