### PR TITLE
feat(wasm-viewer): restore Load Parquet upload affordance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.5"
+version = "5.13.1-alpha.6"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.5"
+version = "5.13.1-alpha.6"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -124,7 +124,45 @@ async function loadParquet(data, filename) {
         fileMetadata: state.fileMetadata,
         selectionPayload: state.selectionPayload,
         reportMode,
+        // Wire the topnav "Load Parquet" button to the same handler the
+        // landing-page dropzone uses. The server viewer uploads via
+        // /api/v1/upload; here we take the File bytes and reuse
+        // loadParquet directly.
+        onUploadParquet: loadFile,
     });
+}
+
+// Shared file-upload entry point: reads the File's bytes and runs the
+// usual loadParquet flow. Used by both the landing-page Choose-File /
+// drop zone and the topnav "Load Parquet" button after a capture is
+// already loaded (which destroys the splash and re-enters loadParquet
+// with the new bytes — same lifecycle as `loadCapture`).
+async function loadFile(file) {
+    if (!file) return;
+    const display = file.name || 'capture.parquet';
+    splashLabel = display;
+    splashProgress = -1;
+    landingError = null;
+    m.redraw();
+    try {
+        const data = new Uint8Array(await file.arrayBuffer());
+        splashLabel = 'Initializing';
+        splashProgress = -1;
+        m.redraw();
+        await loadParquet(data, display);
+        // Drop any URL params that pinned the previous capture so a
+        // refresh doesn't fight the just-uploaded file.
+        const url = new URL(window.location);
+        url.searchParams.delete('demo');
+        url.searchParams.delete('demoA');
+        url.searchParams.delete('demoB');
+        url.searchParams.delete('capture');
+        window.history.replaceState(null, '', url);
+    } catch (e) {
+        splashLabel = null;
+        landingError = `Failed to load ${display}: ${e?.message ?? e ?? 'unknown error'}`;
+        m.redraw();
+    }
 }
 
 // ── Load demo parquet (with download progress) ──────────────────────
@@ -383,6 +421,7 @@ const Root = {
             ]));
         }
         return m('div', m(FileUpload, {
+            onFile: loadFile,
             onDemo: (demo) => {
                 if (demo && Array.isArray(demo.files) && demo.files.length === 2) {
                     loadCompareDemo(


### PR DESCRIPTION
## Summary

The static-site WASM viewer's landing page exposed only **Demos** and **Load URL** — the dropzone wasn't wired (no `onFile` handler) and the topnav **Load Parquet** button never showed up after a capture loaded (`initDashboard` was called without `onUploadParquet`). Both surfaces work in the server viewer; the WASM bootstrap was just missing the glue.

Add a single `loadFile(file)` helper in `site/viewer/lib/script.js` that reads the File's bytes and runs the existing `loadParquet` flow. Pass it as:
- `onFile` on the `FileUpload` landing component → enables the drag-and-drop zone + "Choose File" button on the landing page.
- `onUploadParquet` into `initDashboard` → enables the topnav "Load Parquet" button after a capture is loaded.

Both surfaces share one handler. Drops `?demo` / `?capture` URL params on upload so a refresh doesn't fight the just-uploaded file.

Re-opens the work from the previously-closed PR #920 with the same diff, rebased onto current main.

## Test plan

- [x] `node --check site/viewer/lib/script.js` clean
- [x] `cargo build --bin rezolus` clean
- [x] Manual: load static site, drag parquet onto dropzone → splash → dashboard; topnav Load Parquet replaces the loaded capture; Load Selection appears once a parquet is loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)