### PR TITLE
feat(dashboard): histogram rate|mean card pair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,9 +1270,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "histogram"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6474b5317904e60c23732dfb33be3537204de6f698da37c19c38a95cd9d39895"
+checksum = "78dbc692bf02314a491f06bb95ae039fe842c1e1179f0036df08800fba0fb29b"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448751960f35543c086a2fc16c08f3b282548f223b8dbffa25431f32b612b854"
+checksum = "bdc1dab49ba9be19efd4a14a8484672cf8c29de2b4a67a48838785aacad3c2a1"
 dependencies = [
  "arrow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc1dab49ba9be19efd4a14a8484672cf8c29de2b4a67a48838785aacad3c2a1"
+checksum = "90634cac172e38d3c5f84f842598b418f7df9c62ebcfee567fa9fef554df93cb"
 dependencies = [
  "arrow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.11"
+version = "5.13.1-alpha.13"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.12"
+version = "5.13.1-alpha.13"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.186"
 log = "0.4.29"
 metriken = "0.9.2"
 metriken-exposition = "0.16.0"
-metriken-query = { version = "0.10.4", default-features = false }
+metriken-query = { version = "0.10.6", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2.186"
 log = "0.4.29"
 metriken = "0.9.2"
 metriken-exposition = "0.16.0"
-metriken-query = { version = "0.10.6", default-features = false }
+metriken-query = { version = "0.10.8", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"

--- a/crates/dashboard/src/dashboard/blockio.rs
+++ b/crates/dashboard/src/dashboard/blockio.rs
@@ -50,6 +50,15 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     by_op.describe("Latency percentiles broken down by read vs write.");
     for op in &["Read", "Write"] {
         let op_lower = op.to_lowercase();
+        by_op.histogram_rate_mean(
+            op,
+            &format!("latency-{op_lower}"),
+            &format!("blockio_latency{{op=\"{op_lower}\"}}"),
+            RateSource::Counter(format!(
+                "sum(irate(blockio_operations{{op=\"{op_lower}\"}}[5m]))"
+            )),
+            Unit::Time,
+        );
         by_op.plot_promql(
             PlotOpts::histogram_latency(*op, format!("latency-{op_lower}")),
             format!("blockio_latency{{op=\"{op_lower}\"}}"),
@@ -64,6 +73,15 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     by_op.describe("IO size distribution percentiles broken down by read vs write.");
     for op in &["Read", "Write"] {
         let op_lower = op.to_lowercase();
+        by_op.histogram_rate_mean(
+            op,
+            &format!("size-{op_lower}"),
+            &format!("blockio_size{{op=\"{op_lower}\"}}"),
+            RateSource::Counter(format!(
+                "sum(irate(blockio_operations{{op=\"{op_lower}\"}}[5m]))"
+            )),
+            Unit::Bytes,
+        );
         by_op.plot_promql(
             PlotOpts::histogram(*op, format!("size-{op_lower}"), Unit::Bytes, "percentiles")
                 .with_log_scale(true),
@@ -74,4 +92,28 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     view.group(size);
 
     view
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tsdb;
+
+    #[test]
+    fn blockio_latency_and_size_get_rate_mean_pairs() {
+        let view = generate(&Tsdb::default(), vec![]);
+        // serde escapes the inner `"` of PromQL label selectors; unescape
+        // so the substring checks read like the queries we actually emit.
+        let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
+        // Latency per-op rate uses the accurate operations counter; mean from histogram.
+        assert!(json.contains("sum(irate(blockio_operations{op=\"read\"}[5m]))"));
+        assert!(json.contains("histogram_mean(blockio_latency{op=\"read\"})"));
+        assert!(json.contains("histogram_mean(blockio_latency{op=\"write\"})"));
+        // Size: rate also from operations count; mean is mean IO size.
+        assert!(json.contains("histogram_mean(blockio_size{op=\"read\"})"));
+        assert!(json.contains("histogram_mean(blockio_size{op=\"write\"})"));
+        // Percentile histograms still present.
+        assert!(json.contains("blockio_latency{op=\"read\"}"));
+        assert!(json.contains("blockio_size{op=\"write\"}"));
+    }
 }

--- a/crates/dashboard/src/dashboard/network.rs
+++ b/crates/dashboard/src/dashboard/network.rs
@@ -81,7 +81,7 @@ mod tests {
     fn tcp_packet_latency_gets_from_histogram_rate_mean() {
         let view = generate(&Tsdb::default(), vec![]);
         let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
-        assert!(json.contains("sum(irate(histogram_count(tcp_packet_latency)[5m]))"));
+        assert!(json.contains("sum(histogram_irate(tcp_packet_latency))"));
         assert!(json.contains("histogram_mean(tcp_packet_latency)\""));
         // percentile plot still present
         assert!(json.contains("\"tcp_packet_latency\""));

--- a/crates/dashboard/src/dashboard/network.rs
+++ b/crates/dashboard/src/dashboard/network.rs
@@ -53,6 +53,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let latency = tcp.subgroup("Packet Latency");
     latency.describe("Time from packet received to being processed by the application.");
+    latency.histogram_rate_mean(
+        "TCP Packet",
+        "tcp-packet-latency",
+        "tcp_packet_latency",
+        RateSource::FromHistogram,
+        Unit::Time,
+    );
     latency.plot_promql_full(
         PlotOpts::histogram_latency("TCP Packet Latency", "tcp-packet-latency")
             .with_axis_label("Latency")
@@ -63,4 +70,20 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     view.group(tcp);
 
     view
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tsdb;
+
+    #[test]
+    fn tcp_packet_latency_gets_from_histogram_rate_mean() {
+        let view = generate(&Tsdb::default(), vec![]);
+        let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
+        assert!(json.contains("sum(irate(histogram_count(tcp_packet_latency)[5m]))"));
+        assert!(json.contains("histogram_mean(tcp_packet_latency)\""));
+        // percentile plot still present
+        assert!(json.contains("\"tcp_packet_latency\""));
+    }
 }

--- a/crates/dashboard/src/dashboard/scheduler.rs
+++ b/crates/dashboard/src/dashboard/scheduler.rs
@@ -121,14 +121,14 @@ mod tests {
     fn scheduler_histograms_get_from_histogram_rate_mean() {
         let view = generate(&Tsdb::default(), vec![]);
         let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
-        assert!(json.contains("sum(irate(histogram_count(scheduler_runqueue_latency)[5m]))"));
+        assert!(json.contains("sum(histogram_irate(scheduler_runqueue_latency))"));
         assert!(json.contains("histogram_mean(scheduler_runqueue_latency)\""));
-        assert!(json.contains("sum(irate(histogram_count(scheduler_offcpu)[5m]))"));
+        assert!(json.contains("sum(histogram_irate(scheduler_offcpu))"));
         assert!(json.contains("histogram_mean(scheduler_offcpu)\""));
-        assert!(json.contains("sum(irate(histogram_count(scheduler_running)[5m]))"));
+        assert!(json.contains("sum(histogram_irate(scheduler_running))"));
         assert!(json.contains("histogram_mean(scheduler_running)\""));
         // runqueue_wait must NOT become a rate source.
-        assert!(!json.contains("histogram_count(scheduler_runqueue_wait"));
+        assert!(!json.contains("histogram_irate(scheduler_runqueue_wait"));
         // percentile histograms still present
         assert!(json.contains("scheduler_runqueue_latency"));
         assert!(json.contains("scheduler_offcpu"));

--- a/crates/dashboard/src/dashboard/scheduler.rs
+++ b/crates/dashboard/src/dashboard/scheduler.rs
@@ -17,6 +17,13 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let queueing = scheduler.subgroup("Runqueue Latency");
     queueing.describe("How long tasks waited on the runqueue before getting CPU time.");
+    queueing.histogram_rate_mean(
+        "Runqueue",
+        "scheduler-runqueue-latency",
+        "scheduler_runqueue_latency",
+        RateSource::FromHistogram,
+        Unit::Time,
+    );
     queueing.plot_promql_full(
         PlotOpts::histogram_latency("Runqueue Latency", "scheduler-runqueue-latency")
             .with_axis_label("Latency")
@@ -55,11 +62,25 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let timing = scheduler.subgroup("Task Timing");
     timing.describe("Time tasks spent off-CPU (blocked, waiting) and on-CPU (running).");
+    timing.histogram_rate_mean(
+        "Off CPU",
+        "off-cpu-time",
+        "scheduler_offcpu",
+        RateSource::FromHistogram,
+        Unit::Time,
+    );
     timing.plot_promql(
         PlotOpts::histogram_latency("Off CPU Time", "off-cpu-time")
             .with_axis_label("Time")
             .with_unit_system("time"),
         "scheduler_offcpu".to_string(),
+    );
+    timing.histogram_rate_mean(
+        "Running",
+        "running-time",
+        "scheduler_running",
+        RateSource::FromHistogram,
+        Unit::Time,
     );
     timing.plot_promql(
         PlotOpts::histogram_latency("Running Time", "running-time")
@@ -89,4 +110,28 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     view.group(scheduler);
 
     view
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tsdb;
+
+    #[test]
+    fn scheduler_histograms_get_from_histogram_rate_mean() {
+        let view = generate(&Tsdb::default(), vec![]);
+        let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
+        assert!(json.contains("sum(irate(histogram_count(scheduler_runqueue_latency)[5m]))"));
+        assert!(json.contains("histogram_mean(scheduler_runqueue_latency)\""));
+        assert!(json.contains("sum(irate(histogram_count(scheduler_offcpu)[5m]))"));
+        assert!(json.contains("histogram_mean(scheduler_offcpu)\""));
+        assert!(json.contains("sum(irate(histogram_count(scheduler_running)[5m]))"));
+        assert!(json.contains("histogram_mean(scheduler_running)\""));
+        // runqueue_wait must NOT become a rate source.
+        assert!(!json.contains("histogram_count(scheduler_runqueue_wait"));
+        // percentile histograms still present
+        assert!(json.contains("scheduler_runqueue_latency"));
+        assert!(json.contains("scheduler_offcpu"));
+        assert!(json.contains("scheduler_running"));
+    }
 }

--- a/crates/dashboard/src/dashboard/syscall.rs
+++ b/crates/dashboard/src/dashboard/syscall.rs
@@ -45,7 +45,7 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
         let sg = syscall.subgroup(*op);
         sg.histogram_rate_mean(
             op,
-            &format!("syscall-{op}"),
+            &format!("syscall-{op_lower}"),
             &format!("syscall_latency{{op=\"{op_lower}\"}}"),
             RateSource::Counter(format!("sum(irate(syscall{{op=\"{op_lower}\"}}[5m]))")),
             Unit::Time,

--- a/crates/dashboard/src/dashboard/syscall.rs
+++ b/crates/dashboard/src/dashboard/syscall.rs
@@ -72,7 +72,7 @@ mod tests {
         let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
         // Overall: rate query preserved verbatim, plus mean.
         assert!(json.contains("sum(irate(syscall[5m]))"));
-        assert!(json.contains("histogram_mean(syscall_latency)"));
+        assert!(json.contains("histogram_mean(syscall_latency)\""));
         // Per-op (read): rate preserved, mean added.
         assert!(json.contains("sum(irate(syscall{op=\"read\"}[5m]))"));
         assert!(json.contains("histogram_mean(syscall_latency{op=\"read\"})"));

--- a/crates/dashboard/src/dashboard/syscall.rs
+++ b/crates/dashboard/src/dashboard/syscall.rs
@@ -11,9 +11,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
 
     let overall = syscall.subgroup("Overall");
     overall.describe("Aggregate syscall rate and latency across all operation categories.");
-    overall.plot_promql(
-        PlotOpts::counter("Overall Rate", "syscall-total", Unit::Rate),
-        "sum(irate(syscall[5m]))".to_string(),
+    overall.histogram_rate_mean(
+        "Overall",
+        "syscall-total",
+        "syscall_latency",
+        RateSource::Counter("sum(irate(syscall[5m]))".to_string()),
+        Unit::Time,
     );
     overall.plot_promql(
         PlotOpts::histogram_latency("Overall Latency", "syscall-total-latency"),
@@ -40,9 +43,12 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     ] {
         let op_lower = op.to_lowercase();
         let sg = syscall.subgroup(*op);
-        sg.plot_promql(
-            PlotOpts::counter(format!("{op} Rate"), format!("syscall-{op}"), Unit::Rate),
-            format!("sum(irate(syscall{{op=\"{op_lower}\"}}[5m]))"),
+        sg.histogram_rate_mean(
+            op,
+            &format!("syscall-{op}"),
+            &format!("syscall_latency{{op=\"{op_lower}\"}}"),
+            RateSource::Counter(format!("sum(irate(syscall{{op=\"{op_lower}\"}}[5m]))")),
+            Unit::Time,
         );
         sg.plot_promql(
             PlotOpts::histogram_latency(format!("{op} Latency"), format!("syscall-{op}-latency")),
@@ -53,4 +59,27 @@ pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
     view.group(syscall);
 
     view
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Tsdb;
+
+    #[test]
+    fn syscall_overall_and_per_op_get_rate_mean_pairs() {
+        let view = generate(&Tsdb::default(), vec![]);
+        let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
+        // Overall: rate query preserved verbatim, plus mean.
+        assert!(json.contains("sum(irate(syscall[5m]))"));
+        assert!(json.contains("histogram_mean(syscall_latency)"));
+        // Per-op (read): rate preserved, mean added.
+        assert!(json.contains("sum(irate(syscall{op=\"read\"}[5m]))"));
+        assert!(json.contains("histogram_mean(syscall_latency{op=\"read\"})"));
+        // Percentile histogram still present.
+        assert!(json.contains("syscall_latency{op=\"write\"}"));
+        // No duplicate standalone overall rate: the overall rate query
+        // string appears exactly once.
+        assert_eq!(json.matches("sum(irate(syscall[5m]))").count(), 1);
+    }
 }

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -309,9 +309,9 @@ impl SubGroup {
             Unit::Bytes => "bytes",
             // This helper is only used for latency/size means; guard
             // anything else loudly rather than mis-format silently.
-            other => panic!(
-                "histogram_rate_mean: unsupported mean unit {other:?}; only Time/Bytes"
-            ),
+            other => {
+                panic!("histogram_rate_mean: unsupported mean unit {other:?}; only Time/Bytes")
+            }
         };
         let rate_query = match rate {
             RateSource::Counter(q) => q,

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -316,7 +316,7 @@ impl SubGroup {
         let rate_query = match rate {
             RateSource::Counter(q) => q,
             RateSource::FromHistogram => {
-                format!("sum(irate(histogram_count({selector})[5m]))")
+                format!("sum(histogram_irate({selector}))")
             }
         };
         self.plot_promql(
@@ -784,7 +784,7 @@ mod tests {
         assert_eq!(plots.len(), 2);
         assert_eq!(
             plots[0]["promql_query"],
-            "sum(irate(histogram_count(scheduler_runqueue_latency)[5m]))"
+            "sum(histogram_irate(scheduler_runqueue_latency))"
         );
         assert_eq!(
             plots[1]["promql_query"],

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -286,6 +286,50 @@ impl SubGroup {
             plot.width = PlotWidth::Full;
         }
     }
+
+    /// Append a half-width **rate** card then a half-width **mean**
+    /// card for a percentile histogram `selector`; they render side by
+    /// side. Call immediately before the percentile plot so the
+    /// subgroup reads rate | mean | <percentiles>.
+    ///
+    /// `mean_unit` is the mean card's `Unit` (`Time` for latency,
+    /// `Bytes` for size); `unit_system` is its formatter
+    /// (`"time"` / `"bytes"`). The rate card mirrors existing counter
+    /// rate cards (`Unit::Rate`, no unit system).
+    pub fn histogram_rate_mean(
+        &mut self,
+        title_stem: &str,
+        id_stem: &str,
+        selector: &str,
+        rate: RateSource,
+        mean_unit: Unit,
+        unit_system: &str,
+    ) {
+        let rate_query = match rate {
+            RateSource::Counter(q) => q,
+            RateSource::FromHistogram => {
+                format!("sum(irate(histogram_count({selector})[5m]))")
+            }
+        };
+        self.plot_promql(
+            PlotOpts::counter(
+                format!("{title_stem} Rate"),
+                format!("{id_stem}-rate"),
+                Unit::Rate,
+            ),
+            rate_query,
+        );
+        self.plot_promql(
+            PlotOpts::gauge(
+                format!("{title_stem} Mean"),
+                format!("{id_stem}-mean"),
+                mean_unit,
+            )
+            .with_unit_system(unit_system)
+            .with_axis_label("Mean"),
+            format!("histogram_mean({selector})"),
+        );
+    }
 }
 
 #[derive(Serialize, Clone)]
@@ -318,6 +362,16 @@ pub enum MetricType {
     Gauge,
     DeltaCounter,
     Histogram,
+}
+
+/// Where the "rate" half of a histogram's rate|mean card pair gets its
+/// data. Prefer `Counter` (an accurate standalone counter of exactly
+/// the histogrammed events); `FromHistogram` derives an approximate
+/// rate from the histogram column itself and is subject to lock-free
+/// snapshot undercount — use only when no such counter exists.
+pub enum RateSource {
+    Counter(String),
+    FromHistogram,
 }
 
 #[derive(Serialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -660,6 +714,68 @@ mod tests {
             Labels::from([("other", "x")].as_slice()),
         ];
         assert_eq!(unique_label_count(&labels, "id"), 1);
+    }
+
+    #[test]
+    fn histogram_rate_mean_counter_source_emits_two_half_width_plots() {
+        let mut g = Group::new("G", "g");
+        let sg = g.subgroup("S");
+        sg.histogram_rate_mean(
+            "Read",
+            "latency-read",
+            "blockio_latency{op=\"read\"}",
+            RateSource::Counter("sum(irate(blockio_operations{op=\"read\"}[5m]))".to_string()),
+            Unit::Time,
+            "time",
+        );
+        let json = serde_json::to_value(&g).unwrap();
+        let plots = json["subgroups"][0]["plots"].as_array().unwrap();
+        assert_eq!(plots.len(), 2);
+
+        assert_eq!(plots[0]["opts"]["title"], "Read Rate");
+        assert_eq!(plots[0]["opts"]["id"], "latency-read-rate");
+        assert_eq!(plots[0]["opts"]["type"], "delta_counter");
+        assert!(
+            plots[0].get("width").is_none(),
+            "half width is the serde default (omitted)"
+        );
+        assert_eq!(
+            plots[0]["promql_query"],
+            "sum(irate(blockio_operations{op=\"read\"}[5m]))"
+        );
+
+        assert_eq!(plots[1]["opts"]["title"], "Read Mean");
+        assert_eq!(plots[1]["opts"]["id"], "latency-read-mean");
+        assert_eq!(plots[1]["opts"]["type"], "gauge");
+        assert_eq!(plots[1]["opts"]["format"]["unit_system"], "time");
+        assert_eq!(
+            plots[1]["promql_query"],
+            "histogram_mean(blockio_latency{op=\"read\"})"
+        );
+    }
+
+    #[test]
+    fn histogram_rate_mean_from_histogram_derives_rate_from_count() {
+        let mut g = Group::new("G", "g");
+        let sg = g.subgroup("S");
+        sg.histogram_rate_mean(
+            "Runqueue",
+            "scheduler-runqueue-latency",
+            "scheduler_runqueue_latency",
+            RateSource::FromHistogram,
+            Unit::Time,
+            "time",
+        );
+        let json = serde_json::to_value(&g).unwrap();
+        let plots = json["subgroups"][0]["plots"].as_array().unwrap();
+        assert_eq!(
+            plots[0]["promql_query"],
+            "sum(irate(histogram_count(scheduler_runqueue_latency)[5m]))"
+        );
+        assert_eq!(
+            plots[1]["promql_query"],
+            "histogram_mean(scheduler_runqueue_latency)"
+        );
     }
 }
 

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -259,6 +259,7 @@ impl SubGroup {
             series_names: None,
             promql_query: Some(promql_query),
             promql_query_experiment: None,
+            promql_query_total: None,
             width: PlotWidth::default(),
         });
     }
@@ -329,7 +330,7 @@ impl SubGroup {
         );
         self.plot_promql(
             PlotOpts::gauge(
-                format!("{title_stem} Mean"),
+                format!("{title_stem} Mean/Total"),
                 format!("{id_stem}-mean"),
                 mean_unit,
             )
@@ -337,6 +338,9 @@ impl SubGroup {
             .with_axis_label("Mean"),
             format!("histogram_mean({selector})"),
         );
+        if let Some(mean_plot) = self.plots.last_mut() {
+            mean_plot.promql_query_total = Some(format!("histogram_sum({selector})"));
+        }
     }
 }
 
@@ -358,6 +362,9 @@ pub struct Plot {
     promql_query: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub promql_query_experiment: Option<String>,
+    /// Alt query the viewer's Mean/Total toggle swaps to (= `histogram_sum`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub promql_query_total: Option<String>,
     #[serde(skip_serializing_if = "plot_width_is_half", default)]
     pub width: PlotWidth,
 }
@@ -604,6 +611,7 @@ mod tests {
             series_names: None,
             promql_query: Some("up".into()),
             promql_query_experiment: None,
+            promql_query_total: None,
             width,
         }
     }
@@ -758,13 +766,17 @@ mod tests {
             "sum(irate(blockio_operations{op=\"read\"}[5m]))"
         );
 
-        assert_eq!(plots[1]["opts"]["title"], "Read Mean");
+        assert_eq!(plots[1]["opts"]["title"], "Read Mean/Total");
         assert_eq!(plots[1]["opts"]["id"], "latency-read-mean");
         assert_eq!(plots[1]["opts"]["type"], "gauge");
         assert_eq!(plots[1]["opts"]["format"]["unit_system"], "time");
         assert_eq!(
             plots[1]["promql_query"],
             "histogram_mean(blockio_latency{op=\"read\"})"
+        );
+        assert_eq!(
+            plots[1]["promql_query_total"],
+            "histogram_sum(blockio_latency{op=\"read\"})"
         );
     }
 
@@ -786,9 +798,14 @@ mod tests {
             plots[0]["promql_query"],
             "sum(histogram_irate(scheduler_runqueue_latency))"
         );
+        assert_eq!(plots[1]["opts"]["title"], "Runqueue Mean/Total");
         assert_eq!(
             plots[1]["promql_query"],
             "histogram_mean(scheduler_runqueue_latency)"
+        );
+        assert_eq!(
+            plots[1]["promql_query_total"],
+            "histogram_sum(scheduler_runqueue_latency)"
         );
     }
 }

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -293,9 +293,9 @@ impl SubGroup {
     /// subgroup reads rate | mean | <percentiles>.
     ///
     /// `mean_unit` is the mean card's `Unit` (`Time` for latency,
-    /// `Bytes` for size); `unit_system` is its formatter
-    /// (`"time"` / `"bytes"`). The rate card mirrors existing counter
-    /// rate cards (`Unit::Rate`, no unit system).
+    /// `Bytes` for size); its formatter unit-system is derived from it.
+    /// The rate card mirrors existing counter rate cards (`Unit::Rate`,
+    /// no unit system).
     pub fn histogram_rate_mean(
         &mut self,
         title_stem: &str,
@@ -303,8 +303,16 @@ impl SubGroup {
         selector: &str,
         rate: RateSource,
         mean_unit: Unit,
-        unit_system: &str,
     ) {
+        let unit_system = match mean_unit {
+            Unit::Time => "time",
+            Unit::Bytes => "bytes",
+            // This helper is only used for latency/size means; guard
+            // anything else loudly rather than mis-format silently.
+            other => panic!(
+                "histogram_rate_mean: unsupported mean unit {other:?}; only Time/Bytes"
+            ),
+        };
         let rate_query = match rate {
             RateSource::Counter(q) => q,
             RateSource::FromHistogram => {
@@ -365,10 +373,16 @@ pub enum MetricType {
 }
 
 /// Where the "rate" half of a histogram's rate|mean card pair gets its
-/// data. Prefer `Counter` (an accurate standalone counter of exactly
-/// the histogrammed events); `FromHistogram` derives an approximate
-/// rate from the histogram column itself and is subject to lock-free
-/// snapshot undercount — use only when no such counter exists.
+/// data.
+///
+/// - `Counter(query)`: a verbatim rate query over a *separate, accurate*
+///   counter column (e.g. `sum(irate(blockio_operations…[5m]))`) — it
+///   is deliberately independent of the histogram `selector`, since the
+///   accurate event count lives in a different metric.
+/// - `FromHistogram`: derive an approximate rate from the histogram
+///   column itself; subject to lock-free snapshot undercount — use only
+///   when no accurate counter exists.
+#[derive(Debug)]
 pub enum RateSource {
     Counter(String),
     FromHistogram,
@@ -546,6 +560,7 @@ impl FormatConfig {
     }
 }
 
+#[derive(Debug)]
 pub enum Unit {
     Count,
     Rate,
@@ -726,7 +741,6 @@ mod tests {
             "blockio_latency{op=\"read\"}",
             RateSource::Counter("sum(irate(blockio_operations{op=\"read\"}[5m]))".to_string()),
             Unit::Time,
-            "time",
         );
         let json = serde_json::to_value(&g).unwrap();
         let plots = json["subgroups"][0]["plots"].as_array().unwrap();
@@ -764,10 +778,10 @@ mod tests {
             "scheduler_runqueue_latency",
             RateSource::FromHistogram,
             Unit::Time,
-            "time",
         );
         let json = serde_json::to_value(&g).unwrap();
         let plots = json["subgroups"][0]["plots"].as_array().unwrap();
+        assert_eq!(plots.len(), 2);
         assert_eq!(
             plots[0]["promql_query"],
             "sum(irate(histogram_count(scheduler_runqueue_latency)[5m]))"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -15,3 +15,14 @@ this file is for everything else (dashboard, viewer, tooling).
   histogram/percentile query paths should derive count, mean, and the
   percentile distribution from that one column + one call instead of
   parallel metrics. Reduces parquet columns and query fan-out.
+
+## Viewer
+
+- **Customizable report title + browser tab title.** Let the user set
+  a report title (likely alongside the existing Notebook/Report
+  preamble/notes machinery in `selection.js`, persisted in the
+  selection payload like `tagline`/`note`). When viewing the Report or
+  Notebook routes, overwrite `document.title` with
+  `Report` / `Notebook` plus `: <optional title>` when one is set
+  (e.g. `Report: vLLM prefill regression`); restore the default title
+  on other routes.

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -5,8 +5,7 @@
 import { ViewerApi } from './viewer_api.js';
 import { FileUpload, splitAlias } from './ui/landing.js';
 import { setStorageScope, seedEventsFromMetadata } from './selection/selection.js';
-import { initDashboard, bootstrapSharedSections, clearViewerCaches } from './app.js';
-import { clearMetadataCache } from './data.js';
+import { initDashboard, bootstrapSharedSections } from './app.js';
 
 // ── UI state ────────────────────────────────────────────────────────
 
@@ -108,11 +107,6 @@ const fetchInitialState = async () => {
 // ── Common loader ───────────────────────────────────────────────────
 
 async function loadParquet(data, filename) {
-    // Reloading replaces the WASM TSDB; stale section/chart/metadata
-    // caches keyed by the old file would otherwise short-circuit query
-    // resolution and the new file would render empty.
-    clearViewerCaches();
-    clearMetadataCache();
     await initWasmViewer(data, filename);
     const state = await fetchInitialState();
     // initWasmViewer already called setStorageScope, so a persisted

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -513,5 +513,13 @@ if (_captureRaw.length >= 2) {
     m.mount(document.body, Root);
     loadDemo(_demoParam || 'demo.parquet');
 } else {
+    // No capture in URL — drop a stale section hash (e.g. #/overview
+    // left over from a previous session) so the landing-page URL bar
+    // matches what's actually rendered.
+    if (window.location.hash) {
+        const url = new URL(window.location);
+        url.hash = '';
+        window.history.replaceState(null, '', url);
+    }
     m.mount(document.body, Root);
 }

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -5,7 +5,8 @@
 import { ViewerApi } from './viewer_api.js';
 import { FileUpload, splitAlias } from './ui/landing.js';
 import { setStorageScope, seedEventsFromMetadata } from './selection/selection.js';
-import { initDashboard, bootstrapSharedSections } from './app.js';
+import { initDashboard, bootstrapSharedSections, clearViewerCaches } from './app.js';
+import { clearMetadataCache } from './data.js';
 
 // ── UI state ────────────────────────────────────────────────────────
 
@@ -107,6 +108,11 @@ const fetchInitialState = async () => {
 // ── Common loader ───────────────────────────────────────────────────
 
 async function loadParquet(data, filename) {
+    // Reloading replaces the WASM TSDB; stale section/chart/metadata
+    // caches keyed by the old file would otherwise short-circuit query
+    // resolution and the new file would render empty.
+    clearViewerCaches();
+    clearMetadataCache();
     await initWasmViewer(data, filename);
     const state = await fetchInitialState();
     // initWasmViewer already called setStorageScope, so a persisted

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -5,7 +5,8 @@
 import { ViewerApi } from './viewer_api.js';
 import { FileUpload, splitAlias } from './ui/landing.js';
 import { setStorageScope, seedEventsFromMetadata } from './selection/selection.js';
-import { initDashboard, bootstrapSharedSections } from './app.js';
+import { initDashboard, bootstrapSharedSections, sectionResponseCache, loadSection } from './app.js';
+import { clearMetadataCache } from './data.js';
 
 // ── UI state ────────────────────────────────────────────────────────
 
@@ -108,6 +109,9 @@ const fetchInitialState = async () => {
 
 async function loadParquet(data, filename) {
     await initWasmViewer(data, filename);
+    // Stale {minTime, maxTime} would point fresh queries at a window
+    // outside the new file.
+    clearMetadataCache();
     const state = await fetchInitialState();
     // initWasmViewer already called setStorageScope, so a persisted
     // working set (if any) has been restored; this only seeds the
@@ -134,6 +138,16 @@ async function loadParquet(data, filename) {
         // loadParquet directly.
         onUploadParquet: loadFile,
     });
+    // Evict + refetch the visible section: same route → onmatch
+    // doesn't re-fire, so without an explicit kick the cachedView
+    // spins on a placeholder. Topnav time range rides along.
+    const currentSection = (m.route.get() || '').replace(/^\//, '').split('/')[0];
+    if (currentSection) {
+        delete sectionResponseCache[currentSection];
+        loadSection(currentSection).then(() => m.redraw()).catch(() => m.redraw());
+    } else {
+        m.redraw();
+    }
 }
 
 // Shared file-upload entry point: reads the File's bytes and runs the

--- a/src/viewer/assets/lib/charts/chart.js
+++ b/src/viewer/assets/lib/charts/chart.js
@@ -1106,6 +1106,9 @@ export class Chart {
         if (style !== 'histogram_heatmap') {
             this.domNode?.querySelector('.histogram-toggle')?.remove();
         }
+        if (style !== 'line') {
+            this.domNode?.querySelector('.total-toggle')?.remove();
+        }
 
         // Handle different chart types by delegating to specialized modules
         if (style === 'line') {

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -18,6 +18,8 @@ import {
     CHART_GRID_TOP_WITH_LEGEND,
     COLORS,
 } from './base.js';
+import { FONTS } from './util/fonts.js';
+import { executePromQLRangeQuery, applyResultToPlot } from '../data.js';
 
 /**
  * Configures the Chart based on Chart.spec
@@ -32,6 +34,11 @@ export function configureLineChart(chart) {
         opts
     } = chart.spec;
 
+    // Tooltip series row reflects current toggle state; card header keeps the full suffix.
+    const seriesTitle = chart.spec.promql_query_total
+        ? opts.title.replace(/Mean\/Total\b/, chart._showTotal ? 'Total' : 'Mean')
+        : opts.title;
+
     // Normalize to a list of {name, color, timeData, valueData, fill}.
     // Single-series callers pass `data: [timeData, valueData]` (unchanged).
     // Compare-mode callers pass `multiSeries: [{name,color,timeData,valueData}, ...]`.
@@ -39,7 +46,7 @@ export function configureLineChart(chart) {
         ? multiSeries
         : (data && data.length >= 2 && data[0] && data[1] && data[0].length > 0
             ? [{
-                name: opts.title,
+                name: seriesTitle,
                 color: COLORS.accent,
                 timeData: data[0],
                 valueData: data[1],
@@ -186,4 +193,101 @@ export function configureLineChart(chart) {
         };
         chart.echart.on('legendselectchanged', chart._legendSelectHandler);
     }
+
+    ensureTotalToggle(chart);
+}
+
+// Mean/Total toggle. State on the chart instance (no persistence);
+// pattern mirrors scatter.js's spectrum-controls.
+
+const TOTAL_TOGGLE_CLASS = 'total-toggle';
+
+function renderTotalCheckbox(el, on, pending) {
+    const glyph = on ? '☑' : '☐';
+    const label = pending ? 'Total…' : 'Total';
+    el.innerHTML =
+        `<span style="font-size: 16px; line-height: 1; transform: translateY(-2px);">${glyph}</span>`
+        + `<span>${label}</span>`;
+    el.style.color = on ? COLORS.fg : COLORS.fgSecondary;
+}
+
+function refreshTotalCheckbox(chart) {
+    const el = chart.domNode?.querySelector('.' + TOTAL_TOGGLE_CLASS);
+    if (el) renderTotalCheckbox(el, !!chart._showTotal, !!chart._totalPending);
+}
+
+async function toggleTotal(chart) {
+    if (chart._totalPending) return;
+    const totalQuery = chart.spec.promql_query_total;
+    if (!totalQuery) return;
+
+    if (chart._showTotal) {
+        if (chart._meanDataCache) chart.spec.data = chart._meanDataCache;
+        chart._showTotal = false;
+        refreshTotalCheckbox(chart);
+        chart.configureChartByType();
+        return;
+    }
+
+    chart._meanDataCache = chart.spec.data;
+    if (chart._totalDataCache) {
+        chart.spec.data = chart._totalDataCache;
+        chart._showTotal = true;
+        refreshTotalCheckbox(chart);
+        chart.configureChartByType();
+        return;
+    }
+
+    chart._totalPending = true;
+    refreshTotalCheckbox(chart);
+    try {
+        const result = await executePromQLRangeQuery(totalQuery);
+        chart._totalPending = false;
+        const ok = result?.status === 'success'
+            && (result.data?.result?.length ?? 0) > 0;
+        if (!ok) {
+            chart._meanDataCache = null;
+            refreshTotalCheckbox(chart);
+            return;
+        }
+        applyResultToPlot(chart.spec, result);
+        chart._totalDataCache = chart.spec.data;
+        chart._showTotal = true;
+    } catch (e) {
+        console.warn('[total-toggle] fetch failed:', e);
+        chart._totalPending = false;
+        chart.spec.data = chart._meanDataCache;
+        chart._meanDataCache = null;
+    }
+    refreshTotalCheckbox(chart);
+    chart.configureChartByType();
+}
+
+function ensureTotalToggle(chart) {
+    if (!chart.spec.promql_query_total) {
+        chart.domNode?.querySelector('.' + TOTAL_TOGGLE_CLASS)?.remove();
+        return;
+    }
+    if (!chart.domNode) return;
+    let el = chart.domNode.querySelector('.' + TOTAL_TOGGLE_CLASS);
+    if (!el) {
+        el = document.createElement('span');
+        el.className = TOTAL_TOGGLE_CLASS;
+        // right:60 clears the expand (right:8) + select-pin (right:32) icons.
+        el.style.cssText = `
+            position: absolute;
+            top: 8px;
+            right: 60px;
+            z-index: 10;
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            cursor: pointer;
+            ${FONTS.cssControl}
+            user-select: none;
+        `;
+        chart.domNode.appendChild(el);
+    }
+    el.onclick = () => toggleTotal(chart);
+    renderTotalCheckbox(el, !!chart._showTotal, !!chart._totalPending);
 }

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -263,6 +263,21 @@ async function toggleTotal(chart) {
     chart.configureChartByType();
 }
 
+// Sit below the title, left edge aligned with the echarts plot grid
+// (i.e. just past the y-axis gutter).
+function positionTotalToggle(chart, container) {
+    if (!chart.echart) return;
+    try {
+        const rect = chart.echart.getModel()
+            .getComponent('grid')?.coordinateSystem?.getRect();
+        if (rect && Number.isFinite(rect.x)) {
+            container.style.left = Math.round(rect.x) + 'px';
+        }
+    } catch (_e) {
+        // echarts grid not ready yet; next 'finished' event will retry.
+    }
+}
+
 function ensureTotalToggle(chart) {
     if (!chart.spec.promql_query_total) {
         chart.domNode?.querySelector('.' + TOTAL_TOGGLE_CLASS)?.remove();
@@ -273,11 +288,10 @@ function ensureTotalToggle(chart) {
     if (!el) {
         el = document.createElement('span');
         el.className = TOTAL_TOGGLE_CLASS;
-        // right:60 clears the expand (right:8) + select-pin (right:32) icons.
         el.style.cssText = `
             position: absolute;
-            top: 8px;
-            right: 60px;
+            top: 42px;
+            left: 0px;
             z-index: 10;
             display: inline-flex;
             align-items: center;
@@ -290,4 +304,16 @@ function ensureTotalToggle(chart) {
     }
     el.onclick = () => toggleTotal(chart);
     renderTotalCheckbox(el, !!chart._showTotal, !!chart._totalPending);
+
+    // Reposition on each echarts layout (initial, theme swap, resize,
+    // zoom). Replace any previously bound listener so we don't stack
+    // handlers across reconfigures.
+    if (chart.echart) {
+        if (chart._totalToggleFinishedFn) {
+            chart.echart.off('finished', chart._totalToggleFinishedFn);
+        }
+        chart._totalToggleFinishedFn = () => positionTotalToggle(chart, el);
+        chart.echart.on('finished', chart._totalToggleFinishedFn);
+        positionTotalToggle(chart, el);
+    }
 }

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -183,7 +183,7 @@ for path in / /about /lib/style.css; do
 done
 
 echo "==> served JS bundle has the Notebook rename + new Selection sidebar"
-selection_js=$(curl -fsS "http://127.0.0.1:$PORT_FILE/lib/selection.js")
+selection_js=$(curl -fsS "http://127.0.0.1:$PORT_FILE/lib/selection/selection.js")
 echo "$selection_js" | grep -q "notebookStore" \
     || fail "selection.js missing notebookStore identifier" "" "notebookStore present" "$LOGDIR/file.log"
 echo "$selection_js" | grep -q "loadedSelectionStore" \


### PR DESCRIPTION
## Summary

For every percentile-subtype histogram plot in the dashboard, emit an adjacent half-width Rate + Mean card pair.

- **Mean** is always derived from the histogram column via `histogram_mean(<sel>)` (metriken-query 0.10.5+). Robust to lock-free snapshot undercount because it's a ratio.
- **Rate** prefers an accurate standalone counter when one counts the same events (`blockio_operations` for blockio latency/size, `syscall` for syscall latency — these existing rate cards are kept verbatim, the only change is *adding* the adjacent Mean). Falls back to `sum(histogram_irate(<sel>))` (metriken-query 0.10.6+) for histogram-only families — `scheduler_runqueue_latency`, `scheduler_offcpu`, `scheduler_running`, `tcp_packet_latency`.

Strictly additive: no agent / parquet / exporter / MCP changes. Existing percentile cards untouched.

A small helper `SubGroup::histogram_rate_mean(title_stem, id_stem, selector, RateSource, mean_unit)` keeps the pair adjacent and declarative at call sites.

### Why the fallback uses `histogram_irate` (not the originally spec'd form)

The original spec called for `sum(irate(histogram_count(<sel>)[5m]))`. That doesn't parse — PromQL grammar disallows range vectors on function-call results. In metriken-query's evaluation model (one value per step from the histogram column) the `[5m]` window is vestigial anyway, so the cleaner contract is an instant-vector function with no window. metriken-query 0.10.6 ships `histogram_irate(m)` for exactly this; `sum(histogram_irate(<sel>))` composes directly.

### Drive-by

Smoke-test `selection.js` path updated for the lib/ subdir refactor in #932 (separate commit for clean blame).

## Test plan

- [x] `cargo test -p dashboard` — 39 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `bash tests/viewer_smoke.sh` — all assertions pass
- [x] `cargo run -p dashboard -- /tmp/dump/` — verified scheduler.json + network.json carry `sum(histogram_irate(...))`; blockio/syscall keep their counter-backed rates; every pair card is half-width
- [x] **Manual eyeball on a fresh Linux recording** — confirm the new Rate/Mean cards render with sane lines, idle gaps break (not 0) on Mean, units format correctly. Local fixtures in my worktree aren't queryable (pre-existing data-shape mismatch, not a regression) so this needs to happen on real hardware.