### PR TITLE
viewer: add more vLLM metrics to the dashboard

### DIFF
--- a/config/templates/vllm-decode.json
+++ b/config/templates/vllm-decode.json
@@ -1,61 +1,61 @@
 {
-  "service_name": "vllm",
+  "service_name": "vllm-decode",
   "service_metadata": {},
   "slo": null,
   "kpis": [
     {
       "role": "requests",
       "title": "Requests Running",
-      "query": "vllm_num_requests_running{source=\"vllm\"}",
+      "query": "vllm_num_requests_running{source=\"vllm-decode\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "requests",
       "title": "Request Throughput",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=~\"stop|length\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-decode\",finished_reason=~\"stop|length\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Completed Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=\"stop\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-decode\",finished_reason=\"stop\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Failed Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=~\"error|repetition\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-decode\",finished_reason=~\"error|repetition\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Abort Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=\"abort\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-decode\",finished_reason=\"abort\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Truncated Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=\"length\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-decode\",finished_reason=\"length\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Evicted Rate",
-      "query": "sum(irate(vllm_num_preemptions_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_num_preemptions_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Prompt Tokens per Request",
-      "query": "vllm_request_prompt_tokens{source=\"vllm\"}",
+      "query": "vllm_request_prompt_tokens{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -64,7 +64,7 @@
     {
       "role": "requests",
       "title": "Generation Tokens per Request",
-      "query": "vllm_request_generation_tokens{source=\"vllm\"}",
+      "query": "vllm_request_generation_tokens{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -73,14 +73,14 @@
     {
       "role": "tokens",
       "title": "Prompt Token Rate",
-      "query": "sum(irate(vllm_prompt_tokens_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_prompt_tokens_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "tokens",
       "title": "Generation Token Rate",
-      "query": "sum(irate(vllm_generation_tokens_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_generation_tokens_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -88,7 +88,7 @@
     {
       "role": "latency",
       "title": "Time to First Token (TTFT)",
-      "query": "vllm_time_to_first_token_seconds{source=\"vllm\"}",
+      "query": "vllm_time_to_first_token_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -97,7 +97,7 @@
     {
       "role": "latency",
       "title": "Inter-Token Latency (ITL)",
-      "query": "vllm_inter_token_latency_seconds{source=\"vllm\"}",
+      "query": "vllm_inter_token_latency_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -106,7 +106,7 @@
     {
       "role": "latency",
       "title": "Time per Output Token",
-      "query": "vllm_request_time_per_output_token_seconds{source=\"vllm\"}",
+      "query": "vllm_request_time_per_output_token_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -115,7 +115,7 @@
     {
       "role": "latency",
       "title": "End-to-End Request Latency",
-      "query": "vllm_e2e_request_latency_seconds{source=\"vllm\"}",
+      "query": "vllm_e2e_request_latency_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -124,7 +124,7 @@
     {
       "role": "latency",
       "title": "Prefill Time",
-      "query": "vllm_request_prefill_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_prefill_time_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -133,7 +133,7 @@
     {
       "role": "latency",
       "title": "Decode Time",
-      "query": "vllm_request_decode_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_decode_time_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -142,7 +142,7 @@
     {
       "role": "latency",
       "title": "Inference Time",
-      "query": "vllm_request_inference_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_inference_time_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -151,14 +151,14 @@
     {
       "role": "queueing",
       "title": "Requests Waiting",
-      "query": "vllm_num_requests_waiting{source=\"vllm\"}",
+      "query": "vllm_num_requests_waiting{source=\"vllm-decode\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "queueing",
       "title": "Queue Time",
-      "query": "vllm_request_queue_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_queue_time_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -167,28 +167,28 @@
     {
       "role": "cache",
       "title": "KV Cache Usage",
-      "query": "vllm_kv_cache_usage_perc{source=\"vllm\"}",
+      "query": "vllm_kv_cache_usage_perc{source=\"vllm-decode\"}",
       "type": "gauge",
       "unit_system": "percentage"
     },
     {
       "role": "cache",
       "title": "Prefix Cache Hit Rate",
-      "query": "sum(irate(vllm_prefix_cache_hits_total{source=\"vllm\"}[5s])) / sum(irate(vllm_prefix_cache_queries_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_prefix_cache_hits_total{source=\"vllm-decode\"}[5s])) / sum(irate(vllm_prefix_cache_queries_total{source=\"vllm-decode\"}[5s]))",
       "type": "gauge",
       "unit_system": "percentage"
     },
     {
       "role": "cache",
       "title": "Cached Token Rate",
-      "query": "sum(irate(vllm_prompt_tokens_cached_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_prompt_tokens_cached_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "cache",
       "title": "Prefill KV-Computed Tokens per Request",
-      "query": "vllm_request_prefill_kv_computed_tokens{source=\"vllm\"}",
+      "query": "vllm_request_prefill_kv_computed_tokens{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -197,28 +197,28 @@
     {
       "role": "gpu",
       "title": "Estimated FLOPS per GPU",
-      "query": "sum(irate(vllm_estimated_flops_per_gpu_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_estimated_flops_per_gpu_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "gpu",
       "title": "Estimated Memory Read Bandwidth per GPU",
-      "query": "sum(irate(vllm_estimated_read_bytes_per_gpu_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_estimated_read_bytes_per_gpu_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "gpu",
       "title": "Estimated Memory Write Bandwidth per GPU",
-      "query": "sum(irate(vllm_estimated_write_bytes_per_gpu_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_estimated_write_bytes_per_gpu_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Transfer Time",
-      "query": "vllm_nixl_xfer_time_seconds{source=\"vllm\"}",
+      "query": "vllm_nixl_xfer_time_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -227,7 +227,7 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Post Time",
-      "query": "vllm_nixl_post_time_seconds{source=\"vllm\"}",
+      "query": "vllm_nixl_post_time_seconds{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -236,7 +236,7 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Bytes Transferred",
-      "query": "vllm_nixl_bytes_transferred{source=\"vllm\"}",
+      "query": "vllm_nixl_bytes_transferred{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -245,7 +245,7 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Descriptors per Transfer",
-      "query": "vllm_nixl_num_descriptors{source=\"vllm\"}",
+      "query": "vllm_nixl_num_descriptors{source=\"vllm-decode\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -254,21 +254,21 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Failed Transfer Rate",
-      "query": "sum(irate(vllm_nixl_num_failed_transfers_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_nixl_num_failed_transfers_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Failed Notification Rate",
-      "query": "sum(irate(vllm_nixl_num_failed_notifications_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_nixl_num_failed_notifications_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Expired KV Request Rate",
-      "query": "sum(irate(vllm_nixl_num_kv_expired_reqs_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_nixl_num_kv_expired_reqs_total{source=\"vllm-decode\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     }

--- a/config/templates/vllm-prefill.json
+++ b/config/templates/vllm-prefill.json
@@ -1,61 +1,61 @@
 {
-  "service_name": "vllm",
+  "service_name": "vllm-prefill",
   "service_metadata": {},
   "slo": null,
   "kpis": [
     {
       "role": "requests",
       "title": "Requests Running",
-      "query": "vllm_num_requests_running{source=\"vllm\"}",
+      "query": "vllm_num_requests_running{source=\"vllm-prefill\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "requests",
       "title": "Request Throughput",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=~\"stop|length\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-prefill\",finished_reason=~\"stop|length\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Completed Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=\"stop\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-prefill\",finished_reason=\"stop\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Failed Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=~\"error|repetition\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-prefill\",finished_reason=~\"error|repetition\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Abort Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=\"abort\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-prefill\",finished_reason=\"abort\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Truncated Rate",
-      "query": "sum(irate(vllm_request_success_total{source=\"vllm\",finished_reason=\"length\"}[5s]))",
+      "query": "sum(irate(vllm_request_success_total{source=\"vllm-prefill\",finished_reason=\"length\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Evicted Rate",
-      "query": "sum(irate(vllm_num_preemptions_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_num_preemptions_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "requests",
       "title": "Prompt Tokens per Request",
-      "query": "vllm_request_prompt_tokens{source=\"vllm\"}",
+      "query": "vllm_request_prompt_tokens{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -64,7 +64,7 @@
     {
       "role": "requests",
       "title": "Generation Tokens per Request",
-      "query": "vllm_request_generation_tokens{source=\"vllm\"}",
+      "query": "vllm_request_generation_tokens{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -73,14 +73,14 @@
     {
       "role": "tokens",
       "title": "Prompt Token Rate",
-      "query": "sum(irate(vllm_prompt_tokens_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_prompt_tokens_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "tokens",
       "title": "Generation Token Rate",
-      "query": "sum(irate(vllm_generation_tokens_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_generation_tokens_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate",
       "denominator": true
@@ -88,7 +88,7 @@
     {
       "role": "latency",
       "title": "Time to First Token (TTFT)",
-      "query": "vllm_time_to_first_token_seconds{source=\"vllm\"}",
+      "query": "vllm_time_to_first_token_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -97,7 +97,7 @@
     {
       "role": "latency",
       "title": "Inter-Token Latency (ITL)",
-      "query": "vllm_inter_token_latency_seconds{source=\"vllm\"}",
+      "query": "vllm_inter_token_latency_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -106,7 +106,7 @@
     {
       "role": "latency",
       "title": "Time per Output Token",
-      "query": "vllm_request_time_per_output_token_seconds{source=\"vllm\"}",
+      "query": "vllm_request_time_per_output_token_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -115,7 +115,7 @@
     {
       "role": "latency",
       "title": "End-to-End Request Latency",
-      "query": "vllm_e2e_request_latency_seconds{source=\"vllm\"}",
+      "query": "vllm_e2e_request_latency_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -124,7 +124,7 @@
     {
       "role": "latency",
       "title": "Prefill Time",
-      "query": "vllm_request_prefill_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_prefill_time_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -133,7 +133,7 @@
     {
       "role": "latency",
       "title": "Decode Time",
-      "query": "vllm_request_decode_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_decode_time_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -142,7 +142,7 @@
     {
       "role": "latency",
       "title": "Inference Time",
-      "query": "vllm_request_inference_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_inference_time_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -151,14 +151,14 @@
     {
       "role": "queueing",
       "title": "Requests Waiting",
-      "query": "vllm_num_requests_waiting{source=\"vllm\"}",
+      "query": "vllm_num_requests_waiting{source=\"vllm-prefill\"}",
       "type": "gauge",
       "unit_system": "count"
     },
     {
       "role": "queueing",
       "title": "Queue Time",
-      "query": "vllm_request_queue_time_seconds{source=\"vllm\"}",
+      "query": "vllm_request_queue_time_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -167,28 +167,28 @@
     {
       "role": "cache",
       "title": "KV Cache Usage",
-      "query": "vllm_kv_cache_usage_perc{source=\"vllm\"}",
+      "query": "vllm_kv_cache_usage_perc{source=\"vllm-prefill\"}",
       "type": "gauge",
       "unit_system": "percentage"
     },
     {
       "role": "cache",
       "title": "Prefix Cache Hit Rate",
-      "query": "sum(irate(vllm_prefix_cache_hits_total{source=\"vllm\"}[5s])) / sum(irate(vllm_prefix_cache_queries_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_prefix_cache_hits_total{source=\"vllm-prefill\"}[5s])) / sum(irate(vllm_prefix_cache_queries_total{source=\"vllm-prefill\"}[5s]))",
       "type": "gauge",
       "unit_system": "percentage"
     },
     {
       "role": "cache",
       "title": "Cached Token Rate",
-      "query": "sum(irate(vllm_prompt_tokens_cached_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_prompt_tokens_cached_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "cache",
       "title": "Prefill KV-Computed Tokens per Request",
-      "query": "vllm_request_prefill_kv_computed_tokens{source=\"vllm\"}",
+      "query": "vllm_request_prefill_kv_computed_tokens{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -197,28 +197,28 @@
     {
       "role": "gpu",
       "title": "Estimated FLOPS per GPU",
-      "query": "sum(irate(vllm_estimated_flops_per_gpu_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_estimated_flops_per_gpu_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "gpu",
       "title": "Estimated Memory Read Bandwidth per GPU",
-      "query": "sum(irate(vllm_estimated_read_bytes_per_gpu_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_estimated_read_bytes_per_gpu_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "gpu",
       "title": "Estimated Memory Write Bandwidth per GPU",
-      "query": "sum(irate(vllm_estimated_write_bytes_per_gpu_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_estimated_write_bytes_per_gpu_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "datarate"
     },
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Transfer Time",
-      "query": "vllm_nixl_xfer_time_seconds{source=\"vllm\"}",
+      "query": "vllm_nixl_xfer_time_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -227,7 +227,7 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Post Time",
-      "query": "vllm_nixl_post_time_seconds{source=\"vllm\"}",
+      "query": "vllm_nixl_post_time_seconds{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -236,7 +236,7 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Bytes Transferred",
-      "query": "vllm_nixl_bytes_transferred{source=\"vllm\"}",
+      "query": "vllm_nixl_bytes_transferred{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -245,7 +245,7 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Descriptors per Transfer",
-      "query": "vllm_nixl_num_descriptors{source=\"vllm\"}",
+      "query": "vllm_nixl_num_descriptors{source=\"vllm-prefill\"}",
       "type": "histogram",
       "subtype": "percentiles",
       "percentiles": [0.5, 0.95],
@@ -254,21 +254,21 @@
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Failed Transfer Rate",
-      "query": "sum(irate(vllm_nixl_num_failed_transfers_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_nixl_num_failed_transfers_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Failed Notification Rate",
-      "query": "sum(irate(vllm_nixl_num_failed_notifications_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_nixl_num_failed_notifications_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     },
     {
       "role": "disaggregation (nixl)",
       "title": "NIXL Expired KV Request Rate",
-      "query": "sum(irate(vllm_nixl_num_kv_expired_reqs_total{source=\"vllm\"}[5s]))",
+      "query": "sum(irate(vllm_nixl_num_kv_expired_reqs_total{source=\"vllm-prefill\"}[5s]))",
       "type": "delta_counter",
       "unit_system": "rate"
     }


### PR DESCRIPTION
Add more metrics to the vLLM dashboard and make copies for the prefill and decode ones. This is a lot of duplicated entries but follows the pattern for SGLang.