### PR TITLE
feat(viewer): Save as Report column-trim + report-mode load (PR 4 of 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b0678fc7aff2da892a0fac28bce992ca023548e05ccf4c0e2301a93fff551d"
+checksum = "448751960f35543c086a2fc16c08f3b282548f223b8dbffa25431f32b612b854"
 dependencies = [
  "arrow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.4"
+version = "5.13.1-alpha.5"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.4"
+version = "5.13.1-alpha.5"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.186"
 log = "0.4.29"
 metriken = "0.9.2"
 metriken-exposition = "0.16.0"
-metriken-query = { version = "0.10.2", default-features = false }
+metriken-query = { version = "0.10.4", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -28,6 +28,22 @@ pub fn init() {
     console_error_panic_hook::set_once();
 }
 
+/// Mirrors the server's `regenerate_dashboards` short-circuit: a parquet
+/// produced by Save as Report carries `KEY_REPORT = "trimmed"` in its
+/// footer, and the viewer should suppress the rezolus / service / Query
+/// Explorer sections (their columns were trimmed away). The frontend
+/// reads the same marker out of `getFileMetadata()` and routes to
+/// `/report` instead of the default landing.
+fn is_trimmed_report(file_metadata: &std::collections::HashMap<String, String>) -> bool {
+    file_metadata.get("report").map(String::as_str) == Some("trimmed")
+}
+
+/// `DashboardContext::default()` returns sections=[], filesize=None — the
+/// shape callers want when a parquet should render only the Report view.
+fn empty_dashboard_context() -> dashboard::dashboard::DashboardContext {
+    dashboard::dashboard::DashboardContext::default()
+}
+
 #[wasm_bindgen]
 pub struct Viewer {
     engine: QueryEngine<Arc<Tsdb>>,
@@ -91,7 +107,11 @@ impl Viewer {
         tsdb.set_filename(filename.to_string());
 
         let file_metadata = tsdb.file_metadata().clone();
-        let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
+        let context = if is_trimmed_report(&file_metadata) {
+            empty_dashboard_context()
+        } else {
+            dashboard::dashboard::build_dashboard_context(None, &[], None)
+        };
         let engine = QueryEngine::new(Arc::new(tsdb));
 
         Ok(Viewer {
@@ -278,11 +298,15 @@ impl Viewer {
             .map(|(name, ext)| (name.as_str(), ext))
             .collect();
 
-        let context = dashboard::dashboard::build_dashboard_context(
-            None,
-            &service_refs,
-            None, // single-capture: no category
-        );
+        let context = if is_trimmed_report(&self.file_metadata) {
+            empty_dashboard_context()
+        } else {
+            dashboard::dashboard::build_dashboard_context(
+                None,
+                &service_refs,
+                None, // single-capture: no category
+            )
+        };
         self.context = context;
         self.cached_bodies.borrow_mut().clear();
         Ok(())
@@ -560,7 +584,23 @@ impl WasmCaptureRegistry {
             None => None,
         };
 
-        let context = dashboard::dashboard::build_dashboard_context(None, &service_refs, category);
+        // Trimmed reports — if either slot carries the marker — collapse
+        // both contexts to empty so the frontend lands on /report.
+        let report_mode = self
+            .baseline
+            .as_ref()
+            .map(|v| is_trimmed_report(&v.file_metadata))
+            .unwrap_or(false)
+            || self
+                .experiment
+                .as_ref()
+                .map(|v| is_trimmed_report(&v.file_metadata))
+                .unwrap_or(false);
+        let context = if report_mode {
+            empty_dashboard_context()
+        } else {
+            dashboard::dashboard::build_dashboard_context(None, &service_refs, category)
+        };
         if let Some(baseline) = self.baseline.as_mut() {
             baseline.context = context.clone();
             baseline.cached_bodies.borrow_mut().clear();

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -115,10 +115,15 @@ async function loadParquet(data, filename) {
     } catch (_) {
         bootstrapSharedSections([]);
     }
+    // Match the server viewer's mode.report flag — the WASM crate stamps
+    // the section list to [] when KEY_REPORT="trimmed", and app.js
+    // reroutes to /report when reportMode is true.
+    const reportMode = state.fileMetadata?.report === 'trimmed';
     initDashboard({
         systemInfo: state.systemInfo,
         fileMetadata: state.fileMetadata,
         selectionPayload: state.selectionPayload,
+        reportMode,
     });
 }
 
@@ -319,6 +324,8 @@ async function loadCompareDemo(fileA, fileB, legends = null, category = null) {
         } catch (_) {
             bootstrapSharedSections([]);
         }
+        const reportMode = base.fileMetadata?.report === 'trimmed'
+            || experimentFileMetadata?.report === 'trimmed';
         initDashboard({
             systemInfo: base.systemInfo,
             fileMetadata: base.fileMetadata,
@@ -331,6 +338,7 @@ async function loadCompareDemo(fileA, fileB, legends = null, category = null) {
             experimentFileMetadata,
             experimentFilename,
             experimentQueryRange,
+            reportMode,
         });
 
         // Canonicalize the URL: repeated `capture=label=path` (or bare

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -142,3 +142,18 @@ pub struct AbSide {
 impl AbContainers {
     pub const SCHEMA_VERSION: u32 = 1;
 }
+
+// ── Save-as-Report trimmed parquet ───────────────────────────────────
+
+/// File-level marker: this parquet (or each side of a combined-A/B
+/// tarball) was produced by "Save as Report" and column-trimmed to the
+/// saved selection's queries. Presence flips the viewer into report
+/// mode at load time — empty section list, default route lands on
+/// `/report`.
+///
+/// Value is intentionally a string rather than `bool` so future
+/// variants (e.g. `"full"`) don't require a schema bump.
+pub const KEY_REPORT: &str = "report";
+
+/// Canonical value written by the current writer.
+pub const REPORT_VALUE_TRIMMED: &str = "trimmed";

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -145,15 +145,12 @@ impl AbContainers {
 
 // ── Save-as-Report trimmed parquet ───────────────────────────────────
 
-/// File-level marker: this parquet (or each side of a combined-A/B
-/// tarball) was produced by "Save as Report" and column-trimmed to the
-/// saved selection's queries. Presence flips the viewer into report
-/// mode at load time — empty section list, default route lands on
-/// `/report`.
-///
-/// Value is intentionally a string rather than `bool` so future
-/// variants (e.g. `"full"`) don't require a schema bump.
+/// File-level marker: parquet was column-trimmed by "Save as Report"
+/// (combined-A/B tarballs carry the marker in each per-side parquet).
+/// Presence flips the viewer into report mode — empty section list,
+/// frontend defaults to `/report`. String-typed so future variants
+/// (`"full"`, etc.) don't need a schema bump.
 pub const KEY_REPORT: &str = "report";
 
-/// Canonical value written by the current writer.
+/// Canonical `KEY_REPORT` value written by the current writer.
 pub const REPORT_VALUE_TRIMMED: &str = "trimmed";

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -22,6 +22,7 @@ use super::metadata::{
     build_multinode_systeminfo, compute_file_checksum, extract_parquet_metadata,
     extract_service_extension_metadata, regenerate_dashboards, validate_service_extensions,
 };
+use super::report_save;
 use super::state::{ApiResponse, AppState, LazySectionStore};
 use super::tsdb::Tsdb;
 use ::dashboard;
@@ -575,33 +576,51 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
     let selection_json = body;
 
     if let Some(path) = parquet_path {
-        let result = tokio::task::spawn_blocking(move || {
-            use parquet::file::metadata::KeyValue;
-            let mut kv_meta =
-                crate::parquet_tools::read_file_metadata(&path).map_err(|e| e.to_string())?;
-            kv_meta.retain(|kv| kv.key != "selection");
-            kv_meta.push(KeyValue {
-                key: "selection".to_string(),
-                value: Some(selection_json),
-            });
-            let output = crate::parquet_tools::rewrite_parquet(&path, kv_meta, None)
-                .map_err(|e| e.to_string())?;
-            info!("saved annotated parquet ({} bytes)", output.len());
-            Ok::<Vec<u8>, String>(output)
-        })
-        .await;
+        let is_combined_ab = state.combined_ab_marker.read().is_some();
+        if is_combined_ab {
+            // Combined-A/B repack lands in Task 11; keep today's untrimmed
+            // rewrite so the build stays green.
+            let result = tokio::task::spawn_blocking({
+                let path = path.clone();
+                let body = selection_json.clone();
+                move || {
+                    use parquet::file::metadata::KeyValue;
+                    let mut kv_meta = crate::parquet_tools::read_file_metadata(&path)
+                        .map_err(|e| e.to_string())?;
+                    kv_meta.retain(|kv| kv.key != "selection");
+                    kv_meta.push(KeyValue {
+                        key: "selection".to_string(),
+                        value: Some(body),
+                    });
+                    crate::parquet_tools::rewrite_parquet(&path, kv_meta, None)
+                        .map_err(|e| e.to_string())
+                }
+            })
+            .await;
+            return finalize_report_attachment(result);
+        }
 
-        return match result {
-            Ok(Ok(output)) => parquet_attachment("rezolus-capture-annotated.parquet", output),
-            Ok(Err(e)) => {
-                error!("failed to annotate parquet: {e}");
-                server_error(format!("parquet annotation failed: {e}"))
-            }
+        let payload: report_save::ReportPayload = match serde_json::from_str(&selection_json) {
+            Ok(p) => p,
             Err(e) => {
-                error!("parquet annotation task panicked: {e}");
-                server_error("internal error")
+                return ApiResponse::<()>::err(
+                    format!("invalid selection payload: {e}"),
+                    "bad_data",
+                )
+                .into_response();
             }
         };
+        let tsdb_handle = state.baseline_tsdb();
+        let result = tokio::task::spawn_blocking({
+            let path = path.clone();
+            let body = selection_json.clone();
+            move || {
+                report_save::trim_single_parquet(&path, &payload, &body, &tsdb_handle)
+                    .map_err(|e| e.to_string())
+            }
+        })
+        .await;
+        return finalize_report_attachment(result);
     }
 
     // Live mode: convert snapshots with the selection metadata.
@@ -627,6 +646,25 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
         }
         Err(e) => {
             error!("parquet conversion task panicked: {e}");
+            server_error("internal error")
+        }
+    }
+}
+
+fn finalize_report_attachment(
+    result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
+) -> Response {
+    match result {
+        Ok(Ok(output)) => {
+            info!("saved report parquet ({} bytes)", output.len());
+            parquet_attachment("rezolus-report.parquet", output)
+        }
+        Ok(Err(e)) => {
+            error!("report parquet build failed: {e}");
+            server_error(format!("report build failed: {e}"))
+        }
+        Err(e) => {
+            error!("report parquet task panicked: {e}");
             server_error("internal error")
         }
     }

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -578,26 +578,54 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
     if let Some(path) = parquet_path {
         let is_combined_ab = state.combined_ab_marker.read().is_some();
         if is_combined_ab {
-            // Combined-A/B repack lands in Task 11; keep today's untrimmed
-            // rewrite so the build stays green.
+            let payload: report_save::ReportPayload =
+                match serde_json::from_str(&selection_json) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return ApiResponse::<()>::err(
+                            format!("invalid selection payload: {e}"),
+                            "bad_data",
+                        )
+                        .into_response();
+                    }
+                };
+            // `state.parquet_path` points at the extracted baseline parquet;
+            // the experiment parquet lives at `state.cli_experiment_path`.
+            let Some(experiment_path) = state.cli_experiment_path.read().clone() else {
+                return ApiResponse::<()>::err(
+                    "combined-A/B state missing experiment_path",
+                    "internal",
+                )
+                .into_response();
+            };
+            let manifest = state
+                .combined_ab_marker
+                .read()
+                .clone()
+                .expect("combined_ab_marker checked above");
+            let baseline_tsdb = state.baseline_tsdb();
+            let experiment_tsdb = state
+                .captures
+                .get(CaptureId::Experiment)
+                .expect("experiment slot must be attached in combined-A/B mode");
             let result = tokio::task::spawn_blocking({
-                let path = path.clone();
+                let baseline_path = path.clone();
                 let body = selection_json.clone();
                 move || {
-                    use parquet::file::metadata::KeyValue;
-                    let mut kv_meta = crate::parquet_tools::read_file_metadata(&path)
-                        .map_err(|e| e.to_string())?;
-                    kv_meta.retain(|kv| kv.key != "selection");
-                    kv_meta.push(KeyValue {
-                        key: "selection".to_string(),
-                        value: Some(body),
-                    });
-                    crate::parquet_tools::rewrite_parquet(&path, kv_meta, None)
-                        .map_err(|e| e.to_string())
+                    report_save::trim_combined_ab_to_tarball(
+                        &baseline_path,
+                        &experiment_path,
+                        &payload,
+                        &body,
+                        &baseline_tsdb,
+                        &experiment_tsdb,
+                        &manifest,
+                    )
+                    .map_err(|e| e.to_string())
                 }
             })
             .await;
-            return finalize_report_attachment(result);
+            return finalize_report_attachment_tarball(result);
         }
 
         let payload: report_save::ReportPayload = match serde_json::from_str(&selection_json) {
@@ -668,4 +696,34 @@ fn finalize_report_attachment(
             server_error("internal error")
         }
     }
+}
+
+fn finalize_report_attachment_tarball(
+    result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
+) -> Response {
+    match result {
+        Ok(Ok(output)) => {
+            info!("saved combined-A/B report tarball ({} bytes)", output.len());
+            tar_attachment("rezolus-report.parquet.ab.tar", output)
+        }
+        Ok(Err(e)) => {
+            error!("report tarball build failed: {e}");
+            server_error(format!("report build failed: {e}"))
+        }
+        Err(e) => {
+            error!("report tarball task panicked: {e}");
+            server_error("internal error")
+        }
+    }
+}
+
+fn tar_attachment(filename: &str, body: Vec<u8>) -> Response {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/x-tar")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{filename}\""),
+        )
+        .body(Body::from(body))
+        .unwrap()
 }

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -601,6 +601,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
             }
         };
         let baseline_tsdb = state.baseline_tsdb();
+        let trim_columns = payload.trim_columns;
         // Bind to a local so the temporary read guard from .read() doesn't
         // extend through the `if let` body and trip Send across the await.
         let ab_manifest = state.combined_ab_marker.read().clone();
@@ -625,7 +626,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
                 let baseline_path = path.clone();
                 let body = selection_json.clone();
                 move || {
-                    report_save::trim_combined_ab_to_tarball(
+                    report_save::save_combined_ab_tarball(
                         &baseline_path,
                         &experiment_path,
                         &payload,
@@ -633,6 +634,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
                         &baseline_tsdb,
                         &experiment_tsdb,
                         &manifest,
+                        trim_columns,
                     )
                     .map_err(|e| e.to_string())
                 }
@@ -644,8 +646,14 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
         let result = tokio::task::spawn_blocking({
             let body = selection_json.clone();
             move || {
-                report_save::trim_single_parquet(&path, &payload, &body, &baseline_tsdb)
-                    .map_err(|e| e.to_string())
+                report_save::save_single_parquet(
+                    &path,
+                    &payload,
+                    &body,
+                    &baseline_tsdb,
+                    trim_columns,
+                )
+                .map_err(|e| e.to_string())
             }
         })
         .await;

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -255,10 +255,11 @@ pub fn ingest_baseline_from_path(
     let filesize = std::fs::metadata(&temp_path).map(|m| m.len()).ok();
     data.set_filename(filename.clone());
 
+    // Mirror the regenerate_dashboards short-circuit: a trimmed report
+    // gets an empty section list so /api/v1/sections is consistent with
+    // CLI-mode loading of the same parquet.
     let report_marker = super::read_footer_kv(&temp_path, crate::parquet_metadata::KEY_REPORT);
     let context = if report_marker.is_some() {
-        // Trimmed reports carry only the saved selection's columns;
-        // suppress the section list so the frontend lands on /report.
         ::dashboard::dashboard::DashboardContext {
             filesize,
             ..Default::default()
@@ -579,28 +580,36 @@ pub async fn save_parquet(State(state): State<Arc<AppState>>) -> Response {
     }
 }
 
-/// In file mode, stamp the source parquet's footer with the supplied
-/// selection JSON and stream it back. In live mode, convert buffered
-/// snapshots and stamp the same selection at the same time.
+/// File mode: column-trim the loaded parquet (or repack a combined-A/B
+/// tarball with per-side trims) using the saved selection, embed the
+/// selection JSON in the output footer, and stream it back. Live mode:
+/// convert buffered snapshots into a parquet stamped with the selection
+/// (no trim — there's no source parquet to project from).
 pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: String) -> Response {
     let parquet_path = state.parquet_path.read().clone();
     let selection_json = body;
 
     if let Some(path) = parquet_path {
-        let is_combined_ab = state.combined_ab_marker.read().is_some();
-        if is_combined_ab {
-            let payload: report_save::ReportPayload = match serde_json::from_str(&selection_json) {
-                Ok(p) => p,
-                Err(e) => {
-                    return ApiResponse::<()>::err(
-                        format!("invalid selection payload: {e}"),
-                        "bad_data",
-                    )
-                    .into_response();
-                }
-            };
-            // `state.parquet_path` points at the extracted baseline parquet;
-            // the experiment parquet lives at `state.cli_experiment_path`.
+        let payload: report_save::ReportPayload = match serde_json::from_str(&selection_json) {
+            Ok(p) => p,
+            Err(e) => {
+                return ApiResponse::<()>::err(
+                    format!("invalid selection payload: {e}"),
+                    "bad_data",
+                )
+                .into_response();
+            }
+        };
+        let baseline_tsdb = state.baseline_tsdb();
+        // Bind to a local so the temporary read guard from .read() doesn't
+        // extend through the `if let` body and trip Send across the await.
+        let ab_manifest = state.combined_ab_marker.read().clone();
+
+        if let Some(manifest) = ab_manifest {
+            // parquet_path here is the EXTRACTED baseline parquet (set by
+            // init_file_mode_combined_ab); the experiment side lives at
+            // cli_experiment_path. Both paths outlive the process via the
+            // mem::forget'd extractor handle.
             let Some(experiment_path) = state.cli_experiment_path.read().clone() else {
                 return ApiResponse::<()>::err(
                     "combined-A/B state missing experiment_path",
@@ -608,12 +617,6 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
                 )
                 .into_response();
             };
-            let manifest = state
-                .combined_ab_marker
-                .read()
-                .clone()
-                .expect("combined_ab_marker checked above");
-            let baseline_tsdb = state.baseline_tsdb();
             let experiment_tsdb = state
                 .captures
                 .get(CaptureId::Experiment)
@@ -638,22 +641,10 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
             return finalize_report_attachment_tarball(result);
         }
 
-        let payload: report_save::ReportPayload = match serde_json::from_str(&selection_json) {
-            Ok(p) => p,
-            Err(e) => {
-                return ApiResponse::<()>::err(
-                    format!("invalid selection payload: {e}"),
-                    "bad_data",
-                )
-                .into_response();
-            }
-        };
-        let tsdb_handle = state.baseline_tsdb();
         let result = tokio::task::spawn_blocking({
-            let path = path.clone();
             let body = selection_json.clone();
             move || {
-                report_save::trim_single_parquet(&path, &payload, &body, &tsdb_handle)
+                report_save::trim_single_parquet(&path, &payload, &body, &baseline_tsdb)
                     .map_err(|e| e.to_string())
             }
         })
@@ -692,36 +683,33 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
 fn finalize_report_attachment(
     result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
 ) -> Response {
-    match result {
-        Ok(Ok(output)) => {
-            info!("saved report parquet ({} bytes)", output.len());
-            parquet_attachment("rezolus-report.parquet", output)
-        }
-        Ok(Err(e)) => {
-            error!("report parquet build failed: {e}");
-            server_error(format!("report build failed: {e}"))
-        }
-        Err(e) => {
-            error!("report parquet task panicked: {e}");
-            server_error("internal error")
-        }
-    }
+    finalize_attachment(result, "rezolus-report.parquet", parquet_attachment)
 }
 
 fn finalize_report_attachment_tarball(
     result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
 ) -> Response {
+    finalize_attachment(result, "rezolus-report.parquet.ab.tar", tar_attachment)
+}
+
+/// Convert a `spawn_blocking` outcome into a download Response, logging
+/// success and the two failure modes (build error vs. task panic).
+fn finalize_attachment(
+    result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
+    filename: &'static str,
+    attach: fn(&str, Vec<u8>) -> Response,
+) -> Response {
     match result {
         Ok(Ok(output)) => {
-            info!("saved combined-A/B report tarball ({} bytes)", output.len());
-            tar_attachment("rezolus-report.parquet.ab.tar", output)
+            info!("saved report {filename} ({} bytes)", output.len());
+            attach(filename, output)
         }
         Ok(Err(e)) => {
-            error!("report tarball build failed: {e}");
+            error!("report build failed: {e}");
             server_error(format!("report build failed: {e}"))
         }
         Err(e) => {
-            error!("report tarball task panicked: {e}");
+            error!("report task panicked: {e}");
             server_error("internal error")
         }
     }

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -255,10 +255,20 @@ pub fn ingest_baseline_from_path(
     let filesize = std::fs::metadata(&temp_path).map(|m| m.len()).ok();
     data.set_filename(filename.clone());
 
-    let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
-    validate_service_extensions(&data, &mut service_exts);
-    let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
-    let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None);
+    let report_marker = super::read_footer_kv(&temp_path, crate::parquet_metadata::KEY_REPORT);
+    let context = if report_marker.is_some() {
+        // Trimmed reports carry only the saved selection's columns;
+        // suppress the section list so the frontend lands on /report.
+        ::dashboard::dashboard::DashboardContext {
+            filesize,
+            ..Default::default()
+        }
+    } else {
+        let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
+        validate_service_extensions(&data, &mut service_exts);
+        let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
+        ::dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None)
+    };
     let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 
@@ -270,6 +280,7 @@ pub fn ingest_baseline_from_path(
     *state.sections.write() = LazySectionStore::new(context);
     let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
     *state.parquet_path.write() = Some(temp_path);
+    *state.trimmed_report_marker.write() = report_marker;
     state
         .captures
         .set_baseline_systeminfo(multinode_sysinfo.or(systeminfo));
@@ -593,7 +604,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
             let Some(experiment_path) = state.cli_experiment_path.read().clone() else {
                 return ApiResponse::<()>::err(
                     "combined-A/B state missing experiment_path",
-                    "internal",
+                    "internal_error",
                 )
                 .into_response();
             };
@@ -718,6 +729,7 @@ fn finalize_report_attachment_tarball(
 
 fn tar_attachment(filename: &str, body: Vec<u8>) -> Response {
     Response::builder()
+        .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, "application/x-tar")
         .header(
             header::CONTENT_DISPOSITION,

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -578,17 +578,16 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
     if let Some(path) = parquet_path {
         let is_combined_ab = state.combined_ab_marker.read().is_some();
         if is_combined_ab {
-            let payload: report_save::ReportPayload =
-                match serde_json::from_str(&selection_json) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        return ApiResponse::<()>::err(
-                            format!("invalid selection payload: {e}"),
-                            "bad_data",
-                        )
-                        .into_response();
-                    }
-                };
+            let payload: report_save::ReportPayload = match serde_json::from_str(&selection_json) {
+                Ok(p) => p,
+                Err(e) => {
+                    return ApiResponse::<()>::err(
+                        format!("invalid selection payload: {e}"),
+                        "bad_data",
+                    )
+                    .into_response();
+                }
+            };
             // `state.parquet_path` points at the extracted baseline parquet;
             // the experiment parquet lives at `state.cli_experiment_path`.
             let Some(experiment_path) = state.cli_experiment_path.read().clone() else {

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -66,6 +66,7 @@ const getCachedSections = () => getSections(sectionCacheState);
 // Compare-mode state (Stage 4 of A/B compare plan)
 let compareMode = false;
 let combinedAB = false;
+let reportMode = false;
 let experimentAttached = false;
 let experimentSystemInfo = null;
 let experimentDurationMs = null;
@@ -674,6 +675,7 @@ const initDashboard = (config = {}) => {
     compareMode = config.compareMode === true;
     experimentAttached = compareMode;
     combinedAB = config.combinedAB === true;
+    reportMode = config.reportMode === true;
     experimentSystemInfo = config.experimentSystemInfo || null;
     experimentDurationMs = durationFromFileMetadata(config.experimentFileMetadata);
     experimentQueryRange = config.experimentQueryRange || null;
@@ -749,9 +751,11 @@ const initDashboard = (config = {}) => {
     // rendered map at all.
     const categoryName = config.categoryName || null;
     const serviceNames = Object.keys(serviceInstances || {});
-    const defaultRoute = categoryName
-        ? `/service/${categoryName}`
-        : (serviceNames.length > 0 ? `/service/${serviceNames[0]}` : '/overview');
+    const defaultRoute = reportMode
+        ? '/report'
+        : (categoryName
+            ? `/service/${categoryName}`
+            : (serviceNames.length > 0 ? `/service/${serviceNames[0]}` : '/overview'));
 
     // A stale hash (e.g. `#/service/llm-perf` from a previous session
     // or external link to a different capture) would otherwise drive

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -314,6 +314,7 @@ const showCompareLanding = () => {
 const bootstrap = async () => {
     let compareMode = false;
     let combinedAB = false;
+    let reportMode = false;
     let categoryName = null;
     setSplashLabel('Connecting to viewer');
     try {
@@ -326,6 +327,7 @@ const bootstrap = async () => {
         compareMode = response.compare_mode === true;
         categoryName = response.category || null;
         combinedAB = response.combined_ab === true;
+        reportMode = response.report === true;
     } catch (_) { /* assume loaded file mode */ }
 
     setSplashLabel('Loading capture metadata');
@@ -381,6 +383,7 @@ const bootstrap = async () => {
         liveMode,
         compareMode,
         combinedAB,
+        reportMode,
         categoryName,
         baselineAlias,
         experimentSystemInfo,

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -516,14 +516,18 @@ const saveToParquet = async (store, attrs) => {
     const defaultPrefix = (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-report';
     const cs = attrs.chartsState;
     const hasZoom = cs && !cs.isDefaultZoom();
-    const checkboxes = hasZoom
-        ? [{ key: 'trim', label: 'Trim to selected time range', checked: false }]
-        : [];
+    const checkboxes = [
+        { key: 'trim_columns', label: 'Trim columns to charts in this report', checked: true },
+    ];
+    if (hasZoom) {
+        checkboxes.push({ key: 'trim', label: 'Trim to selected time range', checked: false });
+    }
     const result = await showSaveModal(defaultPrefix, '.parquet', checkboxes);
     if (!result) return;
     const filename = result.filename;
     const trimToSelection = result.trim;
     const payload = buildPayload(store, attrs);
+    payload.trim_columns = result.trim_columns !== false;
 
     // When trimming, compute the absolute time range (ms) from the zoom percentage
     if (trimToSelection) {

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -255,8 +255,8 @@ const selectionCardTitle = (entry, spec) => {
 // Replaces the previous silent-collapse behavior where the chart's
 // .no-data state hid the entire .chart-wrapper, leaving an empty
 // gap that diverged from the loaded entry count.
-const unavailableCard = (entry, spec, controls = null) =>
-    m('div.selection-card', [
+const unavailableCard = (entry, spec, controls = null, dropAttrs = null) =>
+    m('div.selection-card', dropAttrs || {}, [
         m('div.chart-wrapper.chart-wrapper-unavailable', [
             m('div.chart-unavailable', [
                 m('div.chart-unavailable-title', selectionCardTitle(entry, spec)),
@@ -330,6 +330,27 @@ const moveEntry = (store, id, delta) => {
     if (store === notebookStore) persistNotebook();
     else if (store === reportStore) persistReport();
 };
+
+// Move `draggedId` to land immediately before `targetId`. Powers the
+// drag-and-drop reorder; both directions collapse to "insert before"
+// because the splice-then-insert sequence keeps `toIdx` pointing at
+// the right slot whether we moved up or down.
+const reorderEntry = (store, draggedId, targetId) => {
+    if (!draggedId || draggedId === targetId) return;
+    const fromIdx = store.entries.findIndex(e => e.id === draggedId);
+    const toIdx = store.entries.findIndex(e => e.id === targetId);
+    if (fromIdx < 0 || toIdx < 0) return;
+    const [item] = store.entries.splice(fromIdx, 1);
+    store.entries.splice(toIdx, 0, item);
+    if (store === notebookStore) persistNotebook();
+    else if (store === reportStore) persistReport();
+};
+
+// Module-level drag session state. HTML5 DnD's dataTransfer would also
+// work but requires roundtripping through string serialization; a
+// single-page drag has no need for that.
+let _draggedEntryId = null;
+let _dragOverEntryId = null;
 
 // In-memory only — leaves localStorage alone. Used during scope
 // re-binding where the next step is restoring from the scoped key.
@@ -756,6 +777,24 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
                 const cardControls = m('div.selection-card-controls', [
+                    // Only the handle is draggable; clicks/drags inside
+                    // the chart body and notes textarea behave normally.
+                    m('span.selection-card-drag-handle', {
+                        draggable: true,
+                        title: 'Drag to reorder',
+                        ondragstart: (e) => {
+                            _draggedEntryId = entry.id;
+                            e.dataTransfer.effectAllowed = 'move';
+                            // Some browsers refuse to start a drag when
+                            // dataTransfer is empty.
+                            try { e.dataTransfer.setData('text/plain', entry.id); } catch (_) {}
+                        },
+                        ondragend: () => {
+                            _draggedEntryId = null;
+                            _dragOverEntryId = null;
+                            m.redraw();
+                        },
+                    }, '\u22ee\u22ee'),
                     m('button.selection-card-move', {
                         onclick: () => { moveEntry(notebookStore, entry.id, -1); m.redraw(); },
                         title: 'Move up',
@@ -771,8 +810,36 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                         title: 'Remove from Notebook',
                     }, '\u00d7'),
                 ]);
+                // Drop handlers live on the card root so the entire
+                // card surface is a drop target \u2014 only the handle
+                // initiates a drag.
+                const dropAttrs = {
+                    ondragover: (e) => {
+                        if (!_draggedEntryId || _draggedEntryId === entry.id) return;
+                        e.preventDefault(); // marks this card as a valid drop target
+                        e.dataTransfer.dropEffect = 'move';
+                        if (_dragOverEntryId !== entry.id) {
+                            _dragOverEntryId = entry.id;
+                            m.redraw();
+                        }
+                    },
+                    ondragleave: () => {
+                        if (_dragOverEntryId === entry.id) {
+                            _dragOverEntryId = null;
+                            m.redraw();
+                        }
+                    },
+                    ondrop: (e) => {
+                        e.preventDefault();
+                        reorderEntry(notebookStore, _draggedEntryId, entry.id);
+                        _draggedEntryId = null;
+                        _dragOverEntryId = null;
+                        m.redraw();
+                    },
+                    class: _dragOverEntryId === entry.id ? 'drag-over' : null,
+                };
                 if (spec.unavailable) {
-                    return unavailableCard(entry, spec, cardControls);
+                    return unavailableCard(entry, spec, cardControls, dropAttrs);
                 }
                 // In compare mode, render through CompareChartWrapper so
                 // pinned charts mirror the live A/B view (side-by-side,
@@ -805,7 +872,7 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                         categoryMembers: entry.category_members,
                     })
                     : m(Chart, { spec, chartsState: attrs.chartsState, interval });
-                return m('div.selection-card', [
+                return m('div.selection-card', dropAttrs, [
                     m('div.chart-wrapper', [
                         m('div.chart-header', [
                             m('div.chart-title-row', [

--- a/src/viewer/assets/lib/selection.js
+++ b/src/viewer/assets/lib/selection.js
@@ -255,7 +255,7 @@ const selectionCardTitle = (entry, spec) => {
 // Replaces the previous silent-collapse behavior where the chart's
 // .no-data state hid the entire .chart-wrapper, leaving an empty
 // gap that diverged from the loaded entry count.
-const unavailableCard = (entry, spec, removeBtn = null) =>
+const unavailableCard = (entry, spec, controls = null) =>
     m('div.selection-card', [
         m('div.chart-wrapper.chart-wrapper-unavailable', [
             m('div.chart-unavailable', [
@@ -265,7 +265,7 @@ const unavailableCard = (entry, spec, removeBtn = null) =>
                         ? `Failed to load: ${spec.unavailableReason}`
                         : 'No data available in this capture.'),
             ]),
-            removeBtn,
+            controls,
         ]),
     ]);
 
@@ -318,6 +318,17 @@ const removeEntry = (store, id) => {
             persistNotebook();
         } else if (store === reportStore) persistReport();
     }
+};
+
+// Swap entry at `id` with its neighbor. delta = -1 moves up, +1 down.
+// No-op when the move would push past either end of the list.
+const moveEntry = (store, id, delta) => {
+    const idx = store.entries.findIndex(e => e.id === id);
+    const target = idx + delta;
+    if (idx < 0 || target < 0 || target >= store.entries.length) return;
+    [store.entries[idx], store.entries[target]] = [store.entries[target], store.entries[idx]];
+    if (store === notebookStore) persistNotebook();
+    else if (store === reportStore) persistReport();
 };
 
 // In-memory only — leaves localStorage alone. Used during scope
@@ -741,15 +752,27 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                 }, 'Clear All'),
             ]),
 
-            notebookStore.entries.map((entry) => {
+            notebookStore.entries.map((entry, idx, arr) => {
                 const spec = this.specs.get(entry.chartId);
                 if (!spec) return null;
+                const cardControls = m('div.selection-card-controls', [
+                    m('button.selection-card-move', {
+                        onclick: () => { moveEntry(notebookStore, entry.id, -1); m.redraw(); },
+                        title: 'Move up',
+                        disabled: idx === 0,
+                    }, '\u2191'),
+                    m('button.selection-card-move', {
+                        onclick: () => { moveEntry(notebookStore, entry.id, 1); m.redraw(); },
+                        title: 'Move down',
+                        disabled: idx === arr.length - 1,
+                    }, '\u2193'),
+                    m('button.selection-card-remove', {
+                        onclick: () => { removeEntry(notebookStore, entry.id); m.redraw(); },
+                        title: 'Remove from Notebook',
+                    }, '\u00d7'),
+                ]);
                 if (spec.unavailable) {
-                    return unavailableCard(entry, spec,
-                        m('button.selection-card-remove', {
-                            onclick: () => { removeEntry(notebookStore, entry.id); m.redraw(); },
-                            title: 'Remove from Notebook',
-                        }, '\u00d7'));
+                    return unavailableCard(entry, spec, cardControls);
                 }
                 // In compare mode, render through CompareChartWrapper so
                 // pinned charts mirror the live A/B view (side-by-side,
@@ -796,10 +819,7 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
                             spec.opts.description && m('span.chart-subtitle', spec.opts.description),
                         ]),
                         chartBody,
-                        m('button.selection-card-remove', {
-                            onclick: () => { removeEntry(notebookStore, entry.id); m.redraw(); },
-                            title: 'Remove from Notebook',
-                        }, '\u00d7'),
+                        cardControls,
                     ]),
                     (() => {
                         const hasNote = entry.note && entry.note.length > 0;

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -1591,7 +1591,8 @@ main {
 }
 
 .selection-card-move,
-.selection-card-remove {
+.selection-card-remove,
+.selection-card-drag-handle {
     background: transparent;
     border: 1px solid transparent;
     border-radius: 4px;
@@ -1602,6 +1603,24 @@ main {
     line-height: 1;
     padding: 0 6px;
     transition: all var(--transition-base);
+}
+
+.selection-card-drag-handle {
+    cursor: grab;
+    user-select: none;
+    /* Slight visual nudge so the handle reads as "grabbable" — denser
+       glyph than the buttons. */
+    letter-spacing: -2px;
+}
+
+.selection-card-drag-handle:active {
+    cursor: grabbing;
+}
+
+.selection-card-drag-handle:hover {
+    color: var(--fg);
+    border-color: var(--border-strong);
+    background: var(--bg-elevated);
 }
 
 .selection-card-move:hover:not(:disabled) {
@@ -1619,6 +1638,12 @@ main {
     color: var(--danger);
     border-color: color-mix(in srgb, var(--danger) 40%, transparent);
     background: color-mix(in srgb, var(--danger) 15%, transparent);
+}
+
+/* Drop indicator: a top border on the card the dragged entry will
+   land before. Uses an inset box-shadow so it doesn't shift layout. */
+.selection-card.drag-over {
+    box-shadow: inset 0 3px 0 0 var(--accent, #4a90e2);
 }
 
 /* Placeholder card for entries whose data isn't in the loaded

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -1568,10 +1568,30 @@ main {
     margin-bottom: 1.5rem;
 }
 
-.selection-card-remove {
+/* Per-card controls (move up/down + remove) clustered top-right of
+   each Notebook entry. Hidden until the card is hovered, mirroring
+   the previous behavior of the standalone remove button. */
+.selection-card-controls {
     position: absolute;
     top: 8px;
     right: 8px;
+    display: flex;
+    gap: 4px;
+    opacity: 0;
+    transition: opacity var(--transition-base);
+    z-index: 10;
+}
+
+.chart-wrapper:hover .selection-card-controls {
+    opacity: 0.6;
+}
+
+.selection-card-controls:hover {
+    opacity: 1;
+}
+
+.selection-card-move,
+.selection-card-remove {
     background: transparent;
     border: 1px solid transparent;
     border-radius: 4px;
@@ -1581,17 +1601,21 @@ main {
     font-size: 16px;
     line-height: 1;
     padding: 0 6px;
-    opacity: 0;
     transition: all var(--transition-base);
-    z-index: 10;
 }
 
-.chart-wrapper:hover .selection-card-remove {
-    opacity: 0.6;
+.selection-card-move:hover:not(:disabled) {
+    color: var(--fg);
+    border-color: var(--border-strong);
+    background: var(--bg-elevated);
+}
+
+.selection-card-move:disabled {
+    cursor: default;
+    opacity: 0.35;
 }
 
 .selection-card-remove:hover {
-    opacity: 1 !important;
     color: var(--danger);
     border-color: color-mix(in srgb, var(--danger) 40%, transparent);
     background: color-mix(in srgb, var(--danger) 15%, transparent);

--- a/src/viewer/metadata.rs
+++ b/src/viewer/metadata.rs
@@ -449,6 +449,9 @@ mod report_mode_tests {
         *state.trimmed_report_marker.write() = Some("trimmed".to_string());
         regenerate_dashboards(&state);
         let sections = state.sections.read();
-        assert!(sections.is_empty(), "trimmed report should have no sections");
+        assert!(
+            sections.is_empty(),
+            "trimmed report should have no sections"
+        );
     }
 }

--- a/src/viewer/metadata.rs
+++ b/src/viewer/metadata.rs
@@ -371,20 +371,18 @@ pub fn lookup_category<'a>(
 /// HTTP attach/detach so the section list stays in sync.
 pub fn regenerate_dashboards(state: &AppState) {
     if state.is_trimmed_report() {
-        // Trimmed reports carry only the saved selection's columns;
-        // the rezolus topics, service sections, and Query Explorer
-        // would all render mostly empty. Default-construct an empty
-        // context — frontend lands on `/report` instead.
+        // Skip section construction — a trimmed report has columns only
+        // for the saved selection's queries, so rezolus / service /
+        // Query Explorer sections would all render empty.
         let filesize = state
             .parquet_path
             .read()
             .as_ref()
             .and_then(|p| std::fs::metadata(p).ok().map(|m| m.len()));
-        let context = ::dashboard::dashboard::DashboardContext {
+        *state.sections.write() = LazySectionStore::new(::dashboard::dashboard::DashboardContext {
             filesize,
             ..Default::default()
-        };
-        *state.sections.write() = LazySectionStore::new(context);
+        });
         return;
     }
 

--- a/src/viewer/metadata.rs
+++ b/src/viewer/metadata.rs
@@ -370,6 +370,24 @@ pub fn lookup_category<'a>(
 /// Called at CLI startup after the experiment attaches, and on every
 /// HTTP attach/detach so the section list stays in sync.
 pub fn regenerate_dashboards(state: &AppState) {
+    if state.is_trimmed_report() {
+        // Trimmed reports carry only the saved selection's columns;
+        // the rezolus topics, service sections, and Query Explorer
+        // would all render mostly empty. Default-construct an empty
+        // context — frontend lands on `/report` instead.
+        let filesize = state
+            .parquet_path
+            .read()
+            .as_ref()
+            .and_then(|p| std::fs::metadata(p).ok().map(|m| m.len()));
+        let context = ::dashboard::dashboard::DashboardContext {
+            filesize,
+            ..Default::default()
+        };
+        *state.sections.write() = LazySectionStore::new(context);
+        return;
+    }
+
     let registry = &state.templates;
     let baseline_path = state.parquet_path.read().clone();
     // Prefer the HTTP-owned temp path; fall back to the CLI-supplied
@@ -417,4 +435,20 @@ pub fn regenerate_dashboards(state: &AppState) {
 
     let context = dashboard::dashboard::build_dashboard_context(filesize, &service_refs, category);
     *state.sections.write() = LazySectionStore::new(context);
+}
+
+#[cfg(test)]
+mod report_mode_tests {
+    use super::*;
+    use ::dashboard::TemplateRegistry;
+    use metriken_query::Tsdb;
+
+    #[test]
+    fn regenerate_returns_empty_sections_for_trimmed_report() {
+        let state = AppState::new(Tsdb::default(), TemplateRegistry::empty());
+        *state.trimmed_report_marker.write() = Some("trimmed".to_string());
+        regenerate_dashboards(&state);
+        let sections = state.sections.read();
+        assert!(sections.is_empty(), "trimmed report should have no sections");
+    }
 }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -794,9 +794,11 @@ mod report_kv_tests {
 
     #[test]
     fn reads_present_key() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("timestamp", DataType::UInt64, false),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "timestamp",
+            DataType::UInt64,
+            false,
+        )]));
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(UInt64Array::from(vec![1u64]))],
@@ -810,8 +812,7 @@ mod report_kv_tests {
             .set_key_value_metadata(Some(kv))
             .build();
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let mut writer =
-            ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
+        let mut writer = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
         assert_eq!(

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -40,6 +40,7 @@ mod proxy_allow;
 mod ab_extract;
 mod actions;
 mod metadata;
+mod report_save;
 mod routes;
 mod state;
 

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -472,6 +472,8 @@ fn init_file_mode_combined_ab(
     state
         .captures
         .set_baseline_file_metadata(baseline_file_meta);
+    // Probing the baseline side is enough; combined-A/B reports stamp
+    // both per-side parquets identically.
     *state.trimmed_report_marker.write() = read_footer_kv(
         &extracted.baseline_path,
         crate::parquet_metadata::KEY_REPORT,

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -320,6 +320,19 @@ pub fn run(config: Config) {
     std::thread::sleep(Duration::from_millis(200));
 }
 
+/// Pull a single KV value out of a parquet file's footer. Returns
+/// `None` for missing-key, malformed-file, or missing-value cases.
+fn read_footer_kv(path: &Path, key: &str) -> Option<String> {
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+    let file = std::fs::File::open(path).ok()?;
+    let reader = SerializedFileReader::new(file).ok()?;
+    let kv = reader.metadata().file_metadata().key_value_metadata()?;
+    kv.iter()
+        .find(|entry| entry.key == key)
+        .and_then(|entry| entry.value.clone())
+}
+
 /// Build initial AppState for a parquet file source, including the
 /// optional experiment attach and category validation.
 fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> AppState {
@@ -358,6 +371,8 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
     *state.selection.write() = selection;
     *state.file_checksum.write() = file_checksum;
     state.captures.set_baseline_file_metadata(file_meta);
+    *state.trimmed_report_marker.write() =
+        read_footer_kv(path, crate::parquet_metadata::KEY_REPORT);
     state
         .captures
         .set_baseline_alias(config.baseline_alias.clone());
@@ -759,5 +774,46 @@ mod tests {
         let store = LazySectionStore::default();
         assert!(store.is_empty());
         assert_eq!(store.sections().len(), 0);
+    }
+}
+
+#[cfg(test)]
+mod report_kv_tests {
+    use super::read_footer_kv;
+    use arrow::array::UInt64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::metadata::KeyValue;
+    use parquet::file::properties::WriterProperties;
+    use std::sync::Arc;
+
+    #[test]
+    fn reads_present_key() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(UInt64Array::from(vec![1u64]))],
+        )
+        .unwrap();
+        let kv = vec![KeyValue {
+            key: "report".to_string(),
+            value: Some("trimmed".to_string()),
+        }];
+        let props = WriterProperties::builder()
+            .set_key_value_metadata(Some(kv))
+            .build();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut writer =
+            ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        assert_eq!(
+            read_footer_kv(tmp.path(), "report"),
+            Some("trimmed".to_string())
+        );
+        assert_eq!(read_footer_kv(tmp.path(), "missing"), None);
     }
 }

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -472,6 +472,10 @@ fn init_file_mode_combined_ab(
     state
         .captures
         .set_baseline_file_metadata(baseline_file_meta);
+    *state.trimmed_report_marker.write() = read_footer_kv(
+        &extracted.baseline_path,
+        crate::parquet_metadata::KEY_REPORT,
+    );
     state.captures.set_baseline_alias(Some(baseline_alias));
 
     state.captures.attach_experiment(

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -322,7 +322,7 @@ pub fn run(config: Config) {
 
 /// Pull a single KV value out of a parquet file's footer. Returns
 /// `None` for missing-key, malformed-file, or missing-value cases.
-fn read_footer_kv(path: &Path, key: &str) -> Option<String> {
+pub(super) fn read_footer_kv(path: &Path, key: &str) -> Option<String> {
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
     let file = std::fs::File::open(path).ok()?;

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -1,0 +1,57 @@
+//! Save-as-Report write-side helpers — column-trim a source parquet
+//! (or a combined-A/B tarball's per-side parquets) down to just the
+//! columns referenced by the saved selection's queries.
+
+use serde::Deserialize;
+
+/// Subset of the JSON body POSTed to `/api/v1/save_with_selection`
+/// that the trim path actually consumes. The full body carries more
+/// (tagline, anchors, chartToggles, time_range, …) — we ignore those
+/// here because they don't influence which columns the report needs.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReportPayload {
+    #[serde(default)]
+    pub entries: Vec<ReportEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReportEntry {
+    pub promql_query: String,
+    #[serde(default)]
+    pub promql_query_experiment: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_payload() {
+        let json = r#"{
+            "version": 1,
+            "entries": [
+                {"chartId": "c1", "promql_query": "cpu_cores"},
+                {
+                    "chartId": "c2",
+                    "promql_query": "cpu_usage",
+                    "promql_query_experiment": "cpu_usage{state=\"user\"}"
+                }
+            ]
+        }"#;
+        let payload: ReportPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.entries.len(), 2);
+        assert_eq!(payload.entries[0].promql_query, "cpu_cores");
+        assert_eq!(payload.entries[1].promql_query, "cpu_usage");
+        assert_eq!(
+            payload.entries[1].promql_query_experiment.as_deref(),
+            Some("cpu_usage{state=\"user\"}")
+        );
+    }
+
+    #[test]
+    fn experiment_query_optional() {
+        let json = r#"{ "entries": [{"chartId": "c", "promql_query": "m"}] }"#;
+        let payload: ReportPayload = serde_json::from_str(json).unwrap();
+        assert!(payload.entries[0].promql_query_experiment.is_none());
+    }
+}

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -2,7 +2,12 @@
 //! (or a combined-A/B tarball's per-side parquets) down to just the
 //! columns referenced by the saved selection's queries.
 
+use std::collections::HashSet;
+use std::ops::Deref;
+
+use metriken_query::{QueryEngine, Tsdb};
 use serde::Deserialize;
+use tracing::warn;
 
 /// Subset of the JSON body POSTed to `/api/v1/save_with_selection`
 /// that the trim path actually consumes. The full body carries more
@@ -21,9 +26,154 @@ pub struct ReportEntry {
     pub promql_query_experiment: Option<String>,
 }
 
+/// Which side of an A/B compare a column-resolution call is for.
+/// Drives whether `promql_query_experiment` overrides `promql_query`
+/// when both are present on a Notebook entry.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Side {
+    Baseline,
+    Experiment,
+}
+
+/// Resolve every relevant query in the payload against the supplied
+/// engine, union the returned column sets, and add `timestamp` +
+/// `duration`. A query that parses but matches no series contributes
+/// nothing (no error) — the matching column set is intentionally
+/// empty in that case.
+///
+/// A query that fails to PARSE is silently skipped rather than aborting
+/// the whole save, because the writer should produce *something* even
+/// if a single chart's saved query is malformed. (We log the parse
+/// error so the operator can diagnose.)
+pub fn resolve_kept_columns<T: Deref<Target = Tsdb>>(
+    payload: &ReportPayload,
+    engine: &QueryEngine<T>,
+    side: Side,
+) -> HashSet<String> {
+    let mut out = HashSet::new();
+    out.insert("timestamp".to_string());
+    out.insert("duration".to_string());
+    for entry in &payload.entries {
+        let query = match side {
+            Side::Baseline => entry.promql_query.as_str(),
+            Side::Experiment => entry
+                .promql_query_experiment
+                .as_deref()
+                .unwrap_or(entry.promql_query.as_str()),
+        };
+        match engine.columns(query) {
+            Ok(cols) => out.extend(cols),
+            Err(e) => {
+                warn!(
+                    "report-save: failed to resolve columns for query {query:?}: {e}"
+                );
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use arrow::array::{Int64Array, UInt64Array};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use metriken_query::{QueryEngine, Tsdb};
+    use parquet::arrow::ArrowWriter;
+    use parquet::file::metadata::KeyValue;
+    use parquet::file::properties::WriterProperties;
+    use std::sync::Arc;
+
+    /// Write a tiny single-source parquet with timestamp + duration + two
+    /// gauge columns (`m_a` and `m_b`) and load it as a Tsdb. Returns the
+    /// loaded Tsdb plus the temp file holding the bytes (kept alive so
+    /// Tsdb references stay valid where needed).
+    fn build_test_tsdb() -> (Tsdb, tempfile::NamedTempFile) {
+        let sec = 1_000_000_000u64;
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("metric_type".to_string(), "gauge".to_string());
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::UInt64, false),
+            Field::new("duration", DataType::UInt64, false),
+            Field::new("m_a", DataType::Int64, false).with_metadata(meta.clone()),
+            Field::new("m_b", DataType::Int64, false).with_metadata(meta),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(vec![sec, 2 * sec, 3 * sec])),
+                Arc::new(UInt64Array::from(vec![sec; 3])),
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(Int64Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+        let kv = vec![
+            KeyValue { key: "source".into(), value: Some("svc".into()) },
+            KeyValue { key: "sampling_interval_ms".into(), value: Some("1000".into()) },
+        ];
+        let props = WriterProperties::builder()
+            .set_key_value_metadata(Some(kv))
+            .build();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut writer =
+            ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        let tsdb = Tsdb::load(tmp.path()).expect("tsdb loads");
+        (tsdb, tmp)
+    }
+
+    #[test]
+    fn baseline_side_kept_set_includes_timestamp_and_duration() {
+        let (tsdb, _tmp) = build_test_tsdb();
+        let engine = QueryEngine::new(&tsdb);
+        let payload = ReportPayload {
+            entries: vec![ReportEntry {
+                promql_query: "m_a".into(),
+                promql_query_experiment: None,
+            }],
+        };
+        let kept = resolve_kept_columns(&payload, &engine, Side::Baseline);
+        assert!(kept.contains("timestamp"), "kept must include timestamp");
+        assert!(kept.contains("duration"), "kept must include duration");
+        assert!(kept.contains("m_a"), "kept must include the queried column");
+        assert!(!kept.contains("m_b"), "kept must NOT include unqueried columns");
+    }
+
+    #[test]
+    fn experiment_side_falls_back_to_promql_query_when_experiment_unset() {
+        let (tsdb, _tmp) = build_test_tsdb();
+        let engine = QueryEngine::new(&tsdb);
+        let payload = ReportPayload {
+            entries: vec![ReportEntry {
+                promql_query: "m_a".into(),
+                promql_query_experiment: None,
+            }],
+        };
+        let kept = resolve_kept_columns(&payload, &engine, Side::Experiment);
+        assert!(kept.contains("m_a"));
+        assert!(!kept.contains("m_b"));
+    }
+
+    #[test]
+    fn experiment_side_uses_promql_query_experiment_when_set() {
+        let (tsdb, _tmp) = build_test_tsdb();
+        let engine = QueryEngine::new(&tsdb);
+        let payload = ReportPayload {
+            entries: vec![ReportEntry {
+                promql_query: "m_a".into(),
+                promql_query_experiment: Some("m_b".into()),
+            }],
+        };
+        let kept_b = resolve_kept_columns(&payload, &engine, Side::Baseline);
+        let kept_e = resolve_kept_columns(&payload, &engine, Side::Experiment);
+        assert!(kept_b.contains("m_a") && !kept_b.contains("m_b"));
+        assert!(kept_e.contains("m_b") && !kept_e.contains("m_a"));
+    }
 
     #[test]
     fn parses_minimal_payload() {

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -4,10 +4,15 @@
 
 use std::collections::HashSet;
 use std::ops::Deref;
+use std::path::Path;
 
 use metriken_query::{QueryEngine, Tsdb};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::file::metadata::KeyValue;
 use serde::Deserialize;
 use tracing::warn;
+
+use crate::parquet_metadata::{KEY_DESCRIPTIONS, KEY_REPORT, KEY_SELECTION, REPORT_VALUE_TRIMMED};
 
 /// Subset of the JSON body POSTed to `/api/v1/save_with_selection`
 /// that the trim path actually consumes. The full body carries more
@@ -71,6 +76,103 @@ pub fn resolve_kept_columns<T: Deref<Target = Tsdb>>(
         }
     }
     out
+}
+
+/// Trim a parquet file to just the columns whose names appear in `kept`.
+/// Matches against the field name, the `base` before `:suffix`, or the
+/// `metric` metadata key — same predicate `parquet filter` uses.
+///
+/// Stamps the output with `KEY_REPORT = "trimmed"` and the caller's
+/// `selection_json` in the footer KV. Filters `descriptions` to kept names.
+pub fn trim_parquet_to_columns(
+    source_path: &Path,
+    kept: &HashSet<String>,
+    selection_json: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(source_path)?)?;
+    let schema = builder.schema().clone();
+    drop(builder);
+
+    let indices: Vec<usize> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| keep_field(f, kept))
+        .map(|(i, _)| i)
+        .collect();
+
+    if indices.is_empty() {
+        return Err("trim produced an empty column set (source missing timestamp?)".into());
+    }
+
+    let mut kv_meta = crate::parquet_tools::read_file_metadata(source_path)?;
+    kv_meta.retain(|kv| kv.key != KEY_SELECTION && kv.key != KEY_REPORT);
+    kv_meta.push(KeyValue {
+        key: KEY_REPORT.to_string(),
+        value: Some(REPORT_VALUE_TRIMMED.to_string()),
+    });
+    kv_meta.push(KeyValue {
+        key: KEY_SELECTION.to_string(),
+        value: Some(selection_json.to_string()),
+    });
+
+    let kept_names: std::collections::BTreeSet<&str> = indices
+        .iter()
+        .flat_map(|&i| {
+            let f = schema.field(i);
+            let mut names = vec![f.name().as_str()];
+            if let Some(m) = f.metadata().get("metric") {
+                names.push(m.as_str());
+            }
+            names
+        })
+        .collect();
+    filter_descriptions(&mut kv_meta, &kept_names);
+
+    Ok(crate::parquet_tools::rewrite_parquet(
+        source_path,
+        kv_meta,
+        Some(&indices),
+    )?)
+}
+
+/// Mirror `parquet filter`'s field-keep predicate: exact match, base
+/// before `:`, or `metric` metadata fallback.
+fn keep_field(f: &arrow::datatypes::Field, kept: &HashSet<String>) -> bool {
+    let name = f.name();
+    if kept.contains(name) {
+        return true;
+    }
+    if name
+        .split_once(':')
+        .is_some_and(|(base, _)| kept.contains(base))
+    {
+        return true;
+    }
+    if let Some(metric) = f.metadata().get("metric") {
+        if kept.contains(metric) {
+            return true;
+        }
+    }
+    false
+}
+
+fn filter_descriptions(
+    kv_meta: &mut [KeyValue],
+    kept_names: &std::collections::BTreeSet<&str>,
+) {
+    if let Some(entry) = kv_meta.iter_mut().find(|kv| kv.key == KEY_DESCRIPTIONS) {
+        if let Some(value) = &entry.value {
+            if let Ok(mut map) =
+                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(value)
+            {
+                map.retain(|k, _| kept_names.contains(k.as_str()));
+                if let Ok(filtered) = serde_json::to_string(&map) {
+                    entry.value = Some(filtered);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -203,5 +305,59 @@ mod tests {
         let json = r#"{ "entries": [{"chartId": "c", "promql_query": "m"}] }"#;
         let payload: ReportPayload = serde_json::from_str(json).unwrap();
         assert!(payload.entries[0].promql_query_experiment.is_none());
+    }
+
+    use crate::parquet_metadata::{KEY_REPORT, REPORT_VALUE_TRIMMED};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+
+    #[test]
+    fn trim_keeps_only_named_columns_plus_timestamp_duration() {
+        let (_tsdb, tmp) = build_test_tsdb();
+        let mut kept = HashSet::new();
+        kept.insert("timestamp".to_string());
+        kept.insert("duration".to_string());
+        kept.insert("m_a".to_string());
+
+        let selection = r#"{"version": 1, "entries": []}"#;
+        let out = trim_parquet_to_columns(tmp.path(), &kept, selection)
+            .expect("trim succeeds");
+
+        // Parse the output and confirm schema + footer.
+        // Write to a temp file so we can use File-based readers.
+        let out_tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(out_tmp.path(), &out).unwrap();
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(out_tmp.path()).unwrap())
+                .unwrap();
+        let names: Vec<String> = builder
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert_eq!(names, vec!["timestamp", "duration", "m_a"]);
+
+        // Footer carries the report marker + the new selection.
+        let reader = SerializedFileReader::new(std::fs::File::open(out_tmp.path()).unwrap()).unwrap();
+        let kv = reader
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .cloned()
+            .unwrap();
+        let report = kv
+            .iter()
+            .find(|kv| kv.key == KEY_REPORT)
+            .and_then(|kv| kv.value.as_deref())
+            .unwrap();
+        assert_eq!(report, REPORT_VALUE_TRIMMED);
+        let sel = kv
+            .iter()
+            .find(|kv| kv.key == "selection")
+            .and_then(|kv| kv.value.as_deref())
+            .unwrap();
+        assert_eq!(sel, selection);
     }
 }

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -178,6 +178,62 @@ fn filter_descriptions(
     }
 }
 
+/// Trim a combined-A/B tarball's per-side parquets and repack. Returns a
+/// POSIX tar (`baseline.parquet` + `experiment.parquet` + `ab.json`). The
+/// manifest is written through unchanged — alias, sources, and category
+/// survive the round-trip.
+#[allow(clippy::too_many_arguments)]
+pub fn trim_combined_ab_to_tarball(
+    baseline_path: &std::path::Path,
+    experiment_path: &std::path::Path,
+    payload: &ReportPayload,
+    selection_json: &str,
+    baseline_tsdb: &Arc<RwLock<Tsdb>>,
+    experiment_tsdb: &Arc<RwLock<Tsdb>>,
+    manifest: &crate::parquet_metadata::AbContainers,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let baseline_kept = {
+        let t = baseline_tsdb.read();
+        let engine = QueryEngine::new(&*t);
+        resolve_kept_columns(payload, &engine, Side::Baseline)
+    };
+    let experiment_kept = {
+        let t = experiment_tsdb.read();
+        let engine = QueryEngine::new(&*t);
+        resolve_kept_columns(payload, &engine, Side::Experiment)
+    };
+
+    let baseline_bytes = trim_parquet_to_columns(baseline_path, &baseline_kept, selection_json)?;
+    let experiment_bytes =
+        trim_parquet_to_columns(experiment_path, &experiment_kept, selection_json)?;
+    let manifest_bytes = serde_json::to_vec_pretty(manifest)?;
+
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut buf);
+        builder.mode(tar::HeaderMode::Deterministic);
+        append_tar_entry(&mut builder, "baseline.parquet", &baseline_bytes)?;
+        append_tar_entry(&mut builder, "experiment.parquet", &experiment_bytes)?;
+        append_tar_entry(&mut builder, "ab.json", &manifest_bytes)?;
+        builder.into_inner()?;
+    }
+    Ok(buf)
+}
+
+fn append_tar_entry<W: std::io::Write>(
+    builder: &mut tar::Builder<W>,
+    name: &str,
+    data: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut header = tar::Header::new_gnu();
+    header.set_path(name)?;
+    header.set_size(data.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append(&header, data)?;
+    Ok(())
+}
+
 /// HTTP-friendly wrapper for the single-parquet trim path. Resolves kept
 /// columns against the supplied Tsdb, trims the source parquet, and returns
 /// the bytes ready to stream. The original JSON body is embedded verbatim
@@ -407,5 +463,95 @@ mod tests {
             .and_then(|kv| kv.value.as_deref())
             .unwrap();
         assert_eq!(sel, selection);
+    }
+
+    #[test]
+    fn combined_ab_round_trip_trims_each_side_and_repacks() {
+        use crate::parquet_metadata::{AbContainers, AbSide};
+
+        let (tsdb_a, tmp_a) = build_test_tsdb();
+        let (tsdb_b, tmp_b) = build_test_tsdb();
+        let tsdb_a = std::sync::Arc::new(parking_lot::RwLock::new(tsdb_a));
+        let tsdb_b = std::sync::Arc::new(parking_lot::RwLock::new(tsdb_b));
+
+        let payload = ReportPayload {
+            entries: vec![ReportEntry {
+                promql_query: "m_a".into(),
+                promql_query_experiment: Some("m_b".into()),
+            }],
+        };
+        let body = r#"{"version":1,"entries":[]}"#;
+        let manifest = AbContainers {
+            version: AbContainers::SCHEMA_VERSION,
+            baseline: AbSide { alias: "a".into(), sources: vec!["svc".into()] },
+            experiment: AbSide { alias: "b".into(), sources: vec!["svc".into()] },
+            category: None,
+        };
+
+        let out = trim_combined_ab_to_tarball(
+            tmp_a.path(),
+            tmp_b.path(),
+            &payload,
+            body,
+            &tsdb_a,
+            &tsdb_b,
+            &manifest,
+        )
+        .expect("AB trim succeeds");
+
+        // Verify tar contains the three expected entries.
+        let mut archive = tar::Archive::new(std::io::Cursor::new(&out));
+        let mut names = Vec::new();
+        let mut baseline_bytes: Vec<u8> = Vec::new();
+        let mut experiment_bytes: Vec<u8> = Vec::new();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_path_buf();
+            let name = path.file_name().unwrap().to_string_lossy().to_string();
+            names.push(name.clone());
+            match name.as_str() {
+                "baseline.parquet" => {
+                    std::io::copy(&mut entry, &mut baseline_bytes).unwrap();
+                }
+                "experiment.parquet" => {
+                    std::io::copy(&mut entry, &mut experiment_bytes).unwrap();
+                }
+                _ => {}
+            }
+        }
+        assert!(names.iter().any(|n| n == "baseline.parquet"));
+        assert!(names.iter().any(|n| n == "experiment.parquet"));
+        assert!(names.iter().any(|n| n == "ab.json"));
+
+        // Write to tempfiles to use File-based parquet readers.
+        let verify_b = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(verify_b.path(), &baseline_bytes).unwrap();
+        let verify_e = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(verify_e.path(), &experiment_bytes).unwrap();
+
+        let b_schema = ParquetRecordBatchReaderBuilder::try_new(
+            std::fs::File::open(verify_b.path()).unwrap(),
+        )
+        .unwrap()
+        .schema()
+        .clone();
+        let e_schema = ParquetRecordBatchReaderBuilder::try_new(
+            std::fs::File::open(verify_e.path()).unwrap(),
+        )
+        .unwrap()
+        .schema()
+        .clone();
+        let b_names: Vec<&str> = b_schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        let e_names: Vec<&str> = e_schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(b_names, vec!["timestamp", "duration", "m_a"]);
+        assert_eq!(e_names, vec!["timestamp", "duration", "m_b"]);
     }
 }

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -17,13 +17,21 @@ use tracing::warn;
 
 use crate::parquet_metadata::{KEY_DESCRIPTIONS, KEY_REPORT, KEY_SELECTION, REPORT_VALUE_TRIMMED};
 
-/// Trim-relevant subset of the `/api/v1/save_with_selection` body.
-/// Only the entries' queries influence which columns the report needs;
-/// other fields (tagline, anchors, chartToggles, …) are ignored here.
+/// Save-relevant subset of the `/api/v1/save_with_selection` body.
+/// Other fields on the wire (tagline, anchors, chartToggles, …) are
+/// ignored here — only `entries` and `trim_columns` shape the output.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ReportPayload {
     #[serde(default)]
     pub entries: Vec<ReportEntry>,
+    /// Default true so older clients (and any non-UI POSTer) get the
+    /// trim — preserving today's PR4 behavior unless explicitly opted out.
+    #[serde(default = "default_trim_columns")]
+    pub trim_columns: bool,
+}
+
+fn default_trim_columns() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -160,26 +168,50 @@ fn kept_for_side(tsdb: &Arc<RwLock<Tsdb>>, payload: &ReportPayload, side: Side) 
     resolve_kept_columns(payload, &QueryEngine::new(&*t), side)
 }
 
-/// HTTP-friendly wrapper for the single-parquet trim path. The original
-/// body is embedded verbatim under `selection` in the output footer so
-/// loading the report restores the saved Notebook state.
-pub fn trim_single_parquet(
+/// Embed `selection_json` in the source parquet's footer without
+/// touching the columns. Output is byte-for-byte the same shape as the
+/// input plus an updated `selection` KV — no `KEY_REPORT` stamp, so
+/// reading it back behaves like opening a normal capture (full section
+/// list) that happens to carry an embedded selection.
+fn embed_selection_in_parquet(
+    source_path: &Path,
+    selection_json: &str,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut kv_meta = crate::parquet_tools::read_file_metadata(source_path)?;
+    kv_meta.retain(|kv| kv.key != KEY_SELECTION);
+    kv_meta.push(KeyValue {
+        key: KEY_SELECTION.to_string(),
+        value: Some(selection_json.to_string()),
+    });
+    crate::parquet_tools::rewrite_parquet(source_path, kv_meta, None)
+}
+
+/// HTTP-friendly wrapper for the single-parquet save path. With
+/// `trim_columns = true` (the UI default) projects the parquet down to
+/// the saved selection's columns and stamps `KEY_REPORT`; with `false`,
+/// only embeds the selection JSON and leaves all columns intact.
+pub fn save_single_parquet(
     source_path: &Path,
     payload: &ReportPayload,
     selection_json: &str,
     tsdb: &Arc<RwLock<Tsdb>>,
+    trim_columns: bool,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let kept = kept_for_side(tsdb, payload, Side::Baseline);
-    trim_parquet_to_columns(source_path, &kept, selection_json)
+    if trim_columns {
+        let kept = kept_for_side(tsdb, payload, Side::Baseline);
+        trim_parquet_to_columns(source_path, &kept, selection_json)
+    } else {
+        embed_selection_in_parquet(source_path, selection_json)
+    }
 }
 
-/// Trim a combined-A/B tarball's per-side parquets and repack. The
-/// returned bytes are a POSIX tar matching `parquet combine --ab`'s
-/// format: `baseline.parquet` + `experiment.parquet` + `ab.json`. The
-/// manifest is written through unchanged — alias, sources, and category
-/// survive the round-trip.
+/// Combined-A/B equivalent of [`save_single_parquet`]: when trimming,
+/// projects each side independently against its own Tsdb; when not,
+/// passes both per-side parquets through with only the selection
+/// embedded. Either way the manifest survives unchanged inside the
+/// `*.parquet.ab.tar` output.
 #[allow(clippy::too_many_arguments)]
-pub fn trim_combined_ab_to_tarball(
+pub fn save_combined_ab_tarball(
     baseline_path: &Path,
     experiment_path: &Path,
     payload: &ReportPayload,
@@ -187,13 +219,21 @@ pub fn trim_combined_ab_to_tarball(
     baseline_tsdb: &Arc<RwLock<Tsdb>>,
     experiment_tsdb: &Arc<RwLock<Tsdb>>,
     manifest: &crate::parquet_metadata::AbContainers,
+    trim_columns: bool,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let baseline_kept = kept_for_side(baseline_tsdb, payload, Side::Baseline);
-    let experiment_kept = kept_for_side(experiment_tsdb, payload, Side::Experiment);
-
-    let baseline_bytes = trim_parquet_to_columns(baseline_path, &baseline_kept, selection_json)?;
-    let experiment_bytes =
-        trim_parquet_to_columns(experiment_path, &experiment_kept, selection_json)?;
+    let (baseline_bytes, experiment_bytes) = if trim_columns {
+        let baseline_kept = kept_for_side(baseline_tsdb, payload, Side::Baseline);
+        let experiment_kept = kept_for_side(experiment_tsdb, payload, Side::Experiment);
+        (
+            trim_parquet_to_columns(baseline_path, &baseline_kept, selection_json)?,
+            trim_parquet_to_columns(experiment_path, &experiment_kept, selection_json)?,
+        )
+    } else {
+        (
+            embed_selection_in_parquet(baseline_path, selection_json)?,
+            embed_selection_in_parquet(experiment_path, selection_json)?,
+        )
+    };
     let manifest_bytes = serde_json::to_vec_pretty(manifest)?;
 
     let mut buf: Vec<u8> = Vec::new();
@@ -288,6 +328,7 @@ mod tests {
                 promql_query: "m_a".into(),
                 promql_query_experiment: None,
             }],
+            trim_columns: true,
         };
         let kept = resolve_kept_columns(&payload, &engine, Side::Baseline);
         assert!(kept.contains("timestamp"), "kept must include timestamp");
@@ -308,6 +349,7 @@ mod tests {
                 promql_query: "m_a".into(),
                 promql_query_experiment: None,
             }],
+            trim_columns: true,
         };
         let kept = resolve_kept_columns(&payload, &engine, Side::Experiment);
         assert!(kept.contains("m_a"));
@@ -323,6 +365,7 @@ mod tests {
                 promql_query: "m_a".into(),
                 promql_query_experiment: Some("m_b".into()),
             }],
+            trim_columns: true,
         };
         let kept_b = resolve_kept_columns(&payload, &engine, Side::Baseline);
         let kept_e = resolve_kept_columns(&payload, &engine, Side::Experiment);
@@ -360,6 +403,20 @@ mod tests {
         assert!(payload.entries[0].promql_query_experiment.is_none());
     }
 
+    #[test]
+    fn trim_columns_defaults_true_when_omitted() {
+        let json = r#"{ "entries": [] }"#;
+        let payload: ReportPayload = serde_json::from_str(json).unwrap();
+        assert!(payload.trim_columns);
+    }
+
+    #[test]
+    fn trim_columns_false_when_explicit() {
+        let json = r#"{ "entries": [], "trim_columns": false }"#;
+        let payload: ReportPayload = serde_json::from_str(json).unwrap();
+        assert!(!payload.trim_columns);
+    }
+
     use crate::parquet_metadata::{KEY_REPORT, REPORT_VALUE_TRIMMED};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use parquet::file::reader::FileReader;
@@ -374,10 +431,11 @@ mod tests {
                 promql_query: "m_a".into(),
                 promql_query_experiment: None,
             }],
+            trim_columns: true,
         };
         let body = r#"{"version":1,"entries":[{"chartId":"c","promql_query":"m_a"}]}"#;
-        let out = trim_single_parquet(tmp.path(), &payload, body, &tsdb_arc)
-            .expect("trim_single_parquet succeeds");
+        let out = save_single_parquet(tmp.path(), &payload, body, &tsdb_arc, true)
+            .expect("save_single_parquet succeeds");
         let verify = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(verify.path(), &out).unwrap();
         let builder =
@@ -390,6 +448,55 @@ mod tests {
             .map(|f| f.name().clone())
             .collect();
         assert_eq!(names, vec!["timestamp", "duration", "m_a"]);
+    }
+
+    #[test]
+    fn save_with_trim_columns_false_preserves_all_columns_and_skips_marker() {
+        let (tsdb, tmp) = build_test_tsdb();
+        let tsdb_arc = std::sync::Arc::new(parking_lot::RwLock::new(tsdb));
+        let payload = ReportPayload {
+            entries: vec![ReportEntry {
+                promql_query: "m_a".into(),
+                promql_query_experiment: None,
+            }],
+            trim_columns: false,
+        };
+        let selection = r#"{"version":1,"entries":[{"chartId":"c","promql_query":"m_a"}]}"#;
+        let out = save_single_parquet(tmp.path(), &payload, selection, &tsdb_arc, false)
+            .expect("save succeeds with trim_columns=false");
+
+        let out_tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(out_tmp.path(), &out).unwrap();
+        // All four original columns survive — no projection.
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(out_tmp.path()).unwrap())
+                .unwrap();
+        let names: Vec<String> = builder
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert_eq!(names, vec!["timestamp", "duration", "m_a", "m_b"]);
+        // No KEY_REPORT stamp — read side won't enter report mode.
+        let reader =
+            SerializedFileReader::new(std::fs::File::open(out_tmp.path()).unwrap()).unwrap();
+        let kv = reader
+            .metadata()
+            .file_metadata()
+            .key_value_metadata()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            !kv.iter().any(|kv| kv.key == KEY_REPORT),
+            "untrimmed save must not stamp KEY_REPORT"
+        );
+        let sel = kv
+            .iter()
+            .find(|kv| kv.key == "selection")
+            .and_then(|kv| kv.value.as_deref())
+            .unwrap();
+        assert_eq!(sel, selection);
     }
 
     #[test]
@@ -455,6 +562,7 @@ mod tests {
                 promql_query: "m_a".into(),
                 promql_query_experiment: Some("m_b".into()),
             }],
+            trim_columns: true,
         };
         let body = r#"{"version":1,"entries":[]}"#;
         let manifest = AbContainers {
@@ -470,7 +578,7 @@ mod tests {
             category: None,
         };
 
-        let out = trim_combined_ab_to_tarball(
+        let out = save_combined_ab_tarball(
             tmp_a.path(),
             tmp_b.path(),
             &payload,
@@ -478,8 +586,9 @@ mod tests {
             &tsdb_a,
             &tsdb_b,
             &manifest,
+            true,
         )
-        .expect("AB trim succeeds");
+        .expect("AB save succeeds");
 
         // Verify tar contains the three expected entries.
         let mut archive = tar::Archive::new(std::io::Cursor::new(&out));

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -72,9 +72,7 @@ pub fn resolve_kept_columns<T: Deref<Target = Tsdb>>(
         match engine.columns(query) {
             Ok(cols) => out.extend(cols),
             Err(e) => {
-                warn!(
-                    "report-save: failed to resolve columns for query {query:?}: {e}"
-                );
+                warn!("report-save: failed to resolve columns for query {query:?}: {e}");
             }
         }
     }
@@ -132,11 +130,7 @@ pub fn trim_parquet_to_columns(
         .collect();
     filter_descriptions(&mut kv_meta, &kept_names);
 
-    Ok(crate::parquet_tools::rewrite_parquet(
-        source_path,
-        kv_meta,
-        Some(&indices),
-    )?)
+    crate::parquet_tools::rewrite_parquet(source_path, kv_meta, Some(&indices))
 }
 
 /// Mirror `parquet filter`'s field-keep predicate: exact match, base
@@ -160,10 +154,7 @@ fn keep_field(f: &arrow::datatypes::Field, kept: &HashSet<String>) -> bool {
     false
 }
 
-fn filter_descriptions(
-    kv_meta: &mut [KeyValue],
-    kept_names: &std::collections::BTreeSet<&str>,
-) {
+fn filter_descriptions(kv_meta: &mut [KeyValue], kept_names: &std::collections::BTreeSet<&str>) {
     if let Some(entry) = kv_meta.iter_mut().find(|kv| kv.key == KEY_DESCRIPTIONS) {
         if let Some(value) = &entry.value {
             if let Ok(mut map) =
@@ -290,15 +281,20 @@ mod tests {
         )
         .unwrap();
         let kv = vec![
-            KeyValue { key: "source".into(), value: Some("svc".into()) },
-            KeyValue { key: "sampling_interval_ms".into(), value: Some("1000".into()) },
+            KeyValue {
+                key: "source".into(),
+                value: Some("svc".into()),
+            },
+            KeyValue {
+                key: "sampling_interval_ms".into(),
+                value: Some("1000".into()),
+            },
         ];
         let props = WriterProperties::builder()
             .set_key_value_metadata(Some(kv))
             .build();
         let tmp = tempfile::NamedTempFile::new().unwrap();
-        let mut writer =
-            ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
+        let mut writer = ArrowWriter::try_new(tmp.reopen().unwrap(), schema, Some(props)).unwrap();
         writer.write(&batch).unwrap();
         writer.close().unwrap();
         let tsdb = Tsdb::load(tmp.path()).expect("tsdb loads");
@@ -319,7 +315,10 @@ mod tests {
         assert!(kept.contains("timestamp"), "kept must include timestamp");
         assert!(kept.contains("duration"), "kept must include duration");
         assert!(kept.contains("m_a"), "kept must include the queried column");
-        assert!(!kept.contains("m_b"), "kept must NOT include unqueried columns");
+        assert!(
+            !kept.contains("m_b"),
+            "kept must NOT include unqueried columns"
+        );
     }
 
     #[test]
@@ -403,10 +402,9 @@ mod tests {
             .expect("trim_single_parquet succeeds");
         let verify = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(verify.path(), &out).unwrap();
-        let builder = ParquetRecordBatchReaderBuilder::try_new(
-            std::fs::File::open(verify.path()).unwrap(),
-        )
-        .unwrap();
+        let builder =
+            ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(verify.path()).unwrap())
+                .unwrap();
         let names: Vec<String> = builder
             .schema()
             .fields()
@@ -425,8 +423,7 @@ mod tests {
         kept.insert("m_a".to_string());
 
         let selection = r#"{"version": 1, "entries": []}"#;
-        let out = trim_parquet_to_columns(tmp.path(), &kept, selection)
-            .expect("trim succeeds");
+        let out = trim_parquet_to_columns(tmp.path(), &kept, selection).expect("trim succeeds");
 
         // Parse the output and confirm schema + footer.
         // Write to a temp file so we can use File-based readers.
@@ -444,7 +441,8 @@ mod tests {
         assert_eq!(names, vec!["timestamp", "duration", "m_a"]);
 
         // Footer carries the report marker + the new selection.
-        let reader = SerializedFileReader::new(std::fs::File::open(out_tmp.path()).unwrap()).unwrap();
+        let reader =
+            SerializedFileReader::new(std::fs::File::open(out_tmp.path()).unwrap()).unwrap();
         let kv = reader
             .metadata()
             .file_metadata()
@@ -483,8 +481,14 @@ mod tests {
         let body = r#"{"version":1,"entries":[]}"#;
         let manifest = AbContainers {
             version: AbContainers::SCHEMA_VERSION,
-            baseline: AbSide { alias: "a".into(), sources: vec!["svc".into()] },
-            experiment: AbSide { alias: "b".into(), sources: vec!["svc".into()] },
+            baseline: AbSide {
+                alias: "a".into(),
+                sources: vec!["svc".into()],
+            },
+            experiment: AbSide {
+                alias: "b".into(),
+                sources: vec!["svc".into()],
+            },
             category: None,
         };
 
@@ -529,18 +533,16 @@ mod tests {
         let verify_e = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(verify_e.path(), &experiment_bytes).unwrap();
 
-        let b_schema = ParquetRecordBatchReaderBuilder::try_new(
-            std::fs::File::open(verify_b.path()).unwrap(),
-        )
-        .unwrap()
-        .schema()
-        .clone();
-        let e_schema = ParquetRecordBatchReaderBuilder::try_new(
-            std::fs::File::open(verify_e.path()).unwrap(),
-        )
-        .unwrap()
-        .schema()
-        .clone();
+        let b_schema =
+            ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(verify_b.path()).unwrap())
+                .unwrap()
+                .schema()
+                .clone();
+        let e_schema =
+            ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(verify_e.path()).unwrap())
+                .unwrap()
+                .schema()
+                .clone();
         let b_names: Vec<&str> = b_schema
             .fields()
             .iter()

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -555,5 +555,25 @@ mod tests {
             .collect();
         assert_eq!(b_names, vec!["timestamp", "duration", "m_a"]);
         assert_eq!(e_names, vec!["timestamp", "duration", "m_b"]);
+
+        // Each per-side parquet must carry KEY_REPORT = "trimmed".
+        use parquet::file::reader::FileReader;
+        use parquet::file::serialized_reader::SerializedFileReader;
+        for verify in [&verify_b, &verify_e] {
+            let reader =
+                SerializedFileReader::new(std::fs::File::open(verify.path()).unwrap()).unwrap();
+            let kv = reader
+                .metadata()
+                .file_metadata()
+                .key_value_metadata()
+                .cloned()
+                .unwrap();
+            let report = kv
+                .iter()
+                .find(|kv| kv.key == KEY_REPORT)
+                .and_then(|kv| kv.value.as_deref())
+                .unwrap();
+            assert_eq!(report, REPORT_VALUE_TRIMMED);
+        }
     }
 }

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -5,6 +5,9 @@
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::path::Path;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use metriken_query::{QueryEngine, Tsdb};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -175,6 +178,23 @@ fn filter_descriptions(
     }
 }
 
+/// HTTP-friendly wrapper for the single-parquet trim path. Resolves kept
+/// columns against the supplied Tsdb, trims the source parquet, and returns
+/// the bytes ready to stream. The original JSON body is embedded verbatim
+/// under `selection` in the output footer.
+pub fn trim_single_parquet(
+    source_path: &std::path::Path,
+    payload: &ReportPayload,
+    selection_json: &str,
+    tsdb: &Arc<RwLock<Tsdb>>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let tsdb_read = tsdb.read();
+    let engine = QueryEngine::new(&*tsdb_read);
+    let kept = resolve_kept_columns(payload, &engine, Side::Baseline);
+    drop(tsdb_read);
+    trim_parquet_to_columns(source_path, &kept, selection_json)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -311,6 +331,34 @@ mod tests {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use parquet::file::reader::FileReader;
     use parquet::file::serialized_reader::SerializedFileReader;
+
+    #[test]
+    fn single_parquet_round_trip_trims_to_one_column() {
+        let (tsdb, tmp) = build_test_tsdb();
+        let tsdb_arc = std::sync::Arc::new(parking_lot::RwLock::new(tsdb));
+        let payload = ReportPayload {
+            entries: vec![ReportEntry {
+                promql_query: "m_a".into(),
+                promql_query_experiment: None,
+            }],
+        };
+        let body = r#"{"version":1,"entries":[{"chartId":"c","promql_query":"m_a"}]}"#;
+        let out = trim_single_parquet(tmp.path(), &payload, body, &tsdb_arc)
+            .expect("trim_single_parquet succeeds");
+        let verify = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(verify.path(), &out).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(
+            std::fs::File::open(verify.path()).unwrap(),
+        )
+        .unwrap();
+        let names: Vec<String> = builder
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert_eq!(names, vec!["timestamp", "duration", "m_a"]);
+    }
 
     #[test]
     fn trim_keeps_only_named_columns_plus_timestamp_duration() {

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -17,10 +17,9 @@ use tracing::warn;
 
 use crate::parquet_metadata::{KEY_DESCRIPTIONS, KEY_REPORT, KEY_SELECTION, REPORT_VALUE_TRIMMED};
 
-/// Subset of the JSON body POSTed to `/api/v1/save_with_selection`
-/// that the trim path actually consumes. The full body carries more
-/// (tagline, anchors, chartToggles, time_range, …) — we ignore those
-/// here because they don't influence which columns the report needs.
+/// Trim-relevant subset of the `/api/v1/save_with_selection` body.
+/// Only the entries' queries influence which columns the report needs;
+/// other fields (tagline, anchors, chartToggles, …) are ignored here.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ReportPayload {
     #[serde(default)]
@@ -34,33 +33,30 @@ pub struct ReportEntry {
     pub promql_query_experiment: Option<String>,
 }
 
-/// Which side of an A/B compare a column-resolution call is for.
-/// Drives whether `promql_query_experiment` overrides `promql_query`
-/// when both are present on a Notebook entry.
+/// Picks `promql_query` (Baseline) or `promql_query_experiment` with
+/// fallback to `promql_query` (Experiment) per saved entry.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Side {
     Baseline,
     Experiment,
 }
 
-/// Resolve every relevant query in the payload against the supplied
-/// engine, union the returned column sets, and add `timestamp` +
-/// `duration`. A query that parses but matches no series contributes
-/// nothing (no error) — the matching column set is intentionally
-/// empty in that case.
+/// Resolve every entry's query against `engine`, union the returned
+/// columns, and add `timestamp` + `duration` (which `engine.columns`
+/// never returns but `Tsdb::load` requires).
 ///
-/// A query that fails to PARSE is silently skipped rather than aborting
-/// the whole save, because the writer should produce *something* even
-/// if a single chart's saved query is malformed. (We log the parse
-/// error so the operator can diagnose.)
+/// A query that fails to PARSE is logged and skipped — one malformed
+/// chart shouldn't abort the whole save. Queries that parse but match
+/// no series contribute nothing, which is fine.
 pub fn resolve_kept_columns<T: Deref<Target = Tsdb>>(
     payload: &ReportPayload,
     engine: &QueryEngine<T>,
     side: Side,
 ) -> HashSet<String> {
-    let mut out = HashSet::new();
-    out.insert("timestamp".to_string());
-    out.insert("duration".to_string());
+    let mut out: HashSet<String> = ["timestamp", "duration"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     for entry in &payload.entries {
         let query = match side {
             Side::Baseline => entry.promql_query.as_str(),
@@ -71,28 +67,25 @@ pub fn resolve_kept_columns<T: Deref<Target = Tsdb>>(
         };
         match engine.columns(query) {
             Ok(cols) => out.extend(cols),
-            Err(e) => {
-                warn!("report-save: failed to resolve columns for query {query:?}: {e}");
-            }
+            Err(e) => warn!("report-save: skipped malformed query {query:?}: {e}"),
         }
     }
     out
 }
 
-/// Trim a parquet file to just the columns whose names appear in `kept`.
-/// Matches against the field name, the `base` before `:suffix`, or the
-/// `metric` metadata key — same predicate `parquet filter` uses.
-///
-/// Stamps the output with `KEY_REPORT = "trimmed"` and the caller's
-/// `selection_json` in the footer KV. Filters `descriptions` to kept names.
+/// Project the source parquet down to columns matched by `kept`,
+/// stamp `KEY_REPORT` + the selection JSON in the footer, and prune
+/// `descriptions` to the kept names. The marker is what flips the
+/// viewer into report mode at load time.
 pub fn trim_parquet_to_columns(
     source_path: &Path,
     kept: &HashSet<String>,
     selection_json: &str,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let builder = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(source_path)?)?;
-    let schema = builder.schema().clone();
-    drop(builder);
+    // Open just to read the schema; rewrite_parquet will re-open.
+    let schema = ParquetRecordBatchReaderBuilder::try_new(std::fs::File::open(source_path)?)?
+        .schema()
+        .clone();
 
     let indices: Vec<usize> = schema
         .fields()
@@ -101,7 +94,6 @@ pub fn trim_parquet_to_columns(
         .filter(|(_, f)| keep_field(f, kept))
         .map(|(i, _)| i)
         .collect();
-
     if indices.is_empty() {
         return Err("trim produced an empty column set (source missing timestamp?)".into());
     }
@@ -121,11 +113,7 @@ pub fn trim_parquet_to_columns(
         .iter()
         .flat_map(|&i| {
             let f = schema.field(i);
-            let mut names = vec![f.name().as_str()];
-            if let Some(m) = f.metadata().get("metric") {
-                names.push(m.as_str());
-            }
-            names
+            std::iter::once(f.name().as_str()).chain(f.metadata().get("metric").map(String::as_str))
         })
         .collect();
     filter_descriptions(&mut kv_meta, &kept_names);
@@ -133,66 +121,75 @@ pub fn trim_parquet_to_columns(
     crate::parquet_tools::rewrite_parquet(source_path, kv_meta, Some(&indices))
 }
 
-/// Mirror `parquet filter`'s field-keep predicate: exact match, base
-/// before `:`, or `metric` metadata fallback.
+/// Same field-keep ladder as `parquet filter`: exact name, base before
+/// `:` (e.g. `foo` for `foo:buckets`), or the `metric` metadata fallback
+/// for Prometheus-sourced columns whose physical name is a numeric ID.
 fn keep_field(f: &arrow::datatypes::Field, kept: &HashSet<String>) -> bool {
     let name = f.name();
-    if kept.contains(name) {
-        return true;
-    }
-    if name
-        .split_once(':')
-        .is_some_and(|(base, _)| kept.contains(base))
-    {
-        return true;
-    }
-    if let Some(metric) = f.metadata().get("metric") {
-        if kept.contains(metric) {
-            return true;
-        }
-    }
-    false
+    kept.contains(name)
+        || name
+            .split_once(':')
+            .is_some_and(|(base, _)| kept.contains(base))
+        || f.metadata().get("metric").is_some_and(|m| kept.contains(m))
 }
 
+/// Drop entries from the JSON-encoded `descriptions` map whose key isn't
+/// in `kept_names`. Silently no-ops if the key is absent or malformed —
+/// a stale `descriptions` blob is harmless.
 fn filter_descriptions(kv_meta: &mut [KeyValue], kept_names: &std::collections::BTreeSet<&str>) {
-    if let Some(entry) = kv_meta.iter_mut().find(|kv| kv.key == KEY_DESCRIPTIONS) {
-        if let Some(value) = &entry.value {
-            if let Ok(mut map) =
-                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(value)
-            {
-                map.retain(|k, _| kept_names.contains(k.as_str()));
-                if let Ok(filtered) = serde_json::to_string(&map) {
-                    entry.value = Some(filtered);
-                }
-            }
-        }
+    let Some(entry) = kv_meta.iter_mut().find(|kv| kv.key == KEY_DESCRIPTIONS) else {
+        return;
+    };
+    let Some(value) = entry.value.as_deref() else {
+        return;
+    };
+    let Ok(mut map) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(value)
+    else {
+        return;
+    };
+    map.retain(|k, _| kept_names.contains(k.as_str()));
+    if let Ok(filtered) = serde_json::to_string(&map) {
+        entry.value = Some(filtered);
     }
 }
 
-/// Trim a combined-A/B tarball's per-side parquets and repack. Returns a
-/// POSIX tar (`baseline.parquet` + `experiment.parquet` + `ab.json`). The
+/// Resolve `side`'s kept columns under a short-lived read guard. The
+/// guard is dropped before the caller does disk I/O.
+fn kept_for_side(tsdb: &Arc<RwLock<Tsdb>>, payload: &ReportPayload, side: Side) -> HashSet<String> {
+    let t = tsdb.read();
+    resolve_kept_columns(payload, &QueryEngine::new(&*t), side)
+}
+
+/// HTTP-friendly wrapper for the single-parquet trim path. The original
+/// body is embedded verbatim under `selection` in the output footer so
+/// loading the report restores the saved Notebook state.
+pub fn trim_single_parquet(
+    source_path: &Path,
+    payload: &ReportPayload,
+    selection_json: &str,
+    tsdb: &Arc<RwLock<Tsdb>>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let kept = kept_for_side(tsdb, payload, Side::Baseline);
+    trim_parquet_to_columns(source_path, &kept, selection_json)
+}
+
+/// Trim a combined-A/B tarball's per-side parquets and repack. The
+/// returned bytes are a POSIX tar matching `parquet combine --ab`'s
+/// format: `baseline.parquet` + `experiment.parquet` + `ab.json`. The
 /// manifest is written through unchanged — alias, sources, and category
 /// survive the round-trip.
 #[allow(clippy::too_many_arguments)]
 pub fn trim_combined_ab_to_tarball(
-    baseline_path: &std::path::Path,
-    experiment_path: &std::path::Path,
+    baseline_path: &Path,
+    experiment_path: &Path,
     payload: &ReportPayload,
     selection_json: &str,
     baseline_tsdb: &Arc<RwLock<Tsdb>>,
     experiment_tsdb: &Arc<RwLock<Tsdb>>,
     manifest: &crate::parquet_metadata::AbContainers,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let baseline_kept = {
-        let t = baseline_tsdb.read();
-        let engine = QueryEngine::new(&*t);
-        resolve_kept_columns(payload, &engine, Side::Baseline)
-    };
-    let experiment_kept = {
-        let t = experiment_tsdb.read();
-        let engine = QueryEngine::new(&*t);
-        resolve_kept_columns(payload, &engine, Side::Experiment)
-    };
+    let baseline_kept = kept_for_side(baseline_tsdb, payload, Side::Baseline);
+    let experiment_kept = kept_for_side(experiment_tsdb, payload, Side::Experiment);
 
     let baseline_bytes = trim_parquet_to_columns(baseline_path, &baseline_kept, selection_json)?;
     let experiment_bytes =
@@ -200,14 +197,12 @@ pub fn trim_combined_ab_to_tarball(
     let manifest_bytes = serde_json::to_vec_pretty(manifest)?;
 
     let mut buf: Vec<u8> = Vec::new();
-    {
-        let mut builder = tar::Builder::new(&mut buf);
-        builder.mode(tar::HeaderMode::Deterministic);
-        append_tar_entry(&mut builder, "baseline.parquet", &baseline_bytes)?;
-        append_tar_entry(&mut builder, "experiment.parquet", &experiment_bytes)?;
-        append_tar_entry(&mut builder, "ab.json", &manifest_bytes)?;
-        builder.into_inner()?;
-    }
+    let mut builder = tar::Builder::new(&mut buf);
+    builder.mode(tar::HeaderMode::Deterministic);
+    append_tar_entry(&mut builder, "baseline.parquet", &baseline_bytes)?;
+    append_tar_entry(&mut builder, "experiment.parquet", &experiment_bytes)?;
+    append_tar_entry(&mut builder, "ab.json", &manifest_bytes)?;
+    builder.into_inner()?; // releases the &mut buf borrow
     Ok(buf)
 }
 
@@ -223,23 +218,6 @@ fn append_tar_entry<W: std::io::Write>(
     header.set_cksum();
     builder.append(&header, data)?;
     Ok(())
-}
-
-/// HTTP-friendly wrapper for the single-parquet trim path. Resolves kept
-/// columns against the supplied Tsdb, trims the source parquet, and returns
-/// the bytes ready to stream. The original JSON body is embedded verbatim
-/// under `selection` in the output footer.
-pub fn trim_single_parquet(
-    source_path: &std::path::Path,
-    payload: &ReportPayload,
-    selection_json: &str,
-    tsdb: &Arc<RwLock<Tsdb>>,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let tsdb_read = tsdb.read();
-    let engine = QueryEngine::new(&*tsdb_read);
-    let kept = resolve_kept_columns(payload, &engine, Side::Baseline);
-    drop(tsdb_read);
-    trim_parquet_to_columns(source_path, &kept, selection_json)
 }
 
 #[cfg(test)]

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -191,7 +191,7 @@ pub fn strip_sections_from_section_payload(value: &mut serde_json::Value) {
 
 /// Reports viewer mode (live/file/upload-only, compare attached, etc.).
 async fn mode(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
-    let loaded = !state.sections.read().is_empty();
+    let loaded = !state.sections.read().is_empty() || state.is_trimmed_report();
     // The static-site bundle reports "direct" for its own URL input;
     // the binary viewer never reports "direct" — URL loads always go
     // through the local proxy.
@@ -205,6 +205,7 @@ async fn mode(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
         "loaded": loaded,
         "compare_mode": state.captures.experiment_attached(),
         "combined_ab": state.combined_ab(),
+        "report": state.is_trimmed_report(),
         "category": state.category_name.read().clone(),
         "url_loading": url_loading,
     }))

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -121,6 +121,12 @@ pub struct AppState {
     /// `combined_ab: true` so the frontend can pick UX appropriate for
     /// a single-artifact compare.
     pub combined_ab_marker: RwLock<Option<crate::parquet_metadata::AbContainers>>,
+    /// Cached at init from the parquet footer's `KEY_REPORT` value.
+    /// `Some("trimmed")` means this parquet (or, for combined-A/B, its
+    /// per-side parquets) was produced by Save as Report. Drives the
+    /// `regenerate_dashboards` short-circuit and `/api/v1/mode`'s
+    /// `report` flag.
+    pub trimmed_report_marker: RwLock<Option<String>>,
 }
 
 impl AppState {
@@ -139,6 +145,7 @@ impl AppState {
             file_checksum: RwLock::new(None),
             proxy: ProxyState::default(),
             combined_ab_marker: RwLock::new(None),
+            trimmed_report_marker: RwLock::new(None),
         }
     }
 
@@ -174,6 +181,13 @@ impl AppState {
     /// in download / save flows.
     pub fn combined_ab(&self) -> bool {
         self.combined_ab_marker.read().is_some()
+    }
+
+    /// True when this parquet was produced by Save as Report — drives
+    /// report-mode UX (empty section list, default route lands on
+    /// `/report`).
+    pub fn is_trimmed_report(&self) -> bool {
+        self.trimmed_report_marker.read().is_some()
     }
 
     /// Build the navigation + global params payload for `/api/v1/sections`.
@@ -324,5 +338,25 @@ pub fn promql_error_type(e: &super::promql::QueryError) -> &'static str {
         EvaluationError(_) => "execution",
         Unsupported(_) => "unsupported",
         MetricNotFound(_) => "not_found",
+    }
+}
+
+#[cfg(test)]
+mod report_marker_tests {
+    use super::*;
+    use ::dashboard::TemplateRegistry;
+    use metriken_query::Tsdb;
+
+    #[test]
+    fn default_is_not_a_trimmed_report() {
+        let state = AppState::new(Tsdb::default(), TemplateRegistry::empty());
+        assert!(!state.is_trimmed_report());
+    }
+
+    #[test]
+    fn setting_marker_flips_predicate() {
+        let state = AppState::new(Tsdb::default(), TemplateRegistry::empty());
+        *state.trimmed_report_marker.write() = Some("trimmed".to_string());
+        assert!(state.is_trimmed_report());
     }
 }

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -121,11 +121,9 @@ pub struct AppState {
     /// `combined_ab: true` so the frontend can pick UX appropriate for
     /// a single-artifact compare.
     pub combined_ab_marker: RwLock<Option<crate::parquet_metadata::AbContainers>>,
-    /// Cached at init from the parquet footer's `KEY_REPORT` value.
-    /// `Some("trimmed")` means this parquet (or, for combined-A/B, its
-    /// per-side parquets) was produced by Save as Report. Drives the
-    /// `regenerate_dashboards` short-circuit and `/api/v1/mode`'s
-    /// `report` flag.
+    /// Footer `KEY_REPORT` value cached at init. `Some("trimmed")`
+    /// flips the viewer into report mode (empty section list, frontend
+    /// defaults to `/report`).
     pub trimmed_report_marker: RwLock<Option<String>>,
 }
 
@@ -183,9 +181,8 @@ impl AppState {
         self.combined_ab_marker.read().is_some()
     }
 
-    /// True when this parquet was produced by Save as Report — drives
-    /// report-mode UX (empty section list, default route lands on
-    /// `/report`).
+    /// True when the loaded parquet carries `KEY_REPORT` — see
+    /// [`AppState::trimmed_report_marker`] for what that flips.
     pub fn is_trimmed_report(&self) -> bool {
         self.trimmed_report_marker.read().is_some()
     }

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -244,5 +244,45 @@ eq "combined-AB combined_ab"  "$(echo "$mode" | jq -r .combined_ab)"  "true" "$L
 eq "combined-AB compare_mode" "$(echo "$mode" | jq -r .compare_mode)" "true" "$LOGDIR/ab-combined.log"
 eq "combined-AB loaded"       "$(echo "$mode" | jq -r .loaded)"       "true" "$LOGDIR/ab-combined.log"
 
+echo "==> Save as Report produces a trimmed parquet"
+PORT_REPORT=18505
+# Pin one chart and POST a tiny selection that touches one column.
+SELECTION=$(cat <<JSON
+{
+  "version": 1,
+  "saved_at": "2026-05-12T00:00:00Z",
+  "entries": [
+    {"chartId": "cpu_cores", "section": "/cpu", "promql_query": "cpu_cores"}
+  ]
+}
+JSON
+)
+REPORT_PARQUET="$LOGDIR/report.parquet"
+curl -fsS -X POST -H 'content-type: application/json' \
+     -d "$SELECTION" \
+     "http://127.0.0.1:$PORT_FILE/api/v1/save_with_selection" \
+     --output "$REPORT_PARQUET" \
+     || fail "save_with_selection failed" "" "exit 0" "$LOGDIR/file.log"
+[ -s "$REPORT_PARQUET" ] || fail "report parquet is empty" "0" ">0" "$LOGDIR/file.log"
+
+echo "==> trimmed report loads in a fresh viewer with report mode active"
+./target/debug/rezolus view "$REPORT_PARQUET" \
+    --listen 127.0.0.1:$PORT_REPORT \
+    > "$LOGDIR/report.log" 2>&1 &
+PID_REPORT=$!
+trap 'kill $PID_UPLOAD $PID_FILE $PID_AB $PID_PROXY $PID_AB_COMBINED $PID_REPORT 2>/dev/null || true; wait 2>/dev/null || true' EXIT
+
+wait_for_port $PORT_REPORT || {
+    echo "--- log for report viewer ---"
+    cat "$LOGDIR/report.log"
+    exit 1
+}
+
+mode=$(curl -fsS "http://127.0.0.1:$PORT_REPORT/api/v1/mode")
+eq "report mode flag"          "$(echo "$mode" | jq -r .report)"        "true" "$LOGDIR/report.log"
+sections=$(curl -fsS "http://127.0.0.1:$PORT_REPORT/api/v1/sections")
+section_count=$(echo "$sections" | jq -r '.data.sections | length')
+eq "report mode section count" "$section_count"                          "0"    "$LOGDIR/report.log"
+
 echo
 echo "ALL VIEWER SMOKE TESTS PASSED"


### PR DESCRIPTION
## Summary

Final PR in the Notebook / Selection / Report rework (PR 1 = #908, PR 2 = #909, PR 3 = #912 + #917). \"Save as Report\" used to re-stamp the source parquet's footer and stream the whole file back — a 100 MB capture stayed 100 MB even when the report referenced three charts. PR4 trims the output to only the columns the saved selection actually queries, and teaches the viewer to recognize trimmed reports on load and present only the Report view (rezolus / service / Query Explorer sections all render empty when their columns are gone).

### Write side

- New `viewer::report_save` module:
  - `resolve_kept_columns(payload, engine, side)` walks the saved entries, calls `metriken_query::QueryEngine::columns(query)` (0.10.4) per query, unions the result, and adds `timestamp` + `duration`.
  - `trim_parquet_to_columns(source, kept, selection)` projects the source parquet down to columns matched by `kept` (same field-keep ladder as `parquet filter`), stamps `KEY_REPORT = \"trimmed\"` + the selection JSON in the footer, prunes `descriptions` to the kept names.
  - `trim_single_parquet(...)` and `trim_combined_ab_to_tarball(...)` are the HTTP-friendly entry points used by `save_with_selection`.
- `save_with_selection` dispatches:
  - **Single parquet**: trim against the baseline Tsdb → stream as `*.parquet`.
  - **Combined-A/B tarball**: trim each side against its own Tsdb → repack `baseline.parquet` + `experiment.parquet` + `ab.json` (manifest unchanged) → stream as `*.parquet.ab.tar`. (Also fixes a pre-existing bug where AB save returned just the extracted baseline parquet.)
  - **Live mode**: unchanged — converts buffered snapshots, no trim.

### Read side

- New file-level KV `KEY_REPORT` (current value `\"trimmed\"`) + `REPORT_VALUE_TRIMMED` constant in `parquet_metadata.rs`.
- `read_footer_kv(path, key)` helper in `viewer::mod`. Both `init_file_mode` and `init_file_mode_combined_ab` cache the marker into a new `AppState.trimmed_report_marker: RwLock<Option<String>>` field.
- `regenerate_dashboards` short-circuits to an empty `DashboardContext` when the marker is set — no rezolus topics, no service sections, no Query Explorer.
- `/api/v1/mode` exposes `report` flag and now returns `loaded: true` for trimmed reports (previously `loaded` was tied to non-empty section list, which would have routed the frontend to the upload landing for trimmed inputs).
- Frontend bootstrap (`script.js` → `app.js`) reads `mode.report` and overrides `defaultRoute` to `/report` so the user lands on the Notebook view directly.
- HTTP upload path (`ingest_baseline_from_path`) now also propagates the marker so the same UX works when a trimmed parquet is uploaded mid-session, not just at CLI startup.

### Schema

| Key | Where | Value |
|---|---|---|
| `report` | file-level (each trimmed parquet) | `\"trimmed\"` |

The marker is string-typed so future variants (e.g. `\"full\"`) don't need a schema bump. Combined-A/B report tarballs carry the marker in each per-side parquet; the read side probes the baseline side only (both sides are stamped identically by the writer).

### Dependency bump

- `metriken-query 0.10.2 → 0.10.4` for `QueryEngine::columns()`.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 166/166 (gained 12 new tests across the plan)
- [x] `node --test tests/*.mjs` — 82/82
- [x] `cargo fmt --check` clean
- [x] `bash tests/viewer_smoke.sh` — full pass including the new round-trip section: save a 1-chart selection against a file-mode viewer, launch a fresh viewer pointing at the resulting parquet, assert `mode.report: true` and `mode.sections.length == 0`
- [x] Manual end-to-end: pin a chart, Save as Report, load the resulting parquet — only the queried columns + timestamp + duration are present (`rezolus parquet metadata -i <file>` shows the column list shrunk from thousands to a handful), and the viewer lands on `/report`

## Out-of-scope (deferred)

- **Row / time trim** (`trim_range_ms`). The frontend already sends this when the user toggles \"Trim to selected time range\"; server still ignores. Separate PR.
- **Live-mode trim**. Live mode converts msgpack snapshots at save time; PR4 doesn't change that path.
- **Combine-time `--category` validation** (deferred from PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)