### PR TITLE
fix(viewer): chart title-row + spectrum controls survive narrow screens

### DIFF
--- a/src/viewer/assets/lib/charts.css
+++ b/src/viewer/assets/lib/charts.css
@@ -131,7 +131,10 @@
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    gap: 12px;
+    /* Right-side controls (compare toggle, etc.) drop to a second line
+       on narrow screens instead of colliding with a long title. */
+    flex-wrap: wrap;
+    gap: 4px 12px;
     width: 100%;
 }
 

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -448,8 +448,14 @@ function renderSpectrumCheckbox(el, chart, kind) {
     const color = on ? COLORS.fg : COLORS.fgSecondary;
     const glyph = on ? '☑' : '☐';
     const label = pending ? `${SPECTRUM_LABELS[kind]}…` : SPECTRUM_LABELS[kind];
+    // Flex centers the 16px glyph against the 13px label baseline so
+    // they share a vertical midline instead of sitting on a manual
+    // pixel-nudge that drifts across browsers.
+    el.style.display = 'inline-flex';
+    el.style.alignItems = 'center';
+    el.style.gap = '4px';
     el.innerHTML =
-        `<span style="font-size: 16px; vertical-align: bottom; position: relative; top: 2px;">${glyph}</span> ${label}`;
+        `<span style="font-size: 16px; line-height: 1;">${glyph}</span><span>${label}</span>`;
     el.style.color = color;
 }
 
@@ -498,9 +504,11 @@ function positionControlsAtGridLeft(chart, container) {
             // legend's column rather than floating in the left gutter.
             // top:24 keeps a ~6px gap above the legend (at top:42) so
             // the 13px control font doesn't touch the legend baseline.
+            // right:28 = 12px chart inset + ~1em breathing room so the
+            // checkboxes don't crowd the legend's rightmost chip.
             container.style.top = '24px';
             container.style.left = 'auto';
-            container.style.right = '12px';
+            container.style.right = '28px';
         } else {
             container.style.top = '42px';
             container.style.right = 'auto';

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -477,7 +477,9 @@ function toggleSpectrum(chart, kind) {
 //     mobile / narrow viewport widths.
 // The grid rect is only available after echarts has laid out the
 // chart, so we query it via the `finished` event and reposition.
-const SPECTRUM_CONTROLS_NARROW_WIDTH = 500;
+// Threshold picked to cover phones (full-width), phones in compare
+// mode (half-width), tablet portrait, and narrow desktop windows.
+const SPECTRUM_CONTROLS_NARROW_WIDTH = 700;
 function positionControlsAtGridLeft(chart, container) {
     if (!chart.echart) return;
     try {
@@ -494,7 +496,9 @@ function positionControlsAtGridLeft(chart, container) {
             // Narrow chart: stack above the legend on its own line and
             // align to the right edge so it visually anchors to the
             // legend's column rather than floating in the left gutter.
-            container.style.top = '28px';
+            // top:24 keeps a ~6px gap above the legend (at top:42) so
+            // the 13px control font doesn't touch the legend baseline.
+            container.style.top = '24px';
             container.style.left = 'auto';
             container.style.right = '12px';
         } else {

--- a/src/viewer/assets/lib/charts/scatter.js
+++ b/src/viewer/assets/lib/charts/scatter.js
@@ -448,14 +448,14 @@ function renderSpectrumCheckbox(el, chart, kind) {
     const color = on ? COLORS.fg : COLORS.fgSecondary;
     const glyph = on ? '☑' : '☐';
     const label = pending ? `${SPECTRUM_LABELS[kind]}…` : SPECTRUM_LABELS[kind];
-    // Flex centers the 16px glyph against the 13px label baseline so
-    // they share a vertical midline instead of sitting on a manual
-    // pixel-nudge that drifts across browsers.
+    // Flex centers the 16px glyph against the 13px label, then a 2px
+    // upward translate compensates for the ☐/☑ glyph's built-in
+    // bottom whitespace so the visual centers actually line up.
     el.style.display = 'inline-flex';
     el.style.alignItems = 'center';
     el.style.gap = '4px';
     el.innerHTML =
-        `<span style="font-size: 16px; line-height: 1;">${glyph}</span><span>${label}</span>`;
+        `<span style="font-size: 16px; line-height: 1; transform: translateY(-2px);">${glyph}</span><span>${label}</span>`;
     el.style.color = color;
 }
 


### PR DESCRIPTION
## Summary

Layout fixes for narrow viewports (iPhone-class, tablet portrait, narrow desktop windows) on histogram-quantile charts.

- **`.chart-title-row`** got `flex-wrap: wrap` and a `4px 12px` gap. Long titles + the right-side per-card controls (compare toggle, etc.) no longer collide — the right side drops to a second line when the title fills the available width.
- **`SPECTRUM_CONTROLS_NARROW_WIDTH`** bumped 500 → 700px, catching the in-between widths where the narrow code path was needed but didn't fire. Narrow `top` tightened 28 → 24, narrow `right` bumped 12 → 28 so the Full / Tail checkboxes sit ~1em inside the legend's right edge instead of crowding it.
- **Checkbox glyph** centered against its label via `inline-flex; align-items: center` plus a 2px upward `translateY` to compensate for the `☐/☑` characters' built-in bottom whitespace.

## Test plan

- [x] `node --check` on the touched JS files clean
- [x] `node --test tests/*.mjs` — 82/82
- [x] `bash tests/viewer_smoke.sh` — full pass
- [x] Manual: confirmed Full / Tail no longer crowds the percentile legend on narrow charts and that the checkbox glyphs read as centered against the labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)