### PR TITLE
feat(viewer): <rezolus-chart> embed component with exact viewer parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.9"
+version = "5.13.1-alpha.10"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.9"
+version = "5.13.1-alpha.10"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/embed/demo.html
+++ b/src/viewer/assets/lib/embed/demo.html
@@ -53,6 +53,10 @@
     <rezolus-chart id="chart"></rezolus-chart>
 
     <script type="module">
+        // Reuse the viewer's exact label-injection so the embed scopes
+        // the query to one node the same way the dashboard does.
+        import { injectLabel } from '../data.js';
+
         const chartEl = document.getElementById('chart');
         const statusEl = document.getElementById('status');
 
@@ -93,6 +97,22 @@
         // Series are produced by executing promql_query against
         // /api/v1/query_range — mirror executePromQLRangeQuery() in
         // data.js (same window / step recipe) to get real data here.
+        // The dashboard scopes a non-service plot's query to the selected
+        // node (pinned_node, else first node) before executing — see
+        // data.js::buildEffectiveQuery. Without that, a multi-node
+        // recording fans the query out across every node and the embed
+        // diverges from the viewer. Replicate that node pick + reuse the
+        // viewer's own injectLabel so the matcher is identical.
+        async function selectedNode() {
+            const res = await fetch('/api/v1/file_metadata', { cache: 'no-store' });
+            if (!res.ok) return null;
+            const fm = await res.json();
+            const nodes = Array.isArray(fm.nodes) ? fm.nodes : [];
+            if (nodes.length === 0) return null;
+            const pinned = fm.pinned_node;
+            return (pinned && nodes.includes(pinned)) ? pinned : nodes[0];
+        }
+
         async function runPlotQuery(plot) {
             const metaRes = await fetch('/api/v1/metadata', { cache: 'no-store' });
             if (!metaRes.ok) throw new Error(`metadata HTTP ${metaRes.status}`);
@@ -106,8 +126,13 @@
             const start = Math.max(minTime, maxTime - windowDuration);
             const step = Math.max(1, Math.floor(windowDuration / 500));
 
+            const node = await selectedNode();
+            const query = node
+                ? injectLabel(plot.promql_query, 'node', node)
+                : plot.promql_query;
+
             const qs = new URLSearchParams({
-                query: plot.promql_query,
+                query,
                 start: String(start),
                 end: String(maxTime),
                 step: String(step),
@@ -119,11 +144,15 @@
             if (!Array.isArray(series) || series.length === 0) return null;
 
             return {
-                ...plot,
-                data: [
-                    series.map((p) => Number(p[0])),
-                    series.map((p) => parseFloat(p[1])),
-                ],
+                node,
+                query,
+                plot: {
+                    ...plot,
+                    data: [
+                        series.map((p) => Number(p[0])),
+                        series.map((p) => parseFloat(p[1])),
+                    ],
+                },
             };
         }
 
@@ -136,12 +165,16 @@
                 if (!plot) throw new Error('CPU % plot not found in rezolus section');
                 if (!plot.promql_query) throw new Error('CPU plot descriptor has no promql_query');
 
-                const withData = await runPlotQuery(plot);
-                if (withData) {
-                    chartEl.plot = withData;
+                const result = await runPlotQuery(plot);
+                if (result) {
+                    chartEl.plot = result.plot;
                     statusEl.className = 'status ok';
-                    statusEl.innerHTML = `Executed <code>${plot.promql_query}</code> via
-                        <code>/api/v1/query_range</code> — ${withData.data[0].length} data points.`;
+                    const scope = result.node
+                        ? ` scoped to <code>node="${result.node}"</code>`
+                        : '';
+                    statusEl.innerHTML = `Executed <code>${result.query}</code> via
+                        <code>/api/v1/query_range</code>${scope} —
+                        ${result.plot.data[0].length} data points.`;
                     return;
                 }
 

--- a/src/viewer/assets/lib/embed/demo.html
+++ b/src/viewer/assets/lib/embed/demo.html
@@ -4,48 +4,47 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>rezolus-chart embed spike</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+    <!-- Linking style.css gives the page the rezolus tokens (and theme) the
+         component depends on via the shadow-root <link> to charts.css. -->
+    <link rel="stylesheet" href="/lib/style.css"/>
     <script src="/lib/charts/echarts.min.js"></script>
     <script type="module" src="./rezolus-chart.js"></script>
     <style>
         body {
-            font-family: 'Inter', system-ui, sans-serif;
             max-width: 960px;
             margin: 2rem auto;
             padding: 0 1rem;
-            color: #1a1a1a;
         }
-        h1 { font-weight: 600; }
-        h2 { font-weight: 600; font-size: 1.05rem; margin-top: 2rem; }
-        p { line-height: 1.5; }
-        code { background: #f3f4f6; padding: 1px 5px; border-radius: 3px; font-size: 0.92em; }
+        h1 { font-weight: 600; margin-bottom: 0.5rem; }
+        p { line-height: 1.5; max-width: 70ch; color: var(--fg-secondary); }
+        code {
+            background: var(--bg-elevated);
+            color: var(--fg);
+            padding: 1px 5px;
+            border-radius: 3px;
+            font-family: var(--font-mono);
+            font-size: 0.92em;
+        }
         .status {
             padding: 0.6rem 0.9rem;
             border-radius: 6px;
-            border: 1px solid #e5e7eb;
-            background: #f9fafb;
+            border: 1px solid var(--border-default);
+            background: var(--bg-elevated);
+            color: var(--fg-secondary);
             font-size: 0.9rem;
             margin: 0.5rem 0 1rem;
         }
-        .status.ok      { border-color: #bbf7d0; background: #f0fdf4; }
-        .status.fallback { border-color: #fde68a; background: #fffbeb; }
-        rezolus-chart {
-            background: #fff;
-            border: 1px solid #e5e7eb;
-            border-radius: 6px;
-            padding: 12px 14px;
-            box-sizing: border-box;
-        }
+        .status.ok       { border-color: var(--success); color: var(--fg); }
+        .status.fallback { border-color: var(--warning); color: var(--fg); }
     </style>
 </head>
 <body>
     <h1>&lt;rezolus-chart&gt; embed spike</h1>
     <p>Renders the <strong>Rezolus → Resource Usage → CPU %</strong> plot from the
-       <code>rezolus</code> self-report section. Plot descriptor (the JSON shape
-       produced by <code>crates/dashboard/src/dashboard/rezolus.rs</code>) and series
-       data are fetched from <code>/data/rezolus.json</code> served by a running
-       viewer with a recording loaded. Falls back to the same descriptor with
-       synthetic data when the fetch fails so the demo renders standalone too.</p>
+       <code>rezolus</code> self-report section. Card chrome, title typography
+       and sizing come from <code>/lib/charts.css</code> linked into the
+       component's shadow root, so it matches the rest of the rezolus viewer.</p>
 
     <div id="status" class="status">Loading from <code>/data/rezolus.json</code>…</div>
     <rezolus-chart id="chart"></rezolus-chart>
@@ -107,7 +106,6 @@
                     return;
                 }
 
-                // Descriptor available, but no recording loaded yet.
                 chartEl.plot = syntheticData(plot);
                 statusEl.className = 'status fallback';
                 statusEl.innerHTML = `Got real descriptor from <code>/data/rezolus.json</code>

--- a/src/viewer/assets/lib/embed/demo.html
+++ b/src/viewer/assets/lib/embed/demo.html
@@ -5,11 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>rezolus-chart embed spike</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet"/>
-    <!-- Linking style.css gives the page the rezolus tokens (and theme) the
-         component depends on via the shadow-root <link> to charts.css. -->
+    <!-- rezolus tokens the component (and charts.css) read. -->
     <link rel="stylesheet" href="/lib/style.css"/>
-    <!-- echarts + mithril as globals; <rezolus-chart> mounts the
-         viewer's real Chart component, which uses both. -->
+    <!-- globals the reused Chart needs -->
     <script src="/lib/charts/echarts.min.js"></script>
     <script src="/lib/mithril.js"></script>
     <script type="module" src="./rezolus-chart.js"></script>
@@ -53,16 +51,13 @@
     <rezolus-chart id="chart"></rezolus-chart>
 
     <script type="module">
-        // Reuse the viewer's exact label-injection so the embed scopes
-        // the query to one node the same way the dashboard does.
+        // Viewer's exact node-scoping label injection.
         import { injectLabel } from '../data.js';
 
         const chartEl = document.getElementById('chart');
         const statusEl = document.getElementById('status');
 
-        // Hand-authored descriptor matching what rezolus.rs emits for the
-        // first plot of the Rezolus → Resource Usage subgroup. Used as the
-        // standalone fallback so the demo renders even without a viewer.
+        // Standalone fallback: renders even without a viewer.
         const fallbackDescriptor = {
             opts: {
                 title: 'CPU %',
@@ -92,17 +87,8 @@
             return subgroup?.plots?.find(p => p.opts?.id === 'cpu') ?? null;
         }
 
-        // The rezolus viewer is query-driven: /data/rezolus.json carries
-        // plot DESCRIPTORS (opts + promql_query), never inline series.
-        // Series are produced by executing promql_query against
-        // /api/v1/query_range — mirror executePromQLRangeQuery() in
-        // data.js (same window / step recipe) to get real data here.
-        // The dashboard scopes a non-service plot's query to the selected
-        // node (pinned_node, else first node) before executing — see
-        // data.js::buildEffectiveQuery. Without that, a multi-node
-        // recording fans the query out across every node and the embed
-        // diverges from the viewer. Replicate that node pick + reuse the
-        // viewer's own injectLabel so the matcher is identical.
+        // Section JSON is descriptor-only (no inline series), so mirror
+        // data.js: pick the viewer's node, injectLabel, run query_range.
         async function selectedNode() {
             const res = await fetch('/api/v1/file_metadata', { cache: 'no-store' });
             if (!res.ok) return null;

--- a/src/viewer/assets/lib/embed/demo.html
+++ b/src/viewer/assets/lib/embed/demo.html
@@ -85,9 +85,43 @@
             return subgroup?.plots?.find(p => p.opts?.id === 'cpu') ?? null;
         }
 
-        function hasSeriesData(plot) {
-            return Array.isArray(plot?.data) && plot.data.length >= 2
-                && Array.isArray(plot.data[0]) && plot.data[0].length > 0;
+        // The rezolus viewer is query-driven: /data/rezolus.json carries
+        // plot DESCRIPTORS (opts + promql_query), never inline series.
+        // Series are produced by executing promql_query against
+        // /api/v1/query_range — mirror executePromQLRangeQuery() in
+        // data.js (same window / step recipe) to get real data here.
+        async function runPlotQuery(plot) {
+            const metaRes = await fetch('/api/v1/metadata', { cache: 'no-store' });
+            if (!metaRes.ok) throw new Error(`metadata HTTP ${metaRes.status}`);
+            const meta = (await metaRes.json())?.data || {};
+            const minTime = meta.minTime;
+            const maxTime = meta.maxTime;
+            if (!Number.isFinite(minTime) || !Number.isFinite(maxTime) || maxTime <= minTime) {
+                throw new Error('no recording time range (no parquet loaded?)');
+            }
+            const windowDuration = Math.min(3600, maxTime - minTime);
+            const start = Math.max(minTime, maxTime - windowDuration);
+            const step = Math.max(1, Math.floor(windowDuration / 500));
+
+            const qs = new URLSearchParams({
+                query: plot.promql_query,
+                start: String(start),
+                end: String(maxTime),
+                step: String(step),
+            });
+            const qRes = await fetch(`/api/v1/query_range?${qs}`, { cache: 'no-store' });
+            if (!qRes.ok) throw new Error(`query_range HTTP ${qRes.status}`);
+            const body = await qRes.json();
+            const series = body?.status === 'success' ? body.data?.result?.[0]?.values : null;
+            if (!Array.isArray(series) || series.length === 0) return null;
+
+            return {
+                ...plot,
+                data: [
+                    series.map((p) => Number(p[0])),
+                    series.map((p) => parseFloat(p[1])),
+                ],
+            };
         }
 
         async function loadRealOrFallback() {
@@ -97,24 +131,25 @@
                 const view = await res.json();
                 const plot = findCpuPlot(view);
                 if (!plot) throw new Error('CPU % plot not found in rezolus section');
+                if (!plot.promql_query) throw new Error('CPU plot descriptor has no promql_query');
 
-                if (hasSeriesData(plot)) {
-                    chartEl.plot = plot;
+                const withData = await runPlotQuery(plot);
+                if (withData) {
+                    chartEl.plot = withData;
                     statusEl.className = 'status ok';
-                    statusEl.innerHTML = `Loaded real plot from <code>/data/rezolus.json</code>
-                        — ${plot.data[0].length} data points.`;
+                    statusEl.innerHTML = `Executed <code>${plot.promql_query}</code> via
+                        <code>/api/v1/query_range</code> — ${withData.data[0].length} data points.`;
                     return;
                 }
 
                 chartEl.plot = syntheticData(plot);
                 statusEl.className = 'status fallback';
-                statusEl.innerHTML = `Got real descriptor from <code>/data/rezolus.json</code>
-                    but no series data (no recording loaded). Showing synthetic series on the
-                    real descriptor.`;
+                statusEl.innerHTML = `Real descriptor from <code>/data/rezolus.json</code>, but the
+                    query returned no series. Showing synthetic series on the real descriptor.`;
             } catch (err) {
                 chartEl.plot = syntheticData(fallbackDescriptor);
                 statusEl.className = 'status fallback';
-                statusEl.innerHTML = `Fetch failed (<code>${err.message}</code>). Showing
+                statusEl.innerHTML = `Fetch/query failed (<code>${err.message}</code>). Showing
                     hand-authored fallback descriptor with synthetic series.`;
             }
         }

--- a/src/viewer/assets/lib/embed/demo.html
+++ b/src/viewer/assets/lib/embed/demo.html
@@ -8,7 +8,10 @@
     <!-- Linking style.css gives the page the rezolus tokens (and theme) the
          component depends on via the shadow-root <link> to charts.css. -->
     <link rel="stylesheet" href="/lib/style.css"/>
+    <!-- echarts + mithril as globals; <rezolus-chart> mounts the
+         viewer's real Chart component, which uses both. -->
     <script src="/lib/charts/echarts.min.js"></script>
+    <script src="/lib/mithril.js"></script>
     <script type="module" src="./rezolus-chart.js"></script>
     <style>
         body {

--- a/src/viewer/assets/lib/embed/rezolus-chart.js
+++ b/src/viewer/assets/lib/embed/rezolus-chart.js
@@ -1,13 +1,19 @@
 // <rezolus-chart> — Lit web component that renders a single Plot
 // descriptor (the shape produced by crates/dashboard/) inside Shadow DOM.
 //
-// Chrome (card frame, title typography, sizing) comes from
+// Card chrome (frame, title typography, sizing) comes from
 // /lib/charts.css linked into the shadow root, so the component looks
-// like a regular rezolus chart when embedded inside the viewer. CSS
-// custom properties inherited from the host page's :root (--fg,
-// --accent, --bg-card-gradient, etc.) reach into the shadow root
-// automatically. External embedders need to load the same tokens (or
-// override them per :host) for the chrome to render correctly.
+// like a regular rezolus chart when embedded inside the viewer. The
+// echarts content (axes, gridlines, tooltip, series color) reads the
+// rezolus CSS tokens via getComputedStyle and feeds them to setOption
+// — echarts bakes color strings into its option and doesn't observe
+// CSS, so token changes (theme toggles) only land via a re-render. A
+// MutationObserver on <html> data-theme triggers that re-render.
+//
+// CSS custom properties inherit into the shadow root from the host
+// page's :root, so inside the rezolus viewer everything works for
+// free. External embedders need to load the same tokens (or override
+// them per :host) for chrome and chart contents to render correctly.
 //
 // Spike scope: inline-series adapter only. The component accepts a `plot`
 // property whose `data` field is [[timestamps_s], [values]] (PromQL's
@@ -58,6 +64,19 @@ class RezolusChart extends LitElement {
         this.plot = null;
         this._chart = null;
         this._observer = null;
+        this._themeObserver = null;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        // Re-render when the host page flips data-theme. Token reads in
+        // _readTokens() return the new values; setOption with notMerge
+        // applies them to axis/grid/tooltip/series.
+        this._themeObserver = new MutationObserver(() => this._render());
+        this._themeObserver.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme'],
+        });
     }
 
     firstUpdated() {
@@ -73,9 +92,32 @@ class RezolusChart extends LitElement {
 
     disconnectedCallback() {
         super.disconnectedCallback();
+        this._themeObserver?.disconnect();
         this._observer?.disconnect();
         this._chart?.dispose();
         this._chart = null;
+    }
+
+    // Read the rezolus CSS tokens the chart contents (axis, grid, tooltip,
+    // series) depend on. echarts bakes color strings into its option at
+    // setOption time and doesn't observe CSS, so we read on each render
+    // and feed the values in.
+    _readTokens() {
+        const styles = getComputedStyle(this);
+        const v = (name, fallback) => styles.getPropertyValue(name).trim() || fallback;
+        return {
+            fg:            v('--fg', '#1a1a1a'),
+            fgSecondary:   v('--fg-secondary', '#6b7280'),
+            gridLine:      v('--chart-grid-line', 'rgba(48,54,61,0.5)'),
+            accent:        v('--accent', '#58a6ff'),
+            bgCard:        v('--bg-card', '#ffffff'),
+            borderDefault: v('--border-default', 'rgba(48,54,61,0.7)'),
+            chart1:        v('--chart-1', '#1f77b4'),
+        };
+    }
+
+    _isDarkTheme() {
+        return document.documentElement?.getAttribute('data-theme') !== 'light';
     }
 
     _render() {
@@ -105,18 +147,49 @@ class RezolusChart extends LitElement {
         // PromQL convention: timestamps are seconds since epoch. echarts wants ms.
         const seriesData = times.map((t, i) => [t * 1000, values[i]]);
         const fmt = this.plot.opts?.format ?? {};
+        const t = this._readTokens();
 
         this._chart.setOption({
-            // Top is large enough to clear the absolutely-positioned
-            // .chart-header (10px padding + 13px title with line-height).
-            grid: { left: 56, right: 16, top: 36, bottom: 28 },
-            xAxis: { type: 'time' },
+            backgroundColor: 'transparent',
+            darkMode: this._isDarkTheme(),
+            textStyle: { color: t.fg },
+            color: [t.chart1],
+            // Top clears the absolutely-positioned .chart-header (10px
+            // padding + 13px title with line-height).
+            grid: { left: 12, right: 17, top: 36, bottom: 24, containLabel: true },
+            xAxis: {
+                type: 'time',
+                axisLine: { show: false },
+                axisTick: { show: false },
+                axisLabel: { color: t.fgSecondary, fontSize: 10 },
+                splitLine: {
+                    show: true,
+                    lineStyle: { color: t.gridLine, type: 'dashed' },
+                },
+            },
             yAxis: {
                 type: fmt.log_scale ? 'log' : 'value',
                 name: fmt.y_axis_label ?? '',
-                nameTextStyle: { fontSize: 11 },
+                nameTextStyle: { fontSize: 11, color: t.fgSecondary },
+                axisLine: { show: false },
+                axisTick: { show: false },
+                axisLabel: { color: t.fgSecondary, fontSize: 10, margin: 12 },
+                splitLine: { lineStyle: { color: t.gridLine, type: 'dashed' } },
             },
-            tooltip: { trigger: 'axis', appendToBody: false },
+            tooltip: {
+                trigger: 'axis',
+                confine: true,
+                backgroundColor: t.bgCard,
+                borderColor: t.borderDefault,
+                borderWidth: 1,
+                textStyle: { color: t.fg },
+                axisPointer: {
+                    type: 'line',
+                    snap: true,
+                    animation: false,
+                    lineStyle: { color: t.accent, opacity: 0.6, width: 1 },
+                },
+            },
             series: [{
                 name: this.plot.opts?.title ?? '',
                 type: 'line',

--- a/src/viewer/assets/lib/embed/rezolus-chart.js
+++ b/src/viewer/assets/lib/embed/rezolus-chart.js
@@ -1,45 +1,48 @@
 // <rezolus-chart> — Lit web component that renders a single Plot
 // descriptor (the shape produced by crates/dashboard/) inside Shadow DOM.
 //
-// Card chrome (frame, title typography, sizing) comes from
-// /lib/charts.css linked into the shadow root, so the component looks
-// like a regular rezolus chart when embedded inside the viewer. The
-// echarts content (axes, gridlines, tooltip, series color) reads the
-// rezolus CSS tokens via getComputedStyle and feeds them to setOption
-// — echarts bakes color strings into its option and doesn't observe
-// CSS, so token changes (theme toggles) only land via a re-render. A
-// MutationObserver on <html> data-theme triggers that re-render.
+// It does NOT reimplement chart configuration. It mounts the viewer's
+// real `Chart` mithril component (the same `configureChartByType`
+// dispatcher the dashboard uses), so every style — line, scatter,
+// heatmap, quantile, multi — renders byte-for-byte like the viewer:
+// unit-aware axes/tooltip, fonts, gridlines, dataZoom, OOB bands, etc.
+// Visual parity is structural, not chased.
 //
-// CSS custom properties inherit into the shadow root from the host
-// page's :root, so inside the rezolus viewer everything works for
-// free. External embedders need to load the same tokens (or override
-// them per :host) for chrome and chart contents to render correctly.
+// Card chrome (frame, title, sizing) comes from /lib/charts.css linked
+// into the shadow root. The viewer's COLORS read CSS tokens from
+// document.documentElement, so as long as the host page carries the
+// rezolus tokens (link /lib/style.css) chrome and chart contents theme
+// correctly. A data-theme MutationObserver remounts so a theme flip
+// re-reads the tokens (echarts bakes colors at setOption time).
 //
-// Spike scope: inline-series adapter only. The component accepts a `plot`
-// property whose `data` field is [[timestamps_s], [values]] (PromQL's
-// seconds-since-epoch convention). Future adapters (HTTP, WASM, SSE)
-// will live alongside this file and feed the same property contract.
-//
-// Requires echarts to be loaded as a global (see lib/charts/echarts.min.js).
+// Requires, loaded as globals on the host page (the viewer provides
+// all of these): echarts (/lib/charts/echarts.min.js) and mithril
+// (/lib/mithril.js, which sets window.m). `plot` is a descriptor whose
+// `data` field is the viewer spec shape (e.g. [timestamps_s, values]
+// for a single line).
 import { LitElement, html, css } from '../lit/lit.js';
+import { Chart, ChartsState } from '../charts/chart.js';
+
+// One throwaway ChartsState shared by all embedded charts on the page.
+// It only provides the zoom/cursor registry the Chart lifecycle needs;
+// nothing here drives cross-chart sync, so a single bare instance is
+// fine (Chart de-registers itself on unmount via its onremove).
+const embedChartsState = new ChartsState();
 
 class RezolusChart extends LitElement {
     static properties = {
         plot: { type: Object },
+        // Sampling interval (s) — only feeds the Chart's min-zoom calc.
+        interval: { type: Number },
     };
 
-    // Component-local styles. The :host prefix on the overrides bumps
-    // specificity above charts.css so they win without !important
-    // (except for the `> div` selector, which charts.css already marks
-    // !important — must match).
     static styles = css`
         :host {
             display: block;
             min-width: 0;
         }
-        /* charts.css collapses chart wrappers whose .chart has .no-data
-           so section grids fold around missing data. For embed we want a
-           visible placeholder so the consumer can see the slot exists. */
+        /* charts.css collapses wrappers whose .chart has .no-data so
+           section grids fold; for embed show a visible placeholder. */
         :host .chart-wrapper:has(.no-data) {
             display: block;
         }
@@ -62,17 +65,17 @@ class RezolusChart extends LitElement {
     constructor() {
         super();
         this.plot = null;
-        this._chart = null;
-        this._observer = null;
+        this.interval = 1;
+        this._mountHost = null;
+        this._mounted = false;
         this._themeObserver = null;
     }
 
     connectedCallback() {
         super.connectedCallback();
-        // Re-render when the host page flips data-theme. Token reads in
-        // _readTokens() return the new values; setOption with notMerge
-        // applies them to axis/grid/tooltip/series.
-        this._themeObserver = new MutationObserver(() => this._render());
+        // A theme flip changes the CSS tokens; echarts baked the old
+        // colors at setOption time, so remount to re-read them.
+        this._themeObserver = new MutationObserver(() => this._remount());
         this._themeObserver.observe(document.documentElement, {
             attributes: true,
             attributeFilter: ['data-theme'],
@@ -80,128 +83,61 @@ class RezolusChart extends LitElement {
     }
 
     firstUpdated() {
-        const chartEl = this.renderRoot.querySelector('.chart');
-        this._observer = new ResizeObserver(() => this._chart?.resize());
-        if (chartEl) this._observer.observe(chartEl);
-        this._render();
+        this._mountHost = this.renderRoot.querySelector('.rz-chart-host');
+        this._remount();
     }
 
     updated(changed) {
-        if (changed.has('plot')) this._render();
+        if (changed.has('plot') || changed.has('interval')) this._remount();
     }
 
     disconnectedCallback() {
         super.disconnectedCallback();
         this._themeObserver?.disconnect();
-        this._observer?.disconnect();
-        this._chart?.dispose();
-        this._chart = null;
+        this._unmount();
     }
 
-    // Read the rezolus CSS tokens the chart contents (axis, grid, tooltip,
-    // series) depend on. echarts bakes color strings into its option at
-    // setOption time and doesn't observe CSS, so we read on each render
-    // and feed the values in.
-    _readTokens() {
-        const styles = getComputedStyle(this);
-        const v = (name, fallback) => styles.getPropertyValue(name).trim() || fallback;
-        return {
-            fg:            v('--fg', '#1a1a1a'),
-            fgSecondary:   v('--fg-secondary', '#6b7280'),
-            gridLine:      v('--chart-grid-line', 'rgba(48,54,61,0.5)'),
-            accent:        v('--accent', '#58a6ff'),
-            bgCard:        v('--bg-card', '#ffffff'),
-            borderDefault: v('--border-default', 'rgba(48,54,61,0.7)'),
-            chart1:        v('--chart-1', '#1f77b4'),
-        };
-    }
-
-    _isDarkTheme() {
-        return document.documentElement?.getAttribute('data-theme') !== 'light';
-    }
-
-    _render() {
-        const chartEl = this.renderRoot.querySelector('.chart');
-        if (!chartEl) return;
-
-        const data = this.plot?.data;
-        const hasData = Array.isArray(data) && data.length >= 2
-            && Array.isArray(data[0]) && data[0].length > 0;
-
-        if (!hasData) {
-            this._chart?.dispose();
-            this._chart = null;
-            return;
+    _unmount() {
+        // m.mount(host, null) triggers Chart.onremove → echarts dispose
+        // + observer/listener cleanup + chartsState de-registration.
+        if (this._mounted && this._mountHost && window.m) {
+            window.m.mount(this._mountHost, null);
         }
+        this._mounted = false;
+    }
 
+    _remount() {
+        if (!this._mountHost) return;
+        const m = window.m;
+        if (!m) { this._mountHost.textContent = 'mithril not loaded'; return; }
         if (typeof window.echarts === 'undefined') {
-            chartEl.textContent = 'echarts not loaded';
+            this._mountHost.textContent = 'echarts not loaded';
             return;
         }
 
-        if (!this._chart) {
-            this._chart = window.echarts.init(chartEl, null, { renderer: 'canvas' });
+        const spec = this.plot;
+        const hasData = Array.isArray(spec?.data) && spec.data.length >= 2
+            && Array.isArray(spec.data[0]) && spec.data[0].length > 0;
+        if (!spec || !spec.opts || !hasData) {
+            this._unmount();
+            this._mountHost.innerHTML =
+                '<div class="chart no-data"><div>no data</div></div>';
+            return;
         }
 
-        const [times, values] = data;
-        // PromQL convention: timestamps are seconds since epoch. echarts wants ms.
-        const seriesData = times.map((t, i) => [t * 1000, values[i]]);
-        const fmt = this.plot.opts?.format ?? {};
-        const t = this._readTokens();
-
-        this._chart.setOption({
-            backgroundColor: 'transparent',
-            darkMode: this._isDarkTheme(),
-            textStyle: { color: t.fg },
-            color: [t.chart1],
-            // Top clears the absolutely-positioned .chart-header (10px
-            // padding + 13px title with line-height).
-            grid: { left: 12, right: 17, top: 36, bottom: 24, containLabel: true },
-            xAxis: {
-                type: 'time',
-                axisLine: { show: false },
-                axisTick: { show: false },
-                axisLabel: { color: t.fgSecondary, fontSize: 10 },
-                splitLine: {
-                    show: true,
-                    lineStyle: { color: t.gridLine, type: 'dashed' },
-                },
-            },
-            yAxis: {
-                type: fmt.log_scale ? 'log' : 'value',
-                name: fmt.y_axis_label ?? '',
-                nameTextStyle: { fontSize: 11, color: t.fgSecondary },
-                axisLine: { show: false },
-                axisTick: { show: false },
-                axisLabel: { color: t.fgSecondary, fontSize: 10, margin: 12 },
-                splitLine: { lineStyle: { color: t.gridLine, type: 'dashed' } },
-            },
-            tooltip: {
-                trigger: 'axis',
-                confine: true,
-                backgroundColor: t.bgCard,
-                borderColor: t.borderDefault,
-                borderWidth: 1,
-                textStyle: { color: t.fg },
-                axisPointer: {
-                    type: 'line',
-                    snap: true,
-                    animation: false,
-                    lineStyle: { color: t.accent, opacity: 0.6, width: 1 },
-                },
-            },
-            series: [{
-                name: this.plot.opts?.title ?? '',
-                type: 'line',
-                showSymbol: false,
-                data: seriesData,
-            }],
-        }, { notMerge: true });
+        // Remount fresh so the new descriptor goes through the exact
+        // viewer construction path (Chart reads spec on construct, then
+        // configureChartByType dispatches by resolved style).
+        this._unmount();
+        const interval = this.interval;
+        window.m.mount(this._mountHost, {
+            view: () => m(Chart, { spec, chartsState: embedChartsState, interval }),
+        });
+        this._mounted = true;
     }
 
     render() {
         const title = this.plot?.opts?.title;
-        const hasData = this.plot?.data?.[0]?.length > 0;
         return html`
             <link rel="stylesheet" href="/lib/charts.css">
             <div class="chart-wrapper">
@@ -212,9 +148,7 @@ class RezolusChart extends LitElement {
                         </div>
                     </div>
                 ` : ''}
-                <div class="chart ${hasData ? '' : 'no-data'}">
-                    ${!hasData ? html`<div>no data</div>` : ''}
-                </div>
+                <div class="rz-chart-host"></div>
             </div>
         `;
     }

--- a/src/viewer/assets/lib/embed/rezolus-chart.js
+++ b/src/viewer/assets/lib/embed/rezolus-chart.js
@@ -1,32 +1,16 @@
-// <rezolus-chart> — Lit web component that renders a single Plot
-// descriptor (the shape produced by crates/dashboard/) inside Shadow DOM.
+// <rezolus-chart> — embeds one dashboard chart in shadow DOM.
 //
-// It does NOT reimplement chart configuration. It mounts the viewer's
-// real `Chart` mithril component (the same `configureChartByType`
-// dispatcher the dashboard uses), so every style — line, scatter,
-// heatmap, quantile, multi — renders byte-for-byte like the viewer:
-// unit-aware axes/tooltip, fonts, gridlines, dataZoom, OOB bands, etc.
-// Visual parity is structural, not chased.
-//
-// Card chrome (frame, title, sizing) comes from /lib/charts.css linked
-// into the shadow root. The viewer's COLORS read CSS tokens from
-// document.documentElement, so as long as the host page carries the
-// rezolus tokens (link /lib/style.css) chrome and chart contents theme
-// correctly. A data-theme MutationObserver remounts so a theme flip
-// re-reads the tokens (echarts bakes colors at setOption time).
-//
-// Requires, loaded as globals on the host page (the viewer provides
-// all of these): echarts (/lib/charts/echarts.min.js) and mithril
-// (/lib/mithril.js, which sets window.m). `plot` is a descriptor whose
-// `data` field is the viewer spec shape (e.g. [timestamps_s, values]
-// for a single line).
+// Mounts the viewer's real `Chart` (same configureChartByType path)
+// instead of reimplementing config, so every style renders identically.
+// Needs echarts + mithril (window.m) as host globals and the rezolus
+// CSS tokens on document.documentElement (link /lib/style.css), which
+// COLORS reads. `plot.data` is the viewer spec shape, e.g.
+// [timestamps_s, values].
 import { LitElement, html, css } from '../lit/lit.js';
 import { Chart, ChartsState } from '../charts/chart.js';
 
-// One throwaway ChartsState shared by all embedded charts on the page.
-// It only provides the zoom/cursor registry the Chart lifecycle needs;
-// nothing here drives cross-chart sync, so a single bare instance is
-// fine (Chart de-registers itself on unmount via its onremove).
+// Shared, inert: only supplies the zoom/cursor registry Chart's
+// lifecycle needs; no cross-chart sync is driven here.
 const embedChartsState = new ChartsState();
 
 class RezolusChart extends LitElement {
@@ -41,8 +25,7 @@ class RezolusChart extends LitElement {
             display: block;
             min-width: 0;
         }
-        /* charts.css collapses wrappers whose .chart has .no-data so
-           section grids fold; for embed show a visible placeholder. */
+        /* charts.css collapses .no-data wrappers; embed shows a placeholder. */
         :host .chart-wrapper:has(.no-data) {
             display: block;
         }
@@ -73,8 +56,7 @@ class RezolusChart extends LitElement {
 
     connectedCallback() {
         super.connectedCallback();
-        // A theme flip changes the CSS tokens; echarts baked the old
-        // colors at setOption time, so remount to re-read them.
+        // echarts bakes colors at setOption; remount to re-read tokens.
         this._themeObserver = new MutationObserver(() => this._remount());
         this._themeObserver.observe(document.documentElement, {
             attributes: true,
@@ -98,8 +80,7 @@ class RezolusChart extends LitElement {
     }
 
     _unmount() {
-        // m.mount(host, null) triggers Chart.onremove → echarts dispose
-        // + observer/listener cleanup + chartsState de-registration.
+        // null mount → Chart.onremove (dispose + cleanup + de-register).
         if (this._mounted && this._mountHost && window.m) {
             window.m.mount(this._mountHost, null);
         }
@@ -125,9 +106,7 @@ class RezolusChart extends LitElement {
             return;
         }
 
-        // Remount fresh so the new descriptor goes through the exact
-        // viewer construction path (Chart reads spec on construct, then
-        // configureChartByType dispatches by resolved style).
+        // Remount fresh: Chart reads spec on construct.
         this._unmount();
         const interval = this.interval;
         window.m.mount(this._mountHost, {

--- a/src/viewer/assets/lib/embed/rezolus-chart.js
+++ b/src/viewer/assets/lib/embed/rezolus-chart.js
@@ -1,10 +1,18 @@
 // <rezolus-chart> — Lit web component that renders a single Plot
 // descriptor (the shape produced by crates/dashboard/) inside Shadow DOM.
 //
+// Chrome (card frame, title typography, sizing) comes from
+// /lib/charts.css linked into the shadow root, so the component looks
+// like a regular rezolus chart when embedded inside the viewer. CSS
+// custom properties inherited from the host page's :root (--fg,
+// --accent, --bg-card-gradient, etc.) reach into the shadow root
+// automatically. External embedders need to load the same tokens (or
+// override them per :host) for the chrome to render correctly.
+//
 // Spike scope: inline-series adapter only. The component accepts a `plot`
-// property whose `data` field is [[timestamps_ms], [values]]. Future
-// adapters (HTTP, WASM, SSE) will live alongside this file and feed the
-// same property contract.
+// property whose `data` field is [[timestamps_s], [values]] (PromQL's
+// seconds-since-epoch convention). Future adapters (HTTP, WASM, SSE)
+// will live alongside this file and feed the same property contract.
 //
 // Requires echarts to be loaded as a global (see lib/charts/echarts.min.js).
 import { LitElement, html, css } from '../lit/lit.js';
@@ -14,32 +22,34 @@ class RezolusChart extends LitElement {
         plot: { type: Object },
     };
 
+    // Component-local styles. The :host prefix on the overrides bumps
+    // specificity above charts.css so they win without !important
+    // (except for the `> div` selector, which charts.css already marks
+    // !important — must match).
     static styles = css`
         :host {
             display: block;
-            width: 100%;
-            height: 280px;
-            font-family: 'Inter', system-ui, sans-serif;
-            color: #222;
+            min-width: 0;
         }
-        .title {
-            margin: 0 0 0.4rem;
-            font-size: 14px;
-            font-weight: 600;
+        /* charts.css collapses chart wrappers whose .chart has .no-data
+           so section grids fold around missing data. For embed we want a
+           visible placeholder so the consumer can see the slot exists. */
+        :host .chart-wrapper:has(.no-data) {
+            display: block;
         }
-        .canvas {
-            position: relative;
-            width: 100%;
-            height: calc(100% - 1.8rem);
-        }
-        .empty {
+        :host .chart.no-data {
+            height: 270px;
+            border: none;
+            background: none;
             display: flex;
             align-items: center;
             justify-content: center;
-            height: 100%;
-            color: #888;
+            color: var(--fg-muted, #888);
             font-style: italic;
             font-size: 13px;
+        }
+        :host .chart.no-data > div {
+            display: block !important;
         }
     `;
 
@@ -51,9 +61,9 @@ class RezolusChart extends LitElement {
     }
 
     firstUpdated() {
-        const canvas = this.renderRoot.querySelector('.canvas');
+        const chartEl = this.renderRoot.querySelector('.chart');
         this._observer = new ResizeObserver(() => this._chart?.resize());
-        this._observer.observe(canvas);
+        if (chartEl) this._observer.observe(chartEl);
         this._render();
     }
 
@@ -69,8 +79,8 @@ class RezolusChart extends LitElement {
     }
 
     _render() {
-        const canvas = this.renderRoot.querySelector('.canvas');
-        if (!canvas) return;
+        const chartEl = this.renderRoot.querySelector('.chart');
+        if (!chartEl) return;
 
         const data = this.plot?.data;
         const hasData = Array.isArray(data) && data.length >= 2
@@ -83,12 +93,12 @@ class RezolusChart extends LitElement {
         }
 
         if (typeof window.echarts === 'undefined') {
-            canvas.textContent = 'echarts not loaded';
+            chartEl.textContent = 'echarts not loaded';
             return;
         }
 
         if (!this._chart) {
-            this._chart = window.echarts.init(canvas, null, { renderer: 'canvas' });
+            this._chart = window.echarts.init(chartEl, null, { renderer: 'canvas' });
         }
 
         const [times, values] = data;
@@ -97,7 +107,9 @@ class RezolusChart extends LitElement {
         const fmt = this.plot.opts?.format ?? {};
 
         this._chart.setOption({
-            grid: { left: 56, right: 16, top: 12, bottom: 28 },
+            // Top is large enough to clear the absolutely-positioned
+            // .chart-header (10px padding + 13px title with line-height).
+            grid: { left: 56, right: 16, top: 36, bottom: 28 },
             xAxis: { type: 'time' },
             yAxis: {
                 type: fmt.log_scale ? 'log' : 'value',
@@ -118,9 +130,18 @@ class RezolusChart extends LitElement {
         const title = this.plot?.opts?.title;
         const hasData = this.plot?.data?.[0]?.length > 0;
         return html`
-            ${title ? html`<h3 class="title">${title}</h3>` : ''}
-            <div class="canvas">
-                ${!hasData ? html`<div class="empty">no data</div>` : ''}
+            <link rel="stylesheet" href="/lib/charts.css">
+            <div class="chart-wrapper">
+                ${title ? html`
+                    <div class="chart-header">
+                        <div class="chart-title-row">
+                            <h3 class="chart-title">${title}</h3>
+                        </div>
+                    </div>
+                ` : ''}
+                <div class="chart ${hasData ? '' : 'no-data'}">
+                    ${!hasData ? html`<div>no data</div>` : ''}
+                </div>
             </div>
         `;
     }


### PR DESCRIPTION
## Summary

A `<rezolus-chart>` web component for embedding a single dashboard chart outside the viewer, plus a `/lib/embed/demo.html` spike. It renders **identically to the viewer** by mounting the viewer's real chart pipeline rather than reimplementing it. (Rebased onto current main; scope expanded well beyond the original charts.css/token-bridge spike.)

- **`<rezolus-chart>`** (Lit, shadow DOM): card chrome from `/lib/charts.css`; the chart itself is the viewer's actual `Chart` mithril component mounted into the shadow root with a throwaway `ChartsState`. Descriptors flow through the same `configureChartByType` dispatcher the dashboard uses, so line/scatter/heatmap/quantile/multi render byte-for-byte (unit-aware axes & tooltip, fonts, gridlines, dataZoom, OOB bands). `COLORS` read CSS tokens from `document.documentElement`; a `data-theme` MutationObserver remounts so a theme flip re-reads them.
- **`demo.html`** is a faithful, self-contained harness:
  - The viewer is query-driven (`/data/rezolus.json` carries descriptors, never inline series), so the demo executes the plot's `promql_query` via `/api/v1/query_range`, mirroring `data.js::executePromQLRangeQuery`'s window/step recipe.
  - Scopes the query to the selected node exactly like the viewer — picks `pinned_node` (else `nodes[0]`) from `/api/v1/file_metadata` and applies the viewer's own exported `injectLabel`, so a multi-node recording doesn't fan out across nodes.
  - Graceful fallbacks: synthetic series only when the query genuinely returns nothing or the fetch fails.
- `demo.html` loads `echarts` + `mithril` (`window.m`) as globals since the reused `Chart`/`chart.js` use them.

Requires running inside (or behind) the rezolus viewer so the absolute `/lib/...`, `/data/...`, `/api/v1/...` paths resolve — a plain static server won't work.

## Test plan

- [x] Endpoint shapes verified live against `cachecannon.parquet`: `/api/v1/metadata`, `/data/rezolus.json` (descriptor, empty inline data), `/api/v1/query_range`, `/api/v1/file_metadata` (2 nodes, pinned `rezolus-server`)
- [x] Node scoping confirmed: injected query yields the per-node series (~0.0058) vs the old combined-node sum (~0.014)
- [x] Full ES module graph (`rezolus-chart` → `charts/chart.js` → deps, `lit`, `data.js`) resolves 200 over `/lib/`
- [x] Manual: open `/lib/embed/demo.html` next to the live viewer CPU chart — green status, pixel parity, theme toggle, fallback states

🤖 Generated with [Claude Code](https://claude.com/claude-code)