### PR TITLE
feat(viewer): Notebook / Selection / Report rework (PR 2 of 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.0"
+version = "5.13.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.0"
+version = "5.13.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -523,6 +523,8 @@ const SectionContent = {
                 experimentQueryRange,
                 baselineAlias,
                 experimentAlias,
+                // TODO PR 3: set true when loaded parquet has ab_containers metadata
+                combinedAB: false,
             });
         }
 

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -9,7 +9,7 @@ import { TopNav, Sidebar, countCharts, formatSize } from './layout.js';
 import { collectGroupPlots } from './group_utils.js';
 import { CpuTopology } from './topology.js';
 import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, setStepOverride, getStepOverride, setSelectedNode, setSelectedInstance, getSelectedNode, injectLabel, CAPTURE_EXPERIMENT } from './data.js';
-import { reportStore, selectionStore, persistSelection, setStorageScope, loadPayloadIntoStore, SelectionView, ReportView, setChartToggle as setChartToggleInStore, setAnchor } from './selection.js';
+import { reportStore, notebookStore, persistNotebook, setStorageScope, loadPayloadIntoStore, NotebookView, ReportView, setChartToggle as setChartToggleInStore, setAnchor } from './selection.js';
 import { SaveModal } from './overlays.js';
 import { ViewerApi } from './viewer_api.js';
 import { createSystemInfoView, createMetadataView, renderCgroupSection } from './section_views.js';
@@ -84,7 +84,7 @@ let experimentAlias = null;
 export const getBaselineAlias = () => baselineAlias;
 export const getExperimentAlias = () => experimentAlias;
 
-// Compare-mode per-chart toggles + anchors live in `selectionStore` so
+// Compare-mode per-chart toggles + anchors live in `notebookStore` so
 // they persist across page reloads. See selection_migration.js for the
 // schema. The accessors below read-through to the store.
 
