### PR TITLE
fix(mcp): collapse nested if (clippy collapsible_if gate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.11"
+version = "5.13.1-alpha.12"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/mcp/anomaly_detection/mod.rs
+++ b/src/mcp/anomaly_detection/mod.rs
@@ -131,20 +131,18 @@ fn validate_and_fix_query(query: &str) -> Result<String, Box<dyn std::error::Err
     // A bare range vector (e.g. "metric[5m]" with no enclosing function) is invalid
     if query.contains('[') && query.contains(']') {
         let has_function = range_vector_functions.iter().any(|f| query.contains(f));
-        if !has_function {
-            if !query.contains("(") {
-                return Err(format!(
-                    "Query '{}' appears to be a bare range vector selector.\n\
-                    \n\
-                    Range vectors must be used with a function.\n\
-                    For counters, use: rate({})\n\
-                    For gauges, use: avg_over_time({})\n\
-                    \n\
-                    Range vectors alone cannot be graphed or analyzed.",
-                    query, query, query
-                )
-                .into());
-            }
+        if !has_function && !query.contains("(") {
+            return Err(format!(
+                "Query '{}' appears to be a bare range vector selector.\n\
+                \n\
+                Range vectors must be used with a function.\n\
+                For counters, use: rate({})\n\
+                For gauges, use: avg_over_time({})\n\
+                \n\
+                Range vectors alone cannot be graphed or analyzed.",
+                query, query, query
+            )
+            .into());
         }
     }
 


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets -- -D warnings` fails on `main` with clippy 1.95: `collapsible_if` flags the nested `if !has_function { if !query.contains("(") { … } }` in `src/mcp/anomaly_detection/mod.rs`. Pre-existing (not introduced by any recent PR) — surfaced once the toolchain reached 1.95, where this lint fires. Left unfixed it blocks the clippy gate on every PR.

- Collapse to `if !has_function && !query.contains("(")`. Behavior identical.
- Per-PR version bump `5.13.1-alpha.11` → `-alpha.12`.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` now passes
- [x] `cargo build --bin rezolus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)