### PR TITLE
fix(viewer): add missing vllm-prefill/vllm-decode template symlinks

### DIFF
--- a/.claude/scripts/pre-commit-check.sh
+++ b/.claude/scripts/pre-commit-check.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 SRC="$ROOT/src/viewer/assets/lib"
 SITE="$ROOT/site/viewer/lib"
+TEMPLATES_SRC="$ROOT/config/templates"
+TEMPLATES_SITE="$ROOT/site/viewer/templates"
 
 # Files in site/viewer/lib/ that are standalone (not symlinked)
 STANDALONE_TOP="script.js viewer_api.js"
@@ -92,6 +94,23 @@ check_symlinks() {
     done < <(find "$SRC" -type f \( -name '*.js' -o -name '*.css' \))
 }
 
+# ── 3b. Check template symlinks ────────────────────────────────────
+
+check_template_symlinks() {
+    # Every config/templates/*.json must have a matching symlink in
+    # site/viewer/templates/ so the static-site `cp -rL` step picks it
+    # up. Without this, the deployed manifest lists templates whose
+    # JSON files 404 in the browser.
+    for src_file in "$TEMPLATES_SRC"/*.json; do
+        [ -e "$src_file" ] || continue
+        base="$(basename "$src_file")"
+        link="$TEMPLATES_SITE/$base"
+        if [ ! -L "$link" ]; then
+            errors+=("missing symlink: site/viewer/templates/$base — run: ln -s ../../../config/templates/$base $link")
+        fi
+    done
+}
+
 # ── 4. Check capture script sync ──────────────────────────────────
 
 check_capture_sync() {
@@ -145,6 +164,7 @@ check_wasm() {
 check_formatting
 check_clippy
 check_symlinks
+check_template_symlinks
 check_capture_sync
 check_wasm
 

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -126,6 +126,18 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install wabt
       - name: Rebuild WASM viewer
         run: ./crates/viewer/build.sh
+      - name: Check template symlinks are committed
+        # build.sh self-heals missing symlinks under site/viewer/templates/
+        # so the deploy doesn't break, but the symlinks must also be in
+        # git so this isn't a CI-only fix. Fail PRs that add a template
+        # without the matching symlink.
+        run: |
+          missing=$(git status --porcelain site/viewer/templates/ | awk '$1 == "??" {print $2}')
+          if [ -n "$missing" ]; then
+            echo "::error::config/templates/ entries are missing symlinks under site/viewer/templates/. Add them so the static-site viewer can serve the JSON:"
+            echo "$missing" | sed 's/^/  /'
+            exit 1
+          fi
       - name: Validate rebuilt WASM structure
         run: |
           wasm=site/viewer/pkg/wasm_viewer_bg.wasm

--- a/crates/viewer/build.sh
+++ b/crates/viewer/build.sh
@@ -9,7 +9,20 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 OUT_DIR="$SCRIPT_DIR/../../site/viewer/pkg"
 TEMPLATES_DIR="$SCRIPT_DIR/../../config/templates"
-MANIFEST_PATH="$SCRIPT_DIR/../../site/viewer/templates/manifest.json"
+SITE_TEMPLATES_DIR="$SCRIPT_DIR/../../site/viewer/templates"
+MANIFEST_PATH="$SITE_TEMPLATES_DIR/manifest.json"
+
+# Ensure each config/templates/*.json has a matching symlink under
+# site/viewer/templates/ so the pages-deploy `cp -rL` step picks it up.
+# Without this, adding a template to config/templates/ silently 404s in
+# the deployed viewer (the manifest below lists it but the file is gone).
+for src in "$TEMPLATES_DIR"/*.json; do
+    name=$(basename "$src")
+    link="$SITE_TEMPLATES_DIR/$name"
+    if [ ! -L "$link" ] && [ ! -e "$link" ]; then
+        ln -s "../../../config/templates/$name" "$link"
+    fi
+done
 
 # Regenerate the static-site templates manifest from config/templates/*.json
 # so the WASM viewer picks up new templates without manual JS edits.

--- a/site/viewer/templates/vllm-decode.json
+++ b/site/viewer/templates/vllm-decode.json
@@ -1,0 +1,1 @@
+../../../config/templates/vllm-decode.json

--- a/site/viewer/templates/vllm-prefill.json
+++ b/site/viewer/templates/vllm-prefill.json
@@ -1,0 +1,1 @@
+../../../config/templates/vllm-prefill.json


### PR DESCRIPTION
## Summary

The deployed viewer logs `404` for `templates/vllm-prefill.json` and `templates/vllm-decode.json`. PR #918 added the JSON files under `config/templates/` but did not create the matching symlinks under `site/viewer/templates/`, so `crates/viewer/build.sh` ended up regenerating a manifest that listed two templates whose JSON files weren't actually shipped.

This PR adds the missing symlinks and adds three reinforcing layers of protection so this can't recur.

## Changes

- **`site/viewer/templates/{vllm-prefill,vllm-decode}.json`** — new symlinks pointing into `config/templates/`, matching the existing convention.
- **`crates/viewer/build.sh`** — auto-creates any missing `site/viewer/templates/*.json` symlinks before regenerating the manifest. Self-heals the pages-deploy `cp -rL` step.
- **`.claude/scripts/pre-commit-check.sh`** — adds `check_template_symlinks` so a commit that adds `config/templates/foo.json` without the symlink is blocked at commit time.
- **`.github/workflows/cargo.yml`** — the `wasm-viewer` job now fails the build if `build.sh` had to create symlinks that weren't committed, so PRs adding a template without the symlink are caught in CI.

## Test plan

- [ ] Local: `./crates/viewer/build.sh` (the WASM step can fail without `wasm-pack`; what matters is the manifest + symlink prelude). Confirm `site/viewer/templates/manifest.json` lists `vllm-prefill` and `vllm-decode`, and the symlinks resolve.
- [ ] CI: `cargo-build` / `wasm-viewer` job passes (and would fail on a follow-up PR that adds a template JSON without the symlink).
- [ ] Pages deploy: after merge, browser console no longer shows 404s for `vllm-prefill.json` / `vllm-decode.json` on https://rezolus.com/viewer/.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKnp8RFDwffdfGjQkoDbvX)_