@@ -109,9 +109,9 @@ const initComponents = () => {
     Group = createGroupComponent(() => ({
         chartsState, heatmapEnabled, heatmapLoading, heatmapDataCache,
         compareMode,
-        toggles: selectionStore.chartToggles || {},
+        toggles: notebookStore.chartToggles || {},
         setChartToggle,
-        anchors: selectionStore.anchors || { baseline: 0, experiment: 0 },
+        anchors: notebookStore.anchors || { baseline: 0, experiment: 0 },
         experimentQueryRange,
         baselineAlias,
         experimentAlias,
@@ -187,7 +187,7 @@ const attachExperiment = async (file) => {
     // Clamp a stale anchor when the newly-attached experiment is
     // shorter than the previously-saved offset. Avoids a chart starting
     // past the end of its data.
-    const anchors = selectionStore.anchors || { baseline: 0, experiment: 0 };
+    const anchors = notebookStore.anchors || { baseline: 0, experiment: 0 };
     if (experimentDurationMs != null && anchors.experiment > experimentDurationMs) {
         setAnchor(CAPTURE_EXPERIMENT, experimentDurationMs);
         console.info(
@@ -357,7 +357,7 @@ const changeInstance = async (serviceName, instanceId) => {
 };
 
 const CLIENT_ONLY_SECTIONS = new Set([
-    'selection',
+    'notebook',
     'report',
     'systeminfo',
     'metadata',
@@ -367,8 +367,8 @@ const CLIENT_ONLY_SECTIONS = new Set([
 const changeGranularity = async (step) => {
     currentGranularity = step;
     setStepOverride(step);
-    selectionStore.stepOverride = step ?? null;
-    persistSelection();
+    notebookStore.stepOverride = step ?? null;
+    persistNotebook();
 
     const currentRoute = m.route.get();
     const section = currentRoute ? currentRoute.replace(/^\//, '') : '';
@@ -502,10 +502,10 @@ const SectionContent = {
             ]);
         }
 
-        if (sectionName === 'Selection') {
+        if (sectionName === 'Notebook') {
             const sectionMeta = getCachedSectionMeta(sectionResponseCache, interval);
-            return m(SelectionView, {
-                title: 'Selection',
+            return m(NotebookView, {
+                title: 'Notebook',
                 ...sectionMeta,
                 chartsState,
                 fileChecksum,
@@ -513,12 +513,12 @@ const SectionContent = {
                 heatmapLoading,
                 stepOverride: currentGranularity,
                 onToggleHeatmap: toggleGlobalHeatmap,
-                // Compare-mode plumbing — SelectionView mirrors the
+                // Compare-mode plumbing — NotebookView mirrors the
                 // current viewer state, so pinning in compare mode and
-                // visiting /selection renders the compare view.
+                // visiting /notebook renders the compare view.
                 compareMode,
-                anchors: selectionStore.anchors || { baseline: 0, experiment: 0 },
-                toggles: selectionStore.chartToggles || {},
+                anchors: notebookStore.anchors || { baseline: 0, experiment: 0 },
+                toggles: notebookStore.chartToggles || {},
                 setChartToggle,
                 experimentQueryRange,
                 baselineAlias,
@@ -626,7 +626,7 @@ const SectionContent = {
 
 const systemInfoSection = { name: 'System Info', route: '/systeminfo' };
 const metadataSection = { name: 'Metadata', route: '/metadata' };
-const selectionSection = { name: 'Selection', route: '/selection' };
+const notebookSection = { name: 'Notebook', route: '/notebook' };
 const reportSection = { name: 'Report', route: '/report' };
 
 const bootstrapCacheIfNeeded = () => {
@@ -672,7 +672,7 @@ const initDashboard = (config = {}) => {
     // (loaded-from-parquet) wins when both exist so a shared annotated
     // parquet shows the granularity its author intended.
     const restoredStep =
-        reportStore.stepOverride ?? selectionStore.stepOverride ?? null;
+        reportStore.stepOverride ?? notebookStore.stepOverride ?? null;
     if (restoredStep != null) {
         currentGranularity = restoredStep;
         setStepOverride(restoredStep);
@@ -870,13 +870,13 @@ const initDashboard = (config = {}) => {
                     );
                 }
 
-                if (params.section === 'selection') {
+                if (params.section === 'notebook') {
                     bootstrapCacheIfNeeded();
                     return buildClientOnlySectionView(
                         Main,
                         sectionResponseCache,
                         getCachedSections,
-                        selectionSection,
+                        notebookSection,
                         () => compareMode,
                     );
                 }

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -9,7 +9,7 @@ import { TopNav, Sidebar, countCharts, formatSize } from './layout.js';
 import { collectGroupPlots } from './group_utils.js';
 import { CpuTopology } from './topology.js';
 import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, setStepOverride, getStepOverride, setSelectedNode, setSelectedInstance, getSelectedNode, injectLabel, CAPTURE_EXPERIMENT } from './data.js';
-import { reportStore, notebookStore, persistNotebook, setStorageScope, loadPayloadIntoStore, NotebookView, ReportView, setChartToggle as setChartToggleInStore, setAnchor } from './selection.js';
+import { reportStore, notebookStore, loadedSelectionStore, persistNotebook, setStorageScope, loadPayloadIntoStore, NotebookView, ReportView, LoadedSelectionView, setChartToggle as setChartToggleInStore, setAnchor } from './selection.js';
 import { SaveModal } from './overlays.js';
 import { ViewerApi } from './viewer_api.js';
 import { createSystemInfoView, createMetadataView, renderCgroupSection } from './section_views.js';
@@ -358,6 +358,7 @@ const changeInstance = async (serviceName, instanceId) => {
 
 const CLIENT_ONLY_SECTIONS = new Set([
     'notebook',
+    'selection',
     'report',
     'systeminfo',
     'metadata',
@@ -528,6 +529,16 @@ const SectionContent = {
             });
         }
 
+        if (sectionName === 'Selection') {
+            const sectionMeta = getCachedSectionMeta(sectionResponseCache, interval);
+            return m(LoadedSelectionView, {
+                title: 'Selection',
+                ...sectionMeta,
+                chartsState,
+                stepOverride: currentGranularity,
+            });
+        }
+
         if (sectionName === 'Report') {
             const sectionMeta = getCachedSectionMeta(sectionResponseCache, interval);
             return m(ReportView, {
@@ -627,6 +638,7 @@ const SectionContent = {
 const systemInfoSection = { name: 'System Info', route: '/systeminfo' };
 const metadataSection = { name: 'Metadata', route: '/metadata' };
 const notebookSection = { name: 'Notebook', route: '/notebook' };
+const selectionSection = { name: 'Selection', route: '/selection' };
 const reportSection = { name: 'Report', route: '/report' };
 
 const bootstrapCacheIfNeeded = () => {
@@ -877,6 +889,17 @@ const initDashboard = (config = {}) => {
                         sectionResponseCache,
                         getCachedSections,
                         notebookSection,
+                        () => compareMode,
+                    );
+                }
+
+                if (params.section === 'selection') {
+                    bootstrapCacheIfNeeded();
+                    return buildClientOnlySectionView(
+                        Main,
+                        sectionResponseCache,
+                        getCachedSections,
+                        selectionSection,
                         () => compareMode,
                     );
                 }

--- a/src/viewer/assets/lib/chart_controls.js
+++ b/src/viewer/assets/lib/chart_controls.js
@@ -110,7 +110,7 @@ export const expandLink = (spec, sectionRoute) => {
     );
 };
 
-export const selectButton = (spec, sectionRoute, sectionName, groupName) => {
+export const selectButton = (spec, sectionRoute, sectionName, groupName, compareMeta = null) => {
     if (!spec.promql_query) return null;
     const sectionKey = sectionRoute.replace(/^\//, '');
     const selected = isSelected(spec.opts.id);
@@ -118,7 +118,7 @@ export const selectButton = (spec, sectionRoute, sectionName, groupName) => {
         class: selected ? 'chart-selected' : '',
         onclick: (e) => {
             e.stopPropagation();
-            toggleSelection(spec, sectionKey, sectionName, groupName);
+            toggleSelection(spec, sectionKey, sectionName, groupName, compareMeta);
             m.redraw();
         },
         title: selected ? 'Remove from selection' : 'Add to selection',

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -1,5 +1,5 @@
 import { TimeRangeBar, GranularitySelector } from './controls.js';
-import { selectionStore, reportStore, importJSON } from './selection.js';
+import { notebookStore, reportStore, importJSON } from './selection.js';
 import { toggleTheme, currentTheme } from './theme.js';
 import { collectGroupPlots } from './group_utils.js';
 
@@ -263,16 +263,16 @@ const Sidebar = {
                 `Report (${reportStore.entries.length})`,
             ),
 
-            // Selection section (shown only when entries exist)
-            selectionStore.entries.length > 0 && m(
+            // Notebook section (shown only when entries exist)
+            notebookStore.entries.length > 0 && m(
                 m.route.Link,
                 {
-                    class: attrs.activeSection?.route === '/selection'
+                    class: attrs.activeSection?.route === '/notebook'
                         ? 'selected selection-link'
                         : 'selection-link',
-                    href: '/selection',
+                    href: '/notebook',
                 },
-                `Selection (${selectionStore.entries.length})`,
+                `Notebook (${notebookStore.entries.length})`,
             ),
 
             // Overview section first (if exists)

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -1,5 +1,5 @@
 import { TimeRangeBar, GranularitySelector } from './controls.js';
-import { notebookStore, reportStore, importJSON } from './selection.js';
+import { notebookStore, reportStore, loadedSelectionStore, importSelection } from './selection.js';
 import { toggleTheme, currentTheme } from './theme.js';
 import { collectGroupPlots } from './group_utils.js';
 
@@ -136,19 +136,19 @@ const TopNav = {
                     m('span', 'Load Parquet'),
                     m.trust(UPLOAD_ICON_SVG),
                 ]),
-                // Import report JSON (server viewer only). Hidden in
-                // compare mode — reports are single-capture today.
+                // Import selection JSON (server viewer only). Hidden in
+                // compare mode — selections are single-capture today.
                 attrs.onUploadParquet && !compareMode && m('button.transport-btn.import-btn', {
                     class: attrs.filename ? 'parquet-loaded' : '',
                     disabled: !attrs.filename,
-                    onclick: () => importJSON(attrs.fileChecksum),
+                    onclick: () => importSelection(),
                     title: attrs.filename
-                        ? (reportStore.loadedFrom
-                            ? `Loaded: ${reportStore.loadedFrom} — click to replace`
-                            : 'Import report JSON')
+                        ? (loadedSelectionStore.loadedFrom
+                            ? `Loaded: ${loadedSelectionStore.loadedFrom} — click to replace`
+                            : 'Import selection JSON')
                         : 'Load a parquet file first',
                 }, [
-                    m('span', 'Load Report'),
+                    m('span', 'Load Selection'),
                     m.trust(UPLOAD_ICON_SVG),
                 ]),
                 // Transport controls (live mode only)
@@ -273,6 +273,18 @@ const Sidebar = {
                     href: '/notebook',
                 },
                 `Notebook (${notebookStore.entries.length})`,
+            ),
+
+            // Selection section (shown only when JSON loaded)
+            loadedSelectionStore.entries.length > 0 && m(
+                m.route.Link,
+                {
+                    class: attrs.activeSection?.route === '/selection'
+                        ? 'selected selection-link'
+                        : 'selection-link',
+                    href: '/selection',
+                },
+                `Selection (${loadedSelectionStore.entries.length})`,
             ),
 
             // Overview section first (if exists)

--- a/src/viewer/assets/lib/layout.js
+++ b/src/viewer/assets/lib/layout.js
@@ -268,8 +268,8 @@ const Sidebar = {
                 m.route.Link,
                 {
                     class: attrs.activeSection?.route === '/notebook'
-                        ? 'selected selection-link'
-                        : 'selection-link',
+                        ? 'selected selection-link notebook-link'
+                        : 'selection-link notebook-link',
                     href: '/notebook',
                 },
                 `Notebook (${notebookStore.entries.length})`,
@@ -280,8 +280,8 @@ const Sidebar = {
                 m.route.Link,
                 {
                     class: attrs.activeSection?.route === '/selection'
-                        ? 'selected selection-link'
-                        : 'selection-link',
+                        ? 'selected selection-link loaded-selection-link'
+                        : 'selection-link loaded-selection-link',
                     href: '/selection',
                 },
                 `Selection (${loadedSelectionStore.entries.length})`,

--- a/src/viewer/assets/lib/section_views.js
+++ b/src/viewer/assets/lib/section_views.js
@@ -310,7 +310,7 @@ const renderCgroupSection = ({
             m('div.chart-wrapper', [
                 m(Chart, { spec: prefixedSpec, chartsState, interval }),
                 expandLink(spec, sectionRoute),
-                selectButton(spec, sectionRoute, sectionName),
+                selectButton(spec, sectionRoute, sectionName, null, null),
             ]),
             legend,
         ]);

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -694,7 +694,7 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                     'Save as Report (parquet, Selection & Notes) ',
                     downloadIcon,
                 ]),
-                m('button.selection-btn.selection-btn-success', {
+                m('button.selection-btn.selection-btn-indigo', {
                     disabled: hasAnyNote,
                     title: hasAnyNote
                         ? 'Selection has notes \u2014 use Save as Report (parquet, Selection & Notes) to keep them with the data, or clear notes first.'

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -37,7 +37,6 @@ const uuidv7 = () => {
 // ── Stores ───────────────────────────────────────────────────────
 
 const notebookStore = {
-    version: SELECTION_SCHEMA_VERSION,
     tagline: '',
     entries: [],
     zoom: null,
@@ -48,7 +47,6 @@ const notebookStore = {
 };
 
 const reportStore = {
-    version: SELECTION_SCHEMA_VERSION,
     tagline: '',
     entries: [],
     zoom: null,
@@ -66,7 +64,6 @@ const reportStore = {
 };
 
 const loadedSelectionStore = {
-    version: SELECTION_SCHEMA_VERSION,
     tagline: '',
     entries: [],
     zoom: null,
@@ -76,6 +73,26 @@ const loadedSelectionStore = {
     compare: null,
     loadedFrom: null,  // filename of the dropped JSON
 };
+
+// Per-card "notes textarea expanded" tracker for NotebookView.
+// Module-level rather than view-local because removeEntry,
+// clearStore, and openInNotebook all need to clear it before the
+// view next mounts. UI-only state — never persisted.
+const expandedNotes = new Set();
+
+// Hydrate an entries list from a JSON payload. Used by all three
+// load paths (restoreStore, loadPayloadIntoStore, loadJsonIntoSelection)
+// so the entry shape stays in one place.
+const entriesFromPayload = (entries) => (entries || []).map(e => ({
+    id: crypto.randomUUID(),
+    chartId: e.chartId,
+    section: e.section,
+    sectionName: e.sectionName,
+    groupName: e.groupName || '',
+    promql_query: e.promql_query,
+    note: e.note || '',
+    chartOpts: e.chartOpts,
+}));
 
 // ── LocalStorage persistence ─────────────────────────────────────
 
@@ -153,7 +170,6 @@ const restoreStore = (key, store) => {
         const parsed = JSON.parse(raw);
         if (!parsed.entries || !Array.isArray(parsed.entries)) return;
         const data = migrateSelection(parsed);
-        store.version = data.version;
         store.tagline = data.tagline || '';
         store.zoom = data.zoom || null;
         store.stepOverride = data.stepOverride ?? null;
@@ -167,16 +183,7 @@ const restoreStore = (key, store) => {
         if (data.fileChecksum !== undefined) store.fileChecksum = data.fileChecksum;
         if (data.timeRange !== undefined) store.timeRange = data.timeRange;
         if (data.rezolusVersion !== undefined) store.rezolusVersion = data.rezolusVersion;
-        store.entries = data.entries.map(e => ({
-            id: crypto.randomUUID(),
-            chartId: e.chartId,
-            section: e.section,
-            sectionName: e.sectionName,
-            groupName: e.groupName || '',
-            promql_query: e.promql_query,
-            note: e.note || '',
-            chartOpts: e.chartOpts,
-        }));
+        store.entries = entriesFromPayload(data.entries);
     } catch (e) {
         if (e?.message?.includes('unsupported selection schema')) {
             console.warn('[selection] dropped stale localStorage entry:', e.message);
@@ -277,7 +284,7 @@ const removeEntry = (store, id) => {
     if (idx >= 0) {
         store.entries.splice(idx, 1);
         if (store === notebookStore) {
-            NotebookView._expandedNotes.delete(id);
+            expandedNotes.delete(id);
             persistNotebook();
         } else if (store === reportStore) persistReport();
     }
@@ -313,56 +320,35 @@ const clearStore = (store) => {
     if (store === reportStore) {
         localStorage.removeItem(REPORT_STORAGE_KEY);
     } else if (store === notebookStore) {
-        NotebookView._expandedNotes.clear();
+        expandedNotes.clear();
         localStorage.removeItem(NOTEBOOK_STORAGE_KEY);
     }
     // loadedSelectionStore is in-memory only; no localStorage to clear
 };
 
-const openReportInNotebook = () => {
+// Copy a source store (Report or LoadedSelection) into the live
+// Notebook with overwrite-confirm. Shallow-spread on entries with
+// fresh ids — chartOpts is shared by reference with the source,
+// which is safe because the viewer reads chartOpts but never
+// mutates it. Switch to structuredClone if that ever changes.
+const openInNotebook = (sourceStore, kindLabel) => {
     if (notebookStore.entries.length > 0) {
-        const ok = confirm(
-            'Notebook has unsaved entries. Discard them and load the Report?',
-        );
-        if (!ok) return;
+        if (!confirm(`Notebook has unsaved entries. Discard them and load the ${kindLabel}?`)) return;
     }
     resetStoreState(notebookStore);
-    notebookStore.tagline = reportStore.tagline || '';
-    notebookStore.anchors = { ...(reportStore.anchors || { baseline: 0, experiment: 0 }) };
-    notebookStore.chartToggles = { ...(reportStore.chartToggles || {}) };
-    notebookStore.compare = reportStore.compare ? { ...reportStore.compare } : null;
-    // Shallow copy with fresh ids. chartOpts is shared by reference
-    // with the source reportStore entry, which is fine because the
-    // viewer never mutates chartOpts post-load (only reads it). If
-    // that ever changes, switch to a structured-clone or JSON
-    // round-trip here.
-    notebookStore.entries = reportStore.entries.map(e => ({ ...e, id: crypto.randomUUID() }));
-    NotebookView._expandedNotes.clear();
+    notebookStore.tagline = sourceStore.tagline || '';
+    notebookStore.anchors = { ...(sourceStore.anchors || { baseline: 0, experiment: 0 }) };
+    notebookStore.chartToggles = { ...(sourceStore.chartToggles || {}) };
+    notebookStore.compare = sourceStore.compare ? { ...sourceStore.compare } : null;
+    notebookStore.entries = sourceStore.entries.map(e => ({ ...e, id: crypto.randomUUID() }));
+    expandedNotes.clear();
     persistNotebook();
-    notify('info', 'Report opened in Notebook');
+    notify('info', `${kindLabel} opened in Notebook`);
     m.route.set('/notebook');
 };
 
-const openLoadedSelectionInNotebook = () => {
-    if (notebookStore.entries.length > 0) {
-        const ok = confirm(
-            'Notebook has unsaved entries. Discard them and load the Selection?',
-        );
-        if (!ok) return;
-    }
-    resetStoreState(notebookStore);
-    notebookStore.tagline = loadedSelectionStore.tagline || '';
-    notebookStore.anchors = { ...(loadedSelectionStore.anchors || { baseline: 0, experiment: 0 }) };
-    notebookStore.chartToggles = { ...(loadedSelectionStore.chartToggles || {}) };
-    notebookStore.compare = loadedSelectionStore.compare ? { ...loadedSelectionStore.compare } : null;
-    // Shallow copy with fresh ids; chartOpts shared by reference
-    // (viewer reads chartOpts but never mutates it).
-    notebookStore.entries = loadedSelectionStore.entries.map(e => ({ ...e, id: crypto.randomUUID() }));
-    NotebookView._expandedNotes.clear();
-    persistNotebook();
-    notify('info', 'Selection opened in Notebook');
-    m.route.set('/notebook');
-};
+const openReportInNotebook = () => openInNotebook(reportStore, 'Report');
+const openLoadedSelectionInNotebook = () => openInNotebook(loadedSelectionStore, 'Selection');
 
 // ── Export / Import / Parquet ─────────────────────────────────────
 
@@ -416,23 +402,13 @@ const exportJSON = async (store, attrs) => {
 const loadPayloadIntoStore = (store, payload) => {
     try {
         const migrated = migrateSelection(payload);
-        store.version = migrated.version;
         store.tagline = migrated.tagline || '';
         store.zoom = migrated.zoom || null;
         store.stepOverride = migrated.step_override ?? migrated.stepOverride ?? null;
         store.anchors = migrated.anchors || { baseline: 0, experiment: 0 };
         store.chartToggles = migrated.chartToggles || {};
         store.compare = migrated.compare || null;
-        store.entries = payload.entries.map(e => ({
-            id: crypto.randomUUID(),
-            chartId: e.chartId,
-            section: e.section,
-            sectionName: e.sectionName,
-            groupName: e.groupName || '',
-            promql_query: e.promql_query,
-            note: e.note || '',
-            chartOpts: e.chartOpts,
-        }));
+        store.entries = entriesFromPayload(payload.entries);
         if (store === reportStore) {
             store.reportId = payload.report_id || null;
             store.savedAt = payload.saved_at || null;
@@ -495,16 +471,7 @@ const loadJsonIntoSelection = (json, filename) => {
         loadedSelectionStore.anchors = migrated.anchors || { baseline: 0, experiment: 0 };
         loadedSelectionStore.chartToggles = migrated.chartToggles || {};
         loadedSelectionStore.compare = migrated.compare || null;
-        loadedSelectionStore.entries = (migrated.entries || []).map(e => ({
-            id: crypto.randomUUID(),
-            chartId: e.chartId,
-            section: e.section,
-            sectionName: e.sectionName,
-            groupName: e.groupName || '',
-            promql_query: e.promql_query,
-            note: e.note || '',
-            chartOpts: e.chartOpts,
-        }));
+        loadedSelectionStore.entries = entriesFromPayload(migrated.entries);
         loadedSelectionStore.loadedFrom = filename;
         return true;
     } catch (e) {
@@ -628,7 +595,6 @@ const chartLoaderMixin = (store, component) => ({
 
 const NotebookView = {
     _needsReload: false,
-    _expandedNotes: new Set(),  // entry.id values
 };
 Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
     view({ attrs }) {
@@ -740,11 +706,11 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                     ]),
                     (() => {
                         const hasNote = entry.note && entry.note.length > 0;
-                        const expanded = NotebookView._expandedNotes.has(entry.id);
+                        const expanded = expandedNotes.has(entry.id);
                         if (!hasNote && !expanded) {
                             return m('button.notes-affordance', {
                                 onclick: () => {
-                                    NotebookView._expandedNotes.add(entry.id);
+                                    expandedNotes.add(entry.id);
                                     m.redraw();
                                 },
                             }, '+ Add note');
@@ -757,7 +723,7 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                                 oninput: (e) => { entry.note = e.target.value; persistNotebook(); },
                                 onblur: (e) => {
                                     if (!e.target.value) {
-                                        NotebookView._expandedNotes.delete(entry.id);
+                                        expandedNotes.delete(entry.id);
                                         m.redraw();
                                     }
                                 },

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -44,6 +44,7 @@ const selectionStore = {
     stepOverride: null,   // query step in seconds (null = auto)
     anchors: { baseline: 0, experiment: 0 }, // compare-mode offsets in ms
     chartToggles: {},      // per-chart compare-mode toggles, e.g. { chartId: { diff: true } }
+    compare: null,         // { baseline_alias, experiment_alias } when set in compare mode
 };
 
 const reportStore = {
@@ -54,6 +55,7 @@ const reportStore = {
     stepOverride: null,   // query step in seconds (null = auto)
     anchors: { baseline: 0, experiment: 0 },
     chartToggles: {},
+    compare: null,         // { baseline_alias, experiment_alias } when set in compare mode
     loadedFrom: null,    // filename of the imported JSON
     reportId: null,       // UUIDv7 from the imported report
     savedAt: null,        // ISO timestamp
@@ -104,6 +106,7 @@ const persistStore = (key, store) => {
             stepOverride: store.stepOverride ?? undefined,
             anchors: store.anchors || { baseline: 0, experiment: 0 },
             chartToggles: store.chartToggles || {},
+            compare: store.compare || undefined,
             loadedFrom: store.loadedFrom || undefined,
             reportId: store.reportId || undefined,
             savedAt: store.savedAt || undefined,
@@ -140,6 +143,7 @@ const restoreStore = (key, store) => {
         store.stepOverride = data.stepOverride ?? null;
         store.anchors = data.anchors || { baseline: 0, experiment: 0 };
         store.chartToggles = data.chartToggles || {};
+        if (data.compare !== undefined) store.compare = data.compare;
         if (data.loadedFrom !== undefined) store.loadedFrom = data.loadedFrom;
         if (data.reportId !== undefined) store.reportId = data.reportId;
         if (data.savedAt !== undefined) store.savedAt = data.savedAt;
@@ -260,6 +264,7 @@ const resetStoreState = (store) => {
     store.stepOverride = null;
     store.anchors = { baseline: 0, experiment: 0 };
     store.chartToggles = {};
+    store.compare = null;
     if (store === reportStore) {
         store.loadedFrom = null;
         store.reportId = null;
@@ -299,6 +304,7 @@ const buildPayload = (store, attrs) => ({
     step_override: attrs.stepOverride ?? null,
     anchors: store.anchors || { baseline: 0, experiment: 0 },
     chartToggles: store.chartToggles || {},
+    compare: store.compare || undefined,
     tagline: store.tagline,
     entries: store.entries.map(e => ({
         chartId: e.chartId,

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -672,16 +672,6 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
 
             m('div.selection-actions', [
                 m('button.selection-btn', {
-                    disabled: hasAnyNote,
-                    title: hasAnyNote
-                        ? 'Selection has notes \u2014 use Save as Report (annotate parquet) to keep them with the data, or clear notes first.'
-                        : 'Download a JSON pattern (charts + toggles only)',
-                    onclick: () => exportJSON(notebookStore, attrs),
-                }, [
-                    'Save as Selection (JSON) ',
-                    downloadIcon,
-                ]),
-                m('button.selection-btn', {
                     disabled: inTwoFileCompare,
                     title: inTwoFileCompare
                         ? 'Two-file A/B mode has no single parquet to embed in. Use `parquet combine --ab` first.'
@@ -689,6 +679,16 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                     onclick: () => saveToParquet(notebookStore, attrs),
                 }, [
                     'Save as Report (annotate parquet) ',
+                    downloadIcon,
+                ]),
+                m('button.selection-btn.selection-btn-success', {
+                    disabled: hasAnyNote,
+                    title: hasAnyNote
+                        ? 'Selection has notes \u2014 use Save as Report (annotate parquet) to keep them with the data, or clear notes first.'
+                        : 'Download a JSON pattern (charts + toggles only)',
+                    onclick: () => exportJSON(notebookStore, attrs),
+                }, [
+                    'Save as Selection (JSON) ',
                     downloadIcon,
                 ]),
                 m('button.selection-btn.selection-btn-danger', {
@@ -722,19 +722,16 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                     })
                     : m(Chart, { spec, chartsState: attrs.chartsState, interval });
                 return m('div.selection-card', [
-                    m('div.selection-card-header', [
-                        m('span.chart-title', selectionCardTitle(entry, spec)),
-                        m('button.selection-card-remove', {
-                            onclick: () => { removeEntry(notebookStore, entry.id); m.redraw(); },
-                            title: 'Remove',
-                        }, '\u00d7'),  // multiplication sign × — better visual than X
-                    ]),
                     m('div.chart-wrapper', [
                         m('div.chart-header', [
                             m('span.chart-title', selectionCardTitle(entry, spec)),
                             spec.opts.description && m('span.chart-subtitle', spec.opts.description),
                         ]),
                         chartBody,
+                        m('button.selection-card-remove', {
+                            onclick: () => { removeEntry(notebookStore, entry.id); m.redraw(); },
+                            title: 'Remove from Notebook',
+                        }, '\u00d7'),
                     ]),
                     (() => {
                         const hasNote = entry.note && entry.note.length > 0;
@@ -839,9 +836,6 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
                 return m('div.selection-card', [
-                    m('div.selection-card-header', [
-                        m('span.chart-title', selectionCardTitle(entry, spec)),
-                    ]),
                     m('div.chart-wrapper', [
                         m('div.chart-header', [
                             m('span.chart-title', selectionCardTitle(entry, spec)),
@@ -897,9 +891,6 @@ Object.assign(LoadedSelectionView, chartLoaderMixin(loadedSelectionStore, Loaded
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
                 return m('div.selection-card', [
-                    m('div.selection-card-header', [
-                        m('span.chart-title', selectionCardTitle(entry, spec)),
-                    ]),
                     m('div.chart-wrapper', [
                         m('div.chart-header', [
                             m('span.chart-title', selectionCardTitle(entry, spec)),

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -301,7 +301,7 @@ const clearStore = (store) => {
 
 // ── Export / Import / Parquet ─────────────────────────────────────
 
-const buildPayload = (store, attrs) => ({
+const buildPayload = (store, attrs, { includeNotes = true } = {}) => ({
     version: SELECTION_SCHEMA_VERSION,
     report_id: uuidv7(),
     rezolus_version: attrs.version || 'unknown',
@@ -325,7 +325,7 @@ const buildPayload = (store, attrs) => ({
         sectionName: e.sectionName,
         groupName: e.groupName || '',
         promql_query: e.promql_query,
-        note: e.note,
+        note: includeNotes ? e.note : '',
         chartOpts: e.chartOpts,
     })),
 });
@@ -335,7 +335,7 @@ const exportJSON = async (store, attrs) => {
     const result = await showSaveModal(defaultPrefix, '.json');
     if (!result) return;
     const filename = result.filename;
-    const payload = buildPayload(store, attrs);
+    const payload = buildPayload(store, attrs, { includeNotes: false });
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -555,6 +555,9 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
         const cs = attrs.chartsState;
         const hasChartSelection = cs?.hasActiveSelection();
         const hasHistograms = selectionStore.entries.some(e => isHistogramPlot(e));
+        const hasAnyNote = selectionStore.entries.some(e => e.note && e.note.length > 0);
+        const inTwoFileCompare = attrs.compareMode && !attrs.combinedAB;
+        const downloadIcon = m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 10V2m0 8l-3-3m3 3l3-3"/></svg>');
 
         const header = m('div.selection-header', [
             m('div.section-header-row', [
@@ -589,15 +592,25 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
             header,
 
             m('div.selection-actions', [
-                m('button.selection-btn', { onclick: () => exportJSON(selectionStore, attrs) }, [
-                    'Export JSON ',
-                    m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 10V2m0 8l-3-3m3 3l3-3"/></svg>'),
+                m('button.selection-btn', {
+                    disabled: hasAnyNote,
+                    title: hasAnyNote
+                        ? 'Selection has notes \u2014 use Save as Report (annotate parquet) to keep them with the data, or clear notes first.'
+                        : 'Download a JSON pattern (charts + toggles only)',
+                    onclick: () => exportJSON(selectionStore, attrs),
+                }, [
+                    'Save as Selection (JSON) ',
+                    downloadIcon,
                 ]),
                 m('button.selection-btn', {
+                    disabled: inTwoFileCompare,
+                    title: inTwoFileCompare
+                        ? 'Two-file A/B mode has no single parquet to embed in. Use `parquet combine --ab` first.'
+                        : 'Embed selection + notes in the loaded parquet',
                     onclick: () => saveToParquet(selectionStore, attrs),
                 }, [
-                    'Annotate Parquet ',
-                    m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 10V2m0 8l-3-3m3 3l3-3"/></svg>'),
+                    'Save as Report (annotate parquet) ',
+                    downloadIcon,
                 ]),
                 m('button.selection-btn.selection-btn-danger', {
                     onclick: () => { clearStore(selectionStore); m.redraw(); },

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -260,8 +260,10 @@ const removeEntry = (store, id) => {
     const idx = store.entries.findIndex(e => e.id === id);
     if (idx >= 0) {
         store.entries.splice(idx, 1);
-        if (store === selectionStore) persistSelection();
-        else if (store === reportStore) persistReport();
+        if (store === selectionStore) {
+            SelectionView._expandedNotes.delete(id);
+            persistSelection();
+        } else if (store === reportStore) persistReport();
     }
 };
 
@@ -292,6 +294,7 @@ const clearStore = (store) => {
     if (store === reportStore) {
         localStorage.removeItem(REPORT_STORAGE_KEY);
     } else if (store === selectionStore) {
+        SelectionView._expandedNotes.clear();
         localStorage.removeItem(SELECTION_STORAGE_KEY);
     }
 };
@@ -541,6 +544,7 @@ const chartLoaderMixin = (store, component) => ({
 
 const SelectionView = {
     _needsReload: false,
+    _expandedNotes: new Set(),  // entry.id values
 };
 Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
     view({ attrs }) {
@@ -640,7 +644,32 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                         ]),
                         chartBody,
                     ]),
-                    // Notes section rendered by Task 6 (placeholder for now)
+                    (() => {
+                        const hasNote = entry.note && entry.note.length > 0;
+                        const expanded = SelectionView._expandedNotes.has(entry.id);
+                        if (!hasNote && !expanded) {
+                            return m('button.notes-affordance', {
+                                onclick: () => {
+                                    SelectionView._expandedNotes.add(entry.id);
+                                    m.redraw();
+                                },
+                            }, '+ Add note');
+                        }
+                        return m('div.selection-card-notes', [
+                            m('label.selection-notes-label', 'Notes'),
+                            m('textarea.selection-notes', {
+                                placeholder: 'Add notes\u2026',
+                                value: entry.note,
+                                oninput: (e) => { entry.note = e.target.value; persistSelection(); },
+                                onblur: (e) => {
+                                    if (!e.target.value) {
+                                        SelectionView._expandedNotes.delete(entry.id);
+                                        m.redraw();
+                                    }
+                                },
+                            }),
+                        ]);
+                    })(),
                 ]);
             }),
         ]);

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -839,7 +839,7 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
                 ]),
             )),
             m('div.section-header-row', [
-                m('h1.section-title', attrs.title || 'Report'),
+                m('h1.section-title.section-title-report', attrs.title || 'Report'),
                 m('div.section-actions', [
                     hasChartSelection && m('button.section-action-btn', {
                         onclick: () => { cs.resetAll(); m.redraw(); },

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -299,6 +299,31 @@ const clearStore = (store) => {
     }
 };
 
+const openReportInNotebook = () => {
+    if (selectionStore.entries.length > 0) {
+        const ok = confirm(
+            'Notebook has unsaved entries. Discard them and load the Report?',
+        );
+        if (!ok) return;
+    }
+    resetStoreState(selectionStore);
+    selectionStore.tagline = reportStore.tagline || '';
+    selectionStore.anchors = { ...(reportStore.anchors || { baseline: 0, experiment: 0 }) };
+    selectionStore.chartToggles = { ...(reportStore.chartToggles || {}) };
+    selectionStore.compare = reportStore.compare ? { ...reportStore.compare } : null;
+    // Shallow copy with fresh ids. chartOpts is shared by reference
+    // with the source reportStore entry, which is fine because the
+    // viewer never mutates chartOpts post-load (only reads it). If
+    // that ever changes, switch to a structured-clone or JSON
+    // round-trip here.
+    selectionStore.entries = reportStore.entries.map(e => ({ ...e, id: crypto.randomUUID() }));
+    SelectionView._expandedNotes.clear();
+    persistSelection();
+    notify('info', 'Report opened in Notebook');
+    // Navigate to /selection. (The route will be renamed /notebook in Task 9.)
+    m.route.set('/selection');
+};
+
 // ── Export / Import / Parquet ─────────────────────────────────────
 
 const buildPayload = (store, attrs, { includeNotes = true } = {}) => ({
@@ -740,6 +765,10 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
                         onclick: attrs.onToggleHeatmap,
                         disabled: attrs.heatmapLoading,
                     }, attrs.heatmapLoading ? 'LOADING...' : (attrs.heatmapEnabled ? 'SHOW PERCENTILES' : 'SHOW HEATMAPS')),
+                    reportStore.entries.length > 0 && m('button.section-action-btn', {
+                        onclick: openReportInNotebook,
+                        title: 'Copy this Report into the Notebook for editing',
+                    }, 'OPEN IN NOTEBOOK'),
                 ]),
             ]),
             reportStore.tagline && m('p.selection-tagline-text', reportStore.tagline),
@@ -766,9 +795,9 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
                         ]),
                         m(Chart, { spec, chartsState: attrs.chartsState, interval }),
                     ]),
-                    entry.note && m('div.selection-card-notes', [
-                        m('label.selection-notes-label', 'Notes'),
-                        m('p.selection-notes-text', entry.note),
+                    entry.note && m('div.report-card-notes', [
+                        m('label.report-notes-label', 'Notes'),
+                        m('p.report-notes-text', entry.note),
                     ]),
                 ]);
             }),

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -36,7 +36,7 @@ const uuidv7 = () => {
 
 // ── Stores ───────────────────────────────────────────────────────
 
-const selectionStore = {
+const notebookStore = {
     version: SELECTION_SCHEMA_VERSION,
     tagline: '',
     entries: [],
@@ -68,7 +68,7 @@ const reportStore = {
 // ── LocalStorage persistence ─────────────────────────────────────
 
 let REPORT_STORAGE_KEY = 'rezolus_report';
-let SELECTION_STORAGE_KEY = 'rezolus_selection';
+let NOTEBOOK_STORAGE_KEY = 'rezolus_notebook';
 
 /**
  * Scope localStorage keys by a file fingerprint so each parquet file
@@ -87,14 +87,14 @@ const setStorageScope = (info) => {
         .reduce((h, b) => ((h << 5) - h + b) | 0, 0)
         .toString(36);
     REPORT_STORAGE_KEY = `rezolus_report_${suffix}`;
-    SELECTION_STORAGE_KEY = `rezolus_selection_${suffix}`;
+    NOTEBOOK_STORAGE_KEY = `rezolus_notebook_${suffix}`;
     // In-memory reset only — must NOT purge localStorage at the
     // (just-set) scoped key, otherwise we wipe the file's persisted
-    // selection on every page load before restoring it.
-    resetStoreState(selectionStore);
+    // notebook on every page load before restoring it.
+    resetStoreState(notebookStore);
     resetStoreState(reportStore);
     restoreStore(REPORT_STORAGE_KEY, reportStore);
-    restoreStore(SELECTION_STORAGE_KEY, selectionStore);
+    restoreStore(NOTEBOOK_STORAGE_KEY, notebookStore);
 };
 
 const persistStore = (key, store) => {
@@ -172,7 +172,7 @@ const restoreStore = (key, store) => {
 };
 
 const persistReport = () => persistStore(REPORT_STORAGE_KEY, reportStore);
-const persistSelection = () => persistStore(SELECTION_STORAGE_KEY, selectionStore);
+const persistNotebook = () => persistStore(NOTEBOOK_STORAGE_KEY, notebookStore);
 
 // ── Anchors + per-chart toggles (compare-mode state) ─────────────
 
@@ -182,9 +182,9 @@ const persistSelection = () => persistStore(SELECTION_STORAGE_KEY, selectionStor
  */
 const setAnchor = (captureId, ms) => {
     if (captureId !== CAPTURE_BASELINE && captureId !== CAPTURE_EXPERIMENT) return;
-    if (!selectionStore.anchors) selectionStore.anchors = { baseline: 0, experiment: 0 };
-    selectionStore.anchors[captureId] = Number(ms) || 0;
-    persistSelection();
+    if (!notebookStore.anchors) notebookStore.anchors = { baseline: 0, experiment: 0 };
+    notebookStore.anchors[captureId] = Number(ms) || 0;
+    persistNotebook();
     if (typeof m !== 'undefined' && typeof m.redraw === 'function') m.redraw();
 };
 
@@ -194,19 +194,19 @@ const setAnchor = (captureId, ms) => {
  */
 const setChartToggle = (chartId, key, value) => {
     if (!chartId || !key) return;
-    if (!selectionStore.chartToggles) selectionStore.chartToggles = {};
-    if (!selectionStore.chartToggles[chartId]) {
-        selectionStore.chartToggles[chartId] = {};
+    if (!notebookStore.chartToggles) notebookStore.chartToggles = {};
+    if (!notebookStore.chartToggles[chartId]) {
+        notebookStore.chartToggles[chartId] = {};
     }
-    selectionStore.chartToggles[chartId][key] = value;
-    persistSelection();
+    notebookStore.chartToggles[chartId][key] = value;
+    persistNotebook();
     if (typeof m !== 'undefined' && typeof m.redraw === 'function') m.redraw();
 };
 
 // Stores are restored when setStorageScope() is called with a file fingerprint,
 // or eagerly here for the default (unscoped) keys as a fallback.
 restoreStore(REPORT_STORAGE_KEY, reportStore);
-restoreStore(SELECTION_STORAGE_KEY, selectionStore);
+restoreStore(NOTEBOOK_STORAGE_KEY, notebookStore);
 
 // Build the displayed chart title for a selection card. The dashboard
 // gives charts visual context via section/group breadcrumbs ("CPU >
@@ -224,13 +224,13 @@ const selectionCardTitle = (entry, spec) => {
 // ── Selection API (write mode) ───────────────────────────────────
 
 const toggleSelection = (spec, sectionKey, sectionName, groupName, compareMeta = null) => {
-    const idx = selectionStore.entries.findIndex(e => e.chartId === spec.opts.id);
+    const idx = notebookStore.entries.findIndex(e => e.chartId === spec.opts.id);
     if (idx >= 0) {
-        selectionStore.entries.splice(idx, 1);
-        persistSelection();
+        notebookStore.entries.splice(idx, 1);
+        persistNotebook();
         return false;
     }
-    selectionStore.entries.push({
+    notebookStore.entries.push({
         id: crypto.randomUUID(),
         chartId: spec.opts.id,
         section: sectionKey,
@@ -244,25 +244,25 @@ const toggleSelection = (spec, sectionKey, sectionName, groupName, compareMeta =
     // overwrite later pins so the first author's intent wins (e.g.,
     // the user pinned a chart, attached a different experiment, then
     // pinned more — the original baseline_alias stands).
-    if (compareMeta && !selectionStore.compare) {
-        selectionStore.compare = {
+    if (compareMeta && !notebookStore.compare) {
+        notebookStore.compare = {
             baseline_alias: compareMeta.baselineAlias || null,
             experiment_alias: compareMeta.experimentAlias || null,
         };
     }
-    persistSelection();
+    persistNotebook();
     return true;
 };
 
-const isSelected = (chartId) => selectionStore.entries.some(e => e.chartId === chartId);
+const isSelected = (chartId) => notebookStore.entries.some(e => e.chartId === chartId);
 
 const removeEntry = (store, id) => {
     const idx = store.entries.findIndex(e => e.id === id);
     if (idx >= 0) {
         store.entries.splice(idx, 1);
-        if (store === selectionStore) {
-            SelectionView._expandedNotes.delete(id);
-            persistSelection();
+        if (store === notebookStore) {
+            NotebookView._expandedNotes.delete(id);
+            persistNotebook();
         } else if (store === reportStore) persistReport();
     }
 };
@@ -293,35 +293,34 @@ const clearStore = (store) => {
     resetStoreState(store);
     if (store === reportStore) {
         localStorage.removeItem(REPORT_STORAGE_KEY);
-    } else if (store === selectionStore) {
-        SelectionView._expandedNotes.clear();
-        localStorage.removeItem(SELECTION_STORAGE_KEY);
+    } else if (store === notebookStore) {
+        NotebookView._expandedNotes.clear();
+        localStorage.removeItem(NOTEBOOK_STORAGE_KEY);
     }
 };
 
 const openReportInNotebook = () => {
-    if (selectionStore.entries.length > 0) {
+    if (notebookStore.entries.length > 0) {
         const ok = confirm(
             'Notebook has unsaved entries. Discard them and load the Report?',
         );
         if (!ok) return;
     }
-    resetStoreState(selectionStore);
-    selectionStore.tagline = reportStore.tagline || '';
-    selectionStore.anchors = { ...(reportStore.anchors || { baseline: 0, experiment: 0 }) };
-    selectionStore.chartToggles = { ...(reportStore.chartToggles || {}) };
-    selectionStore.compare = reportStore.compare ? { ...reportStore.compare } : null;
+    resetStoreState(notebookStore);
+    notebookStore.tagline = reportStore.tagline || '';
+    notebookStore.anchors = { ...(reportStore.anchors || { baseline: 0, experiment: 0 }) };
+    notebookStore.chartToggles = { ...(reportStore.chartToggles || {}) };
+    notebookStore.compare = reportStore.compare ? { ...reportStore.compare } : null;
     // Shallow copy with fresh ids. chartOpts is shared by reference
     // with the source reportStore entry, which is fine because the
     // viewer never mutates chartOpts post-load (only reads it). If
     // that ever changes, switch to a structured-clone or JSON
     // round-trip here.
-    selectionStore.entries = reportStore.entries.map(e => ({ ...e, id: crypto.randomUUID() }));
-    SelectionView._expandedNotes.clear();
-    persistSelection();
+    notebookStore.entries = reportStore.entries.map(e => ({ ...e, id: crypto.randomUUID() }));
+    NotebookView._expandedNotes.clear();
+    persistNotebook();
     notify('info', 'Report opened in Notebook');
-    // Navigate to /selection. (The route will be renamed /notebook in Task 9.)
-    m.route.set('/selection');
+    m.route.set('/notebook');
 };
 
 // ── Export / Import / Parquet ─────────────────────────────────────
@@ -565,13 +564,13 @@ const chartLoaderMixin = (store, component) => ({
     },
 });
 
-// ── SelectionView (write mode) ───────────────────────────────────
+// ── NotebookView (write mode) ────────────────────────────────────
 
-const SelectionView = {
+const NotebookView = {
     _needsReload: false,
     _expandedNotes: new Set(),  // entry.id values
 };
-Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
+Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
     view({ attrs }) {
         this._checkReload();
         this._applyZoom(attrs);
@@ -579,8 +578,8 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
         const interval = attrs.interval || 1;
         const cs = attrs.chartsState;
         const hasChartSelection = cs?.hasActiveSelection();
-        const hasHistograms = selectionStore.entries.some(e => isHistogramPlot(e));
-        const hasAnyNote = selectionStore.entries.some(e => e.note && e.note.length > 0);
+        const hasHistograms = notebookStore.entries.some(e => isHistogramPlot(e));
+        const hasAnyNote = notebookStore.entries.some(e => e.note && e.note.length > 0);
         const inTwoFileCompare = attrs.compareMode && !attrs.combinedAB;
         const downloadIcon = m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 10V2m0 8l-3-3m3 3l3-3"/></svg>');
 
@@ -588,7 +587,7 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
             m('div.section-header-row', [
                 m('h1.section-title', [
                     sectionTitlePin(),
-                    attrs.title || 'Selection',
+                    attrs.title || 'Notebook',
                 ]),
                 m('div.section-actions', [
                     hasChartSelection && m('button.section-action-btn', {
@@ -604,8 +603,8 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
             m('input.selection-tagline', {
                 type: 'text',
                 placeholder: 'Add a tagline\u2026',
-                value: selectionStore.tagline,
-                oninput: (e) => { selectionStore.tagline = e.target.value; persistSelection(); },
+                value: notebookStore.tagline,
+                oninput: (e) => { notebookStore.tagline = e.target.value; persistNotebook(); },
             }),
         ]);
 
@@ -622,7 +621,7 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                     title: hasAnyNote
                         ? 'Selection has notes \u2014 use Save as Report (annotate parquet) to keep them with the data, or clear notes first.'
                         : 'Download a JSON pattern (charts + toggles only)',
-                    onclick: () => exportJSON(selectionStore, attrs),
+                    onclick: () => exportJSON(notebookStore, attrs),
                 }, [
                     'Save as Selection (JSON) ',
                     downloadIcon,
@@ -632,17 +631,17 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                     title: inTwoFileCompare
                         ? 'Two-file A/B mode has no single parquet to embed in. Use `parquet combine --ab` first.'
                         : 'Embed selection + notes in the loaded parquet',
-                    onclick: () => saveToParquet(selectionStore, attrs),
+                    onclick: () => saveToParquet(notebookStore, attrs),
                 }, [
                     'Save as Report (annotate parquet) ',
                     downloadIcon,
                 ]),
                 m('button.selection-btn.selection-btn-danger', {
-                    onclick: () => { clearStore(selectionStore); m.redraw(); },
+                    onclick: () => { clearStore(notebookStore); m.redraw(); },
                 }, 'Clear All'),
             ]),
 
-            selectionStore.entries.map((entry) => {
+            notebookStore.entries.map((entry) => {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
                 // In compare mode, render through CompareChartWrapper so
@@ -661,7 +660,7 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                         anchors: attrs.anchors,
                         toggles: attrs.toggles,
                         setChartToggle: attrs.setChartToggle,
-                        sectionRoute: '/selection',
+                        sectionRoute: '/notebook',
                         step: interval,
                         experimentQueryRange: attrs.experimentQueryRange,
                         captureLabels,
@@ -671,7 +670,7 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                     m('div.selection-card-header', [
                         m('span.chart-title', selectionCardTitle(entry, spec)),
                         m('button.selection-card-remove', {
-                            onclick: () => { removeEntry(selectionStore, entry.id); m.redraw(); },
+                            onclick: () => { removeEntry(notebookStore, entry.id); m.redraw(); },
                             title: 'Remove',
                         }, '\u00d7'),  // multiplication sign × — better visual than X
                     ]),
@@ -684,11 +683,11 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                     ]),
                     (() => {
                         const hasNote = entry.note && entry.note.length > 0;
-                        const expanded = SelectionView._expandedNotes.has(entry.id);
+                        const expanded = NotebookView._expandedNotes.has(entry.id);
                         if (!hasNote && !expanded) {
                             return m('button.notes-affordance', {
                                 onclick: () => {
-                                    SelectionView._expandedNotes.add(entry.id);
+                                    NotebookView._expandedNotes.add(entry.id);
                                     m.redraw();
                                 },
                             }, '+ Add note');
@@ -698,10 +697,10 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                             m('textarea.selection-notes', {
                                 placeholder: 'Add notes\u2026',
                                 value: entry.note,
-                                oninput: (e) => { entry.note = e.target.value; persistSelection(); },
+                                oninput: (e) => { entry.note = e.target.value; persistNotebook(); },
                                 onblur: (e) => {
                                     if (!e.target.value) {
-                                        SelectionView._expandedNotes.delete(entry.id);
+                                        NotebookView._expandedNotes.delete(entry.id);
                                         m.redraw();
                                     }
                                 },
@@ -806,10 +805,10 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
 });
 
 export {
-    selectionStore,
+    notebookStore,
     reportStore,
     setStorageScope,
-    persistSelection,
+    persistNotebook,
     toggleSelection,
     isSelected,
     clearStore,
@@ -817,7 +816,7 @@ export {
     loadPayloadIntoStore,
     setAnchor,
     setChartToggle,
-    SelectionView,
+    NotebookView,
     ReportView,
     migrateSelection,
     SELECTION_SCHEMA_VERSION,

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -223,7 +223,7 @@ const selectionCardTitle = (entry, spec) => {
 
 // ── Selection API (write mode) ───────────────────────────────────
 
-const toggleSelection = (spec, sectionKey, sectionName, groupName) => {
+const toggleSelection = (spec, sectionKey, sectionName, groupName, compareMeta = null) => {
     const idx = selectionStore.entries.findIndex(e => e.chartId === spec.opts.id);
     if (idx >= 0) {
         selectionStore.entries.splice(idx, 1);
@@ -240,6 +240,16 @@ const toggleSelection = (spec, sectionKey, sectionName, groupName) => {
         note: '',
         chartOpts: JSON.parse(JSON.stringify(spec.opts)),
     });
+    // Capture compare metadata on first pin in compare mode. Don't
+    // overwrite later pins so the first author's intent wins (e.g.,
+    // the user pinned a chart, attached a different experiment, then
+    // pinned more — the original baseline_alias stands).
+    if (compareMeta && !selectionStore.compare) {
+        selectionStore.compare = {
+            baseline_alias: compareMeta.baselineAlias || null,
+            experiment_alias: compareMeta.experimentAlias || null,
+        };
+    }
     persistSelection();
     return true;
 };

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -103,8 +103,12 @@ const setStorageScope = (info) => {
     // In-memory reset only — must NOT purge localStorage at the
     // (just-set) scoped key, otherwise we wipe the file's persisted
     // notebook on every page load before restoring it.
+    // loadedSelectionStore is in-memory only; reset so a Selection
+    // imported against a previous parquet doesn't survive into the
+    // new file's session (its chart specs may not even resolve).
     resetStoreState(notebookStore);
     resetStoreState(reportStore);
+    resetStoreState(loadedSelectionStore);
     restoreStore(REPORT_STORAGE_KEY, reportStore);
     restoreStore(NOTEBOOK_STORAGE_KEY, notebookStore);
 };
@@ -418,6 +422,7 @@ const loadPayloadIntoStore = (store, payload) => {
         store.stepOverride = migrated.step_override ?? migrated.stepOverride ?? null;
         store.anchors = migrated.anchors || { baseline: 0, experiment: 0 };
         store.chartToggles = migrated.chartToggles || {};
+        store.compare = migrated.compare || null;
         store.entries = payload.entries.map(e => ({
             id: crypto.randomUUID(),
             chartId: e.chartId,

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -244,6 +244,25 @@ const selectionCardTitle = (entry, spec) => {
     return parts.join(': ');
 };
 
+// Render a placeholder card for an entry whose chart can't render
+// in this capture (metric absent, query errored, no series matched).
+// Replaces the previous silent-collapse behavior where the chart's
+// .no-data state hid the entire .chart-wrapper, leaving an empty
+// gap that diverged from the loaded entry count.
+const unavailableCard = (entry, spec, removeBtn = null) =>
+    m('div.selection-card', [
+        m('div.chart-wrapper.chart-wrapper-unavailable', [
+            m('div.chart-unavailable', [
+                m('div.chart-unavailable-title', selectionCardTitle(entry, spec)),
+                m('div.chart-unavailable-message',
+                    spec.unavailableReason
+                        ? `Failed to load: ${spec.unavailableReason}`
+                        : 'No data available in this capture.'),
+            ]),
+            removeBtn,
+        ]),
+    ]);
+
 // ── Selection API (write mode) ───────────────────────────────────
 
 const toggleSelection = (spec, sectionKey, sectionName, groupName, compareMeta = null) => {
@@ -545,13 +564,21 @@ const chartLoaderMixin = (store, component) => ({
 
     async _loadCharts() {
         const promises = store.entries.map(async (entry) => {
-            if (!entry.promql_query) return;
+            // Always set a spec so the view can render a placeholder card
+            // for entries whose query won't run or returns nothing in this
+            // capture — silent collapse confused users (the original entry
+            // count and visible cards diverged with no explanation).
+            const spec = {
+                opts: { ...entry.chartOpts },
+                promql_query: entry.promql_query,
+                data: [],
+            };
+            if (!entry.promql_query) {
+                spec.unavailable = true;
+                this.specs.set(entry.chartId, spec);
+                return;
+            }
             try {
-                const spec = {
-                    opts: { ...entry.chartOpts },
-                    promql_query: entry.promql_query,
-                    data: [],
-                };
                 // Histogram metrics need histogram_quantiles / heatmap
                 // wrapping; the dashboard pipeline does this via
                 // buildEffectiveQuery, but the stored entry only has
@@ -561,12 +588,26 @@ const chartLoaderMixin = (store, component) => ({
                 if (result) {
                     applyResultToPlot(spec, result);
                 }
-                this.specs.set(entry.chartId, spec);
+                const hasData = result?.status === 'success' && result?.data?.result?.length > 0;
+                if (!hasData) spec.unavailable = true;
             } catch (e) {
                 console.warn('[selection] failed to load chart:', entry.chartId, e);
+                spec.unavailable = true;
+                spec.unavailableReason = e.message;
             }
+            this.specs.set(entry.chartId, spec);
         });
         await Promise.all(promises);
+        // Surface the gap between "loaded N entries" and "visible cards" once
+        // per data-load. component._lastUnavailableNotice debounces re-mounts;
+        // it's reset by _checkReload when fresh data lands.
+        const unavailable = [...this.specs.values()].filter(s => s.unavailable).length;
+        const noticeKey = `${this.specs.size}/${unavailable}`;
+        if (unavailable > 0 && component._lastUnavailableNotice !== noticeKey) {
+            component._lastUnavailableNotice = noticeKey;
+            notify('warn',
+                `${unavailable} of ${this.specs.size} pinned ${this.specs.size === 1 ? 'chart has' : 'charts have'} no data in this capture`);
+        }
         this.loading = false;
         m.redraw();
     },
@@ -574,6 +615,7 @@ const chartLoaderMixin = (store, component) => ({
     _checkReload() {
         if (component._needsReload) {
             component._needsReload = false;
+            component._lastUnavailableNotice = null;  // re-arm the notify
             this.specs = new Map();
             this.loading = true;
             this._zoomApplied = false;
@@ -649,17 +691,17 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                         : 'Embed selection + notes in the loaded parquet',
                     onclick: () => saveToParquet(notebookStore, attrs),
                 }, [
-                    'Save as Report (annotate parquet) ',
+                    'Save as Report (parquet, Selection & Notes) ',
                     downloadIcon,
                 ]),
                 m('button.selection-btn.selection-btn-success', {
                     disabled: hasAnyNote,
                     title: hasAnyNote
-                        ? 'Selection has notes \u2014 use Save as Report (annotate parquet) to keep them with the data, or clear notes first.'
+                        ? 'Selection has notes \u2014 use Save as Report (parquet, Selection & Notes) to keep them with the data, or clear notes first.'
                         : 'Download a JSON pattern (charts + toggles only)',
                     onclick: () => exportJSON(notebookStore, attrs),
                 }, [
-                    'Save as Selection (JSON) ',
+                    'Save as Selection (JSON, Notes dropped) ',
                     downloadIcon,
                 ]),
                 m('button.selection-btn.selection-btn-danger', {
@@ -670,6 +712,13 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
             notebookStore.entries.map((entry) => {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
+                if (spec.unavailable) {
+                    return unavailableCard(entry, spec,
+                        m('button.selection-card-remove', {
+                            onclick: () => { removeEntry(notebookStore, entry.id); m.redraw(); },
+                            title: 'Remove from Notebook',
+                        }, '\u00d7'));
+                }
                 // In compare mode, render through CompareChartWrapper so
                 // pinned charts mirror the live A/B view (side-by-side,
                 // diff, etc.). Service-template charts that lack a
@@ -806,6 +855,7 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
             reportStore.entries.map((entry) => {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
+                if (spec.unavailable) return unavailableCard(entry, spec);
                 return m('div.selection-card', [
                     m('div.chart-wrapper', [
                         m('div.chart-header', [
@@ -861,6 +911,7 @@ Object.assign(LoadedSelectionView, chartLoaderMixin(loadedSelectionStore, Loaded
             loadedSelectionStore.entries.map((entry) => {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
+                if (spec.unavailable) return unavailableCard(entry, spec);
                 return m('div.selection-card', [
                     m('div.chart-wrapper', [
                         m('div.chart-header', [

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -705,6 +705,19 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                     downloadIcon,
                 ]),
                 m('button.selection-btn.selection-btn-danger', {
+                    disabled: !hasAnyNote,
+                    title: hasAnyNote
+                        ? 'Clear notes from all pinned charts (charts and toggles preserved)'
+                        : 'No notes to clear',
+                    onclick: () => {
+                        if (!confirm('Clear notes from all pinned charts? This cannot be undone.')) return;
+                        notebookStore.entries.forEach(e => { e.note = ''; });
+                        expandedNotes.clear();
+                        persistNotebook();
+                        m.redraw();
+                    },
+                }, 'Clear Notes'),
+                m('button.selection-btn.selection-btn-danger', {
                     onclick: () => { clearStore(notebookStore); m.redraw(); },
                 }, 'Clear All'),
             ]),

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -839,7 +839,7 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
                 ]),
             )),
             m('div.section-header-row', [
-                m('h1.section-title.section-title-report', attrs.title || 'Report'),
+                m('h1.section-title', attrs.title || 'Report'),
                 m('div.section-actions', [
                     hasChartSelection && m('button.section-action-btn', {
                         onclick: () => { cs.resetAll(); m.redraw(); },

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -65,6 +65,18 @@ const reportStore = {
     rezolusVersion: null,
 };
 
+const loadedSelectionStore = {
+    version: SELECTION_SCHEMA_VERSION,
+    tagline: '',
+    entries: [],
+    zoom: null,
+    stepOverride: null,
+    anchors: { baseline: 0, experiment: 0 },
+    chartToggles: {},
+    compare: null,
+    loadedFrom: null,  // filename of the dropped JSON
+};
+
 // ── LocalStorage persistence ─────────────────────────────────────
 
 let REPORT_STORAGE_KEY = 'rezolus_report';
@@ -286,6 +298,9 @@ const resetStoreState = (store) => {
         store.timeRange = null;
         store.rezolusVersion = null;
     }
+    if (store === loadedSelectionStore) {
+        store.loadedFrom = null;
+    }
 };
 
 // Full purge: in-memory + localStorage. Used by the "Clear All" UI.
@@ -297,6 +312,7 @@ const clearStore = (store) => {
         NotebookView._expandedNotes.clear();
         localStorage.removeItem(NOTEBOOK_STORAGE_KEY);
     }
+    // loadedSelectionStore is in-memory only; no localStorage to clear
 };
 
 const openReportInNotebook = () => {
@@ -320,6 +336,27 @@ const openReportInNotebook = () => {
     NotebookView._expandedNotes.clear();
     persistNotebook();
     notify('info', 'Report opened in Notebook');
+    m.route.set('/notebook');
+};
+
+const openLoadedSelectionInNotebook = () => {
+    if (notebookStore.entries.length > 0) {
+        const ok = confirm(
+            'Notebook has unsaved entries. Discard them and load the Selection?',
+        );
+        if (!ok) return;
+    }
+    resetStoreState(notebookStore);
+    notebookStore.tagline = loadedSelectionStore.tagline || '';
+    notebookStore.anchors = { ...(loadedSelectionStore.anchors || { baseline: 0, experiment: 0 }) };
+    notebookStore.chartToggles = { ...(loadedSelectionStore.chartToggles || {}) };
+    notebookStore.compare = loadedSelectionStore.compare ? { ...loadedSelectionStore.compare } : null;
+    // Shallow copy with fresh ids; chartOpts shared by reference
+    // (viewer reads chartOpts but never mutates it).
+    notebookStore.entries = loadedSelectionStore.entries.map(e => ({ ...e, id: crypto.randomUUID() }));
+    NotebookView._expandedNotes.clear();
+    persistNotebook();
+    notify('info', 'Selection opened in Notebook');
     m.route.set('/notebook');
 };
 
@@ -407,7 +444,7 @@ const loadPayloadIntoStore = (store, payload) => {
     }
 };
 
-const importJSON = (currentChecksum) => {
+const importSelection = () => {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.json';
@@ -420,37 +457,55 @@ const importJSON = (currentChecksum) => {
             try {
                 payload = JSON.parse(text);
             } catch {
-                notify('error', 'Not a valid Rezolus report');
+                notify('error', 'Not a valid Rezolus selection');
                 return;
             }
             if (!payload.entries || !Array.isArray(payload.entries)) {
-                notify('error', 'Not a valid Rezolus report');
+                notify('error', 'Not a valid Rezolus selection');
                 return;
             }
-            if (payload.file_checksum && currentChecksum && payload.file_checksum !== currentChecksum) {
-                const ok = confirm(
-                    `This report was saved from a different parquet file` +
-                    (payload.filename ? ` ("${payload.filename}")` : '') +
-                    `. Charts may not render correctly. Load anyway?`
-                );
-                if (!ok) return;
-                notify('warn', 'Report was saved from a different parquet file');
-            }
-            loadPayloadIntoStore(reportStore, payload);
-            reportStore.loadedFrom = file.name;
-            notify('info', `Loaded report (${reportStore.entries.length} charts)`);
-            if (m.route.get() === '/report') {
-                ReportView._needsReload = true;
+            const ok = loadJsonIntoSelection(payload, file.name);
+            if (!ok) return;
+            notify('info', `Loaded selection (${loadedSelectionStore.entries.length} charts)`);
+            if (m.route.get() === '/selection') {
+                LoadedSelectionView._needsReload = true;
                 m.redraw();
             } else {
-                m.route.set('/report');
+                m.route.set('/selection');
             }
         } catch (e) {
-            notify('error', 'Failed to import report');
+            notify('error', 'Failed to import selection');
             console.error('[selection] failed to import JSON:', e);
         }
     };
     input.click();
+};
+
+const loadJsonIntoSelection = (json, filename) => {
+    try {
+        const parsed = typeof json === 'string' ? JSON.parse(json) : json;
+        const migrated = migrateSelection(parsed);
+        resetStoreState(loadedSelectionStore);
+        loadedSelectionStore.tagline = migrated.tagline || '';
+        loadedSelectionStore.anchors = migrated.anchors || { baseline: 0, experiment: 0 };
+        loadedSelectionStore.chartToggles = migrated.chartToggles || {};
+        loadedSelectionStore.compare = migrated.compare || null;
+        loadedSelectionStore.entries = (migrated.entries || []).map(e => ({
+            id: crypto.randomUUID(),
+            chartId: e.chartId,
+            section: e.section,
+            sectionName: e.sectionName,
+            groupName: e.groupName || '',
+            promql_query: e.promql_query,
+            note: e.note || '',
+            chartOpts: e.chartOpts,
+        }));
+        loadedSelectionStore.loadedFrom = filename;
+        return true;
+    } catch (e) {
+        notify('error', `Cannot load Selection: ${e.message}`);
+        return false;
+    }
 };
 
 const saveToParquet = async (store, attrs) => {
@@ -804,20 +859,77 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
     },
 });
 
+// ── LoadedSelectionView (read-only mode for dropped JSON) ──────
+
+const LoadedSelectionView = {
+    _needsReload: false,
+};
+Object.assign(LoadedSelectionView, chartLoaderMixin(loadedSelectionStore, LoadedSelectionView), {
+    view({ attrs }) {
+        this._checkReload();
+        this._applyZoom(attrs);
+
+        const interval = attrs.interval || 1;
+
+        const header = m('div.selection-header', [
+            m('div.section-header-row', [
+                m('h1.section-title', attrs.title || 'Selection'),
+                m('div.section-actions', [
+                    loadedSelectionStore.entries.length > 0 && m('button.section-action-btn', {
+                        onclick: openLoadedSelectionInNotebook,
+                        title: 'Copy this Selection into the Notebook for editing',
+                    }, 'OPEN IN NOTEBOOK'),
+                ]),
+            ]),
+            loadedSelectionStore.loadedFrom && m('p.selection-source',
+                `Loaded from: ${loadedSelectionStore.loadedFrom}`),
+            loadedSelectionStore.tagline && m('p.selection-tagline-text', loadedSelectionStore.tagline),
+        ]);
+
+        if (this.loading) {
+            return m('div#section-content.selection-section', [header, m('p', 'Loading charts\u2026')]);
+        }
+
+        return m('div#section-content.selection-section', [
+            header,
+
+            loadedSelectionStore.entries.map((entry) => {
+                const spec = this.specs.get(entry.chartId);
+                if (!spec) return null;
+                return m('div.selection-card', [
+                    m('div.selection-card-header', [
+                        m('span.chart-title', selectionCardTitle(entry, spec)),
+                    ]),
+                    m('div.chart-wrapper', [
+                        m('div.chart-header', [
+                            m('span.chart-title', selectionCardTitle(entry, spec)),
+                            spec.opts.description && m('span.chart-subtitle', spec.opts.description),
+                        ]),
+                        m(Chart, { spec, chartsState: attrs.chartsState, interval }),
+                    ]),
+                ]);
+            }),
+        ]);
+    },
+});
+
 export {
     notebookStore,
     reportStore,
+    loadedSelectionStore,
     setStorageScope,
     persistNotebook,
     toggleSelection,
     isSelected,
     clearStore,
-    importJSON,
+    importSelection,
     loadPayloadIntoStore,
+    loadJsonIntoSelection,
     setAnchor,
     setChartToggle,
     NotebookView,
     ReportView,
+    LoadedSelectionView,
     migrateSelection,
     SELECTION_SCHEMA_VERSION,
 };

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -701,7 +701,7 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                         : 'Download a JSON pattern (charts + toggles only)',
                     onclick: () => exportJSON(notebookStore, attrs),
                 }, [
-                    'Save as Selection (JSON, Notes dropped) ',
+                    'Save as Selection (JSON, no Notes) ',
                     downloadIcon,
                 ]),
                 m('button.selection-btn.selection-btn-danger', {

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -401,7 +401,7 @@ const buildPayload = (store, attrs, { includeNotes = true } = {}) => ({
 });
 
 const exportJSON = async (store, attrs) => {
-    const defaultPrefix = `report-${Date.now()}`;
+    const defaultPrefix = (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-selection';
     const result = await showSaveModal(defaultPrefix, '.json');
     if (!result) return;
     const filename = result.filename;
@@ -500,7 +500,7 @@ const loadJsonIntoSelection = (json, filename) => {
 };
 
 const saveToParquet = async (store, attrs) => {
-    const defaultPrefix = (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-annotated';
+    const defaultPrefix = (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-report';
     const cs = attrs.chartsState;
     const hasZoom = cs && !cs.isDefaultZoom();
     const checkboxes = hasZoom

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -626,29 +626,21 @@ Object.assign(SelectionView, chartLoaderMixin(selectionStore, SelectionView), {
                     })
                     : m(Chart, { spec, chartsState: attrs.chartsState, interval });
                 return m('div.selection-card', [
-                    m('div.selection-card-body', [
-                        m('div.selection-card-chart', [
-                            m('button.selection-card-remove', {
-                                onclick: () => { removeEntry(selectionStore, entry.id); m.redraw(); },
-                                title: 'Remove',
-                            }, 'X'),
-                            m('div.chart-wrapper', [
-                                m('div.chart-header', [
-                                    m('span.chart-title', selectionCardTitle(entry, spec)),
-                                    spec.opts.description && m('span.chart-subtitle', spec.opts.description),
-                                ]),
-                                chartBody,
-                            ]),
-                        ]),
-                        m('div.selection-card-notes', [
-                            m('label.selection-notes-label', 'Notes'),
-                            m('textarea.selection-notes', {
-                                placeholder: 'Add notes\u2026',
-                                value: entry.note,
-                                oninput: (e) => { entry.note = e.target.value; persistSelection(); },
-                            }),
-                        ]),
+                    m('div.selection-card-header', [
+                        m('span.chart-title', selectionCardTitle(entry, spec)),
+                        m('button.selection-card-remove', {
+                            onclick: () => { removeEntry(selectionStore, entry.id); m.redraw(); },
+                            title: 'Remove',
+                        }, '\u00d7'),  // multiplication sign × — better visual than X
                     ]),
+                    m('div.chart-wrapper', [
+                        m('div.chart-header', [
+                            m('span.chart-title', selectionCardTitle(entry, spec)),
+                            spec.opts.description && m('span.chart-subtitle', spec.opts.description),
+                        ]),
+                        chartBody,
+                    ]),
+                    // Notes section rendered by Task 6 (placeholder for now)
                 ]);
             }),
         ]);
@@ -722,20 +714,19 @@ Object.assign(ReportView, chartLoaderMixin(reportStore, ReportView), {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
                 return m('div.selection-card', [
-                    m('div.selection-card-body', [
-                        m('div.selection-card-chart', [
-                            m('div.chart-wrapper', [
-                                m('div.chart-header', [
-                                    m('span.chart-title', selectionCardTitle(entry, spec)),
-                                    spec.opts.description && m('span.chart-subtitle', spec.opts.description),
-                                ]),
-                                m(Chart, { spec, chartsState: attrs.chartsState, interval }),
-                            ]),
+                    m('div.selection-card-header', [
+                        m('span.chart-title', selectionCardTitle(entry, spec)),
+                    ]),
+                    m('div.chart-wrapper', [
+                        m('div.chart-header', [
+                            m('span.chart-title', selectionCardTitle(entry, spec)),
+                            spec.opts.description && m('span.chart-subtitle', spec.opts.description),
                         ]),
-                        entry.note && m('div.selection-card-notes', [
-                            m('label.selection-notes-label', 'Notes'),
-                            m('p.selection-notes-text', entry.note),
-                        ]),
+                        m(Chart, { spec, chartsState: attrs.chartsState, interval }),
+                    ]),
+                    entry.note && m('div.selection-card-notes', [
+                        m('label.selection-notes-label', 'Notes'),
+                        m('p.selection-notes-text', entry.note),
                     ]),
                 ]);
             }),

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -158,7 +158,12 @@ const restoreStore = (key, store) => {
             chartOpts: e.chartOpts,
         }));
     } catch (e) {
-        console.warn('[selection] failed to restore:', e);
+        if (e?.message?.includes('unsupported selection schema')) {
+            console.warn('[selection] dropped stale localStorage entry:', e.message);
+            localStorage.removeItem(key);
+        } else {
+            console.warn('[selection] failed to restore:', e);
+        }
     }
 };
 
@@ -325,31 +330,37 @@ const exportJSON = async (store, attrs) => {
 };
 
 const loadPayloadIntoStore = (store, payload) => {
-    const migrated = migrateSelection(payload);
-    store.version = migrated.version;
-    store.tagline = migrated.tagline || '';
-    store.zoom = migrated.zoom || null;
-    store.stepOverride = migrated.step_override ?? migrated.stepOverride ?? null;
-    store.anchors = migrated.anchors || { baseline: 0, experiment: 0 };
-    store.chartToggles = migrated.chartToggles || {};
-    store.entries = payload.entries.map(e => ({
-        id: crypto.randomUUID(),
-        chartId: e.chartId,
-        section: e.section,
-        sectionName: e.sectionName,
-        groupName: e.groupName || '',
-        promql_query: e.promql_query,
-        note: e.note || '',
-        chartOpts: e.chartOpts,
-    }));
-    if (store === reportStore) {
-        store.reportId = payload.report_id || null;
-        store.savedAt = payload.saved_at || null;
-        store.sourceFilename = payload.filename || null;
-        store.fileChecksum = payload.file_checksum || null;
-        store.timeRange = payload.time_range || null;
-        store.rezolusVersion = payload.rezolus_version || null;
-        persistReport();
+    try {
+        const migrated = migrateSelection(payload);
+        store.version = migrated.version;
+        store.tagline = migrated.tagline || '';
+        store.zoom = migrated.zoom || null;
+        store.stepOverride = migrated.step_override ?? migrated.stepOverride ?? null;
+        store.anchors = migrated.anchors || { baseline: 0, experiment: 0 };
+        store.chartToggles = migrated.chartToggles || {};
+        store.entries = payload.entries.map(e => ({
+            id: crypto.randomUUID(),
+            chartId: e.chartId,
+            section: e.section,
+            sectionName: e.sectionName,
+            groupName: e.groupName || '',
+            promql_query: e.promql_query,
+            note: e.note || '',
+            chartOpts: e.chartOpts,
+        }));
+        if (store === reportStore) {
+            store.reportId = payload.report_id || null;
+            store.savedAt = payload.saved_at || null;
+            store.sourceFilename = payload.filename || null;
+            store.fileChecksum = payload.file_checksum || null;
+            store.timeRange = payload.time_range || null;
+            store.rezolusVersion = payload.rezolus_version || null;
+            persistReport();
+        }
+        return true;
+    } catch (e) {
+        notify('error', `Cannot load: ${e.message}`);
+        return false;
     }
 };
 

--- a/src/viewer/assets/lib/selection_migration.js
+++ b/src/viewer/assets/lib/selection_migration.js
@@ -1,16 +1,12 @@
-// Pure (DOM-free, Mithril-free) selection-migration helpers.
+// Pure (DOM-free, Mithril-free) selection-schema validator.
 //
-// Kept separate from `selection.js` so Node-based tests can import the
-// migration logic without dragging in Mithril, localStorage, or other
-// browser-only globals. Re-exported from `selection.js` for callers
-// that already pull their selection API from one module.
+// Lives separately from selection.js so Node tests can exercise it
+// without pulling in Mithril or localStorage. Re-exported from
+// selection.js for callers that pull all selection APIs from one
+// module.
 
-export const SELECTION_SCHEMA_VERSION = 2;
+export const SELECTION_SCHEMA_VERSION = 3;
 
-/**
- * Return a fresh v2-shaped selection default. Used when the input is
- * null/undefined and as a template for migration fill-ins.
- */
 export const defaultSelection = () => ({
     version: SELECTION_SCHEMA_VERSION,
     tagline: '',
@@ -22,33 +18,35 @@ export const defaultSelection = () => ({
 });
 
 /**
- * Migrate a parsed selection object (as loaded from localStorage or
- * from an imported JSON payload) to the current schema version.
+ * Validate a parsed selection payload against the current schema (v3).
  *
- * Guarantees on the returned object:
- *   - version === SELECTION_SCHEMA_VERSION
- *   - anchors has numeric `baseline` and `experiment` keys
- *   - chartToggles is a plain object (possibly empty)
+ * Returns a normalized v3 object on success. Throws on unsupported
+ * older versions — pre-v3 payloads (v1 unversioned, v2) are not
+ * migrated, by design (see spec non-goals).
  *
- * Callers may pass `null`/`undefined` to get a default selection
- * instead of an empty migration result.
+ * Pass null/undefined to get a fresh default selection.
  */
 export const migrateSelection = (sel) => {
     if (sel == null) return defaultSelection();
+    const version = Number(sel.version) || 1;
+    if (version !== SELECTION_SCHEMA_VERSION) {
+        throw new Error(
+            `unsupported selection schema version ${version} ` +
+            `(expected ${SELECTION_SCHEMA_VERSION}); ` +
+            `re-export from the original session with a v${SELECTION_SCHEMA_VERSION} viewer`,
+        );
+    }
     const out = { ...sel };
-    if (!out.version || out.version < 2) {
-        if (!out.anchors || typeof out.anchors !== 'object') {
-            out.anchors = { baseline: 0, experiment: 0 };
-        } else {
-            out.anchors = {
-                baseline: Number(out.anchors.baseline) || 0,
-                experiment: Number(out.anchors.experiment) || 0,
-            };
-        }
-        if (!out.chartToggles || typeof out.chartToggles !== 'object') {
-            out.chartToggles = {};
-        }
-        out.version = SELECTION_SCHEMA_VERSION;
+    if (!out.anchors || typeof out.anchors !== 'object') {
+        out.anchors = { baseline: 0, experiment: 0 };
+    } else {
+        out.anchors = {
+            baseline: Number(out.anchors.baseline) || 0,
+            experiment: Number(out.anchors.experiment) || 0,
+        };
+    }
+    if (!out.chartToggles || typeof out.chartToggles !== 'object') {
+        out.chartToggles = {};
     }
     return out;
 };

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -2287,6 +2287,23 @@ main {
     border-color: var(--danger);
 }
 
+.selection-btn-success {
+    background: color-mix(in srgb, var(--success) 15%, transparent);
+    color: var(--success);
+    border-color: color-mix(in srgb, var(--success) 40%, transparent);
+}
+
+.selection-btn-success:hover {
+    background: color-mix(in srgb, var(--success) 25%, transparent);
+    color: var(--success);
+    border-color: var(--success);
+}
+
+.selection-btn-success:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .save-modal-input-row + .save-modal-options {
     margin-top: -11px;
 }
@@ -2318,62 +2335,36 @@ main {
 }
 
 .selection-card {
-    border: 1px solid var(--border-default);
-    border-radius: 8px;
-    background: var(--bg-surface);
     margin-bottom: 1.5rem;
-    overflow: hidden;
-}
-
-.selection-card-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.5rem;
-    padding: 8px 16px;
-    background: var(--bg-inset);
-    border-bottom: 1px solid var(--border-default);
-    font-family: var(--font-mono);
-    font-size: 12px;
-}
-
-.selection-card-section-link {
-    color: var(--accent);
-    text-decoration: none;
-}
-
-.selection-card-section-link:hover {
-    text-decoration: underline;
-}
-
-.selection-card-sep {
-    color: var(--fg-muted);
-}
-
-.selection-card-title {
-    color: var(--fg);
-}
-
-.selection-card-desc {
-    color: var(--fg-muted);
-    font-size: 0.85em;
-    flex: 1;
 }
 
 .selection-card-remove {
+    position: absolute;
+    top: 8px;
+    right: 8px;
     background: transparent;
-    border: none;
-    font-family: var(--font-mono);
-    font-size: 14px;
-    font-weight: 600;
+    border: 1px solid transparent;
+    border-radius: 4px;
     color: var(--fg-muted);
     cursor: pointer;
-    padding: 0 0.25rem;
-    transition: color var(--transition-base);
+    font-family: var(--font-mono);
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 6px;
+    opacity: 0;
+    transition: all var(--transition-base);
+    z-index: 10;
+}
+
+.chart-wrapper:hover .selection-card-remove {
+    opacity: 0.6;
 }
 
 .selection-card-remove:hover {
+    opacity: 1 !important;
     color: var(--danger);
+    border-color: color-mix(in srgb, var(--danger) 40%, transparent);
+    background: color-mix(in srgb, var(--danger) 15%, transparent);
 }
 
 .notes-affordance {

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -2400,6 +2400,31 @@ main {
     border-top: 1px solid var(--border-default);
 }
 
+.report-card-notes {
+    padding: 12px;
+    border-top: 1px solid var(--border-default);
+    background: var(--bg-inset);
+}
+
+.report-notes-label {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.4rem;
+}
+
+.report-notes-text {
+    margin: 0;
+    color: var(--fg);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+}
+
 .selection-notes-label {
     font-family: var(--font-mono);
     font-size: 10px;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -2328,6 +2328,7 @@ main {
 .selection-card-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 0.5rem;
     padding: 8px 16px;
     background: var(--bg-inset);
@@ -2363,14 +2364,11 @@ main {
     background: transparent;
     border: none;
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 14px;
     font-weight: 600;
     color: var(--fg-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
     cursor: pointer;
-    padding: 0;
-    margin-bottom: 6px;
+    padding: 0 0.25rem;
     transition: color var(--transition-base);
 }
 
@@ -2378,29 +2376,11 @@ main {
     color: var(--danger);
 }
 
-.selection-card-body {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0;
-}
-
-.selection-card-chart {
-    flex: 1 1 calc(50% - 1rem);
-    max-width: calc(50% - 1rem);
-    min-width: 300px;
-    padding: 12px;
-}
-
-.selection-card-chart .chart {
-    height: 250px;
-}
-
 .selection-card-notes {
-    flex: 1 1 200px;
     display: flex;
     flex-direction: column;
     padding: 12px;
-    border-left: 1px solid var(--border-default);
+    border-top: 1px solid var(--border-default);
 }
 
 .selection-notes-label {
@@ -3052,19 +3032,6 @@ main {
         white-space: normal;
     }
 
-    /* ── Selection cards: stack vertically ── */
-    .selection-card-body {
-        flex-direction: column;
-    }
-
-    .selection-card-chart {
-        flex: 1 1 100%;
-        max-width: 100%;
-    }
-
-    .selection-card-notes {
-        flex: 1 1 auto;
-    }
 }
 
 /* ---- Landing / File Upload Page ---- */

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -927,6 +927,10 @@ main {
     flex-shrink: 0;
 }
 
+.section-title-report {
+    color: var(--accent);
+}
+
 .section-actions {
     display: flex;
     align-items: center;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -41,6 +41,12 @@
     --accent-subtle: rgba(56, 139, 253, 0.15);
     --accent-glow: rgba(56, 139, 253, 0.25);
 
+    /* Selection brand color — indigo, distinct from Notebook (green) and Report (blue). */
+    --indigo: #a371f7;
+    --indigo-emphasis: #c297fc;
+    --indigo-muted: rgba(163, 113, 247, 0.4);
+    --indigo-subtle: rgba(163, 113, 247, 0.15);
+
     /* A/B compare mode — baseline is blue, experiment is green. */
     --compare-baseline: #2E5BFF;
     --compare-baseline-bg: rgba(46, 91, 255, 0.08);
@@ -719,14 +725,14 @@ body::after {
 }
 
 #topnav .topnav-actions .transport-btn.import-btn.parquet-loaded {
-    color: var(--success);
-    border-color: color-mix(in srgb, var(--success) 40%, transparent);
+    color: var(--indigo);
+    border-color: var(--indigo-muted);
 }
 
 #topnav .topnav-actions .transport-btn.import-btn.parquet-loaded:hover {
-    background: color-mix(in srgb, var(--success) 15%, transparent);
-    color: var(--success);
-    box-shadow: 0 0 12px color-mix(in srgb, var(--success) 20%, transparent);
+    background: var(--indigo-subtle);
+    color: var(--indigo);
+    box-shadow: 0 0 12px color-mix(in srgb, var(--indigo) 20%, transparent);
 }
 
 #topnav .theme-toggle-btn {
@@ -2287,19 +2293,19 @@ main {
     border-color: var(--danger);
 }
 
-.selection-btn-success {
-    background: color-mix(in srgb, var(--success) 15%, transparent);
-    color: var(--success);
-    border-color: color-mix(in srgb, var(--success) 40%, transparent);
+.selection-btn-indigo {
+    background: var(--indigo-subtle);
+    color: var(--indigo);
+    border-color: var(--indigo-muted);
 }
 
-.selection-btn-success:hover {
-    background: color-mix(in srgb, var(--success) 25%, transparent);
-    color: var(--success);
-    border-color: var(--success);
+.selection-btn-indigo:hover {
+    background: color-mix(in srgb, var(--indigo) 25%, transparent);
+    color: var(--indigo);
+    border-color: var(--indigo);
 }
 
-.selection-btn-success:disabled {
+.selection-btn-indigo:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
@@ -2496,7 +2502,14 @@ main {
 
 .selection-link {
     font-weight: 600 !important;
+}
+
+.notebook-link {
     color: var(--success) !important;
+}
+
+.loaded-selection-link {
+    color: var(--indigo) !important;
 }
 
 .report-link {

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -927,10 +927,6 @@ main {
     flex-shrink: 0;
 }
 
-.section-title-report {
-    color: var(--accent);
-}
-
 .section-actions {
     display: flex;
     align-items: center;
@@ -2504,7 +2500,7 @@ main {
 }
 
 .report-link {
-    color: var(--success) !important;
+    color: var(--accent) !important;
 }
 
 /* Report metadata */

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -2376,6 +2376,23 @@ main {
     color: var(--danger);
 }
 
+.notes-affordance {
+    align-self: flex-start;
+    background: transparent;
+    border: none;
+    color: var(--fg-muted);
+    cursor: pointer;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    padding: 0.25rem 0.75rem 0.5rem;
+    border-radius: 4px;
+    transition: color var(--transition-base);
+}
+
+.notes-affordance:hover {
+    color: var(--accent);
+}
+
 .selection-card-notes {
     display: flex;
     flex-direction: column;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -2367,6 +2367,34 @@ main {
     background: color-mix(in srgb, var(--danger) 15%, transparent);
 }
 
+/* Placeholder card for entries whose data isn't in the loaded
+   capture (metric absent, query errored, no series matched). */
+.chart-wrapper-unavailable {
+    background: var(--bg-inset);
+    border-style: dashed;
+}
+
+.chart-unavailable {
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.chart-unavailable-title {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg-muted);
+}
+
+.chart-unavailable-message {
+    font-family: var(--font-sans);
+    font-size: 12px;
+    color: var(--fg-muted);
+    font-style: italic;
+}
+
 .notes-affordance {
     align-self: flex-start;
     background: transparent;

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -554,7 +554,10 @@ export function createGroupComponent(getState) {
                         chartHeader(renderSpec.opts, renderSpec),
                         chartBody(renderSpec, spec),
                         expandLink(spec, sectionRoute),
-                        selectButton(spec, sectionRoute, sectionName, attrs.name),
+                        selectButton(spec, sectionRoute, sectionName, attrs.name, compareMode ? {
+                            baselineAlias: captureLabels.baseline,
+                            experimentAlias: captureLabels.experiment,
+                        } : null),
                     ]),
                 ]);
             };

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -305,7 +305,9 @@ pub fn run(config: Config) {
 
     rt.spawn(async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
-        if open::that(format!("http://{addr}")).is_err() {
+        if std::env::var_os("REZOLUS_NO_OPEN").is_some() {
+            info!("Use your browser to view: http://{addr}");
+        } else if open::that(format!("http://{addr}")).is_err() {
             info!("Use your browser to view: http://{addr}");
         } else {
             info!("Launched browser to view: http://{addr}");

--- a/tests/selection_migration.test.mjs
+++ b/tests/selection_migration.test.mjs
@@ -66,3 +66,37 @@ test('missing chartToggles becomes empty object on v3', () => {
     const s = migrateSelection({ version: 3, entries: [] });
     assert.deepEqual(s.chartToggles, {});
 });
+
+// Round-trip test: a v3 payload shaped like buildPayload's output
+// (the JSON-export shape) survives migrateSelection without losing
+// the optional compare field. Codifies the contract that any caller
+// in the load path (loadPayloadIntoStore, restoreStore, etc.) will
+// see compare intact when present. Catches regressions where a new
+// field strips or reshapes compare during validation.
+test('buildPayload-shaped v3 payload round-trips through migrateSelection with compare intact', () => {
+    const v3 = {
+        version: 3,
+        report_id: '0192f6a8-7c2e-7000-8000-000000000001',
+        rezolus_version: '5.13.1-alpha.1',
+        saved_at: '2026-05-10T20:00:00.000Z',
+        source: 'rezolus',
+        filename: 'capture.parquet',
+        file_checksum: null,
+        time_range: { start_ms: 0, end_ms: 1000 },
+        zoom: null,
+        step_override: null,
+        anchors: { baseline: 100, experiment: 200 },
+        chartToggles: { 'cpu/usage': { diff: true } },
+        compare: { baseline_alias: 'vllm', experiment_alias: 'sglang' },
+        tagline: 'compare run #42',
+        entries: [
+            { chartId: 'cpu/usage', section: 'cpu', sectionName: 'CPU', groupName: 'usage', promql_query: 'rate(...)', note: '', chartOpts: { id: 'cpu/usage', title: 'CPU' } },
+        ],
+    };
+    const s = migrateSelection(v3);
+    assert.deepEqual(s.compare, { baseline_alias: 'vllm', experiment_alias: 'sglang' });
+    assert.deepEqual(s.anchors, { baseline: 100, experiment: 200 });
+    assert.deepEqual(s.chartToggles, { 'cpu/usage': { diff: true } });
+    assert.equal(s.tagline, 'compare run #42');
+    assert.equal(s.entries.length, 1);
+});

--- a/tests/selection_migration.test.mjs
+++ b/tests/selection_migration.test.mjs
@@ -2,55 +2,67 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { migrateSelection, SELECTION_SCHEMA_VERSION, defaultSelection } from '../src/viewer/assets/lib/selection_migration.js';
 
-test('schema version is 2', () => {
-    assert.equal(SELECTION_SCHEMA_VERSION, 2);
+test('schema version is 3', () => {
+    assert.equal(SELECTION_SCHEMA_VERSION, 3);
 });
 
-test('old (v1) selection gains default anchors and toggles', () => {
-    const old = { version: 1, timeRange: [0, 100] };
-    const m = migrateSelection(old);
-    assert.equal(m.version, 2);
-    assert.deepEqual(m.anchors, { baseline: 0, experiment: 0 });
-    assert.deepEqual(m.chartToggles, {});
-    // Other fields pass through unchanged.
-    assert.deepEqual(m.timeRange, [0, 100]);
+test('null/undefined input yields a default v3 selection', () => {
+    const s = migrateSelection(null);
+    assert.equal(s.version, 3);
+    assert.deepEqual(s.entries, []);
+    assert.deepEqual(s.anchors, { baseline: 0, experiment: 0 });
+    assert.deepEqual(s.chartToggles, {});
+    assert.equal(s.compare, undefined);
 });
 
-test('unversioned legacy selection upgrades to v2', () => {
-    const legacy = { timeRange: [0, 100], entries: [] };
-    const m = migrateSelection(legacy);
-    assert.equal(m.version, 2);
-    assert.deepEqual(m.anchors, { baseline: 0, experiment: 0 });
-    assert.deepEqual(m.chartToggles, {});
-});
-
-test('v2 selection unchanged by migration', () => {
-    const cur = {
-        version: 2,
-        anchors: { baseline: 5, experiment: 10 },
-        chartToggles: { cpu: { diff: true } },
+test('v3 selection passes through unchanged', () => {
+    const v3 = {
+        version: 3,
+        tagline: 'hi',
+        entries: [{ chartId: 'x' }],
+        anchors: { baseline: 1, experiment: 2 },
+        chartToggles: { x: { diff: true } },
     };
-    const m = migrateSelection(cur);
-    assert.deepEqual(m, cur);
+    const s = migrateSelection(v3);
+    assert.equal(s.version, 3);
+    assert.equal(s.tagline, 'hi');
+    assert.deepEqual(s.entries, [{ chartId: 'x' }]);
 });
 
-test('null/undefined input yields a default selection', () => {
-    const a = migrateSelection(null);
-    const b = migrateSelection(undefined);
-    assert.equal(a.version, 2);
-    assert.equal(b.version, 2);
-    assert.deepEqual(a.anchors, { baseline: 0, experiment: 0 });
-    assert.deepEqual(a.chartToggles, {});
-    assert.deepEqual(a, defaultSelection());
+test('v3 selection preserves optional compare field', () => {
+    const v3 = {
+        version: 3,
+        entries: [],
+        compare: { baseline_alias: 'vllm', experiment_alias: 'sglang' },
+    };
+    const s = migrateSelection(v3);
+    assert.deepEqual(s.compare, { baseline_alias: 'vllm', experiment_alias: 'sglang' });
 });
 
-test('malformed anchors are coerced to numeric baseline/experiment', () => {
-    const m = migrateSelection({ version: 1, anchors: { baseline: '42', experiment: 'not-a-number' } });
-    assert.equal(m.anchors.baseline, 42);
-    assert.equal(m.anchors.experiment, 0);
+test('v2 input throws explicit unsupported error', () => {
+    assert.throws(
+        () => migrateSelection({ version: 2, entries: [] }),
+        /unsupported.*version.*2/i,
+    );
 });
 
-test('malformed chartToggles is replaced with empty object', () => {
-    const m = migrateSelection({ version: 1, chartToggles: 'not an object' });
-    assert.deepEqual(m.chartToggles, {});
+test('v1 (versionless) input throws explicit unsupported error', () => {
+    assert.throws(
+        () => migrateSelection({ entries: [] }),
+        /unsupported.*version/i,
+    );
+});
+
+test('malformed anchors are coerced to numeric on v3', () => {
+    const s = migrateSelection({
+        version: 3,
+        entries: [],
+        anchors: { baseline: 'oops', experiment: '5' },
+    });
+    assert.deepEqual(s.anchors, { baseline: 0, experiment: 5 });
+});
+
+test('missing chartToggles becomes empty object on v3', () => {
+    const s = migrateSelection({ version: 3, entries: [] });
+    assert.deepEqual(s.chartToggles, {});
 });

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -31,6 +31,9 @@ echo "logs: $LOGDIR"
 # Build before launching anything so a compile failure surfaces early.
 cargo build --bin rezolus 2>&1 | tail -3
 
+# Don't pop browser tabs during the smoke test.
+export REZOLUS_NO_OPEN=1
+
 # Launch all four. Each writes its log to $LOGDIR so failures can be
 # triaged without re-running.
 ./target/debug/rezolus view \

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -177,5 +177,22 @@ for path in / /about /lib/style.css; do
     eq "static $path" "$status" "200" "$LOGDIR/upload.log"
 done
 
+echo "==> served JS bundle has the Notebook rename + new Selection sidebar"
+selection_js=$(curl -fsS "http://127.0.0.1:$PORT_FILE/lib/selection.js")
+echo "$selection_js" | grep -q "notebookStore" \
+    || fail "selection.js missing notebookStore identifier" "" "notebookStore present" "$LOGDIR/file.log"
+echo "$selection_js" | grep -q "loadedSelectionStore" \
+    || fail "selection.js missing loadedSelectionStore identifier" "" "loadedSelectionStore present" "$LOGDIR/file.log"
+echo "$selection_js" | grep -q "LoadedSelectionView" \
+    || fail "selection.js missing LoadedSelectionView" "" "LoadedSelectionView present" "$LOGDIR/file.log"
+# Sanity: the old identifiers should be gone (modulo the unrelated
+# `toggleSelection`, `isSelected`, `selectionCardTitle`, etc. which
+# stay — only the workspace-store identifiers were renamed).
+if echo "$selection_js" | grep -E "(\bselectionStore\b|\bSelectionView\b|\bpersistSelection\b)" >/dev/null; then
+    fail "selection.js still has old workspace identifiers" \
+         "$(echo "$selection_js" | grep -nE '(\bselectionStore\b|\bSelectionView\b|\bpersistSelection\b)' | head -3)" \
+         "no old store identifiers" "$LOGDIR/file.log"
+fi
+
 echo
 echo "ALL VIEWER SMOKE TESTS PASSED"


### PR DESCRIPTION
## Summary

Splits the viewer's pinned-charts feature into three named artifact types with explicit boundaries and brand colors:

- **Notebook** (live editor, green) — workspace where charts get pinned and notes get drafted. Renamed from "Selection".
- **Selection** (loaded JSON pattern, indigo, read-only) — drag-dropped JSON exports, pattern-only (charts + toggles, no notes).
- **Report** (loaded parquet annotation, blue, read-only) — server-fetched annotations embedded in a parquet, full pattern + notes.

Each has a sidebar entry that appears only when populated. Read-only views have an "Open in Notebook" button that copies state into the live editor (with overwrite-confirm). v3 JSON schema is a clean break from v2 — no migration, since the feature isn't widely used yet.

PR 1 (live-compare-mode plumbing the Notebook depends on) shipped as #908. PR 3 (combined-A/B parquet artifact + per-capture container labels) is independent and gets its own PR.

### Notable changes
- v3 schema validator throws on non-v3 input; localStorage drafts of v1/v2 are dropped on load.
- "Save as Selection (JSON, no Notes)" disabled when any pinned chart has a note (use Save as Report).
- "Save as Report (parquet, Selection & Notes)" disabled in two-file A/B mode (no single parquet to embed in; PR 3 will lift this when combined-A/B parquets land).
- Pinned-chart cards stack vertically; notes hidden behind a "+ Add note" affordance until populated; × delete is an overlay button on the chart-wrapper.
- Unavailable charts (metric absent in this capture) render a dashed placeholder with the breadcrumb title and "No data available" message — replaces the previous silent collapse.
- "Clear Notes" button drops all notes while preserving pinned charts.
- Default save names: \`<parquet>-selection.json\` / \`<parquet>-report.parquet\`.
- \`REZOLUS_NO_OPEN=1\` env var suppresses the browser-launch on \`rezolus view\` startup; smoke test sets it so CI runs are quiet.

### Known deferred
- The two \`confirm()\` calls in \`openInNotebook\` could use a styled modal (codebase has \`SaveModal\` precedent); intentionally left for a separate cleanup.
- Card render is duplicated across the three views; will diverge further in PR 3, so kept separate for now.
- \`loadJsonIntoSelection\` returns true/false — could throw + catch at boundary for unified error contract; left as-is.

## Test plan
- [x] \`cargo build\` clean, \`cargo test\` passes (116 tests)
- [x] \`cargo clippy --bin rezolus -- -D warnings\` clean
- [x] \`node --test tests/*.mjs\` (selection_migration round-trip + 8 schema tests, compare_math)
- [x] \`bash tests/viewer_smoke.sh\` (10 assertion sections covering mode/sections/query/proxy/attach-detach/static-assets/Notebook bundle grep)
- [x] Manual: pin charts → see vertical card with overlay × → click \`+ Add note\` → text persists across reload
- [ ] Manual: drop a v2 JSON → clear \`notify('error')\` message ("unsupported selection schema")
- [x] Manual: drop a v3 Selection JSON → Selection sidebar entry appears (indigo) → Open in Notebook copies entries with overwrite-confirm
- [x] Manual: load parquet with embedded report → Report sidebar entry (blue) → notes render as static styled blocks → Open in Notebook works
- [ ] Manual: in compare mode, pin a chart → \`notebookStore.compare\` populated → JSON export includes \`compare: { baseline_alias, experiment_alias }\`
- [ ] Manual: load Selection against a parquet missing some metrics → "N of M pinned charts have no data" toast → missing entries render dashed placeholder cards
- [ ] Manual: switch parquet files via "Load Parquet" → loaded Selection sidebar entry clears (no stale state)
- [x] Manual: "Clear Notes" button — confirms before wiping; disabled when no notes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)