### PR TITLE
ci(cargo): drop release-profile builds from PR CI

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -2,6 +2,7 @@ name: cargo-build
 
 on:
   push:
+    branches: [main]
     paths-ignore:
       - 'site/**'
   pull_request:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - 'site/**'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - 'site/**'
 
@@ -14,12 +14,8 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
-  # First stage: these are quick jobs that give immediate feedback on a PR.
-  # They already ran while the PR was a draft, so on ready_for_review we
-  # skip them and only build the new release matrix added below.
   check:
     name: check
-    if: github.event.action != 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -38,7 +34,6 @@ jobs:
           cargo check --all-targets
 
   clippy:
-    if: github.event.action != 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -80,7 +75,6 @@ jobs:
         sarif_file: clippy.sarif
 
   audit:
-    if: github.event.action != 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -96,7 +90,6 @@ jobs:
 
   rustfmt:
     name: rustfmt
-    if: github.event.action != 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -119,7 +112,6 @@ jobs:
   # `Table.grow(): failed to grow table by 4`.
   wasm-viewer:
     name: wasm-viewer
-    if: github.event.action != 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -169,10 +161,9 @@ jobs:
       - name: determine build profiles
         id: set-profiles
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.action }}" == "ready_for_review" ]]; then
-            # Draft already covered debug; only the release matrix is new.
-            echo 'profiles=["release"]' >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "true" ]]; then
+          # PRs build debug only; release builds run on push (to main) and
+          # in release.yml at tag time, where packaging happens.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo 'profiles=["debug"]' >> $GITHUB_OUTPUT
           else
             echo 'profiles=["release", "debug"]' >> $GITHUB_OUTPUT
@@ -249,8 +240,6 @@ jobs:
 
   check-success:
     name: verify all tests pass
-    # Run even when some deps are skipped (e.g. on ready_for_review the
-    # quick-feedback jobs are skipped because the draft already ran them).
     if: always()
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Summary

PR CI in `cargo.yml` now runs the **debug** matrix only. Release builds still run:

- on push (to `main`) as a pre-tag safety net, and
- in `release.yml` at tag time, which is where actual packaging happens.

The `ready_for_review` event handler and the per-job
`if: github.event.action != 'ready_for_review'` guards existed only to bridge draft → ready transitions (covering the release matrix on ready); both are gone.

### Profile logic

```yaml
if [[ "${{ github.event_name }}" == "pull_request" ]]; then
  echo 'profiles=["debug"]' >> $GITHUB_OUTPUT
else
  echo 'profiles=["release", "debug"]' >> $GITHUB_OUTPUT
fi
```

### Net effect

- PRs are ~half the CI work (no per-OS release build + smoketest).
- Release breakage is still caught on push to `main` before any tag.
- Packaging (release.yml) is unaffected.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses
- [ ] First PR run on this branch confirms only debug matrix builds (`build-*-debug-*` jobs, no `build-*-release-*`)
- [ ] After merge, the first push to `main` still triggers both `release` and `debug` matrices


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6u3HqzXgvUNxc7375RozJ)_