### PR TITLE
Adopt metriken-query 0.11 streaming ParquetReader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,8 @@ dependencies = [
 [[package]]
 name = "metriken"
 version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d88b3f3ec8c532945831eeea8170f9410a37f444feb1322b8e124f3a4a3b9"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -2040,6 +2042,8 @@ dependencies = [
 [[package]]
 name = "metriken-core"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab27bd3058a12219267acc9a86c68c9a55ab456825582758f5c0376a1267e31"
 dependencies = [
  "histogram",
  "linkme",
@@ -2050,6 +2054,8 @@ dependencies = [
 [[package]]
 name = "metriken-derive"
 version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3643374c9873e69a27e50404db6006ad09f0c1ee944e8ce928d586df077b71db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2060,6 +2066,8 @@ dependencies = [
 [[package]]
 name = "metriken-exposition"
 version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01819b48e04904d3116bda74c380de43c3593d8c38fb870361b4d219ba61440d"
 dependencies = [
  "arrow",
  "chrono",
@@ -2073,6 +2081,8 @@ dependencies = [
 [[package]]
 name = "metriken-query"
 version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1d36e7af9c54c46a96003238535462c95dcad93dfcf8855c9d30fc23bba2f7"
 dependencies = [
  "arrow",
  "bytes",
@@ -2084,6 +2094,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1247,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1980,6 +1988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,11 +2072,12 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.8"
+version = "0.11.0"
 dependencies = [
  "arrow",
  "bytes",
  "histogram",
+ "lru",
  "metriken-exposition",
  "parquet",
  "promql-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,9 +1270,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "histogram"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6474b5317904e60c23732dfb33be3537204de6f698da37c19c38a95cd9d39895"
+checksum = "78dbc692bf02314a491f06bb95ae039fe842c1e1179f0036df08800fba0fb29b"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2012,8 +2012,6 @@ dependencies = [
 [[package]]
 name = "metriken"
 version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d88b3f3ec8c532945831eeea8170f9410a37f444feb1322b8e124f3a4a3b9"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -2025,8 +2023,6 @@ dependencies = [
 [[package]]
 name = "metriken-core"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab27bd3058a12219267acc9a86c68c9a55ab456825582758f5c0376a1267e31"
 dependencies = [
  "histogram",
  "linkme",
@@ -2037,8 +2033,6 @@ dependencies = [
 [[package]]
 name = "metriken-derive"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3643374c9873e69a27e50404db6006ad09f0c1ee944e8ce928d586df077b71db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2049,8 +2043,6 @@ dependencies = [
 [[package]]
 name = "metriken-exposition"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01819b48e04904d3116bda74c380de43c3593d8c38fb870361b4d219ba61440d"
 dependencies = [
  "arrow",
  "chrono",
@@ -2063,9 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448751960f35543c086a2fc16c08f3b282548f223b8dbffa25431f32b612b854"
+version = "0.10.8"
 dependencies = [
  "arrow",
  "bytes",
@@ -2709,6 +2699,7 @@ name = "report-save"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "bytes",
  "dashboard",
  "metriken-query",
  "parquet",
@@ -2756,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.11"
+version = "5.13.1-alpha.12"
 dependencies = [
  "allan",
  "anyhow",
@@ -2765,6 +2756,7 @@ dependencies = [
  "async-trait",
  "axum",
  "backtrace",
+ "bytes",
  "chrono",
  "clap",
  "clocksource",
@@ -3817,6 +3809,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "viewer"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "console_error_panic_hook",
  "dashboard",
  "metriken-query",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ console_error_panic_hook = "0.1"
 histogram = "1.3.1"
 libc = "0.2.186"
 log = "0.4.29"
-metriken = { path = "../metriken/metriken" }
-metriken-exposition = { path = "../metriken/metriken-exposition" }
-metriken-query = { path = "../metriken/metriken-query", default-features = false }
+metriken = "0.9.2"
+metriken-exposition = "0.16.0"
+metriken-query = { version = "0.11.0", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ console_error_panic_hook = "0.1"
 histogram = "1.3.1"
 libc = "0.2.186"
 log = "0.4.29"
-metriken = "0.9.2"
-metriken-exposition = "0.16.0"
-metriken-query = { version = "0.10.4", default-features = false }
+metriken = { path = "../metriken/metriken" }
+metriken-exposition = { path = "../metriken/metriken-exposition" }
+metriken-query = { path = "../metriken/metriken-query", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
@@ -48,6 +48,7 @@ arrow = "58.2.0"
 async-trait = "0.1.89"
 axum = "0.8.9"
 backtrace = "0.3.76"
+bytes = "1"
 chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["derive"] }
 clocksource = "1.0.0"

--- a/crates/dashboard/src/dashboard/blockio.rs
+++ b/crates/dashboard/src/dashboard/blockio.rs
@@ -1,7 +1,7 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
     let mut operations = Group::new("Operations", "operations");

--- a/crates/dashboard/src/dashboard/category.rs
+++ b/crates/dashboard/src/dashboard/category.rs
@@ -273,7 +273,15 @@ mod tests {
         let a = ext("a", vec![kpi("throughput", "Token Rate", "a_q")]);
         let b = ext("b", vec![]); // missing the categorized title
 
-        let view = generate(&metriken_query::MemoryStore::builder().build(), vec![], &category, "a", &a, "b", &b);
+        let view = generate(
+            &metriken_query::MemoryStore::builder().build(),
+            vec![],
+            &category,
+            "a",
+            &a,
+            "b",
+            &b,
+        );
         let json = serde_json::to_value(&view).unwrap();
 
         let unavailable = json
@@ -315,7 +323,15 @@ mod tests {
         b_kpi.available = false;
         let b = ext("b", vec![b_kpi]);
 
-        let view = generate(&metriken_query::MemoryStore::builder().build(), vec![], &category, "a", &a, "b", &b);
+        let view = generate(
+            &metriken_query::MemoryStore::builder().build(),
+            vec![],
+            &category,
+            "a",
+            &a,
+            "b",
+            &b,
+        );
         let json = serde_json::to_value(&view).unwrap();
 
         let unavailable = json

--- a/crates/dashboard/src/dashboard/category.rs
+++ b/crates/dashboard/src/dashboard/category.rs
@@ -1,9 +1,9 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 use crate::service_extension::{CategoryExtension, ServiceExtension};
 
 pub fn generate(
-    data: &Tsdb,
+    data: &dyn MetricsSource,
     all_sections: Vec<Section>,
     category: &CategoryExtension,
     baseline_member: &str,
@@ -216,7 +216,7 @@ mod tests {
             vec![kpi("throughput", "Generation Token Rate", "sglang_q")],
         );
 
-        let data = Tsdb::default();
+        let data = metriken_query::MemoryStore::builder().build();
         let view = generate(
             &data,
             vec![],
@@ -273,7 +273,7 @@ mod tests {
         let a = ext("a", vec![kpi("throughput", "Token Rate", "a_q")]);
         let b = ext("b", vec![]); // missing the categorized title
 
-        let view = generate(&Tsdb::default(), vec![], &category, "a", &a, "b", &b);
+        let view = generate(&metriken_query::MemoryStore::builder().build(), vec![], &category, "a", &a, "b", &b);
         let json = serde_json::to_value(&view).unwrap();
 
         let unavailable = json
@@ -315,7 +315,7 @@ mod tests {
         b_kpi.available = false;
         let b = ext("b", vec![b_kpi]);
 
-        let view = generate(&Tsdb::default(), vec![], &category, "a", &a, "b", &b);
+        let view = generate(&metriken_query::MemoryStore::builder().build(), vec![], &category, "a", &a, "b", &b);
         let json = serde_json::to_value(&view).unwrap();
 
         let unavailable = json

--- a/crates/dashboard/src/dashboard/cgroups.rs
+++ b/crates/dashboard/src/dashboard/cgroups.rs
@@ -1,4 +1,4 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
 /// Adds the standard cgroup metric plots for either aggregate or individual mode.
@@ -129,7 +129,7 @@ fn add_cgroup_metrics(group: &mut Group, individual: bool) {
     }
 }
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections.clone());
 
     // Add metadata for cgroup selection UI

--- a/crates/dashboard/src/dashboard/cpu.rs
+++ b/crates/dashboard/src/dashboard/cpu.rs
@@ -1,9 +1,9 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
 /// True iff the recording has more than one CPU. Per-core charts are
 /// suppressed when this is false because they degenerate to the aggregate.
-fn has_multiple_cpus(data: &Tsdb) -> bool {
+fn has_multiple_cpus(data: &dyn MetricsSource) -> bool {
     [
         "cpu_usage",
         "cpu_cycles",
@@ -16,7 +16,7 @@ fn has_multiple_cpus(data: &Tsdb) -> bool {
     .any(|m| metric_unique_label_count(data, m, "id") > 1)
 }
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
     let multi_cpu = has_multiple_cpus(data);
 

--- a/crates/dashboard/src/dashboard/exceptions.rs
+++ b/crates/dashboard/src/dashboard/exceptions.rs
@@ -1,4 +1,4 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
 /// Centralized view of true error / fault metrics across subsystems:
@@ -6,7 +6,7 @@ use crate::plot::*;
 /// hits, and quota-driven throttling. Excludes ordinary performance
 /// counters like cache misses or page faults — those belong in their
 /// own subsystem sections.
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
     let mut network = Group::new("Network", "network");

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -1,9 +1,9 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
 /// True iff the recording has more than one GPU. Per-device charts are
 /// suppressed when this is false because they degenerate to the aggregate.
-fn has_multiple_gpus(data: &Tsdb) -> bool {
+fn has_multiple_gpus(data: &dyn MetricsSource) -> bool {
     [
         "gpu_utilization",
         "gpu_memory",
@@ -17,7 +17,7 @@ fn has_multiple_gpus(data: &Tsdb) -> bool {
     .any(|m| metric_unique_label_count(data, m, "id") > 1)
 }
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
     let multi_gpu = has_multiple_gpus(data);
 

--- a/crates/dashboard/src/dashboard/memory.rs
+++ b/crates/dashboard/src/dashboard/memory.rs
@@ -1,7 +1,7 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
     let mut usage = Group::new("Usage", "usage");

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -1,4 +1,4 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 use crate::service_extension::{CategoryExtension, ServiceExtension};
 
@@ -18,7 +18,7 @@ mod service;
 mod softirq;
 mod syscall;
 
-type Generator = fn(&Tsdb, Vec<Section>) -> View;
+type Generator = fn(&dyn MetricsSource, Vec<Section>) -> View;
 
 static SECTION_META: &[(&str, &str, Generator)] = &[
     // Exceptions sits after Overview — it's a cross-sampler triage view,
@@ -146,7 +146,7 @@ pub fn build_dashboard_context(
 ///
 /// Filesize is not applied — callers that want a filesize on the response
 /// should call `view.set_filesize(...)` themselves.
-pub fn generate_section(data: &Tsdb, route: &str, ctx: &DashboardContext) -> Option<View> {
+pub fn generate_section(data: &dyn MetricsSource, route: &str, ctx: &DashboardContext) -> Option<View> {
     let view = if route == "/overview" {
         overview::generate(data, ctx.sections.clone(), ctx.throughput_query.as_deref())
     } else if let Some((_, _, generator)) = SECTION_META.iter().find(|(_, r, _)| *r == route) {
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn generate_section_renders_known_routes_returns_none_for_unknown() {
-        let data = Tsdb::default();
+        let data = metriken_query::MemoryStore::builder().build();
         let ctx = build_dashboard_context(None, &[], None);
 
         // Overview renders.
@@ -269,7 +269,7 @@ mod tests {
             kpis: vec![kpi("throughput", "Generation Token Rate", "sglang_q")],
         };
 
-        let data = Tsdb::default();
+        let data = metriken_query::MemoryStore::builder().build();
 
         // Per-service flow (no category).
         let ctx = build_dashboard_context(None, &[("vllm", &vllm)], None);
@@ -379,7 +379,7 @@ mod tests {
         assert!(!routes.contains(&"/service/sglang"));
 
         // generate_section honors the same: category route renders, members 404.
-        let data = Tsdb::default();
+        let data = metriken_query::MemoryStore::builder().build();
         assert!(generate_section(&data, "/service/inference-library", &ctx).is_some());
         assert!(generate_section(&data, "/service/vllm", &ctx).is_none());
         assert!(generate_section(&data, "/service/sglang", &ctx).is_none());
@@ -430,7 +430,7 @@ mod tests {
         // The deduped service ext list also collapses to one entry, so
         // generate_section can still render the route.
         assert_eq!(ctx.service_exts.len(), 1);
-        let data = Tsdb::default();
+        let data = metriken_query::MemoryStore::builder().build();
         assert!(generate_section(&data, "/service/vllm", &ctx).is_some());
     }
 }

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -146,7 +146,11 @@ pub fn build_dashboard_context(
 ///
 /// Filesize is not applied — callers that want a filesize on the response
 /// should call `view.set_filesize(...)` themselves.
-pub fn generate_section(data: &dyn MetricsSource, route: &str, ctx: &DashboardContext) -> Option<View> {
+pub fn generate_section(
+    data: &dyn MetricsSource,
+    route: &str,
+    ctx: &DashboardContext,
+) -> Option<View> {
     let view = if route == "/overview" {
         overview::generate(data, ctx.sections.clone(), ctx.throughput_query.as_deref())
     } else if let Some((_, _, generator)) = SECTION_META.iter().find(|(_, r, _)| *r == route) {

--- a/crates/dashboard/src/dashboard/network.rs
+++ b/crates/dashboard/src/dashboard/network.rs
@@ -1,7 +1,7 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
     let mut traffic = Group::new("Traffic", "traffic");

--- a/crates/dashboard/src/dashboard/overview.rs
+++ b/crates/dashboard/src/dashboard/overview.rs
@@ -1,7 +1,7 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>, throughput_query: Option<&str>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>, throughput_query: Option<&str>) -> View {
     let mut view = View::new(data, sections);
 
     let mut cpu = Group::new("CPU", "cpu");

--- a/crates/dashboard/src/dashboard/overview.rs
+++ b/crates/dashboard/src/dashboard/overview.rs
@@ -1,7 +1,11 @@
 use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>, throughput_query: Option<&str>) -> View {
+pub fn generate(
+    data: &dyn MetricsSource,
+    sections: Vec<Section>,
+    throughput_query: Option<&str>,
+) -> View {
     let mut view = View::new(data, sections);
 
     let mut cpu = Group::new("CPU", "cpu");

--- a/crates/dashboard/src/dashboard/query_explorer.rs
+++ b/crates/dashboard/src/dashboard/query_explorer.rs
@@ -1,7 +1,7 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     // Query Explorer is fully dynamic on the frontend; the backend just
     // returns an empty view (no pre-computed data needed).
     View::new(data, sections)

--- a/crates/dashboard/src/dashboard/rezolus.rs
+++ b/crates/dashboard/src/dashboard/rezolus.rs
@@ -1,7 +1,7 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
     let mut rezolus = Group::new("Rezolus", "rezolus");

--- a/crates/dashboard/src/dashboard/scheduler.rs
+++ b/crates/dashboard/src/dashboard/scheduler.rs
@@ -1,15 +1,15 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
 /// True iff the recording has more than one CPU. Per-core charts are
 /// suppressed when this is false because they degenerate to the aggregate.
-fn has_multiple_cpus(data: &Tsdb) -> bool {
+fn has_multiple_cpus(data: &dyn MetricsSource) -> bool {
     ["scheduler_runqueue_wait", "scheduler_context_switch"]
         .iter()
         .any(|m| metric_unique_label_count(data, m, "id") > 1)
 }
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
     let multi_cpu = has_multiple_cpus(data);
 

--- a/crates/dashboard/src/dashboard/service.rs
+++ b/crates/dashboard/src/dashboard/service.rs
@@ -1,8 +1,8 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 use crate::service_extension::ServiceExtension;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>, service_ext: &ServiceExtension) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>, service_ext: &ServiceExtension) -> View {
     let mut view = View::new(data, sections);
 
     // Embed service metadata in the view so the frontend can display it

--- a/crates/dashboard/src/dashboard/service.rs
+++ b/crates/dashboard/src/dashboard/service.rs
@@ -2,7 +2,11 @@ use crate::MetricsSource;
 use crate::plot::*;
 use crate::service_extension::ServiceExtension;
 
-pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>, service_ext: &ServiceExtension) -> View {
+pub fn generate(
+    data: &dyn MetricsSource,
+    sections: Vec<Section>,
+    service_ext: &ServiceExtension,
+) -> View {
     let mut view = View::new(data, sections);
 
     // Embed service metadata in the view so the frontend can display it

--- a/crates/dashboard/src/dashboard/softirq.rs
+++ b/crates/dashboard/src/dashboard/softirq.rs
@@ -1,4 +1,4 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
 /// Adds the standard 4-plot pattern for a softirq kind in two subgroups:
@@ -41,7 +41,7 @@ fn add_softirq_group(view: &mut View, label: &str, kind: &str) {
     view.group(group);
 }
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
     // Total softirq (uses the same pattern but without a kind filter)

--- a/crates/dashboard/src/dashboard/syscall.rs
+++ b/crates/dashboard/src/dashboard/syscall.rs
@@ -1,7 +1,7 @@
-use crate::Tsdb;
+use crate::MetricsSource;
 use crate::plot::*;
 
-pub fn generate(data: &Tsdb, sections: Vec<Section>) -> View {
+pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
 
     let mut syscall = Group::new("Syscall", "syscall");

--- a/crates/dashboard/src/lib.rs
+++ b/crates/dashboard/src/lib.rs
@@ -4,7 +4,8 @@ mod plot;
 mod service_extension;
 
 pub use events::{Event, Events};
-pub use metriken_query::Tsdb;
+// Re-export for callers that use &dyn MetricsSource through the dashboard crate.
+pub use metriken_query::MetricsSource;
 pub use plot::*;
 pub use service_extension::{CategoryExtension, Kpi, ServiceExtension, TemplateRegistry};
 

--- a/crates/dashboard/src/main.rs
+++ b/crates/dashboard/src/main.rs
@@ -6,7 +6,6 @@
 //! Without arguments, prints all section JSON to stdout.
 //! With a directory argument, writes each section as a pretty-printed JSON file.
 
-use dashboard::Tsdb;
 use dashboard::dashboard::{build_dashboard_context, generate_section};
 use std::collections::HashMap;
 
@@ -15,7 +14,7 @@ fn main() {
 
     // Render every section in the navigation list. The lazy API replaces
     // the old eager `generate` shim — same coverage, just hand-walked.
-    let data = Tsdb::default();
+    let data = metriken_query::MemoryStore::builder().build();
     let ctx = build_dashboard_context(None, &[], None);
     let mut rendered: HashMap<String, String> = HashMap::new();
     for section in &ctx.sections {

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -58,19 +58,7 @@ impl View {
         };
 
         // Count total time series (each metric x label combination)
-        let num_series = {
-            let mut count = 0usize;
-            for name in data.counter_names() {
-                count += data.counter_labels(&name).len();
-            }
-            for name in data.gauge_names() {
-                count += data.gauge_labels(&name).len();
-            }
-            for name in data.histogram_names() {
-                count += data.histogram_labels(&name).len();
-            }
-            Some(count)
-        };
+        let num_series = Some(data.total_series_count());
 
         Self {
             interval,

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -1,16 +1,15 @@
-use metriken_query::Tsdb;
-use metriken_query::tsdb::Labels;
+use metriken_query::MetricsSource;
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Count distinct values of `key` across `labels`. Series missing the
 /// key are skipped. Used by section generators to decide whether
 /// per-device charts are worth showing (a single GPU/CPU makes the
 /// per-device variant identical to the aggregate).
-pub fn unique_label_count(labels: &[Labels], key: &str) -> usize {
+pub fn unique_label_count(labels: &[BTreeMap<String, String>], key: &str) -> usize {
     let mut seen: HashSet<&str> = HashSet::new();
     for l in labels {
-        if let Some(v) = l.inner.get(key) {
+        if let Some(v) = l.get(key) {
             seen.insert(v.as_str());
         }
     }
@@ -20,15 +19,18 @@ pub fn unique_label_count(labels: &[Labels], key: &str) -> usize {
 /// Convenience: how many distinct values of `key` exist for `metric`
 /// in `data`, looking across counter/gauge/histogram collections.
 /// Returns 0 if the metric is unknown.
-pub fn metric_unique_label_count(data: &Tsdb, metric: &str, key: &str) -> usize {
-    if let Some(l) = data.gauge_labels(metric) {
-        return unique_label_count(&l, key);
+pub fn metric_unique_label_count(data: &dyn MetricsSource, metric: &str, key: &str) -> usize {
+    let gauge = data.gauge_labels(metric);
+    if !gauge.is_empty() {
+        return unique_label_count(&gauge, key);
     }
-    if let Some(l) = data.counter_labels(metric) {
-        return unique_label_count(&l, key);
+    let counter = data.counter_labels(metric);
+    if !counter.is_empty() {
+        return unique_label_count(&counter, key);
     }
-    if let Some(l) = data.histogram_labels(metric) {
-        return unique_label_count(&l, key);
+    let histogram = data.histogram_labels(metric);
+    if !histogram.is_empty() {
+        return unique_label_count(&histogram, key);
     }
     0
 }
@@ -56,15 +58,14 @@ pub struct View {
 }
 
 impl View {
-    pub fn new(data: &Tsdb, sections: Vec<Section>) -> Self {
+    pub fn new(data: &dyn MetricsSource, sections: Vec<Section>) -> Self {
         let interval = data.interval();
-        let source = data.source().to_string();
-        let version = data.version().to_string();
-        let filename = data.filename().to_string();
+        let source = data.source();
+        let version = data.version();
 
-        // Epoch milliseconds (source is nanoseconds).
+        // Epoch milliseconds (source is seconds).
         let (start_time, end_time) = match data.time_range() {
-            Some((min, max)) => (Some(min as f64 / 1e6), Some(max as f64 / 1e6)),
+            Some((min, max)) => (Some(min * 1000.0), Some(max * 1000.0)),
             None => (None, None),
         };
 
@@ -72,13 +73,13 @@ impl View {
         let num_series = {
             let mut count = 0usize;
             for name in data.counter_names() {
-                count += data.counter_labels(name).map_or(0, |l| l.len());
+                count += data.counter_labels(&name).len();
             }
             for name in data.gauge_names() {
-                count += data.gauge_labels(name).map_or(0, |l| l.len());
+                count += data.gauge_labels(&name).len();
             }
             for name in data.histogram_names() {
-                count += data.histogram_labels(name).map_or(0, |l| l.len());
+                count += data.histogram_labels(&name).len();
             }
             Some(count)
         };
@@ -87,7 +88,7 @@ impl View {
             interval,
             source,
             version,
-            filename,
+            filename: String::new(),
             filesize: None,
             start_time,
             end_time,
@@ -96,6 +97,10 @@ impl View {
             sections,
             metadata: HashMap::new(),
         }
+    }
+
+    pub fn set_filename(&mut self, filename: String) {
+        self.filename = filename;
     }
 
     pub fn set_filesize(&mut self, size: u64) {
@@ -636,28 +641,30 @@ mod tests {
 
     #[test]
     fn unique_label_count_returns_zero_for_empty_input() {
-        let labels: Vec<metriken_query::tsdb::Labels> = vec![];
+        let labels: Vec<BTreeMap<String, String>> = vec![];
         assert_eq!(unique_label_count(&labels, "id"), 0);
+    }
+
+    fn make_labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
     }
 
     #[test]
     fn unique_label_count_counts_distinct_values() {
-        use metriken_query::tsdb::Labels;
-        let labels: Vec<Labels> = vec![
-            Labels::from([("id", "0"), ("state", "user")].as_slice()),
-            Labels::from([("id", "0"), ("state", "system")].as_slice()),
-            Labels::from([("id", "1"), ("state", "user")].as_slice()),
-            Labels::from([("id", "1"), ("state", "system")].as_slice()),
+        let labels: Vec<BTreeMap<String, String>> = vec![
+            make_labels(&[("id", "0"), ("state", "user")]),
+            make_labels(&[("id", "0"), ("state", "system")]),
+            make_labels(&[("id", "1"), ("state", "user")]),
+            make_labels(&[("id", "1"), ("state", "system")]),
         ];
         assert_eq!(unique_label_count(&labels, "id"), 2);
     }
 
     #[test]
     fn unique_label_count_ignores_series_missing_the_key() {
-        use metriken_query::tsdb::Labels;
-        let labels: Vec<Labels> = vec![
-            Labels::from([("id", "0")].as_slice()),
-            Labels::from([("other", "x")].as_slice()),
+        let labels: Vec<BTreeMap<String, String>> = vec![
+            make_labels(&[("id", "0")]),
+            make_labels(&[("other", "x")]),
         ];
         assert_eq!(unique_label_count(&labels, "id"), 1);
     }

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -20,19 +20,7 @@ pub fn unique_label_count(labels: &[BTreeMap<String, String>], key: &str) -> usi
 /// in `data`, looking across counter/gauge/histogram collections.
 /// Returns 0 if the metric is unknown.
 pub fn metric_unique_label_count(data: &dyn MetricsSource, metric: &str, key: &str) -> usize {
-    let gauge = data.gauge_labels(metric);
-    if !gauge.is_empty() {
-        return unique_label_count(&gauge, key);
-    }
-    let counter = data.counter_labels(metric);
-    if !counter.is_empty() {
-        return unique_label_count(&counter, key);
-    }
-    let histogram = data.histogram_labels(metric);
-    if !histogram.is_empty() {
-        return unique_label_count(&histogram, key);
-    }
-    0
+    data.label_values(metric, key).len()
 }
 
 #[derive(Default, Serialize)]

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -699,7 +699,10 @@ mod tests {
     }
 
     fn make_labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
-        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
     }
 
     #[test]
@@ -715,10 +718,8 @@ mod tests {
 
     #[test]
     fn unique_label_count_ignores_series_missing_the_key() {
-        let labels: Vec<BTreeMap<String, String>> = vec![
-            make_labels(&[("id", "0")]),
-            make_labels(&[("other", "x")]),
-        ];
+        let labels: Vec<BTreeMap<String, String>> =
+            vec![make_labels(&[("id", "0")]), make_labels(&[("other", "x")])];
         assert_eq!(unique_label_count(&labels, "id"), 1);
     }
 

--- a/crates/report-save/Cargo.toml
+++ b/crates/report-save/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 arrow = "58.2.0"
+bytes = "1"
 parquet = { version = "58.2.0", default-features = false, features = ["arrow", "simdutf8", "zstd"] }
 tar = { version = "0.4.45", default-features = false }
 serde.workspace = true

--- a/crates/report-save/src/lib.rs
+++ b/crates/report-save/src/lib.rs
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn baseline_side_kept_set_includes_timestamp_and_duration() {
         let (_bytes, reader) = build_test(true);
-        
+
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn experiment_side_falls_back_to_promql_query_when_experiment_unset() {
         let (_bytes, reader) = build_test(true);
-        
+
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn experiment_side_uses_promql_query_experiment_when_set() {
         let (_bytes, reader) = build_test(true);
-        
+
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),

--- a/crates/report-save/src/lib.rs
+++ b/crates/report-save/src/lib.rs
@@ -11,11 +11,11 @@
 //! through, and the WASM viewer reuses the bytes it already holds.
 
 use std::collections::{BTreeSet, HashSet};
-use std::ops::Deref;
 
 use arrow::datatypes::Field;
+use bytes::Bytes;
 use dashboard::Event;
-use metriken_query::{Bytes, QueryEngine, Tsdb};
+use metriken_query::MetricsSource;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
 use parquet::file::metadata::KeyValue;
@@ -89,16 +89,15 @@ fn events_payload_json(events: &[Event]) -> Option<String> {
 
 // ── Column resolution ────────────────────────────────────────────────
 
-/// Resolve every entry's query against `engine`, union the returned
-/// columns, and always keep `timestamp` + `duration` (which
-/// `engine.columns` never returns but `Tsdb::load` requires).
+/// Resolve every entry's query against `source`, union the returned
+/// columns, and always keep `timestamp` + `duration`.
 ///
 /// Queries that fail to PARSE are logged and skipped — one malformed
 /// chart shouldn't abort the whole save. Queries that parse but match
 /// no series contribute nothing.
-pub fn resolve_kept_columns<T: Deref<Target = Tsdb>>(
+pub fn resolve_kept_columns(
     payload: &ReportPayload,
-    engine: &QueryEngine<T>,
+    source: &dyn MetricsSource,
     side: Side,
 ) -> HashSet<String> {
     let mut out: HashSet<String> = ["timestamp", "duration"]
@@ -113,7 +112,7 @@ pub fn resolve_kept_columns<T: Deref<Target = Tsdb>>(
                 .as_deref()
                 .unwrap_or(entry.promql_query.as_str()),
         };
-        match engine.columns(query) {
+        match source.columns(query) {
             Ok(cols) => out.extend(cols),
             Err(e) => warn!("report-save: skipped malformed query {query:?}: {e}"),
         }
@@ -131,13 +130,12 @@ pub fn save_single_parquet(
     source_bytes: Bytes,
     payload: &ReportPayload,
     selection_json: &str,
-    tsdb: &Tsdb,
+    source: &dyn MetricsSource,
     trim_columns: bool,
 ) -> Result<Vec<u8>, String> {
     let events_json = events_payload_json(&payload.events);
     if trim_columns {
-        let engine = QueryEngine::new(tsdb);
-        let kept = resolve_kept_columns(payload, &engine, Side::Baseline);
+        let kept = resolve_kept_columns(payload, source, Side::Baseline);
         trim_parquet_to_columns(source_bytes, &kept, selection_json, events_json.as_deref())
     } else {
         embed_selection_in_parquet(source_bytes, selection_json, events_json.as_deref())
@@ -155,21 +153,15 @@ pub fn save_combined_ab_tarball(
     experiment_bytes: Bytes,
     payload: &ReportPayload,
     selection_json: &str,
-    baseline_tsdb: &Tsdb,
-    experiment_tsdb: &Tsdb,
+    baseline_source: &dyn MetricsSource,
+    experiment_source: &dyn MetricsSource,
     manifest_bytes: &[u8],
     trim_columns: bool,
 ) -> Result<Vec<u8>, String> {
     let events_json = events_payload_json(&payload.events);
     let (baseline_out, experiment_out) = if trim_columns {
-        let baseline_kept = {
-            let engine = QueryEngine::new(baseline_tsdb);
-            resolve_kept_columns(payload, &engine, Side::Baseline)
-        };
-        let experiment_kept = {
-            let engine = QueryEngine::new(experiment_tsdb);
-            resolve_kept_columns(payload, &engine, Side::Experiment)
-        };
+        let baseline_kept = resolve_kept_columns(payload, baseline_source, Side::Baseline);
+        let experiment_kept = resolve_kept_columns(payload, experiment_source, Side::Experiment);
         (
             trim_parquet_to_columns(
                 baseline_bytes,
@@ -375,13 +367,13 @@ mod tests {
     use arrow::array::{Int64Array, UInt64Array};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
+    use metriken_query::ParquetReader;
     use std::sync::Arc;
 
     /// Build a tiny single-source parquet (timestamp, duration, m_a,
     /// m_b) entirely in memory and return both its bytes and the loaded
-    /// Tsdb. The Tsdb keeps an Arc on the bytes internally; we hand
-    /// back the bytes too so callers can pass them to save_*.
-    fn build_test(parquet: bool) -> (Bytes, Tsdb) {
+    /// ParquetReader.
+    fn build_test(_parquet: bool) -> (Bytes, ParquetReader) {
         let sec = 1_000_000_000u64;
         let mut meta = std::collections::HashMap::new();
         meta.insert("metric_type".to_string(), "gauge".to_string());
@@ -423,9 +415,8 @@ mod tests {
             writer.close().unwrap();
         }
         let bytes = Bytes::from(buf);
-        let tsdb = Tsdb::load_from_bytes(bytes.clone()).expect("tsdb loads");
-        let _ = parquet;
-        (bytes, tsdb)
+        let reader = ParquetReader::open_bytes(bytes.clone()).expect("reader loads");
+        (bytes, reader)
     }
 
     fn schema_names(bytes: &[u8]) -> Vec<String> {
@@ -449,8 +440,8 @@ mod tests {
 
     #[test]
     fn baseline_side_kept_set_includes_timestamp_and_duration() {
-        let (_bytes, tsdb) = build_test(true);
-        let engine = QueryEngine::new(&tsdb);
+        let (_bytes, reader) = build_test(true);
+        
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -459,7 +450,7 @@ mod tests {
             trim_columns: true,
             events: vec![],
         };
-        let kept = resolve_kept_columns(&payload, &engine, Side::Baseline);
+        let kept = resolve_kept_columns(&payload, &reader, Side::Baseline);
         assert!(kept.contains("timestamp"));
         assert!(kept.contains("duration"));
         assert!(kept.contains("m_a"));
@@ -468,8 +459,8 @@ mod tests {
 
     #[test]
     fn experiment_side_falls_back_to_promql_query_when_experiment_unset() {
-        let (_bytes, tsdb) = build_test(true);
-        let engine = QueryEngine::new(&tsdb);
+        let (_bytes, reader) = build_test(true);
+        
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -478,15 +469,15 @@ mod tests {
             trim_columns: true,
             events: vec![],
         };
-        let kept = resolve_kept_columns(&payload, &engine, Side::Experiment);
+        let kept = resolve_kept_columns(&payload, &reader, Side::Experiment);
         assert!(kept.contains("m_a"));
         assert!(!kept.contains("m_b"));
     }
 
     #[test]
     fn experiment_side_uses_promql_query_experiment_when_set() {
-        let (_bytes, tsdb) = build_test(true);
-        let engine = QueryEngine::new(&tsdb);
+        let (_bytes, reader) = build_test(true);
+        
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -495,8 +486,8 @@ mod tests {
             trim_columns: true,
             events: vec![],
         };
-        let kept_b = resolve_kept_columns(&payload, &engine, Side::Baseline);
-        let kept_e = resolve_kept_columns(&payload, &engine, Side::Experiment);
+        let kept_b = resolve_kept_columns(&payload, &reader, Side::Baseline);
+        let kept_e = resolve_kept_columns(&payload, &reader, Side::Experiment);
         assert!(kept_b.contains("m_a") && !kept_b.contains("m_b"));
         assert!(kept_e.contains("m_b") && !kept_e.contains("m_a"));
     }
@@ -543,7 +534,7 @@ mod tests {
 
     #[test]
     fn single_parquet_round_trip_trims_to_one_column() {
-        let (bytes, tsdb) = build_test(true);
+        let (bytes, reader) = build_test(true);
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -553,7 +544,7 @@ mod tests {
             events: vec![],
         };
         let body = r#"{"version":1,"entries":[{"chartId":"c","promql_query":"m_a"}]}"#;
-        let out = save_single_parquet(bytes, &payload, body, &tsdb, true).unwrap();
+        let out = save_single_parquet(bytes, &payload, body, &reader, true).unwrap();
         assert_eq!(schema_names(&out), vec!["timestamp", "duration", "m_a"]);
         let kv = footer_kv(&out);
         assert_eq!(
@@ -572,7 +563,7 @@ mod tests {
 
     #[test]
     fn save_with_trim_columns_false_preserves_all_columns_and_skips_marker() {
-        let (bytes, tsdb) = build_test(true);
+        let (bytes, reader) = build_test(true);
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -582,7 +573,7 @@ mod tests {
             events: vec![],
         };
         let selection = r#"{"version":1,"entries":[{"chartId":"c","promql_query":"m_a"}]}"#;
-        let out = save_single_parquet(bytes, &payload, selection, &tsdb, false).unwrap();
+        let out = save_single_parquet(bytes, &payload, selection, &reader, false).unwrap();
         assert_eq!(
             schema_names(&out),
             vec!["timestamp", "duration", "m_a", "m_b"]
@@ -625,8 +616,8 @@ mod tests {
 
     #[test]
     fn combined_ab_round_trip_trims_each_side_and_repacks() {
-        let (bytes_a, tsdb_a) = build_test(true);
-        let (bytes_b, tsdb_b) = build_test(true);
+        let (bytes_a, reader_a) = build_test(true);
+        let (bytes_b, reader_b) = build_test(true);
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -645,8 +636,8 @@ mod tests {
             bytes_b,
             &payload,
             body,
-            &tsdb_a,
-            &tsdb_b,
+            &reader_a,
+            &reader_b,
             manifest_bytes,
             true,
         )
@@ -689,7 +680,7 @@ mod tests {
 
     #[test]
     fn save_single_parquet_writes_key_events_when_payload_has_events() {
-        let (bytes, tsdb) = build_test(true);
+        let (bytes, reader) = build_test(true);
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -711,7 +702,7 @@ mod tests {
             }],
         };
         let body = r#"{"entries":[{"chartId":"c","promql_query":"m_a"}]}"#;
-        let out = save_single_parquet(bytes, &payload, body, &tsdb, true).unwrap();
+        let out = save_single_parquet(bytes, &payload, body, &reader, true).unwrap();
         let kv = footer_kv(&out);
         let events_value = kv
             .iter()
@@ -727,7 +718,7 @@ mod tests {
 
     #[test]
     fn save_single_parquet_skips_key_events_when_no_events() {
-        let (bytes, tsdb) = build_test(true);
+        let (bytes, reader) = build_test(true);
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -737,7 +728,7 @@ mod tests {
             events: vec![],
         };
         let body = r#"{"entries":[{"chartId":"c","promql_query":"m_a"}]}"#;
-        let out = save_single_parquet(bytes, &payload, body, &tsdb, true).unwrap();
+        let out = save_single_parquet(bytes, &payload, body, &reader, true).unwrap();
         let kv = footer_kv(&out);
         assert!(
             !kv.iter().any(|kv| kv.key == "events"),
@@ -747,8 +738,8 @@ mod tests {
 
     #[test]
     fn combined_ab_writes_events_to_both_sides() {
-        let (bytes_a, tsdb_a) = build_test(true);
-        let (bytes_b, tsdb_b) = build_test(true);
+        let (bytes_a, reader_a) = build_test(true);
+        let (bytes_b, reader_b) = build_test(true);
         let payload = ReportPayload {
             entries: vec![ReportEntry {
                 promql_query: "m_a".into(),
@@ -776,8 +767,8 @@ mod tests {
             bytes_b,
             &payload,
             body,
-            &tsdb_a,
-            &tsdb_b,
+            &reader_a,
+            &reader_b,
             manifest_bytes,
             true,
         )

--- a/crates/viewer/Cargo.toml
+++ b/crates/viewer/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
+bytes = "1"
 # Workspace declares metriken-query with default-features = false. The browser
 # doesn't need the server-side http or ingest features, so we inherit as-is.
 metriken-query.workspace = true

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -78,8 +78,6 @@ fn synthesize_manifest(baseline: &Viewer, experiment: &Viewer) -> report_save::A
 #[wasm_bindgen]
 pub struct Viewer {
     reader: Arc<ParquetReader>,
-    /// Filename stored separately since it's no longer on the reader.
-    filename: String,
     file_metadata: std::collections::HashMap<String, String>,
     /// Lazy section context. Populated by `init_templates` (single
     /// capture) or `WasmCaptureRegistry::regenerate_combined` (compare
@@ -144,6 +142,7 @@ impl Viewer {
         let reader = Arc::new(
             ParquetReader::open_bytes(bytes)
                 .map_err(|e| JsValue::from_str(&format!("Failed to load parquet: {}", e)))?
+                .with_filename(filename.to_string())
         );
 
         let file_metadata = reader.file_metadata();
@@ -155,7 +154,6 @@ impl Viewer {
 
         Ok(Viewer {
             reader,
-            filename: filename.to_string(),
             file_metadata,
             context,
             cached_bodies: std::cell::RefCell::new(std::collections::HashMap::new()),
@@ -195,7 +193,7 @@ impl Viewer {
             interval: self.reader.interval(),
             source: self.reader.source(),
             version: self.reader.version(),
-            filename: self.filename.clone(),
+            filename: self.reader.filename().unwrap_or_default().to_string(),
             min_time,
             max_time,
             counter_names: self.reader.counter_names(),
@@ -401,7 +399,7 @@ impl Viewer {
         // Render on demand.
         let mut view =
             dashboard::dashboard::generate_section(self.reader.as_ref(), &route, &self.context)?;
-        view.set_filename(self.filename.clone());
+        view.set_filename(self.reader.filename().unwrap_or_default().to_string());
         if let Some(size) = self.context.filesize {
             view.set_filesize(size);
         }

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -1,7 +1,15 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use metriken_query::{MetricsSource, ParquetReader};
+use metriken_query::{BufferPool, MetricsSource, ParquetReader};
+
+/// Buffer pool budget for the WASM viewer: 64 MB.
+///
+/// Browsers impose tighter heap limits than servers; the source bytes
+/// are already in memory, so the effective warm-cache speedup is bounded
+/// by how many row groups fit alongside them. 64 MB is a conservative
+/// default — enough for a moderate recording without crowding the JS heap.
+const WASM_CACHE_SIZE_BYTES: usize = 64 * 1024 * 1024;
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
@@ -78,6 +86,9 @@ fn synthesize_manifest(baseline: &Viewer, experiment: &Viewer) -> report_save::A
 #[wasm_bindgen]
 pub struct Viewer {
     reader: Arc<ParquetReader>,
+    /// Per-Viewer buffer pool. WASM is single-upload-per-Viewer; each
+    /// Viewer gets its own pool sized at `WASM_CACHE_SIZE_BYTES`.
+    _pool: Arc<BufferPool>,
     file_metadata: std::collections::HashMap<String, String>,
     /// Lazy section context. Populated by `init_templates` (single
     /// capture) or `WasmCaptureRegistry::regenerate_combined` (compare
@@ -139,8 +150,9 @@ impl Viewer {
     pub fn new(data: &[u8], filename: &str) -> Result<Viewer, JsValue> {
         let bytes = Bytes::from(data.to_vec());
         let source_bytes = bytes.clone();
+        let pool = BufferPool::new(WASM_CACHE_SIZE_BYTES);
         let reader = Arc::new(
-            ParquetReader::open_bytes(bytes)
+            ParquetReader::open_bytes_with_pool(bytes, Arc::clone(&pool))
                 .map_err(|e| JsValue::from_str(&format!("Failed to load parquet: {}", e)))?
                 .with_filename(filename.to_string())
         );
@@ -154,6 +166,7 @@ impl Viewer {
 
         Ok(Viewer {
             reader,
+            _pool: pool,
             file_metadata,
             context,
             cached_bodies: std::cell::RefCell::new(std::collections::HashMap::new()),

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use metriken_query::{Bytes, QueryEngine, Tsdb};
+use bytes::Bytes;
+use metriken_query::{MetricsSource, ParquetReader};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
@@ -61,14 +62,14 @@ fn synthesize_manifest(baseline: &Viewer, experiment: &Viewer) -> report_save::A
                 .alias
                 .clone()
                 .unwrap_or_else(|| "baseline".to_string()),
-            sources: to_sources(baseline.engine.tsdb().source()),
+            sources: to_sources(&baseline.reader.source()),
         },
         experiment: report_save::AbSide {
             alias: experiment
                 .alias
                 .clone()
                 .unwrap_or_else(|| "experiment".to_string()),
-            sources: to_sources(experiment.engine.tsdb().source()),
+            sources: to_sources(&experiment.reader.source()),
         },
         category: None,
     }
@@ -76,7 +77,9 @@ fn synthesize_manifest(baseline: &Viewer, experiment: &Viewer) -> report_save::A
 
 #[wasm_bindgen]
 pub struct Viewer {
-    engine: QueryEngine<Arc<Tsdb>>,
+    reader: Arc<ParquetReader>,
+    /// Filename stored separately since it's no longer on the reader.
+    filename: String,
     file_metadata: std::collections::HashMap<String, String>,
     /// Lazy section context. Populated by `init_templates` (single
     /// capture) or `WasmCaptureRegistry::regenerate_combined` (compare
@@ -92,8 +95,8 @@ pub struct Viewer {
     /// one (e.g. via an `alias=path` static-site URL param). None
     /// means the UI falls back to the capture id.
     alias: Option<String>,
-    /// Original parquet bytes kept alongside the Tsdb. Save as Report
-    /// re-encodes a projection from this source, not from the Tsdb
+    /// Original parquet bytes kept alongside the reader. Save as Report
+    /// re-encodes a projection from this source, not from the reader
     /// (which has lost internal Arrow field metadata like the
     /// `metric` key used by `parquet filter`'s keep-field predicate).
     source_bytes: Bytes,
@@ -138,20 +141,21 @@ impl Viewer {
     pub fn new(data: &[u8], filename: &str) -> Result<Viewer, JsValue> {
         let bytes = Bytes::from(data.to_vec());
         let source_bytes = bytes.clone();
-        let mut tsdb = Tsdb::load_from_bytes(bytes)
-            .map_err(|e| JsValue::from_str(&format!("Failed to load parquet: {}", e)))?;
-        tsdb.set_filename(filename.to_string());
+        let reader = Arc::new(
+            ParquetReader::open_bytes(bytes)
+                .map_err(|e| JsValue::from_str(&format!("Failed to load parquet: {}", e)))?
+        );
 
-        let file_metadata = tsdb.file_metadata().clone();
+        let file_metadata = reader.file_metadata();
         let context = if is_trimmed_report(&file_metadata) {
             empty_dashboard_context()
         } else {
             dashboard::dashboard::build_dashboard_context(None, &[], None)
         };
-        let engine = QueryEngine::new(Arc::new(tsdb));
 
         Ok(Viewer {
-            engine,
+            reader,
+            filename: filename.to_string(),
             file_metadata,
             context,
             cached_bodies: std::cell::RefCell::new(std::collections::HashMap::new()),
@@ -169,11 +173,7 @@ impl Viewer {
 
     /// Returns JSON metadata compatible with /api/v1/metadata
     pub fn metadata(&self) -> String {
-        let tsdb = self.engine.tsdb();
-        let (min_time, max_time) = tsdb
-            .time_range()
-            .map(|(min, max)| (min as f64 / 1e9, max as f64 / 1e9))
-            .unwrap_or((0.0, 0.0));
+        let (min_time, max_time) = self.reader.time_range().unwrap_or((0.0, 0.0));
 
         serde_json::to_string(&MetadataResponse {
             status: "success".to_string(),
@@ -189,34 +189,18 @@ impl Viewer {
 
     /// Returns JSON with viewer info (interval, source, version, metric names)
     pub fn info(&self) -> String {
-        let tsdb = self.engine.tsdb();
-        let (min_time, max_time) = tsdb
-            .time_range()
-            .map(|(min, max)| (min as f64 / 1e9, max as f64 / 1e9))
-            .unwrap_or((0.0, 0.0));
+        let (min_time, max_time) = self.reader.time_range().unwrap_or((0.0, 0.0));
 
         serde_json::to_string(&ViewerInfo {
-            interval: tsdb.interval(),
-            source: tsdb.source().to_string(),
-            version: tsdb.version().to_string(),
-            filename: tsdb.filename().to_string(),
+            interval: self.reader.interval(),
+            source: self.reader.source(),
+            version: self.reader.version(),
+            filename: self.filename.clone(),
             min_time,
             max_time,
-            counter_names: tsdb
-                .counter_names()
-                .into_iter()
-                .map(|s| s.to_string())
-                .collect(),
-            gauge_names: tsdb
-                .gauge_names()
-                .into_iter()
-                .map(|s| s.to_string())
-                .collect(),
-            histogram_names: tsdb
-                .histogram_names()
-                .into_iter()
-                .map(|s| s.to_string())
-                .collect(),
+            counter_names: self.reader.counter_names(),
+            gauge_names: self.reader.gauge_names(),
+            histogram_names: self.reader.histogram_names(),
         })
         .unwrap()
     }
@@ -282,7 +266,7 @@ impl Viewer {
     /// Execute a PromQL range query. Returns JSON compatible with
     /// /api/v1/query_range response format.
     pub fn query_range(&self, query: &str, start: f64, end: f64, step: f64) -> String {
-        match self.engine.query_range(query, start, end, step) {
+        match self.reader.query_range(query, start, end, step) {
             Ok(result) => {
                 let json = serde_json::to_string(&result).unwrap_or_else(|e| {
                     format!(
@@ -301,7 +285,7 @@ impl Viewer {
 
     /// Execute a PromQL instant query.
     pub fn query(&self, query: &str, time: f64) -> String {
-        match self.engine.query(query, Some(time)) {
+        match self.reader.query(query, Some(time)) {
             Ok(result) => {
                 let json = serde_json::to_string(&result).unwrap_or_else(|e| {
                     format!(
@@ -383,16 +367,15 @@ impl Viewer {
             }
         }
         if service_exts.is_empty() {
-            let tsdb = self.engine.tsdb();
-            let source = tsdb.source().to_string();
+            let source = self.reader.source();
             if let Some(ext) = registry.get(&source) {
                 service_exts.push((source, ext.clone()));
             }
         }
 
-        // Validate against this capture's own tsdb so per-capture
+        // Validate against this capture's own reader so per-capture
         // unavailability is correctly reported.
-        validate_service_extensions_inline(&self.engine, &mut service_exts);
+        validate_service_extensions_inline(self.reader.as_ref(), &mut service_exts);
         service_exts
     }
 
@@ -415,10 +398,10 @@ impl Viewer {
             return serialize_lean_section(value);
         }
 
-        // Render on demand. The engine owns the Arc<Tsdb> so we can pass
-        // `self.engine.tsdb()` as `&Tsdb`.
+        // Render on demand.
         let mut view =
-            dashboard::dashboard::generate_section(self.engine.tsdb(), &route, &self.context)?;
+            dashboard::dashboard::generate_section(self.reader.as_ref(), &route, &self.context)?;
+        view.set_filename(self.filename.clone());
         if let Some(size) = self.context.filesize {
             view.set_filesize(size);
         }
@@ -680,8 +663,8 @@ impl WasmCaptureRegistry {
                     experiment.source_bytes.clone(),
                     &payload,
                     payload_json,
-                    baseline.engine.tsdb(),
-                    experiment.engine.tsdb(),
+                    baseline.reader.as_ref(),
+                    experiment.reader.as_ref(),
                     &manifest,
                     payload.trim_columns,
                 )
@@ -691,7 +674,7 @@ impl WasmCaptureRegistry {
                 baseline.source_bytes.clone(),
                 &payload,
                 payload_json,
-                baseline.engine.tsdb(),
+                baseline.reader.as_ref(),
                 payload.trim_columns,
             )
             .map_err(|e| JsValue::from_str(&e)),
@@ -782,25 +765,22 @@ fn parse_template_registry(
 }
 
 /// Validate KPI availability for service extensions by running each KPI's
-/// PromQL query against the Viewer's existing query engine. Re-creating a
-/// fresh engine over `&Tsdb` has diverged for histogram queries in the WASM
-/// parquet-bytes path, which produced false "Unavailable KPIs" notes even
-/// though the same queries succeeded through the attached Viewer engine.
-fn validate_service_extensions_inline<T: std::ops::Deref<Target = Tsdb>>(
-    engine: &QueryEngine<T>,
+/// PromQL query against the data source.
+fn validate_service_extensions_inline(
+    data: &dyn MetricsSource,
     exts: &mut [(String, dashboard::ServiceExtension)],
 ) {
-    use metriken_query::promql;
-    let (start, end) = engine.get_time_range();
+    use metriken_query::QueryResult;
+    let (start, end) = data.time_range().unwrap_or((0.0, 0.0));
     for (_source, ext) in exts.iter_mut() {
         for kpi in &mut ext.kpis {
             let query = kpi.effective_query();
-            let has_data = match engine.query_range(&query, start, end, 1.0) {
+            let has_data = match data.query_range(&query, start, end, 1.0) {
                 Ok(result) => match &result {
-                    promql::QueryResult::Vector { result } => !result.is_empty(),
-                    promql::QueryResult::Matrix { result } => !result.is_empty(),
-                    promql::QueryResult::Scalar { .. } => true,
-                    promql::QueryResult::HistogramHeatmap { result } => !result.data.is_empty(),
+                    QueryResult::Vector { result } => !result.is_empty(),
+                    QueryResult::Matrix { result } => !result.is_empty(),
+                    QueryResult::Scalar { .. } => true,
+                    QueryResult::HistogramHeatmap { result } => !result.data.is_empty(),
                 },
                 Err(_) => false,
             };

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -154,7 +154,7 @@ impl Viewer {
         let reader = Arc::new(
             ParquetReader::open_bytes_with_pool(bytes, Arc::clone(&pool))
                 .map_err(|e| JsValue::from_str(&format!("Failed to load parquet: {}", e)))?
-                .with_filename(filename.to_string())
+                .with_filename(filename.to_string()),
         );
 
         let file_metadata = reader.file_metadata();

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -193,7 +193,7 @@ impl Viewer {
             interval: self.reader.interval(),
             source: self.reader.source(),
             version: self.reader.version(),
-            filename: self.reader.filename().unwrap_or_default().to_string(),
+            filename: self.reader.filename_or_default(),
             min_time,
             max_time,
             counter_names: self.reader.counter_names(),
@@ -399,7 +399,7 @@ impl Viewer {
         // Render on demand.
         let mut view =
             dashboard::dashboard::generate_section(self.reader.as_ref(), &route, &self.context)?;
-        view.set_filename(self.reader.filename().unwrap_or_default().to_string());
+        view.set_filename(self.reader.filename_or_default());
         if let Some(size) = self.context.filesize {
             view.set_filesize(size);
         }

--- a/crates/viewer/src/report_save.rs
+++ b/crates/viewer/src/report_save.rs
@@ -4,7 +4,8 @@
 //! attached viewers (compare mode loads two separate parquets, never
 //! a real tar manifest) and serializes it for the shared crate.
 
-use metriken_query::{Bytes, Tsdb};
+use bytes::Bytes;
+use metriken_query::MetricsSource;
 use serde::Serialize;
 
 pub use report_save::ReportPayload;
@@ -33,29 +34,26 @@ impl AbContainers {
     pub const SCHEMA_VERSION: u32 = 1;
 }
 
-/// Trim or embed-only single-parquet save. Thin pass-through to the
-/// shared crate; takes `Bytes` (which the WASM `Viewer` already holds).
+/// Trim or embed-only single-parquet save.
 pub fn save_single_parquet(
     source_bytes: Bytes,
     payload: &ReportPayload,
     selection_json: &str,
-    tsdb: &Tsdb,
+    source: &dyn MetricsSource,
     trim_columns: bool,
 ) -> Result<Vec<u8>, String> {
-    report_save::save_single_parquet(source_bytes, payload, selection_json, tsdb, trim_columns)
+    report_save::save_single_parquet(source_bytes, payload, selection_json, source, trim_columns)
 }
 
-/// Trim or embed-only combined-A/B repack. Serializes the manifest
-/// here and hands the bytes to the shared crate, which writes them as
-/// `ab.json` inside the tar.
+/// Trim or embed-only combined-A/B repack.
 #[allow(clippy::too_many_arguments)]
 pub fn save_combined_ab_tarball(
     baseline_bytes: Bytes,
     experiment_bytes: Bytes,
     payload: &ReportPayload,
     selection_json: &str,
-    baseline_tsdb: &Tsdb,
-    experiment_tsdb: &Tsdb,
+    baseline_source: &dyn MetricsSource,
+    experiment_source: &dyn MetricsSource,
     manifest: &AbContainers,
     trim_columns: bool,
 ) -> Result<Vec<u8>, String> {
@@ -65,8 +63,8 @@ pub fn save_combined_ab_tarball(
         experiment_bytes,
         payload,
         selection_json,
-        baseline_tsdb,
-        experiment_tsdb,
+        baseline_source,
+        experiment_source,
         &manifest_bytes,
         trim_columns,
     )

--- a/src/mcp/anomaly_detection/mod.rs
+++ b/src/mcp/anomaly_detection/mod.rs
@@ -1,5 +1,5 @@
-use metriken_query::{MetricsSource, QueryResult};
 use chrono::{DateTime, Utc};
+use metriken_query::{MetricsSource, QueryResult};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
@@ -250,7 +250,10 @@ fn show_available_labels(
 
 /// Automatically construct appropriate query based on metric type
 /// If query is just a metric name, construct the right query for its type
-fn auto_construct_query(query: &str, data: &dyn MetricsSource) -> Result<String, Box<dyn std::error::Error>> {
+fn auto_construct_query(
+    query: &str,
+    data: &dyn MetricsSource,
+) -> Result<String, Box<dyn std::error::Error>> {
     let query = query.trim();
 
     // A bare metric name has no functions, brackets, or operators

--- a/src/mcp/anomaly_detection/mod.rs
+++ b/src/mcp/anomaly_detection/mod.rs
@@ -1,9 +1,7 @@
-use crate::viewer::promql::{QueryEngine, QueryResult};
-use crate::viewer::tsdb::Tsdb;
+use metriken_query::{MetricsSource, QueryResult};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashMap};
 
 mod cusum;
 mod mad;
@@ -181,14 +179,12 @@ fn extract_metric_name(query: &str) -> Option<&str> {
 fn show_available_labels(
     output: &mut String,
     metric_name: &str,
-    labels_list: &[crate::viewer::tsdb::Labels],
+    labels_list: &[BTreeMap<String, String>],
 ) {
-    use std::collections::HashMap;
-
     let mut label_values: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
 
     for labels in labels_list {
-        for (key, value) in labels.inner.iter() {
+        for (key, value) in labels.iter() {
             if key != "metric" && key != "unit" && key != "metric_type" {
                 label_values
                     .entry(key.clone())
@@ -254,7 +250,7 @@ fn show_available_labels(
 
 /// Automatically construct appropriate query based on metric type
 /// If query is just a metric name, construct the right query for its type
-fn auto_construct_query(query: &str, tsdb: &Tsdb) -> Result<String, Box<dyn std::error::Error>> {
+fn auto_construct_query(query: &str, data: &dyn MetricsSource) -> Result<String, Box<dyn std::error::Error>> {
     let query = query.trim();
 
     // A bare metric name has no functions, brackets, or operators
@@ -276,19 +272,19 @@ fn auto_construct_query(query: &str, tsdb: &Tsdb) -> Result<String, Box<dyn std:
         query
     };
 
-    if tsdb.counter_names().contains(&metric_name) {
+    if data.counter_names().iter().any(|n| n == metric_name) {
         eprintln!(
             "Auto-detected '{}' as COUNTER, using: sum(rate({}[1m]))",
             metric_name, query
         );
         Ok(format!("sum(rate({}[1m]))", query))
-    } else if tsdb.gauge_names().contains(&metric_name) {
+    } else if data.gauge_names().iter().any(|n| n == metric_name) {
         eprintln!(
             "Auto-detected '{}' as GAUGE, using: sum({})",
             metric_name, query
         );
         Ok(format!("sum({})", query))
-    } else if tsdb.histogram_names().contains(&metric_name) {
+    } else if data.histogram_names().iter().any(|n| n == metric_name) {
         eprintln!(
             "Auto-detected '{}' as HISTOGRAM, using: histogram_quantile(0.99, {})",
             metric_name, query
@@ -302,18 +298,17 @@ fn auto_construct_query(query: &str, tsdb: &Tsdb) -> Result<String, Box<dyn std:
 
 /// Perform anomaly detection on a time series
 pub fn detect_anomalies(
-    engine: &Arc<QueryEngine>,
-    tsdb: &Arc<Tsdb>,
+    data: &dyn MetricsSource,
     query: &str,
 ) -> Result<AnomalyDetectionResult, Box<dyn std::error::Error>> {
     // Undo JSON escaping of quotes
     let query = query.replace("\\\"", "\"");
 
-    let query = auto_construct_query(&query, tsdb)?;
+    let query = auto_construct_query(&query, data)?;
 
     let query = validate_and_fix_query(&query)?;
 
-    let (start_time, end_time) = engine.get_time_range();
+    let (start_time, end_time) = data.time_range().unwrap_or((0.0, 0.0));
 
     if start_time >= end_time {
         return Err(format!(
@@ -336,7 +331,7 @@ pub fn detect_anomalies(
         .into());
     }
 
-    let query_result = match engine.query_range(&query, start_time, end_time, step) {
+    let query_result = match data.query_range(&query, start_time, end_time, step) {
         Ok(result) => result,
         Err(e) => {
             let error_msg = e.to_string();
@@ -345,23 +340,23 @@ pub fn detect_anomalies(
                 let metric_hint = extract_metric_name(&query);
 
                 let mut all_metrics = Vec::new();
-                all_metrics.extend(tsdb.counter_names());
-                all_metrics.extend(tsdb.gauge_names());
-                all_metrics.extend(tsdb.histogram_names());
+                all_metrics.extend(data.counter_names());
+                all_metrics.extend(data.gauge_names());
+                all_metrics.extend(data.histogram_names());
 
-                let mut suggestions = Vec::new();
+                let mut suggestions: Vec<&str> = Vec::new();
                 if let Some(hint) = metric_hint {
                     let hint_normalized = hint.replace(['/', '-'], "_");
 
                     for metric in &all_metrics {
                         // Exact matches go to the front so they rank above partial matches
-                        if *metric == hint || *metric == hint_normalized {
-                            suggestions.insert(0, *metric);
+                        if metric.as_str() == hint || metric.as_str() == hint_normalized {
+                            suggestions.insert(0, metric.as_str());
                         } else if metric.contains(&hint_normalized)
                             || metric.starts_with(&format!("{}_", hint_normalized))
                             || metric.ends_with(&format!("_{}", hint_normalized))
                         {
-                            suggestions.push(*metric);
+                            suggestions.push(metric.as_str());
                         }
                     }
                 }
@@ -375,38 +370,41 @@ pub fn detect_anomalies(
                         if !suggestions.is_empty() && suggestions[0] == metric_name {
                             error_with_help.push_str("\n\nThe metric exists but your label selector might be filtering out all series.");
 
-                            if let Some(labels_list) = tsdb.counter_labels(metric_name) {
+                            let counter_labels = data.counter_labels(metric_name);
+                            let gauge_labels = data.gauge_labels(metric_name);
+                            let histogram_labels = data.histogram_labels(metric_name);
+                            if !counter_labels.is_empty() {
                                 error_with_help.push_str(&format!(
                                     "\n\nMetric '{}' (COUNTER) has {} series.",
                                     metric_name,
-                                    labels_list.len()
+                                    counter_labels.len()
                                 ));
                                 show_available_labels(
                                     &mut error_with_help,
                                     metric_name,
-                                    &labels_list,
+                                    &counter_labels,
                                 );
-                            } else if let Some(labels_list) = tsdb.gauge_labels(metric_name) {
+                            } else if !gauge_labels.is_empty() {
                                 error_with_help.push_str(&format!(
                                     "\n\nMetric '{}' (GAUGE) has {} series.",
                                     metric_name,
-                                    labels_list.len()
+                                    gauge_labels.len()
                                 ));
                                 show_available_labels(
                                     &mut error_with_help,
                                     metric_name,
-                                    &labels_list,
+                                    &gauge_labels,
                                 );
-                            } else if let Some(labels_list) = tsdb.histogram_labels(metric_name) {
+                            } else if !histogram_labels.is_empty() {
                                 error_with_help.push_str(&format!(
                                     "\n\nMetric '{}' (HISTOGRAM) has {} series.",
                                     metric_name,
-                                    labels_list.len()
+                                    histogram_labels.len()
                                 ));
                                 show_available_labels(
                                     &mut error_with_help,
                                     metric_name,
-                                    &labels_list,
+                                    &histogram_labels,
                                 );
                             }
 
@@ -453,27 +451,30 @@ pub fn detect_anomalies(
                 query
             );
 
-            if let Some(labels_list) = tsdb.counter_labels(metric_name) {
+            let counter_labels = data.counter_labels(metric_name);
+            let gauge_labels = data.gauge_labels(metric_name);
+            let histogram_labels = data.histogram_labels(metric_name);
+            if !counter_labels.is_empty() {
                 error_msg.push_str(&format!(
                     "\nMetric '{}' (COUNTER) exists with {} series.\n",
                     metric_name,
-                    labels_list.len()
+                    counter_labels.len()
                 ));
-                show_available_labels(&mut error_msg, metric_name, &labels_list);
-            } else if let Some(labels_list) = tsdb.gauge_labels(metric_name) {
+                show_available_labels(&mut error_msg, metric_name, &counter_labels);
+            } else if !gauge_labels.is_empty() {
                 error_msg.push_str(&format!(
                     "\nMetric '{}' (GAUGE) exists with {} series.\n",
                     metric_name,
-                    labels_list.len()
+                    gauge_labels.len()
                 ));
-                show_available_labels(&mut error_msg, metric_name, &labels_list);
-            } else if let Some(labels_list) = tsdb.histogram_labels(metric_name) {
+                show_available_labels(&mut error_msg, metric_name, &gauge_labels);
+            } else if !histogram_labels.is_empty() {
                 error_msg.push_str(&format!(
                     "\nMetric '{}' (HISTOGRAM) exists with {} series.\n",
                     metric_name,
-                    labels_list.len()
+                    histogram_labels.len()
                 ));
-                show_available_labels(&mut error_msg, metric_name, &labels_list);
+                show_available_labels(&mut error_msg, metric_name, &histogram_labels);
             } else {
                 error_msg.push_str(&format!(
                     "\nMetric '{}' not found in this recording.\n",

--- a/src/mcp/anomaly_detection/mod.rs
+++ b/src/mcp/anomaly_detection/mod.rs
@@ -272,19 +272,19 @@ fn auto_construct_query(query: &str, data: &dyn MetricsSource) -> Result<String,
         query
     };
 
-    if data.counter_names().iter().any(|n| n == metric_name) {
+    if data.has_counter(metric_name) {
         eprintln!(
             "Auto-detected '{}' as COUNTER, using: sum(rate({}[1m]))",
             metric_name, query
         );
         Ok(format!("sum(rate({}[1m]))", query))
-    } else if data.gauge_names().iter().any(|n| n == metric_name) {
+    } else if data.has_gauge(metric_name) {
         eprintln!(
             "Auto-detected '{}' as GAUGE, using: sum({})",
             metric_name, query
         );
         Ok(format!("sum({})", query))
-    } else if data.histogram_names().iter().any(|n| n == metric_name) {
+    } else if data.has_histogram(metric_name) {
         eprintln!(
             "Auto-detected '{}' as HISTOGRAM, using: histogram_quantile(0.99, {})",
             metric_name, query
@@ -339,10 +339,7 @@ pub fn detect_anomalies(
             if error_msg.contains("Metric not found") || error_msg.contains("not found") {
                 let metric_hint = extract_metric_name(&query);
 
-                let mut all_metrics = Vec::new();
-                all_metrics.extend(data.counter_names());
-                all_metrics.extend(data.gauge_names());
-                all_metrics.extend(data.histogram_names());
+                let all_metrics = data.all_names();
 
                 let mut suggestions: Vec<&str> = Vec::new();
                 if let Some(hint) = metric_hint {

--- a/src/mcp/correlation.rs
+++ b/src/mcp/correlation.rs
@@ -1,8 +1,6 @@
-use crate::viewer::promql::{MatrixSample, QueryEngine, QueryResult};
-use crate::viewer::tsdb::Tsdb;
+use metriken_query::{MatrixSample, MetricsSource, QueryResult};
 use rayon::prelude::*;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 // Fixed time intervals optimized for system performance analysis
 // Balances coverage with computational efficiency
@@ -61,16 +59,15 @@ pub struct SeriesCorrelation {
 ///
 /// Note: Use describe_metrics tool to identify counter vs gauge metrics.
 pub fn calculate_correlation(
-    engine: &Arc<QueryEngine>,
-    tsdb: &Arc<Tsdb>,
+    data: &dyn MetricsSource,
     expr1: &str,
     expr2: &str,
 ) -> Result<CorrelationResult, Box<dyn std::error::Error>> {
-    let (start, end) = engine.get_time_range();
-    let step = tsdb.interval();
+    let (start, end) = data.time_range().unwrap_or((0.0, 0.0));
+    let step = data.interval();
 
-    let result1 = engine.query_range(expr1, start, end, step)?;
-    let result2 = engine.query_range(expr2, start, end, step)?;
+    let result1 = data.query_range(expr1, start, end, step)?;
+    let result2 = data.query_range(expr2, start, end, step)?;
 
     let samples1 = extract_matrix_samples(&result1)?;
     let samples2 = extract_matrix_samples(&result2)?;

--- a/src/mcp/describe_metrics.rs
+++ b/src/mcp/describe_metrics.rs
@@ -1,133 +1,87 @@
-use crate::viewer::tsdb::Tsdb;
-use std::sync::Arc;
+use metriken_query::MetricsSource;
 
 /// Format metrics description for display
-pub fn format_metrics_description(tsdb: &Arc<Tsdb>) -> String {
+pub fn format_metrics_description(data: &dyn MetricsSource) -> String {
     let mut output = String::new();
     output.push_str("Available Metrics in Recording\n");
     output.push_str("===============================\n\n");
 
     let descriptions = crate::common::metric_descriptions();
 
-    let mut counter_names = tsdb.counter_names();
+    let helper = |output: &mut String, name: &str, labels_list: &[std::collections::BTreeMap<String, String>]| {
+        let mut all_keys = std::collections::HashSet::new();
+        for labels in labels_list {
+            for (key, _) in labels.iter() {
+                if key != "metric" && key != "unit" && key != "metric_type" {
+                    all_keys.insert(key.clone());
+                }
+            }
+        }
+        if !all_keys.is_empty() {
+            let mut keys: Vec<_> = all_keys.into_iter().collect();
+            keys.sort();
+            output.push_str(&format!("  Labels: {}\n", keys.join(", ")));
+        }
+        output.push_str(&format!("  Series count: {}\n", labels_list.len()));
+        let _ = name;
+    };
+
+    let mut counter_names = data.counter_names();
     if !counter_names.is_empty() {
         counter_names.sort();
         output.push_str("COUNTERS (monotonically increasing values):\n");
         output.push_str("-------------------------------------------\n");
-        for name in counter_names {
+        for name in &counter_names {
             output.push_str(&format!("• {name}\n"));
-            if let Some(desc) = descriptions.get(name) {
+            if let Some(desc) = descriptions.get(name.as_str()) {
                 output.push_str(&format!("  Description: {desc}\n"));
             }
-            if let Some(labels_list) = tsdb.counter_labels(name) {
-                // Get unique label keys, excluding metadata labels
-                let mut all_keys = std::collections::HashSet::new();
-                for labels in &labels_list {
-                    for (key, _) in labels.inner.iter() {
-                        if key != "metric" && key != "unit" && key != "metric_type" {
-                            all_keys.insert(key.clone());
-                        }
-                    }
-                }
-                if !all_keys.is_empty() {
-                    let mut keys: Vec<_> = all_keys.into_iter().collect();
-                    keys.sort();
-                    output.push_str(&format!("  Labels: {}\n", keys.join(", ")));
-                }
-                output.push_str(&format!("  Series count: {}\n", labels_list.len()));
-            }
+            let labels_list = data.counter_labels(name);
+            helper(&mut output, name, &labels_list);
             output.push('\n');
         }
     }
 
-    let mut gauge_names = tsdb.gauge_names();
+    let mut gauge_names = data.gauge_names();
     if !gauge_names.is_empty() {
         gauge_names.sort();
         output.push_str("\nGAUGES (values that can go up or down):\n");
         output.push_str("----------------------------------------\n");
-        for name in gauge_names {
+        for name in &gauge_names {
             output.push_str(&format!("• {name}\n"));
-            if let Some(desc) = descriptions.get(name) {
+            if let Some(desc) = descriptions.get(name.as_str()) {
                 output.push_str(&format!("  Description: {desc}\n"));
             }
-            if let Some(labels_list) = tsdb.gauge_labels(name) {
-                // Get unique label keys, excluding metadata labels
-                let mut all_keys = std::collections::HashSet::new();
-                for labels in &labels_list {
-                    for (key, _) in labels.inner.iter() {
-                        if key != "metric" && key != "unit" && key != "metric_type" {
-                            all_keys.insert(key.clone());
-                        }
-                    }
-                }
-                if !all_keys.is_empty() {
-                    let mut keys: Vec<_> = all_keys.into_iter().collect();
-                    keys.sort();
-                    output.push_str(&format!("  Labels: {}\n", keys.join(", ")));
-                }
-                output.push_str(&format!("  Series count: {}\n", labels_list.len()));
-            }
+            let labels_list = data.gauge_labels(name);
+            helper(&mut output, name, &labels_list);
             output.push('\n');
         }
     }
 
-    let mut histogram_names = tsdb.histogram_names();
+    let mut histogram_names = data.histogram_names();
     if !histogram_names.is_empty() {
         histogram_names.sort();
         output.push_str("\nHISTOGRAMS (distributions of values):\n");
         output.push_str("--------------------------------------\n");
-        for name in histogram_names {
+        for name in &histogram_names {
             output.push_str(&format!("• {name}\n"));
-            if let Some(desc) = descriptions.get(name) {
+            if let Some(desc) = descriptions.get(name.as_str()) {
                 output.push_str(&format!("  Description: {desc}\n"));
             }
-            if let Some(labels_list) = tsdb.histogram_labels(name) {
-                // Get unique label keys, excluding metadata labels
-                let mut all_keys = std::collections::HashSet::new();
-                for labels in &labels_list {
-                    for (key, _) in labels.inner.iter() {
-                        if key != "metric" && key != "unit" && key != "metric_type" {
-                            all_keys.insert(key.clone());
-                        }
-                    }
-                }
-                if !all_keys.is_empty() {
-                    let mut keys: Vec<_> = all_keys.into_iter().collect();
-                    keys.sort();
-                    output.push_str(&format!("  Labels: {}\n", keys.join(", ")));
-                }
-                output.push_str(&format!("  Series count: {}\n", labels_list.len()));
-            }
+            let labels_list = data.histogram_labels(name);
+            helper(&mut output, name, &labels_list);
             output.push('\n');
         }
     }
 
-    let total_counters = tsdb.counter_names().len();
-    let total_gauges = tsdb.gauge_names().len();
-    let total_histograms = tsdb.histogram_names().len();
+    let total_counters = counter_names.len();
+    let total_gauges = gauge_names.len();
+    let total_histograms = histogram_names.len();
     let total_metrics = total_counters + total_gauges + total_histograms;
 
-    let mut total_counter_series = 0;
-    for name in tsdb.counter_names() {
-        if let Some(labels_list) = tsdb.counter_labels(name) {
-            total_counter_series += labels_list.len();
-        }
-    }
-
-    let mut total_gauge_series = 0;
-    for name in tsdb.gauge_names() {
-        if let Some(labels_list) = tsdb.gauge_labels(name) {
-            total_gauge_series += labels_list.len();
-        }
-    }
-
-    let mut total_histogram_series = 0;
-    for name in tsdb.histogram_names() {
-        if let Some(labels_list) = tsdb.histogram_labels(name) {
-            total_histogram_series += labels_list.len();
-        }
-    }
-
+    let total_counter_series: usize = counter_names.iter().map(|n| data.counter_labels(n).len()).sum();
+    let total_gauge_series: usize = gauge_names.iter().map(|n| data.gauge_labels(n).len()).sum();
+    let total_histogram_series: usize = histogram_names.iter().map(|n| data.histogram_labels(n).len()).sum();
     let total_series = total_counter_series + total_gauge_series + total_histogram_series;
 
     output.push_str("\nSUMMARY:\n");
@@ -142,7 +96,7 @@ pub fn format_metrics_description(tsdb: &Arc<Tsdb>) -> String {
     output.push_str(&format!("  Histogram series: {total_histogram_series}\n"));
     output.push_str(&format!(
         "\nSampling interval: {}ms\n",
-        tsdb.interval() * 1000.0
+        data.interval() * 1000.0
     ));
 
     output.push_str("\n\nCOMMON QUERY PATTERNS:\n");

--- a/src/mcp/describe_metrics.rs
+++ b/src/mcp/describe_metrics.rs
@@ -8,7 +8,9 @@ pub fn format_metrics_description(data: &dyn MetricsSource) -> String {
 
     let descriptions = crate::common::metric_descriptions();
 
-    let helper = |output: &mut String, name: &str, labels_list: &[std::collections::BTreeMap<String, String>]| {
+    let helper = |output: &mut String,
+                  name: &str,
+                  labels_list: &[std::collections::BTreeMap<String, String>]| {
         let mut all_keys = std::collections::HashSet::new();
         for labels in labels_list {
             for (key, _) in labels.iter() {
@@ -79,9 +81,15 @@ pub fn format_metrics_description(data: &dyn MetricsSource) -> String {
     let total_histograms = histogram_names.len();
     let total_metrics = total_counters + total_gauges + total_histograms;
 
-    let total_counter_series: usize = counter_names.iter().map(|n| data.counter_labels(n).len()).sum();
+    let total_counter_series: usize = counter_names
+        .iter()
+        .map(|n| data.counter_labels(n).len())
+        .sum();
     let total_gauge_series: usize = gauge_names.iter().map(|n| data.gauge_labels(n).len()).sum();
-    let total_histogram_series: usize = histogram_names.iter().map(|n| data.histogram_labels(n).len()).sum();
+    let total_histogram_series: usize = histogram_names
+        .iter()
+        .map(|n| data.histogram_labels(n).len())
+        .sum();
     let total_series = total_counter_series + total_gauge_series + total_histogram_series;
 
     output.push_str("\nSUMMARY:\n");

--- a/src/mcp/discover_correlations.rs
+++ b/src/mcp/discover_correlations.rs
@@ -1,7 +1,5 @@
-use crate::viewer::promql::QueryEngine;
-use crate::viewer::tsdb::Tsdb;
+use metriken_query::MetricsSource;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use super::correlation::{calculate_correlation, CorrelationResult, SeriesCorrelation};
 
@@ -58,8 +56,7 @@ pub struct CorrelationDiscoveryResult {
 
 /// Discover significant correlations automatically
 pub fn discover_correlations(
-    engine: &Arc<QueryEngine>,
-    tsdb: &Arc<Tsdb>,
+    data: &dyn MetricsSource,
     params: Option<DiscoveryParams>,
 ) -> Result<CorrelationDiscoveryResult, Box<dyn std::error::Error>> {
     let start_time = std::time::Instant::now();
@@ -86,7 +83,7 @@ pub fn discover_correlations(
             println!("Processed {}/{} pairs...", processed, total_pairs);
         }
         
-        match calculate_correlation(engine, tsdb, &query1.query, &query2.query) {
+        match calculate_correlation(data, &query1.query, &query2.query) {
             Ok(result) => {
                 if result.max_correlation.abs() >= params.min_correlation {
                     let relationship_type = if cat1 == cat2 {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -214,7 +214,7 @@ fn run_exhaustive_detection(reader: Arc<ParquetReader>) {
     let mut derived_metrics = Vec::new();
 
     // CPU Frequency = (aperf / mperf) - shows actual vs max performance
-    if reader.counter_names().iter().any(|n| n == "cpu_aperf") && reader.counter_names().iter().any(|n| n == "cpu_mperf") {
+    if reader.has_counter("cpu_aperf") && reader.has_counter("cpu_mperf") {
         derived_metrics.push((
             "cpu_frequency_ratio".to_string(),
             "derived",
@@ -223,9 +223,7 @@ fn run_exhaustive_detection(reader: Arc<ParquetReader>) {
     }
 
     // CPU Instructions Per Cycle (IPC) - efficiency metric
-    if reader.counter_names().iter().any(|n| n == "cpu_instructions")
-        && reader.counter_names().iter().any(|n| n == "cpu_cycles")
-    {
+    if reader.has_counter("cpu_instructions") && reader.has_counter("cpu_cycles") {
         derived_metrics.push((
             "cpu_instructions_per_cycle".to_string(),
             "derived",
@@ -234,9 +232,7 @@ fn run_exhaustive_detection(reader: Arc<ParquetReader>) {
     }
 
     // Cgroup versions of the same
-    if reader.counter_names().iter().any(|n| n == "cgroup_cpu_aperf")
-        && reader.counter_names().iter().any(|n| n == "cgroup_cpu_mperf")
-    {
+    if reader.has_counter("cgroup_cpu_aperf") && reader.has_counter("cgroup_cpu_mperf") {
         derived_metrics.push((
             "cgroup_cpu_frequency_ratio".to_string(),
             "derived",
@@ -244,9 +240,7 @@ fn run_exhaustive_detection(reader: Arc<ParquetReader>) {
         ));
     }
 
-    if reader.counter_names().iter().any(|n| n == "cgroup_cpu_instructions")
-        && reader.counter_names().iter().any(|n| n == "cgroup_cpu_cycles")
-    {
+    if reader.has_counter("cgroup_cpu_instructions") && reader.has_counter("cgroup_cpu_cycles") {
         derived_metrics.push((
             "cgroup_cpu_instructions_per_cycle".to_string(),
             "derived",

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8,8 +8,8 @@ pub mod correlation;
 mod describe_metrics;
 mod server;
 
-use metriken_query::{MetricsSource, ParquetReader, QueryResult};
 use chrono::{DateTime, Utc};
+use metriken_query::{MetricsSource, ParquetReader, QueryResult};
 
 /// Format recording information for display
 pub fn format_recording_info(file_path: &str, data: &dyn MetricsSource) -> String {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -8,13 +8,12 @@ pub mod correlation;
 mod describe_metrics;
 mod server;
 
-use crate::viewer::promql::{QueryEngine, QueryResult};
-use crate::viewer::tsdb::Tsdb;
+use metriken_query::{MetricsSource, ParquetReader, QueryResult};
 use chrono::{DateTime, Utc};
 
 /// Format recording information for display
-pub fn format_recording_info(file_path: &str, tsdb: &Arc<Tsdb>, engine: &QueryEngine) -> String {
-    let (start_time, end_time) = engine.get_time_range();
+pub fn format_recording_info(file_path: &str, data: &dyn MetricsSource) -> String {
+    let (start_time, end_time) = data.time_range().unwrap_or((0.0, 0.0));
     let duration_seconds = end_time - start_time;
 
     let hours = (duration_seconds / 3600.0) as u64;
@@ -47,8 +46,8 @@ pub fn format_recording_info(file_path: &str, tsdb: &Arc<Tsdb>, engine: &QueryEn
          Start Time: {} (epoch: {:.0})\n\
          End Time: {} (epoch: {:.0})",
         file_path,
-        tsdb.version(),
-        tsdb.source(),
+        data.version(),
+        data.source(),
         duration_str,
         duration_seconds,
         start_datetime,
@@ -98,20 +97,15 @@ fn run_server(config: Config) {
 }
 
 fn run_analyze_correlation(file: PathBuf, query1: String, query2: String) {
-    use crate::viewer::promql::QueryEngine;
-    use crate::viewer::tsdb::Tsdb;
-
-    let tsdb = match Tsdb::load(&file) {
-        Ok(tsdb) => Arc::new(tsdb),
+    let reader = match ParquetReader::open(&file) {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to load parquet file: {e}");
             std::process::exit(1);
         }
     };
 
-    let engine = Arc::new(QueryEngine::new(tsdb.clone()));
-
-    match correlation::calculate_correlation(&engine, &tsdb, &query1, &query2) {
+    match correlation::calculate_correlation(&reader, &query1, &query2) {
         Ok(result) => {
             println!("{}", correlation::format_correlation_result(&result));
         }
@@ -123,46 +117,42 @@ fn run_analyze_correlation(file: PathBuf, query1: String, query2: String) {
 }
 
 fn run_describe_recording(file: PathBuf) {
-    let tsdb = match Tsdb::load(&file) {
-        Ok(tsdb) => Arc::new(tsdb),
+    let reader = match ParquetReader::open(&file) {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to load parquet file: {e}");
             std::process::exit(1);
         }
     };
 
-    let engine = QueryEngine::new(tsdb.clone());
-
-    let output = format_recording_info(file.to_str().unwrap_or("<unknown>"), &tsdb, &engine);
+    let output = format_recording_info(file.to_str().unwrap_or("<unknown>"), &reader);
     println!("{output}");
 }
 
 fn run_describe_metrics(file: PathBuf) {
-    let tsdb = match Tsdb::load(&file) {
-        Ok(tsdb) => Arc::new(tsdb),
+    let reader = match ParquetReader::open(&file) {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to load parquet file: {e}");
             std::process::exit(1);
         }
     };
 
-    let output = describe_metrics::format_metrics_description(&tsdb);
+    let output = describe_metrics::format_metrics_description(&reader);
     println!("{output}");
 }
 
 fn run_detect_anomalies(file: PathBuf, query: Option<String>) {
-    let tsdb = match Tsdb::load(&file) {
-        Ok(tsdb) => Arc::new(tsdb),
+    let reader = match ParquetReader::open(&file) {
+        Ok(r) => Arc::new(r),
         Err(e) => {
             eprintln!("Failed to load parquet file: {e}");
             std::process::exit(1);
         }
     };
 
-    let engine = Arc::new(QueryEngine::new(tsdb.clone()));
-
     if let Some(query) = query {
-        match anomaly_detection::detect_anomalies(&engine, &tsdb, &query) {
+        match anomaly_detection::detect_anomalies(reader.as_ref(), &query) {
             Ok(result) => {
                 println!(
                     "{}",
@@ -177,10 +167,10 @@ fn run_detect_anomalies(file: PathBuf, query: Option<String>) {
         return;
     }
 
-    run_exhaustive_detection(engine, tsdb);
+    run_exhaustive_detection(reader);
 }
 
-fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
+fn run_exhaustive_detection(reader: Arc<ParquetReader>) {
     // Metrics to skip - these are raw building blocks or redundant metrics
     let skip_metrics = [
         // CPU building blocks - only meaningful when combined
@@ -202,19 +192,19 @@ fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
 
     let mut metrics_to_analyze = Vec::new();
 
-    for name in tsdb.counter_names() {
-        if !skip_metrics.contains(&name) {
+    for name in reader.counter_names() {
+        if !skip_metrics.iter().any(|n| *n == name.as_str()) {
             metrics_to_analyze.push((name.to_string(), "counter", None));
         }
     }
 
-    for name in tsdb.gauge_names() {
-        if !skip_metrics.contains(&name) {
+    for name in reader.gauge_names() {
+        if !skip_metrics.iter().any(|n| *n == name.as_str()) {
             metrics_to_analyze.push((name.to_string(), "gauge", None));
         }
     }
 
-    for name in tsdb.histogram_names() {
+    for name in reader.histogram_names() {
         metrics_to_analyze.push((name.to_string(), "histogram_p50", None));
         metrics_to_analyze.push((name.to_string(), "histogram_p90", None));
         metrics_to_analyze.push((name.to_string(), "histogram_p99", None));
@@ -224,7 +214,7 @@ fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
     let mut derived_metrics = Vec::new();
 
     // CPU Frequency = (aperf / mperf) - shows actual vs max performance
-    if tsdb.counter_names().contains(&"cpu_aperf") && tsdb.counter_names().contains(&"cpu_mperf") {
+    if reader.counter_names().iter().any(|n| n == "cpu_aperf") && reader.counter_names().iter().any(|n| n == "cpu_mperf") {
         derived_metrics.push((
             "cpu_frequency_ratio".to_string(),
             "derived",
@@ -233,8 +223,8 @@ fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
     }
 
     // CPU Instructions Per Cycle (IPC) - efficiency metric
-    if tsdb.counter_names().contains(&"cpu_instructions")
-        && tsdb.counter_names().contains(&"cpu_cycles")
+    if reader.counter_names().iter().any(|n| n == "cpu_instructions")
+        && reader.counter_names().iter().any(|n| n == "cpu_cycles")
     {
         derived_metrics.push((
             "cpu_instructions_per_cycle".to_string(),
@@ -244,8 +234,8 @@ fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
     }
 
     // Cgroup versions of the same
-    if tsdb.counter_names().contains(&"cgroup_cpu_aperf")
-        && tsdb.counter_names().contains(&"cgroup_cpu_mperf")
+    if reader.counter_names().iter().any(|n| n == "cgroup_cpu_aperf")
+        && reader.counter_names().iter().any(|n| n == "cgroup_cpu_mperf")
     {
         derived_metrics.push((
             "cgroup_cpu_frequency_ratio".to_string(),
@@ -254,8 +244,8 @@ fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
         ));
     }
 
-    if tsdb.counter_names().contains(&"cgroup_cpu_instructions")
-        && tsdb.counter_names().contains(&"cgroup_cpu_cycles")
+    if reader.counter_names().iter().any(|n| n == "cgroup_cpu_instructions")
+        && reader.counter_names().iter().any(|n| n == "cgroup_cpu_cycles")
     {
         derived_metrics.push((
             "cgroup_cpu_instructions_per_cycle".to_string(),
@@ -293,7 +283,7 @@ fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
             }
         };
 
-        match anomaly_detection::detect_anomalies(&engine, &tsdb, &query) {
+        match anomaly_detection::detect_anomalies(reader.as_ref(), &query) {
             Ok(result) => {
                 if !result.anomalies.is_empty() {
                     let high_severity = result
@@ -377,20 +367,18 @@ fn run_exhaustive_detection(engine: Arc<QueryEngine>, tsdb: Arc<Tsdb>) {
 }
 
 fn run_query(file: PathBuf, query: String) {
-    let tsdb = match Tsdb::load(&file) {
-        Ok(tsdb) => Arc::new(tsdb),
+    let reader = match ParquetReader::open(&file) {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to load parquet file: {e}");
             std::process::exit(1);
         }
     };
 
-    let engine = Arc::new(QueryEngine::new(tsdb.clone()));
-
-    let (start_time, end_time) = engine.get_time_range();
+    let (start_time, end_time) = reader.time_range().unwrap_or((0.0, 0.0));
     let step = 1.0;
 
-    match engine.query_range(&query, start_time, end_time, step) {
+    match reader.query_range(&query, start_time, end_time, step) {
         Ok(result) => {
             println!("{}", format_query_result(&result));
         }

--- a/src/mcp/resource_usage.rs
+++ b/src/mcp/resource_usage.rs
@@ -1,7 +1,5 @@
-use crate::viewer::promql::QueryEngine;
-use crate::viewer::tsdb::Tsdb;
+use metriken_query::MetricsSource;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 /// Result of resource usage analysis
 #[derive(Debug)]
@@ -26,18 +24,17 @@ pub struct ResourceConsumer {
 
 /// Analyze top resource consumers for a given query
 pub fn analyze_resource_usage(
-    engine: &Arc<QueryEngine>,
-    tsdb: &Arc<Tsdb>,
+    data: &dyn MetricsSource,
     query: &str,
     description: &str,
     top_n: usize,
 ) -> Result<ResourceUsageResult, Box<dyn std::error::Error>> {
-    let (start, end) = engine.get_time_range();
-    let step = tsdb.interval();
+    let (start, end) = data.time_range().unwrap_or((0.0, 0.0));
+    let step = data.interval();
 
-    let result = engine.query_range(query, start, end, step)?;
+    let result = data.query_range(query, start, end, step)?;
 
-    use crate::viewer::promql::{QueryResult, Sample};
+    use metriken_query::{QueryResult, Sample};
 
     let mut consumers = Vec::new();
     let mut total_sum = 0.0;
@@ -225,8 +222,7 @@ fn truncate_string(s: &str, max_len: usize) -> String {
 
 /// Analyze multiple resource metrics
 pub fn analyze_multiple_resources(
-    engine: &Arc<QueryEngine>,
-    tsdb: &Arc<Tsdb>,
+    data: &dyn MetricsSource,
 ) -> Result<Vec<ResourceUsageResult>, Box<dyn std::error::Error>> {
     let queries = vec![
         ("sum by(name) (irate(cgroup_cpu_usage[1m])) / 1e9", "Container CPU Usage"),
@@ -234,15 +230,15 @@ pub fn analyze_multiple_resources(
         ("sum by(id) (irate(cpu_usage[1m]))", "Per-Core CPU Usage"),
         ("sum by(op) (irate(syscall[1m]))", "System Call Types"),
     ];
-    
+
     let mut results = Vec::new();
-    
+
     for (query, description) in queries {
-        match analyze_resource_usage(engine, tsdb, query, description, 10) {
+        match analyze_resource_usage(data, query, description, 10) {
             Ok(result) => results.push(result),
             Err(e) => eprintln!("Failed to analyze {}: {}", description, e),
         }
     }
-    
+
     Ok(results)
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-use metriken_query::{MetricsSource, ParquetReader};
+use metriken_query::{BufferPool, MetricsSource, ParquetReader};
 
 /// MCP protocol methods
 #[derive(Debug)]
@@ -59,15 +59,25 @@ impl From<&str> for McpTool {
     }
 }
 
+/// Default buffer pool budget for the MCP server: 500 MB.
+///
+/// Multiple parquet files may be queried in a single MCP session; the
+/// shared pool means row groups decoded for one file stay warm for the
+/// next tool call against the same file.
+const MCP_CACHE_SIZE_BYTES: usize = 500 * 1024 * 1024;
+
 /// MCP server state
 pub struct Server {
     reader_cache: Arc<RwLock<HashMap<String, Arc<ParquetReader>>>>,
+    /// Shared LRU row-group cache for all readers opened by this server.
+    pool: Arc<BufferPool>,
 }
 
 impl Server {
     pub fn new() -> Self {
         Self {
             reader_cache: Arc::new(RwLock::new(HashMap::new())),
+            pool: BufferPool::new(MCP_CACHE_SIZE_BYTES),
         }
     }
 
@@ -479,7 +489,7 @@ impl Server {
             return Err(format!("Parquet file not found: {parquet_file}").into());
         }
 
-        let reader = Arc::new(ParquetReader::open(path)?);
+        let reader = Arc::new(ParquetReader::open_with_pool(path, Arc::clone(&self.pool))?);
         let output = super::format_recording_info(parquet_file, reader.as_ref());
         Ok(output)
     }
@@ -498,7 +508,7 @@ impl Server {
             return Err(format!("Parquet file not found: {parquet_file}").into());
         }
 
-        let reader = Arc::new(ParquetReader::open(path)?);
+        let reader = Arc::new(ParquetReader::open_with_pool(path, Arc::clone(&self.pool))?);
 
         {
             let mut cache = self.reader_cache.write().unwrap();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -495,7 +495,10 @@ impl Server {
     }
 
     /// Load or get cached ParquetReader
-    async fn get_reader(&self, parquet_file: &str) -> Result<Arc<ParquetReader>, Box<dyn std::error::Error>> {
+    async fn get_reader(
+        &self,
+        parquet_file: &str,
+    ) -> Result<Arc<ParquetReader>, Box<dyn std::error::Error>> {
         {
             let cache = self.reader_cache.read().unwrap();
             if let Some(reader) = cache.get(parquet_file) {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,8 +5,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-use crate::viewer::promql::QueryEngine;
-use crate::viewer::tsdb::Tsdb;
+use metriken_query::{MetricsSource, ParquetReader};
 
 /// MCP protocol methods
 #[derive(Debug)]
@@ -62,15 +61,13 @@ impl From<&str> for McpTool {
 
 /// MCP server state
 pub struct Server {
-    tsdb_cache: Arc<RwLock<HashMap<String, Arc<Tsdb>>>>,
-    query_engine_cache: Arc<RwLock<HashMap<String, Arc<QueryEngine>>>>,
+    reader_cache: Arc<RwLock<HashMap<String, Arc<ParquetReader>>>>,
 }
 
 impl Server {
     pub fn new() -> Self {
         Self {
-            tsdb_cache: Arc::new(RwLock::new(HashMap::new())),
-            query_engine_cache: Arc::new(RwLock::new(HashMap::new())),
+            reader_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -482,21 +479,17 @@ impl Server {
             return Err(format!("Parquet file not found: {parquet_file}").into());
         }
 
-        let tsdb = Arc::new(Tsdb::load(path)?);
-
-        use crate::viewer::promql::QueryEngine;
-        let engine = QueryEngine::new(Arc::clone(&tsdb));
-
-        let output = super::format_recording_info(parquet_file, &tsdb, &engine);
+        let reader = Arc::new(ParquetReader::open(path)?);
+        let output = super::format_recording_info(parquet_file, reader.as_ref());
         Ok(output)
     }
 
-    /// Load or get cached TSDB
-    async fn get_tsdb(&self, parquet_file: &str) -> Result<Arc<Tsdb>, Box<dyn std::error::Error>> {
+    /// Load or get cached ParquetReader
+    async fn get_reader(&self, parquet_file: &str) -> Result<Arc<ParquetReader>, Box<dyn std::error::Error>> {
         {
-            let cache = self.tsdb_cache.read().unwrap();
-            if let Some(tsdb) = cache.get(parquet_file) {
-                return Ok(Arc::clone(tsdb));
+            let cache = self.reader_cache.read().unwrap();
+            if let Some(reader) = cache.get(parquet_file) {
+                return Ok(Arc::clone(reader));
             }
         }
 
@@ -505,37 +498,14 @@ impl Server {
             return Err(format!("Parquet file not found: {parquet_file}").into());
         }
 
-        let tsdb = Arc::new(Tsdb::load(path)?);
+        let reader = Arc::new(ParquetReader::open(path)?);
 
         {
-            let mut cache = self.tsdb_cache.write().unwrap();
-            cache.insert(parquet_file.to_string(), Arc::clone(&tsdb));
+            let mut cache = self.reader_cache.write().unwrap();
+            cache.insert(parquet_file.to_string(), Arc::clone(&reader));
         }
 
-        Ok(tsdb)
-    }
-
-    /// Load or get cached QueryEngine
-    async fn get_query_engine(
-        &self,
-        parquet_file: &str,
-    ) -> Result<Arc<QueryEngine>, Box<dyn std::error::Error>> {
-        {
-            let cache = self.query_engine_cache.read().unwrap();
-            if let Some(engine) = cache.get(parquet_file) {
-                return Ok(Arc::clone(engine));
-            }
-        }
-
-        let tsdb = self.get_tsdb(parquet_file).await?;
-        let engine = Arc::new(QueryEngine::new(tsdb));
-
-        {
-            let mut cache = self.query_engine_cache.write().unwrap();
-            cache.insert(parquet_file.to_string(), Arc::clone(&engine));
-        }
-
-        Ok(engine)
+        Ok(reader)
     }
 
     /// Analyze correlation between two metrics
@@ -558,12 +528,11 @@ impl Server {
             .and_then(|m| m.as_str())
             .ok_or("Missing metric2")?;
 
-        let tsdb = self.get_tsdb(parquet_file).await?;
-        let engine = self.get_query_engine(parquet_file).await?;
+        let reader = self.get_reader(parquet_file).await?;
 
         use crate::mcp::correlation::{calculate_correlation, format_correlation_result};
 
-        let result = calculate_correlation(&engine, &tsdb, metric1, metric2)?;
+        let result = calculate_correlation(reader.as_ref(), metric1, metric2)?;
         Ok(format_correlation_result(&result))
     }
 
@@ -577,10 +546,10 @@ impl Server {
             .and_then(|f| f.as_str())
             .ok_or("Missing parquet_file")?;
 
-        let tsdb = self.get_tsdb(parquet_file).await?;
+        let reader = self.get_reader(parquet_file).await?;
 
         use crate::mcp::describe_metrics::format_metrics_description;
-        Ok(format_metrics_description(&tsdb))
+        Ok(format_metrics_description(reader.as_ref()))
     }
 
     /// Detect anomalies in time series data
@@ -598,12 +567,11 @@ impl Server {
             .and_then(|q| q.as_str())
             .ok_or("Missing query")?;
 
-        let tsdb = self.get_tsdb(parquet_file).await?;
-        let engine = self.get_query_engine(parquet_file).await?;
+        let reader = self.get_reader(parquet_file).await?;
 
         use crate::mcp::anomaly_detection::{detect_anomalies, format_anomaly_detection_result};
 
-        let result = detect_anomalies(&engine, &tsdb, query)?;
+        let result = detect_anomalies(reader.as_ref(), query)?;
         Ok(format_anomaly_detection_result(&result))
     }
 
@@ -619,12 +587,12 @@ impl Server {
             .and_then(|q| q.as_str())
             .ok_or("Missing query")?;
 
-        let engine = self.get_query_engine(parquet_file).await?;
+        let reader = self.get_reader(parquet_file).await?;
 
-        let (start_time, end_time) = engine.get_time_range();
+        let (start_time, end_time) = reader.time_range().unwrap_or((0.0, 0.0));
         let step = 1.0;
 
-        let result = engine.query_range(query, start_time, end_time, step)?;
+        let result = reader.query_range(query, start_time, end_time, step)?;
 
         Ok(serde_json::to_string_pretty(&result)?)
     }

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -6,8 +6,7 @@ use std::sync::Arc;
 use crate::parquet_metadata::{
     KEY_NODE, KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, KEY_SYSTEMINFO,
 };
-use crate::viewer::promql::QueryEngine;
-use crate::viewer::tsdb::Tsdb;
+use metriken_query::ParquetReader;
 use crate::viewer::{ServiceExtension, TemplateRegistry};
 
 pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
@@ -176,16 +175,15 @@ fn run_undo(path: &Path) {
 /// Sets `available` on each KPI based on whether its query returns data.
 /// Prints warnings for unavailable KPIs and exits if none match.
 fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
-    let tsdb = match Tsdb::load(path) {
-        Ok(tsdb) => Arc::new(tsdb),
+    let reader = match ParquetReader::open(path) {
+        Ok(r) => r,
         Err(e) => {
             eprintln!("warning: could not load parquet for validation: {e}");
             return;
         }
     };
 
-    let engine = QueryEngine::new(tsdb);
-    let (start, end) = engine.get_time_range();
+    let (start, end) = reader.time_range().unwrap_or((0.0, 0.0));
     let step = 1.0;
 
     let mut matched = 0;
@@ -193,7 +191,7 @@ fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
 
     for kpi in &mut ext.kpis {
         let query = kpi.effective_query();
-        let has_data = match engine.query_range(&query, start, end, step) {
+        let has_data = match reader.query_range(&query, start, end, step) {
             Ok(result) => !query_result_is_empty(&result),
             Err(_) => false,
         };
@@ -248,8 +246,8 @@ pub(super) fn extract_metric_selectors(query: &str) -> BTreeSet<String> {
         .collect()
 }
 
-fn query_result_is_empty(result: &crate::viewer::promql::QueryResult) -> bool {
-    use crate::viewer::promql::QueryResult;
+fn query_result_is_empty(result: &metriken_query::QueryResult) -> bool {
+    use metriken_query::QueryResult;
     match result {
         QueryResult::Vector { result } => result.is_empty(),
         QueryResult::Matrix { result } => result.is_empty(),

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use crate::parquet_metadata::{
     KEY_NODE, KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, KEY_SYSTEMINFO,
 };
-use metriken_query::ParquetReader;
 use crate::viewer::{ServiceExtension, TemplateRegistry};
+use metriken_query::ParquetReader;
 
 pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
     let path = args.get_one::<PathBuf>("FILE").unwrap();

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -1,7 +1,6 @@
 use clap::ArgMatches;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use crate::parquet_metadata::{
     KEY_NODE, KEY_PER_SOURCE_METADATA, KEY_SERVICE_QUERIES, KEY_SOURCE, KEY_SYSTEMINFO,

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -13,7 +13,7 @@ use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Json, Response};
 use http::{header, StatusCode};
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use reqwest::{Client, Url};
 use tracing::{debug, error, info, warn};
 

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -271,7 +271,7 @@ pub fn ingest_baseline_from_path(
     let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 
-    let display_filename = reader_arc.filename().unwrap_or_default();
+    let display_filename = reader_arc.filename_or_default();
     state.replace_baseline(reader_arc);
     *state.sections.write() = LazySectionStore::new(context);
     let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
@@ -466,7 +466,7 @@ pub async fn reset_tsdb(
     let data = state.baseline_data();
     let source = data.source();
     let version = data.version();
-    let filename = data.filename().unwrap_or_default();
+    let filename = data.filename_or_default();
 
     let new_store = MemoryStore::builder()
         .source(source)

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -17,6 +17,8 @@ use parking_lot::{Mutex, RwLock};
 use reqwest::{Client, Url};
 use tracing::{debug, error, info, warn};
 
+use metriken_query::{MemoryStore, MetricsSource, ParquetReader};
+
 use super::capture_registry::CaptureId;
 use super::metadata::{
     build_multinode_systeminfo, compute_file_checksum, extract_parquet_metadata,
@@ -24,7 +26,6 @@ use super::metadata::{
 };
 use super::report_save;
 use super::state::{ApiResponse, AppState, LazySectionStore};
-use super::tsdb::Tsdb;
 use ::dashboard;
 
 // ── Snapshot ingest (live mode) ───────────────────────────────────────
@@ -32,7 +33,7 @@ use ::dashboard;
 /// Background task that polls a live agent and ingests snapshots.
 pub async fn ingest_loop(
     url: Url,
-    tsdb: Arc<RwLock<Tsdb>>,
+    store: MemoryStore,
     snapshots: Arc<Mutex<VecDeque<Vec<u8>>>>,
     source: String,
     version: String,
@@ -45,13 +46,11 @@ pub async fn ingest_loop(
         }
     };
 
-    {
-        let mut tsdb = tsdb.write();
-        tsdb.set_sampling_interval_ms(1000);
-        tsdb.set_source(source);
-        tsdb.set_version(version);
-        tsdb.set_filename(url.to_string());
-    }
+    // source/version/interval already set during construction; update in case
+    // they changed (connect_agent path).
+    store.set_source(&source);
+    store.set_version(&version);
+    store.set_sampling_interval_ms(1000);
 
     let interval_duration = Duration::from_secs(1);
     let mut interval = crate::common::aligned_interval(interval_duration);
@@ -78,7 +77,7 @@ pub async fn ingest_loop(
 
         debug!("sampling latency: {} us", start.elapsed().as_micros());
 
-        let snapshot: metriken_exposition::Snapshot = match rmp_serde::from_slice(&body) {
+        let mut snapshot: metriken_exposition::Snapshot = match rmp_serde::from_slice(&body) {
             Ok(s) => s,
             Err(e) => {
                 warn!("failed to deserialize snapshot: {e}");
@@ -86,8 +85,7 @@ pub async fn ingest_loop(
             }
         };
 
-        let mut tsdb = tsdb.write();
-        tsdb.ingest(snapshot);
+        store.ingest_snapshot(&mut snapshot);
         sample_count += 1;
 
         snapshots.lock().push_back(body.to_vec());
@@ -96,9 +94,9 @@ pub async fn ingest_loop(
             debug!(
                 "ingested {} samples, counters: {}, gauges: {}, histograms: {}",
                 sample_count,
-                tsdb.counter_names().len(),
-                tsdb.gauge_names().len(),
-                tsdb.histogram_names().len(),
+                store.counter_names().len(),
+                store.gauge_names().len(),
+                store.histogram_names().len(),
             );
         }
     }
@@ -245,15 +243,15 @@ pub fn ingest_baseline_from_path(
     temp_path: PathBuf,
     filename: String,
 ) -> Json<ApiResponse<serde_json::Value>> {
-    let mut data = match Tsdb::load(&temp_path) {
-        Ok(d) => d,
+    let reader = match ParquetReader::open(&temp_path) {
+        Ok(r) => r,
         Err(e) => {
             let _ = std::fs::remove_file(&temp_path);
             return ApiResponse::err(format!("failed to load parquet: {e}"), "invalid_parquet");
         }
     };
     let filesize = std::fs::metadata(&temp_path).map(|m| m.len()).ok();
-    data.set_filename(filename.clone());
+    let reader_arc: Arc<dyn MetricsSource + Send + Sync> = Arc::new(reader);
 
     // Mirror the regenerate_dashboards short-circuit: a trimmed report
     // gets an empty section list so /api/v1/sections is consistent with
@@ -266,18 +264,14 @@ pub fn ingest_baseline_from_path(
         }
     } else {
         let mut service_exts = extract_service_extension_metadata(&temp_path, &state.templates);
-        validate_service_extensions(&data, &mut service_exts);
+        validate_service_extensions(reader_arc.as_ref(), &mut service_exts);
         let service_refs: Vec<_> = service_exts.iter().map(|(s, e)| (s.as_str(), e)).collect();
         ::dashboard::dashboard::build_dashboard_context(filesize, &service_refs, None)
     };
     let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 
-    {
-        let tsdb_handle = state.baseline_tsdb();
-        let mut tsdb = tsdb_handle.write();
-        *tsdb = data;
-    }
+    state.replace_baseline(reader_arc, filename.clone());
     *state.sections.write() = LazySectionStore::new(context);
     let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
     *state.parquet_path.write() = Some(temp_path);
@@ -338,8 +332,8 @@ pub async fn attach_experiment(
             .into_response();
     }
 
-    let mut tsdb = match Tsdb::load(&temp_path) {
-        Ok(t) => t,
+    let exp_reader = match ParquetReader::open(&temp_path) {
+        Ok(r) => r,
         Err(e) => {
             let _ = std::fs::remove_file(&temp_path);
             return (
@@ -349,15 +343,18 @@ pub async fn attach_experiment(
                 .into_response();
         }
     };
-    tsdb.set_filename(filename);
 
     let (sysinfo, _selection, file_meta) = extract_parquet_metadata(&temp_path);
     // HTTP-attached experiments don't carry an alias today; the
     // parameter is here so a future `x-rezolus-alias` header can thread
     // one through without further signature changes.
-    state
-        .captures
-        .attach_experiment(tsdb, sysinfo.clone(), file_meta, None);
+    state.captures.attach_experiment(
+        Arc::new(exp_reader) as Arc<dyn MetricsSource + Send + Sync>,
+        filename,
+        sysinfo.clone(),
+        file_meta,
+        None,
+    );
     *state.experiment_parquet_path.write() = Some(temp_path);
 
     regenerate_dashboards(&state);
@@ -419,30 +416,26 @@ pub async fn connect_agent(
         Err(e) => return ApiResponse::err(e, "connection_error"),
     };
 
-    let mut tsdb = Tsdb::default();
-    tsdb.set_sampling_interval_ms(1000);
-    tsdb.set_source(info.source.clone());
-    tsdb.set_version(info.version.clone());
-    tsdb.set_filename(url.to_string());
+    let new_store = MemoryStore::builder()
+        .source(info.source.clone())
+        .version(info.version.clone())
+        .sampling_interval_ms(1000)
+        .build();
+    let new_store_arc: Arc<dyn MetricsSource + Send + Sync> = Arc::new(new_store.clone());
     let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
 
-    {
-        let tsdb_handle = state.baseline_tsdb();
-        let mut db = tsdb_handle.write();
-        *db = tsdb;
-    }
+    state.replace_baseline(new_store_arc, url.to_string());
     *state.sections.write() = LazySectionStore::new(context);
     state.captures.set_baseline_systeminfo(info.sysinfo);
     state.live.store(true, Ordering::Relaxed);
 
-    let ingest_tsdb = state.baseline_tsdb();
     let ingest_snapshots = state.snapshots.clone();
     let mut ingest_url = url.clone();
     ingest_url.set_path("/metrics/binary");
 
     tokio::spawn(ingest_loop(
         ingest_url,
-        ingest_tsdb,
+        new_store,
         ingest_snapshots,
         info.source.clone(),
         info.version.clone(),
@@ -469,23 +462,19 @@ pub async fn reset_tsdb(
         return ApiResponse::err("reset is only available in live mode", "bad_request");
     }
 
-    let tsdb_handle = state.baseline_tsdb();
-    let (source, version, filename) = {
-        let tsdb = tsdb_handle.read();
-        (
-            tsdb.source().to_string(),
-            tsdb.version().to_string(),
-            tsdb.filename().to_string(),
-        )
-    };
-    {
-        let mut tsdb = tsdb_handle.write();
-        *tsdb = Tsdb::default();
-        tsdb.set_sampling_interval_ms(1000);
-        tsdb.set_source(source);
-        tsdb.set_version(version);
-        tsdb.set_filename(filename);
-    }
+    let data = state.baseline_data();
+    let source = data.source();
+    let version = data.version();
+    let filename = state.captures.filename(CaptureId::Baseline);
+
+    let new_store = MemoryStore::builder()
+        .source(source)
+        .version(version)
+        .sampling_interval_ms(1000)
+        .build();
+    let new_store_arc: Arc<dyn MetricsSource + Send + Sync> = Arc::new(new_store);
+    state.replace_baseline(new_store_arc, filename);
+
     state.snapshots.lock().clear();
     info!("TSDB reset by user");
     ApiResponse::ok(serde_json::json!({ "ok": true }))
@@ -600,7 +589,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
                 .into_response();
             }
         };
-        let baseline_tsdb = state.baseline_tsdb();
+        let baseline_data = state.baseline_data();
         let trim_columns = payload.trim_columns;
         // Bind to a local so the temporary read guard from .read() doesn't
         // extend through the `if let` body and trip Send across the await.
@@ -618,7 +607,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
                 )
                 .into_response();
             };
-            let experiment_tsdb = state
+            let experiment_data = state
                 .captures
                 .get(CaptureId::Experiment)
                 .expect("experiment slot must be attached in combined-A/B mode");
@@ -631,10 +620,10 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
                         &experiment_path,
                         &payload,
                         &body,
-                        &baseline_tsdb,
-                        &experiment_tsdb,
                         &manifest,
                         trim_columns,
+                        baseline_data.as_ref(),
+                        experiment_data.as_ref(),
                     )
                     .map_err(|e| e.to_string())
                 }
@@ -650,7 +639,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
                     &path,
                     &payload,
                     &body,
-                    &baseline_tsdb,
+                    baseline_data.as_ref(),
                     trim_columns,
                 )
                 .map_err(|e| e.to_string())

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -77,7 +77,7 @@ pub async fn ingest_loop(
 
         debug!("sampling latency: {} us", start.elapsed().as_micros());
 
-        let mut snapshot: metriken_exposition::Snapshot = match rmp_serde::from_slice(&body) {
+        let snapshot: metriken_exposition::Snapshot = match rmp_serde::from_slice(&body) {
             Ok(s) => s,
             Err(e) => {
                 warn!("failed to deserialize snapshot: {e}");
@@ -85,7 +85,7 @@ pub async fn ingest_loop(
             }
         };
 
-        store.ingest_snapshot(&mut snapshot);
+        store.ingest_snapshot(snapshot);
         sample_count += 1;
 
         snapshots.lock().push_back(body.to_vec());
@@ -244,14 +244,14 @@ pub fn ingest_baseline_from_path(
     filename: String,
 ) -> Json<ApiResponse<serde_json::Value>> {
     let reader = match ParquetReader::open(&temp_path) {
-        Ok(r) => r,
+        Ok(r) => r.with_filename(filename),
         Err(e) => {
             let _ = std::fs::remove_file(&temp_path);
             return ApiResponse::err(format!("failed to load parquet: {e}"), "invalid_parquet");
         }
     };
     let filesize = std::fs::metadata(&temp_path).map(|m| m.len()).ok();
-    let reader_arc: Arc<dyn MetricsSource + Send + Sync> = Arc::new(reader);
+    let reader_arc: Arc<dyn MetricsSource> = Arc::new(reader);
 
     // Mirror the regenerate_dashboards short-circuit: a trimmed report
     // gets an empty section list so /api/v1/sections is consistent with
@@ -271,7 +271,8 @@ pub fn ingest_baseline_from_path(
     let (systeminfo, selection, file_meta) = extract_parquet_metadata(&temp_path);
     let file_checksum = compute_file_checksum(&temp_path);
 
-    state.replace_baseline(reader_arc, filename.clone());
+    let display_filename = reader_arc.filename().unwrap_or_default();
+    state.replace_baseline(reader_arc);
     *state.sections.write() = LazySectionStore::new(context);
     let multinode_sysinfo = build_multinode_systeminfo(&temp_path);
     *state.parquet_path.write() = Some(temp_path);
@@ -283,7 +284,7 @@ pub fn ingest_baseline_from_path(
     *state.file_checksum.write() = file_checksum;
     state.captures.set_baseline_file_metadata(file_meta);
 
-    ApiResponse::ok(serde_json::json!({ "filename": filename }))
+    ApiResponse::ok(serde_json::json!({ "filename": display_filename }))
 }
 
 pub fn baseline_temp_path() -> PathBuf {
@@ -333,7 +334,7 @@ pub async fn attach_experiment(
     }
 
     let exp_reader = match ParquetReader::open(&temp_path) {
-        Ok(r) => r,
+        Ok(r) => r.with_filename(filename),
         Err(e) => {
             let _ = std::fs::remove_file(&temp_path);
             return (
@@ -349,8 +350,7 @@ pub async fn attach_experiment(
     // parameter is here so a future `x-rezolus-alias` header can thread
     // one through without further signature changes.
     state.captures.attach_experiment(
-        Arc::new(exp_reader) as Arc<dyn MetricsSource + Send + Sync>,
-        filename,
+        Arc::new(exp_reader) as Arc<dyn MetricsSource>,
         sysinfo.clone(),
         file_meta,
         None,
@@ -420,11 +420,12 @@ pub async fn connect_agent(
         .source(info.source.clone())
         .version(info.version.clone())
         .sampling_interval_ms(1000)
+        .filename(url.to_string())
         .build();
-    let new_store_arc: Arc<dyn MetricsSource + Send + Sync> = Arc::new(new_store.clone());
+    let new_store_arc: Arc<dyn MetricsSource> = Arc::new(new_store.clone());
     let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
 
-    state.replace_baseline(new_store_arc, url.to_string());
+    state.replace_baseline(new_store_arc);
     *state.sections.write() = LazySectionStore::new(context);
     state.captures.set_baseline_systeminfo(info.sysinfo);
     state.live.store(true, Ordering::Relaxed);
@@ -465,15 +466,16 @@ pub async fn reset_tsdb(
     let data = state.baseline_data();
     let source = data.source();
     let version = data.version();
-    let filename = state.captures.filename(CaptureId::Baseline);
+    let filename = data.filename().unwrap_or_default();
 
     let new_store = MemoryStore::builder()
         .source(source)
         .version(version)
         .sampling_interval_ms(1000)
+        .filename(filename)
         .build();
-    let new_store_arc: Arc<dyn MetricsSource + Send + Sync> = Arc::new(new_store);
-    state.replace_baseline(new_store_arc, filename);
+    let new_store_arc: Arc<dyn MetricsSource> = Arc::new(new_store);
+    state.replace_baseline(new_store_arc);
 
     state.snapshots.lock().clear();
     info!("TSDB reset by user");

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -243,7 +243,7 @@ pub fn ingest_baseline_from_path(
     temp_path: PathBuf,
     filename: String,
 ) -> Json<ApiResponse<serde_json::Value>> {
-    let reader = match ParquetReader::open(&temp_path) {
+    let reader = match ParquetReader::open_with_pool(&temp_path, Arc::clone(&state.pool)) {
         Ok(r) => r.with_filename(filename),
         Err(e) => {
             let _ = std::fs::remove_file(&temp_path);
@@ -333,7 +333,7 @@ pub async fn attach_experiment(
             .into_response();
     }
 
-    let exp_reader = match ParquetReader::open(&temp_path) {
+    let exp_reader = match ParquetReader::open_with_pool(&temp_path, Arc::clone(&state.pool)) {
         Ok(r) => r.with_filename(filename),
         Err(e) => {
             let _ = std::fs::remove_file(&temp_path);

--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -82,12 +82,7 @@ impl CaptureRegistry {
     /// storage needed since the reader/store carries the name.
     pub fn filename(&self, id: CaptureId) -> String {
         match id {
-            CaptureId::Baseline => self
-                .baseline
-                .data
-                .read()
-                .filename()
-                .unwrap_or_default(),
+            CaptureId::Baseline => self.baseline.data.read().filename().unwrap_or_default(),
             CaptureId::Experiment => self
                 .experiment
                 .read()

--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -33,9 +33,9 @@ impl CaptureId {
 
 pub struct CaptureSlot {
     /// The data source behind a RwLock so it can be replaced on upload.
-    pub data: RwLock<Arc<dyn MetricsSource + Send + Sync>>,
-    /// Filename is tracked separately since it's no longer on the reader.
-    pub filename: RwLock<String>,
+    /// The display filename is stored on the data source itself via
+    /// `MetricsSource::filename()` — no separate field needed.
+    pub data: RwLock<Arc<dyn MetricsSource>>,
     pub systeminfo: RwLock<Option<String>>,
     pub file_metadata: RwLock<Option<String>>,
     /// Optional display alias for this capture (e.g. "redis", "valkey").
@@ -50,8 +50,7 @@ pub struct CaptureRegistry {
 
 impl CaptureRegistry {
     pub fn new(
-        baseline_data: Arc<dyn MetricsSource + Send + Sync>,
-        baseline_filename: String,
+        baseline_data: Arc<dyn MetricsSource>,
         baseline_systeminfo: Option<String>,
         baseline_file_metadata: Option<String>,
         baseline_alias: Option<String>,
@@ -59,7 +58,6 @@ impl CaptureRegistry {
         Self {
             baseline: CaptureSlot {
                 data: RwLock::new(baseline_data),
-                filename: RwLock::new(baseline_filename),
                 systeminfo: RwLock::new(baseline_systeminfo),
                 file_metadata: RwLock::new(baseline_file_metadata),
                 alias: RwLock::new(baseline_alias),
@@ -68,7 +66,7 @@ impl CaptureRegistry {
         }
     }
 
-    pub fn get(&self, id: CaptureId) -> Option<Arc<dyn MetricsSource + Send + Sync>> {
+    pub fn get(&self, id: CaptureId) -> Option<Arc<dyn MetricsSource>> {
         match id {
             CaptureId::Baseline => Some(self.baseline.data.read().clone()),
             CaptureId::Experiment => self
@@ -79,20 +77,24 @@ impl CaptureRegistry {
         }
     }
 
+    /// Returns the display filename for the given capture.
+    /// Reads it from the data source's `filename()` method — no separate
+    /// storage needed since the reader/store carries the name.
     pub fn filename(&self, id: CaptureId) -> String {
         match id {
-            CaptureId::Baseline => self.baseline.filename.read().clone(),
+            CaptureId::Baseline => self
+                .baseline
+                .data
+                .read()
+                .filename()
+                .unwrap_or_default(),
             CaptureId::Experiment => self
                 .experiment
                 .read()
                 .as_ref()
-                .map(|slot| slot.filename.read().clone())
+                .and_then(|slot| slot.data.read().filename())
                 .unwrap_or_default(),
         }
-    }
-
-    pub fn set_baseline_filename(&self, filename: String) {
-        *self.baseline.filename.write() = filename;
     }
 
     pub fn systeminfo(&self, id: CaptureId) -> Option<String> {
@@ -146,27 +148,21 @@ impl CaptureRegistry {
         *self.baseline.file_metadata.write() = file_metadata;
     }
 
-    /// Replace the baseline data store and filename.
-    pub fn set_baseline_data(
-        &self,
-        data: Arc<dyn MetricsSource + Send + Sync>,
-        filename: String,
-    ) {
+    /// Replace the baseline data store. The display filename is carried on
+    /// the data source itself via `MetricsSource::filename()`.
+    pub fn set_baseline_data(&self, data: Arc<dyn MetricsSource>) {
         *self.baseline.data.write() = data;
-        *self.baseline.filename.write() = filename;
     }
 
     pub fn attach_experiment(
         &self,
-        data: Arc<dyn MetricsSource + Send + Sync>,
-        filename: String,
+        data: Arc<dyn MetricsSource>,
         systeminfo: Option<String>,
         file_metadata: Option<String>,
         alias: Option<String>,
     ) {
         *self.experiment.write() = Some(CaptureSlot {
             data: RwLock::new(data),
-            filename: RwLock::new(filename),
             systeminfo: RwLock::new(systeminfo),
             file_metadata: RwLock::new(file_metadata),
             alias: RwLock::new(alias),

--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -1,10 +1,10 @@
-//! Holds the two TSDB stores (baseline + optional experiment) plus their
+//! Holds the two capture stores (baseline + optional experiment) plus their
 //! per-capture metadata. All cross-capture composition lives outside this
 //! module; the registry is intentionally dumb about comparison.
 
 use std::sync::Arc;
 
-use metriken_query::Tsdb;
+use metriken_query::MetricsSource;
 use parking_lot::RwLock;
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, serde::Deserialize)]
@@ -32,7 +32,10 @@ impl CaptureId {
 }
 
 pub struct CaptureSlot {
-    pub tsdb: Arc<RwLock<Tsdb>>,
+    /// The data source behind a RwLock so it can be replaced on upload.
+    pub data: RwLock<Arc<dyn MetricsSource + Send + Sync>>,
+    /// Filename is tracked separately since it's no longer on the reader.
+    pub filename: RwLock<String>,
     pub systeminfo: RwLock<Option<String>>,
     pub file_metadata: RwLock<Option<String>>,
     /// Optional display alias for this capture (e.g. "redis", "valkey").
@@ -47,14 +50,16 @@ pub struct CaptureRegistry {
 
 impl CaptureRegistry {
     pub fn new(
-        baseline_tsdb: Tsdb,
+        baseline_data: Arc<dyn MetricsSource + Send + Sync>,
+        baseline_filename: String,
         baseline_systeminfo: Option<String>,
         baseline_file_metadata: Option<String>,
         baseline_alias: Option<String>,
     ) -> Self {
         Self {
             baseline: CaptureSlot {
-                tsdb: Arc::new(RwLock::new(baseline_tsdb)),
+                data: RwLock::new(baseline_data),
+                filename: RwLock::new(baseline_filename),
                 systeminfo: RwLock::new(baseline_systeminfo),
                 file_metadata: RwLock::new(baseline_file_metadata),
                 alias: RwLock::new(baseline_alias),
@@ -63,15 +68,31 @@ impl CaptureRegistry {
         }
     }
 
-    pub fn get(&self, id: CaptureId) -> Option<Arc<RwLock<Tsdb>>> {
+    pub fn get(&self, id: CaptureId) -> Option<Arc<dyn MetricsSource + Send + Sync>> {
         match id {
-            CaptureId::Baseline => Some(self.baseline.tsdb.clone()),
+            CaptureId::Baseline => Some(self.baseline.data.read().clone()),
             CaptureId::Experiment => self
                 .experiment
                 .read()
                 .as_ref()
-                .map(|slot| slot.tsdb.clone()),
+                .map(|slot| slot.data.read().clone()),
         }
+    }
+
+    pub fn filename(&self, id: CaptureId) -> String {
+        match id {
+            CaptureId::Baseline => self.baseline.filename.read().clone(),
+            CaptureId::Experiment => self
+                .experiment
+                .read()
+                .as_ref()
+                .map(|slot| slot.filename.read().clone())
+                .unwrap_or_default(),
+        }
+    }
+
+    pub fn set_baseline_filename(&self, filename: String) {
+        *self.baseline.filename.write() = filename;
     }
 
     pub fn systeminfo(&self, id: CaptureId) -> Option<String> {
@@ -110,15 +131,12 @@ impl CaptureRegistry {
         }
     }
 
-    /// Overwrite the baseline slot's alias. Useful when the agent mode
-    /// swaps in a newly-recorded baseline without tearing the registry
-    /// down.
+    /// Overwrite the baseline slot's alias.
     pub fn set_baseline_alias(&self, alias: Option<String>) {
         *self.baseline.alias.write() = alias;
     }
 
-    /// Overwrite the baseline slot's systeminfo. The baseline TSDB Arc is
-    /// unaffected so callers holding it keep working across updates.
+    /// Overwrite the baseline slot's systeminfo.
     pub fn set_baseline_systeminfo(&self, systeminfo: Option<String>) {
         *self.baseline.systeminfo.write() = systeminfo;
     }
@@ -128,15 +146,27 @@ impl CaptureRegistry {
         *self.baseline.file_metadata.write() = file_metadata;
     }
 
+    /// Replace the baseline data store and filename.
+    pub fn set_baseline_data(
+        &self,
+        data: Arc<dyn MetricsSource + Send + Sync>,
+        filename: String,
+    ) {
+        *self.baseline.data.write() = data;
+        *self.baseline.filename.write() = filename;
+    }
+
     pub fn attach_experiment(
         &self,
-        tsdb: Tsdb,
+        data: Arc<dyn MetricsSource + Send + Sync>,
+        filename: String,
         systeminfo: Option<String>,
         file_metadata: Option<String>,
         alias: Option<String>,
     ) {
         *self.experiment.write() = Some(CaptureSlot {
-            tsdb: Arc::new(RwLock::new(tsdb)),
+            data: RwLock::new(data),
+            filename: RwLock::new(filename),
             systeminfo: RwLock::new(systeminfo),
             file_metadata: RwLock::new(file_metadata),
             alias: RwLock::new(alias),
@@ -170,13 +200,7 @@ mod tests {
 
     #[test]
     fn registry_experiment_attached_toggles() {
-        // Building a real Tsdb requires a parquet on disk (Tsdb::load(path)).
-        // Exercise only the boolean state transitions that do not need a
-        // backing store. Full attach/get is covered by manual verification
-        // in Task 29.
-        //
-        // Compile-only smoke: the types exist and the method signatures
-        // are reachable.
+        // Compile-only smoke: the types exist and the method signatures are reachable.
         #[allow(dead_code)]
         fn _compile_only(reg: &CaptureRegistry) -> bool {
             reg.experiment_attached()

--- a/src/viewer/metadata.rs
+++ b/src/viewer/metadata.rs
@@ -12,9 +12,9 @@ use parquet::file::serialized_reader::SerializedFileReader;
 use tracing::warn;
 
 use super::capture_registry::CaptureId;
-use super::promql::{self, QueryEngine};
+use metriken_query::{MetricsSource, QueryResult};
+
 use super::state::{AppState, LazySectionStore};
-use super::tsdb::Tsdb;
 use ::dashboard::{self, CategoryExtension, ServiceExtension, TemplateRegistry};
 
 /// Read systeminfo, selection, and the full key-value map (with
@@ -321,19 +321,18 @@ pub fn extract_service_extension_metadata(
 
 /// Run each KPI's PromQL against the loaded TSDB so the dashboard can
 /// hide KPIs whose queries return no data (e.g. zero-traffic histograms).
-pub fn validate_service_extensions(tsdb: &Tsdb, exts: &mut [(String, ServiceExtension)]) {
-    let engine = QueryEngine::new(tsdb);
-    let (start, end) = engine.get_time_range();
+pub fn validate_service_extensions(data: &dyn MetricsSource, exts: &mut [(String, ServiceExtension)]) {
+    let (start, end) = data.time_range().unwrap_or((0.0, 0.0));
 
     for (_source, ext) in exts.iter_mut() {
         for kpi in &mut ext.kpis {
             let query = kpi.effective_query();
-            let has_data = match engine.query_range(&query, start, end, 1.0) {
+            let has_data = match data.query_range(&query, start, end, 1.0) {
                 Ok(result) => match &result {
-                    promql::QueryResult::Vector { result } => !result.is_empty(),
-                    promql::QueryResult::Matrix { result } => !result.is_empty(),
-                    promql::QueryResult::Scalar { .. } => true,
-                    promql::QueryResult::HistogramHeatmap { result } => !result.data.is_empty(),
+                    QueryResult::Vector { result } => !result.is_empty(),
+                    QueryResult::Matrix { result } => !result.is_empty(),
+                    QueryResult::Scalar { .. } => true,
+                    QueryResult::HistogramHeatmap { result } => !result.data.is_empty(),
                 },
                 Err(_) => false,
             };
@@ -410,14 +409,12 @@ pub fn regenerate_dashboards(state: &AppState) {
         .unwrap_or_default();
 
     {
-        let baseline_handle = state.baseline_tsdb();
-        let baseline_data = baseline_handle.read();
-        validate_service_extensions(&baseline_data, &mut baseline_exts);
+        let baseline_data = state.baseline_data();
+        validate_service_extensions(baseline_data.as_ref(), &mut baseline_exts);
     }
     if !experiment_exts.is_empty() {
-        if let Some(experiment_handle) = state.captures.get(CaptureId::Experiment) {
-            let experiment_data = experiment_handle.read();
-            validate_service_extensions(&experiment_data, &mut experiment_exts);
+        if let Some(experiment_data) = state.captures.get(CaptureId::Experiment) {
+            validate_service_extensions(experiment_data.as_ref(), &mut experiment_exts);
         }
     }
 
@@ -439,11 +436,13 @@ pub fn regenerate_dashboards(state: &AppState) {
 mod report_mode_tests {
     use super::*;
     use ::dashboard::TemplateRegistry;
-    use metriken_query::Tsdb;
+    use metriken_query::MemoryStore;
+    use std::sync::Arc;
 
     #[test]
     fn regenerate_returns_empty_sections_for_trimmed_report() {
-        let state = AppState::new(Tsdb::default(), TemplateRegistry::empty());
+        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn metriken_query::MetricsSource + Send + Sync>;
+        let state = AppState::new(store, String::new(), TemplateRegistry::empty());
         *state.trimmed_report_marker.write() = Some("trimmed".to_string());
         regenerate_dashboards(&state);
         let sections = state.sections.read();

--- a/src/viewer/metadata.rs
+++ b/src/viewer/metadata.rs
@@ -441,8 +441,8 @@ mod report_mode_tests {
 
     #[test]
     fn regenerate_returns_empty_sections_for_trimmed_report() {
-        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn metriken_query::MetricsSource + Send + Sync>;
-        let state = AppState::new(store, String::new(), TemplateRegistry::empty());
+        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn metriken_query::MetricsSource>;
+        let state = AppState::new(store, TemplateRegistry::empty());
         *state.trimmed_report_marker.write() = Some("trimmed".to_string());
         regenerate_dashboards(&state);
         let sections = state.sections.read();

--- a/src/viewer/metadata.rs
+++ b/src/viewer/metadata.rs
@@ -321,7 +321,10 @@ pub fn extract_service_extension_metadata(
 
 /// Run each KPI's PromQL against the loaded TSDB so the dashboard can
 /// hide KPIs whose queries return no data (e.g. zero-traffic histograms).
-pub fn validate_service_extensions(data: &dyn MetricsSource, exts: &mut [(String, ServiceExtension)]) {
+pub fn validate_service_extensions(
+    data: &dyn MetricsSource,
+    exts: &mut [(String, ServiceExtension)],
+) {
     let (start, end) = data.time_range().unwrap_or((0.0, 0.0));
 
     for (_source, ext) in exts.iter_mut() {
@@ -441,7 +444,8 @@ mod report_mode_tests {
 
     #[test]
     fn regenerate_returns_empty_sections_for_trimmed_report() {
-        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn metriken_query::MetricsSource>;
+        let store =
+            Arc::new(MemoryStore::builder().build()) as Arc<dyn metriken_query::MetricsSource>;
         let state = AppState::new(store, TemplateRegistry::empty());
         *state.trimmed_report_marker.write() = Some("trimmed".to_string());
         regenerate_dashboards(&state);

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -29,10 +29,13 @@ use notify::Watcher;
 pub use dashboard::Kpi;
 pub use dashboard::{Event, Events, ServiceExtension, TemplateRegistry};
 
-pub use metriken_query::promql;
-pub use metriken_query::tsdb;
-
-use tsdb::*;
+/// Re-export PromQL types so other modules can use `crate::viewer::promql::*`.
+pub mod promql {
+    pub use metriken_query::{HistogramHeatmapResult, MatrixSample, QueryError, QueryResult, Sample};
+    /// Adapter: callers that previously constructed `QueryEngine::new(data).query_range(...)`
+    /// can now call these functions directly on any `MetricsSource`.
+    pub use metriken_query::MetricsSource as QueryEngine;
+}
 
 pub mod capture_registry;
 mod proxy_allow;
@@ -277,7 +280,9 @@ pub fn run(config: Config) {
         Source::Live(url) => init_live_mode(&rt, url, &registry),
         Source::Empty => {
             info!("No input file — starting in upload-only mode");
-            AppState::new(Tsdb::default(), registry.clone())
+            let empty_store: std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync> =
+                std::sync::Arc::new(metriken_query::MemoryStore::builder().build());
+            AppState::new(empty_store, String::new(), registry.clone())
         }
     };
 
@@ -347,13 +352,20 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
     let (systeminfo, selection, file_meta) = metadata::extract_parquet_metadata(path);
     let multinode_sysinfo = metadata::build_multinode_systeminfo(path);
 
-    let data = Tsdb::load(path).unwrap_or_else(|e| {
-        eprintln!("failed to load data from parquet: {e}");
-        std::process::exit(1);
-    });
+    let reader = std::sync::Arc::new(
+        metriken_query::ParquetReader::open(path).unwrap_or_else(|e| {
+            eprintln!("failed to load data from parquet: {e}");
+            std::process::exit(1);
+        })
+    );
+    let filename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("capture.parquet")
+        .to_string();
 
     let mut service_exts = metadata::extract_service_extension_metadata(path, registry);
-    metadata::validate_service_extensions(&data, &mut service_exts);
+    metadata::validate_service_extensions(reader.as_ref(), &mut service_exts);
 
     info!("Computing file checksum...");
     let file_checksum = metadata::compute_file_checksum(path);
@@ -363,7 +375,7 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
     }
     log_service_exts(&service_exts, "baseline");
 
-    let state = AppState::new(data, registry.clone());
+    let state = AppState::new(reader as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>, filename, registry.clone());
     *state.parquet_path.write() = Some(path.to_path_buf());
     state
         .captures
@@ -419,33 +431,32 @@ fn init_file_mode_combined_ab(
         metadata::extract_parquet_metadata(&extracted.experiment_path);
     let experiment_multinode = metadata::build_multinode_systeminfo(&extracted.experiment_path);
 
-    let mut baseline_tsdb = Tsdb::load(&extracted.baseline_path).unwrap_or_else(|e| {
-        eprintln!("failed to load baseline parquet from tarball: {e}");
-        std::process::exit(1);
-    });
-    let mut experiment_tsdb = Tsdb::load(&extracted.experiment_path).unwrap_or_else(|e| {
-        eprintln!("failed to load experiment parquet from tarball: {e}");
-        std::process::exit(1);
-    });
-    // Tsdb's filename defaults to the on-disk path of the extracted parquet
-    // (a tempdir path that disappears on shutdown). Replace it with the
-    // tarball's filename so user-facing displays show the artifact the
-    // user actually pointed at.
     let display_filename = path
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("combined-ab.parquet.ab.tar")
         .to_string();
-    baseline_tsdb.set_filename(display_filename.clone());
-    experiment_tsdb.set_filename(display_filename);
+
+    let baseline_reader = std::sync::Arc::new(
+        metriken_query::ParquetReader::open(&extracted.baseline_path).unwrap_or_else(|e| {
+            eprintln!("failed to load baseline parquet from tarball: {e}");
+            std::process::exit(1);
+        })
+    );
+    let experiment_reader = std::sync::Arc::new(
+        metriken_query::ParquetReader::open(&extracted.experiment_path).unwrap_or_else(|e| {
+            eprintln!("failed to load experiment parquet from tarball: {e}");
+            std::process::exit(1);
+        })
+    );
 
     let mut baseline_service_exts =
         metadata::extract_service_extension_metadata(&extracted.baseline_path, registry);
-    metadata::validate_service_extensions(&baseline_tsdb, &mut baseline_service_exts);
+    metadata::validate_service_extensions(baseline_reader.as_ref(), &mut baseline_service_exts);
     log_service_exts(&baseline_service_exts, "baseline");
     let mut experiment_service_exts =
         metadata::extract_service_extension_metadata(&extracted.experiment_path, registry);
-    metadata::validate_service_extensions(&experiment_tsdb, &mut experiment_service_exts);
+    metadata::validate_service_extensions(experiment_reader.as_ref(), &mut experiment_service_exts);
     log_service_exts(&experiment_service_exts, "experiment");
 
     info!("Computing file checksum...");
@@ -457,7 +468,11 @@ fn init_file_mode_combined_ab(
         .unwrap_or_else(|| ab.baseline.alias.clone());
     let experiment_alias = ab.experiment.alias.clone();
 
-    let state = AppState::new(baseline_tsdb, registry.clone());
+    let state = AppState::new(
+        baseline_reader as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>,
+        display_filename.clone(),
+        registry.clone(),
+    );
     // Point parquet_path at the *extracted* baseline parquet (not the
     // tar itself) so `regenerate_dashboards` and other parquet-aware
     // consumers can read its metadata. Same for the experiment side via
@@ -481,7 +496,8 @@ fn init_file_mode_combined_ab(
     state.captures.set_baseline_alias(Some(baseline_alias));
 
     state.captures.attach_experiment(
-        experiment_tsdb,
+        experiment_reader as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>,
+        display_filename,
         experiment_multinode.or(experiment_systeminfo),
         experiment_file_meta,
         Some(experiment_alias),
@@ -547,8 +563,8 @@ fn validate_category_at_startup(
     });
     let mut experiment_exts =
         metadata::extract_service_extension_metadata(experiment_path, registry);
-    if let Ok(exp_data) = Tsdb::load(experiment_path) {
-        metadata::validate_service_extensions(&exp_data, &mut experiment_exts);
+    if let Ok(exp_reader) = metriken_query::ParquetReader::open(experiment_path) {
+        metadata::validate_service_extensions(&exp_reader, &mut experiment_exts);
     }
     let experiment_sources: Vec<String> = experiment_exts.iter().map(|(s, _)| s.clone()).collect();
     for source in baseline_sources.iter().chain(experiment_sources.iter()) {
@@ -578,8 +594,8 @@ fn attach_cli_experiment(
 ) {
     info!("Loading experiment from parquet file...");
     let (exp_sysinfo, _exp_selection, exp_file_meta) = metadata::extract_parquet_metadata(exp_path);
-    let mut exp_tsdb = match Tsdb::load(exp_path) {
-        Ok(t) => t,
+    let exp_reader = match metriken_query::ParquetReader::open(exp_path) {
+        Ok(r) => std::sync::Arc::new(r),
         Err(e) => {
             warn!(
                 "failed to load experiment '{}': {e}. Starting in single-capture mode.",
@@ -588,22 +604,24 @@ fn attach_cli_experiment(
             return;
         }
     };
-    let base = exp_path
+    let exp_filename = exp_path
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("experiment.parquet")
         .to_string();
-    exp_tsdb.set_filename(base);
-    state
-        .captures
-        .attach_experiment(exp_tsdb, exp_sysinfo, exp_file_meta, alias);
+    state.captures.attach_experiment(
+        exp_reader.clone() as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>,
+        exp_filename,
+        exp_sysinfo,
+        exp_file_meta,
+        alias,
+    );
     *state.cli_experiment_path.write() = Some(exp_path.to_path_buf());
     info!("Attached experiment capture: {}", exp_path.display());
 
     let mut exp_exts = metadata::extract_service_extension_metadata(exp_path, registry);
-    if let Some(handle) = state.captures.get(CaptureId::Experiment) {
-        let exp_data = handle.read();
-        metadata::validate_service_extensions(&exp_data, &mut exp_exts);
+    if let Some(exp_data) = state.captures.get(CaptureId::Experiment) {
+        metadata::validate_service_extensions(exp_data.as_ref(), &mut exp_exts);
     }
     if exp_exts.is_empty() {
         warn!("no service extension matched the experiment parquet's source metadata");
@@ -649,25 +667,26 @@ fn init_live_mode(
         version = info.version
     );
 
-    let mut tsdb = Tsdb::default();
-    tsdb.set_sampling_interval_ms(1000);
-    tsdb.set_source(info.source.clone());
-    tsdb.set_version(info.version.clone());
-    tsdb.set_filename(url.to_string());
-    let state = AppState::new(tsdb, registry.clone());
+    let store = metriken_query::MemoryStore::builder()
+        .source(info.source.clone())
+        .version(info.version.clone())
+        .sampling_interval_ms(1000)
+        .build();
+    let store_arc: std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync> =
+        std::sync::Arc::new(store.clone());
+    let state = AppState::new(store_arc, url.to_string(), registry.clone());
     let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
     *state.sections.write() = state::LazySectionStore::new(context);
     state.live.store(true, Ordering::Relaxed);
     state.captures.set_baseline_systeminfo(info.sysinfo);
 
-    let ingest_tsdb = state.baseline_tsdb();
     let ingest_snapshots = state.snapshots.clone();
     let mut ingest_url = url.clone();
     ingest_url.set_path("/metrics/binary");
 
     rt.spawn(actions::ingest_loop(
         ingest_url,
-        ingest_tsdb,
+        store,
         ingest_snapshots,
         info.source,
         info.version,

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -31,10 +31,7 @@ pub use dashboard::Kpi;
 pub use dashboard::{Event, Events, ServiceExtension, TemplateRegistry};
 
 /// Re-export PromQL types so other modules can use `crate::viewer::promql::*`.
-pub mod promql {
-    
-    
-}
+pub mod promql {}
 
 pub mod capture_registry;
 mod proxy_allow;
@@ -374,7 +371,12 @@ pub(super) fn read_footer_kv(path: &Path, key: &str) -> Option<String> {
 
 /// Build initial AppState for a parquet file source, including the
 /// optional experiment attach and category validation.
-fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry, pool: Arc<metriken_query::BufferPool>) -> AppState {
+fn init_file_mode(
+    config: &Config,
+    path: &Path,
+    registry: &TemplateRegistry,
+    pool: Arc<metriken_query::BufferPool>,
+) -> AppState {
     info!("Loading data from parquet file...");
 
     // Combined-A/B tarball detection runs first — bare parquets fall
@@ -388,10 +390,12 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry, poo
 
     // ParquetReader::open defaults filename() to the path's basename.
     let reader = std::sync::Arc::new(
-        metriken_query::ParquetReader::open_with_pool(path, Arc::clone(&pool)).unwrap_or_else(|e| {
-            eprintln!("failed to load data from parquet: {e}");
-            std::process::exit(1);
-        })
+        metriken_query::ParquetReader::open_with_pool(path, Arc::clone(&pool)).unwrap_or_else(
+            |e| {
+                eprintln!("failed to load data from parquet: {e}");
+                std::process::exit(1);
+            },
+        ),
     );
 
     let mut service_exts = metadata::extract_service_extension_metadata(path, registry);
@@ -405,7 +409,11 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry, poo
     }
     log_service_exts(&service_exts, "baseline");
 
-    let state = AppState::with_pool(reader as std::sync::Arc<dyn metriken_query::MetricsSource>, registry.clone(), Arc::clone(&pool));
+    let state = AppState::with_pool(
+        reader as std::sync::Arc<dyn metriken_query::MetricsSource>,
+        registry.clone(),
+        Arc::clone(&pool),
+    );
     *state.parquet_path.write() = Some(path.to_path_buf());
     state
         .captures
@@ -420,11 +428,24 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry, poo
         .set_baseline_alias(config.baseline_alias.clone());
 
     if let Some(ref cat_name) = config.category_name {
-        validate_category_at_startup(&state, registry, cat_name, &service_exts, config, Arc::clone(&pool));
+        validate_category_at_startup(
+            &state,
+            registry,
+            cat_name,
+            &service_exts,
+            config,
+            Arc::clone(&pool),
+        );
     }
 
     if let Some(exp_path) = &config.experiment_path {
-        attach_cli_experiment(&state, exp_path, registry, config.experiment_alias.clone(), Arc::clone(&pool));
+        attach_cli_experiment(
+            &state,
+            exp_path,
+            registry,
+            config.experiment_alias.clone(),
+            Arc::clone(&pool),
+        );
     }
 
     info!("Generating dashboards...");
@@ -476,15 +497,18 @@ fn init_file_mode_combined_ab(
                 eprintln!("failed to load baseline parquet from tarball: {e}");
                 std::process::exit(1);
             })
-            .with_filename(display_filename.clone())
+            .with_filename(display_filename.clone()),
     );
     let experiment_reader = std::sync::Arc::new(
-        metriken_query::ParquetReader::open_with_pool(&extracted.experiment_path, Arc::clone(&pool))
-            .unwrap_or_else(|e| {
-                eprintln!("failed to load experiment parquet from tarball: {e}");
-                std::process::exit(1);
-            })
-            .with_filename(display_filename.clone())
+        metriken_query::ParquetReader::open_with_pool(
+            &extracted.experiment_path,
+            Arc::clone(&pool),
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("failed to load experiment parquet from tarball: {e}");
+            std::process::exit(1);
+        })
+        .with_filename(display_filename.clone()),
     );
 
     let mut baseline_service_exts =
@@ -562,7 +586,14 @@ fn init_file_mode_combined_ab(
         if config.category_name.is_none() {
             info!("Applying category {cat_name:?} from combined-A/B manifest");
         }
-        validate_category_at_startup(&state, registry, cat_name, &baseline_service_exts, config, Arc::clone(&pool));
+        validate_category_at_startup(
+            &state,
+            registry,
+            cat_name,
+            &baseline_service_exts,
+            config,
+            Arc::clone(&pool),
+        );
     }
 
     info!("Generating dashboards...");
@@ -600,7 +631,9 @@ fn validate_category_at_startup(
     });
     let mut experiment_exts =
         metadata::extract_service_extension_metadata(experiment_path, registry);
-    if let Ok(exp_reader) = metriken_query::ParquetReader::open_with_pool(experiment_path, Arc::clone(&pool)) {
+    if let Ok(exp_reader) =
+        metriken_query::ParquetReader::open_with_pool(experiment_path, Arc::clone(&pool))
+    {
         metadata::validate_service_extensions(&exp_reader, &mut experiment_exts);
     }
     let experiment_sources: Vec<String> = experiment_exts.iter().map(|(s, _)| s.clone()).collect();
@@ -633,16 +666,17 @@ fn attach_cli_experiment(
     info!("Loading experiment from parquet file...");
     let (exp_sysinfo, _exp_selection, exp_file_meta) = metadata::extract_parquet_metadata(exp_path);
     // ParquetReader::open_with_pool defaults filename() to the path's basename.
-    let exp_reader = match metriken_query::ParquetReader::open_with_pool(exp_path, Arc::clone(&pool)) {
-        Ok(r) => std::sync::Arc::new(r),
-        Err(e) => {
-            warn!(
-                "failed to load experiment '{}': {e}. Starting in single-capture mode.",
-                exp_path.display(),
-            );
-            return;
-        }
-    };
+    let exp_reader =
+        match metriken_query::ParquetReader::open_with_pool(exp_path, Arc::clone(&pool)) {
+            Ok(r) => std::sync::Arc::new(r),
+            Err(e) => {
+                warn!(
+                    "failed to load experiment '{}': {e}. Starting in single-capture mode.",
+                    exp_path.display(),
+                );
+                return;
+            }
+        };
     state.captures.attach_experiment(
         exp_reader.clone() as std::sync::Arc<dyn metriken_query::MetricsSource>,
         exp_sysinfo,

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -32,10 +32,8 @@ pub use dashboard::{Event, Events, ServiceExtension, TemplateRegistry};
 
 /// Re-export PromQL types so other modules can use `crate::viewer::promql::*`.
 pub mod promql {
-    pub use metriken_query::{HistogramHeatmapResult, MatrixSample, QueryError, QueryResult, Sample};
-    /// Adapter: callers that previously constructed `QueryEngine::new(data).query_range(...)`
-    /// can now call these functions directly on any `MetricsSource`.
-    pub use metriken_query::MetricsSource as QueryEngine;
+    
+    
 }
 
 pub mod capture_registry;

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -280,9 +280,9 @@ pub fn run(config: Config) {
         Source::Live(url) => init_live_mode(&rt, url, &registry),
         Source::Empty => {
             info!("No input file — starting in upload-only mode");
-            let empty_store: std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync> =
+            let empty_store: std::sync::Arc<dyn metriken_query::MetricsSource> =
                 std::sync::Arc::new(metriken_query::MemoryStore::builder().build());
-            AppState::new(empty_store, String::new(), registry.clone())
+            AppState::new(empty_store, registry.clone())
         }
     };
 
@@ -352,17 +352,13 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
     let (systeminfo, selection, file_meta) = metadata::extract_parquet_metadata(path);
     let multinode_sysinfo = metadata::build_multinode_systeminfo(path);
 
+    // ParquetReader::open defaults filename() to the path's basename.
     let reader = std::sync::Arc::new(
         metriken_query::ParquetReader::open(path).unwrap_or_else(|e| {
             eprintln!("failed to load data from parquet: {e}");
             std::process::exit(1);
         })
     );
-    let filename = path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("capture.parquet")
-        .to_string();
 
     let mut service_exts = metadata::extract_service_extension_metadata(path, registry);
     metadata::validate_service_extensions(reader.as_ref(), &mut service_exts);
@@ -375,7 +371,7 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
     }
     log_service_exts(&service_exts, "baseline");
 
-    let state = AppState::new(reader as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>, filename, registry.clone());
+    let state = AppState::new(reader as std::sync::Arc<dyn metriken_query::MetricsSource>, registry.clone());
     *state.parquet_path.write() = Some(path.to_path_buf());
     state
         .captures
@@ -431,6 +427,8 @@ fn init_file_mode_combined_ab(
         metadata::extract_parquet_metadata(&extracted.experiment_path);
     let experiment_multinode = metadata::build_multinode_systeminfo(&extracted.experiment_path);
 
+    // Both readers use the tar's display name so the frontend shows the
+    // original combined-A/B filename rather than the extracted temp paths.
     let display_filename = path
         .file_name()
         .and_then(|s| s.to_str())
@@ -438,16 +436,20 @@ fn init_file_mode_combined_ab(
         .to_string();
 
     let baseline_reader = std::sync::Arc::new(
-        metriken_query::ParquetReader::open(&extracted.baseline_path).unwrap_or_else(|e| {
-            eprintln!("failed to load baseline parquet from tarball: {e}");
-            std::process::exit(1);
-        })
+        metriken_query::ParquetReader::open(&extracted.baseline_path)
+            .unwrap_or_else(|e| {
+                eprintln!("failed to load baseline parquet from tarball: {e}");
+                std::process::exit(1);
+            })
+            .with_filename(display_filename.clone())
     );
     let experiment_reader = std::sync::Arc::new(
-        metriken_query::ParquetReader::open(&extracted.experiment_path).unwrap_or_else(|e| {
-            eprintln!("failed to load experiment parquet from tarball: {e}");
-            std::process::exit(1);
-        })
+        metriken_query::ParquetReader::open(&extracted.experiment_path)
+            .unwrap_or_else(|e| {
+                eprintln!("failed to load experiment parquet from tarball: {e}");
+                std::process::exit(1);
+            })
+            .with_filename(display_filename.clone())
     );
 
     let mut baseline_service_exts =
@@ -469,8 +471,7 @@ fn init_file_mode_combined_ab(
     let experiment_alias = ab.experiment.alias.clone();
 
     let state = AppState::new(
-        baseline_reader as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>,
-        display_filename.clone(),
+        baseline_reader as std::sync::Arc<dyn metriken_query::MetricsSource>,
         registry.clone(),
     );
     // Point parquet_path at the *extracted* baseline parquet (not the
@@ -496,8 +497,7 @@ fn init_file_mode_combined_ab(
     state.captures.set_baseline_alias(Some(baseline_alias));
 
     state.captures.attach_experiment(
-        experiment_reader as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>,
-        display_filename,
+        experiment_reader as std::sync::Arc<dyn metriken_query::MetricsSource>,
         experiment_multinode.or(experiment_systeminfo),
         experiment_file_meta,
         Some(experiment_alias),
@@ -594,6 +594,7 @@ fn attach_cli_experiment(
 ) {
     info!("Loading experiment from parquet file...");
     let (exp_sysinfo, _exp_selection, exp_file_meta) = metadata::extract_parquet_metadata(exp_path);
+    // ParquetReader::open defaults filename() to the path's basename.
     let exp_reader = match metriken_query::ParquetReader::open(exp_path) {
         Ok(r) => std::sync::Arc::new(r),
         Err(e) => {
@@ -604,14 +605,8 @@ fn attach_cli_experiment(
             return;
         }
     };
-    let exp_filename = exp_path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("experiment.parquet")
-        .to_string();
     state.captures.attach_experiment(
-        exp_reader.clone() as std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync>,
-        exp_filename,
+        exp_reader.clone() as std::sync::Arc<dyn metriken_query::MetricsSource>,
         exp_sysinfo,
         exp_file_meta,
         alias,
@@ -671,10 +666,11 @@ fn init_live_mode(
         .source(info.source.clone())
         .version(info.version.clone())
         .sampling_interval_ms(1000)
+        .filename(url.to_string())
         .build();
-    let store_arc: std::sync::Arc<dyn metriken_query::MetricsSource + Send + Sync> =
+    let store_arc: std::sync::Arc<dyn metriken_query::MetricsSource> =
         std::sync::Arc::new(store.clone());
-    let state = AppState::new(store_arc, url.to_string(), registry.clone());
+    let state = AppState::new(store_arc, registry.clone());
     let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
     *state.sections.write() = state::LazySectionStore::new(context);
     state.live.store(true, Ordering::Relaxed);

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -21,6 +21,7 @@ use tower_livereload::LiveReloadLayer;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::Path;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 #[cfg(feature = "developer-mode")]
 use notify::Watcher;
@@ -168,6 +169,19 @@ pub fn command() -> Command {
                 )
                 .action(clap::ArgAction::SetTrue),
         )
+        .arg(
+            clap::Arg::new("CACHE_SIZE_MB")
+                .long("cache-size-mb")
+                .value_name("MB")
+                .help(
+                    "Row-group buffer cache size in megabytes. Larger values \
+                     speed up repeated queries against the same data (typical \
+                     dashboard workload); smaller values reduce peak RSS. \
+                     Overrides REZOLUS_CACHE_MB. Default: 500.",
+                )
+                .value_parser(value_parser!(usize))
+                .action(clap::ArgAction::Set),
+        )
 }
 
 pub struct Config {
@@ -180,6 +194,8 @@ pub struct Config {
     listen: SocketAddr,
     templates_dir: Option<PathBuf>,
     proxy_allow: proxy_allow::Allowlist,
+    /// Buffer pool budget in bytes. Defaults to `DEFAULT_CACHE_SIZE_BYTES`.
+    cache_size_bytes: usize,
 }
 
 /// Split a positional input into an optional alias and the remaining
@@ -244,6 +260,18 @@ impl TryFrom<ArgMatches> for Config {
             )
         };
 
+        // Resolve cache size: CLI flag > env var > compile-time default.
+        let cache_size_bytes = args
+            .get_one::<usize>("CACHE_SIZE_MB")
+            .copied()
+            .or_else(|| {
+                std::env::var("REZOLUS_CACHE_MB")
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+            })
+            .map(|mb| mb * 1024 * 1024)
+            .unwrap_or(state::DEFAULT_CACHE_SIZE_BYTES);
+
         Ok(Config {
             source,
             experiment_path,
@@ -256,6 +284,7 @@ impl TryFrom<ArgMatches> for Config {
                 .unwrap_or(&"127.0.0.1:0".to_socket_addrs().unwrap().next().unwrap()),
             templates_dir: args.get_one::<PathBuf>("templates").cloned(),
             proxy_allow,
+            cache_size_bytes,
         })
     }
 }
@@ -275,14 +304,21 @@ pub fn run(config: Config) {
 
     let registry = load_template_registry(config.templates_dir.as_deref());
 
+    // One shared pool for all ParquetReaders in this process.
+    let pool = metriken_query::BufferPool::new(config.cache_size_bytes);
+    info!(
+        "Buffer pool: {} MB",
+        config.cache_size_bytes / (1024 * 1024)
+    );
+
     let mut state = match &config.source {
-        Source::File(path) => init_file_mode(&config, path, &registry),
-        Source::Live(url) => init_live_mode(&rt, url, &registry),
+        Source::File(path) => init_file_mode(&config, path, &registry, Arc::clone(&pool)),
+        Source::Live(url) => init_live_mode(&rt, url, &registry, Arc::clone(&pool)),
         Source::Empty => {
             info!("No input file — starting in upload-only mode");
             let empty_store: std::sync::Arc<dyn metriken_query::MetricsSource> =
                 std::sync::Arc::new(metriken_query::MemoryStore::builder().build());
-            AppState::new(empty_store, registry.clone())
+            AppState::with_pool(empty_store, registry.clone(), Arc::clone(&pool))
         }
     };
 
@@ -340,13 +376,13 @@ pub(super) fn read_footer_kv(path: &Path, key: &str) -> Option<String> {
 
 /// Build initial AppState for a parquet file source, including the
 /// optional experiment attach and category validation.
-fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> AppState {
+fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry, pool: Arc<metriken_query::BufferPool>) -> AppState {
     info!("Loading data from parquet file...");
 
     // Combined-A/B tarball detection runs first — bare parquets fall
     // through to the normal load path below.
     if ab_extract::looks_like_ab_tarball(path) {
-        return init_file_mode_combined_ab(config, path, registry);
+        return init_file_mode_combined_ab(config, path, registry, pool);
     }
 
     let (systeminfo, selection, file_meta) = metadata::extract_parquet_metadata(path);
@@ -354,7 +390,7 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
 
     // ParquetReader::open defaults filename() to the path's basename.
     let reader = std::sync::Arc::new(
-        metriken_query::ParquetReader::open(path).unwrap_or_else(|e| {
+        metriken_query::ParquetReader::open_with_pool(path, Arc::clone(&pool)).unwrap_or_else(|e| {
             eprintln!("failed to load data from parquet: {e}");
             std::process::exit(1);
         })
@@ -371,7 +407,7 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
     }
     log_service_exts(&service_exts, "baseline");
 
-    let state = AppState::new(reader as std::sync::Arc<dyn metriken_query::MetricsSource>, registry.clone());
+    let state = AppState::with_pool(reader as std::sync::Arc<dyn metriken_query::MetricsSource>, registry.clone(), Arc::clone(&pool));
     *state.parquet_path.write() = Some(path.to_path_buf());
     state
         .captures
@@ -386,11 +422,11 @@ fn init_file_mode(config: &Config, path: &Path, registry: &TemplateRegistry) -> 
         .set_baseline_alias(config.baseline_alias.clone());
 
     if let Some(ref cat_name) = config.category_name {
-        validate_category_at_startup(&state, registry, cat_name, &service_exts, config);
+        validate_category_at_startup(&state, registry, cat_name, &service_exts, config, Arc::clone(&pool));
     }
 
     if let Some(exp_path) = &config.experiment_path {
-        attach_cli_experiment(&state, exp_path, registry, config.experiment_alias.clone());
+        attach_cli_experiment(&state, exp_path, registry, config.experiment_alias.clone(), Arc::clone(&pool));
     }
 
     info!("Generating dashboards...");
@@ -407,6 +443,7 @@ fn init_file_mode_combined_ab(
     config: &Config,
     path: &Path,
     registry: &TemplateRegistry,
+    pool: Arc<metriken_query::BufferPool>,
 ) -> AppState {
     info!("Combined-A/B tarball detected — extracting per-side parquets");
 
@@ -436,7 +473,7 @@ fn init_file_mode_combined_ab(
         .to_string();
 
     let baseline_reader = std::sync::Arc::new(
-        metriken_query::ParquetReader::open(&extracted.baseline_path)
+        metriken_query::ParquetReader::open_with_pool(&extracted.baseline_path, Arc::clone(&pool))
             .unwrap_or_else(|e| {
                 eprintln!("failed to load baseline parquet from tarball: {e}");
                 std::process::exit(1);
@@ -444,7 +481,7 @@ fn init_file_mode_combined_ab(
             .with_filename(display_filename.clone())
     );
     let experiment_reader = std::sync::Arc::new(
-        metriken_query::ParquetReader::open(&extracted.experiment_path)
+        metriken_query::ParquetReader::open_with_pool(&extracted.experiment_path, Arc::clone(&pool))
             .unwrap_or_else(|e| {
                 eprintln!("failed to load experiment parquet from tarball: {e}");
                 std::process::exit(1);
@@ -470,9 +507,10 @@ fn init_file_mode_combined_ab(
         .unwrap_or_else(|| ab.baseline.alias.clone());
     let experiment_alias = ab.experiment.alias.clone();
 
-    let state = AppState::new(
+    let state = AppState::with_pool(
         baseline_reader as std::sync::Arc<dyn metriken_query::MetricsSource>,
         registry.clone(),
+        Arc::clone(&pool),
     );
     // Point parquet_path at the *extracted* baseline parquet (not the
     // tar itself) so `regenerate_dashboards` and other parquet-aware
@@ -526,7 +564,7 @@ fn init_file_mode_combined_ab(
         if config.category_name.is_none() {
             info!("Applying category {cat_name:?} from combined-A/B manifest");
         }
-        validate_category_at_startup(&state, registry, cat_name, &baseline_service_exts, config);
+        validate_category_at_startup(&state, registry, cat_name, &baseline_service_exts, config, Arc::clone(&pool));
     }
 
     info!("Generating dashboards...");
@@ -543,6 +581,7 @@ fn validate_category_at_startup(
     cat_name: &str,
     baseline_exts: &[(String, ServiceExtension)],
     config: &Config,
+    pool: Arc<metriken_query::BufferPool>,
 ) {
     let category = registry.get_category(cat_name).unwrap_or_else(|| {
         eprintln!("no category template named {cat_name:?} found in the registry");
@@ -563,7 +602,7 @@ fn validate_category_at_startup(
     });
     let mut experiment_exts =
         metadata::extract_service_extension_metadata(experiment_path, registry);
-    if let Ok(exp_reader) = metriken_query::ParquetReader::open(experiment_path) {
+    if let Ok(exp_reader) = metriken_query::ParquetReader::open_with_pool(experiment_path, Arc::clone(&pool)) {
         metadata::validate_service_extensions(&exp_reader, &mut experiment_exts);
     }
     let experiment_sources: Vec<String> = experiment_exts.iter().map(|(s, _)| s.clone()).collect();
@@ -591,11 +630,12 @@ fn attach_cli_experiment(
     exp_path: &Path,
     registry: &TemplateRegistry,
     alias: Option<String>,
+    pool: Arc<metriken_query::BufferPool>,
 ) {
     info!("Loading experiment from parquet file...");
     let (exp_sysinfo, _exp_selection, exp_file_meta) = metadata::extract_parquet_metadata(exp_path);
-    // ParquetReader::open defaults filename() to the path's basename.
-    let exp_reader = match metriken_query::ParquetReader::open(exp_path) {
+    // ParquetReader::open_with_pool defaults filename() to the path's basename.
+    let exp_reader = match metriken_query::ParquetReader::open_with_pool(exp_path, Arc::clone(&pool)) {
         Ok(r) => std::sync::Arc::new(r),
         Err(e) => {
             warn!(
@@ -641,6 +681,7 @@ fn init_live_mode(
     rt: &tokio::runtime::Runtime,
     url: &Url,
     registry: &TemplateRegistry,
+    pool: Arc<metriken_query::BufferPool>,
 ) -> AppState {
     info!("Connecting to live agent at {url}...");
     let info = rt.block_on(async {
@@ -670,7 +711,7 @@ fn init_live_mode(
         .build();
     let store_arc: std::sync::Arc<dyn metriken_query::MetricsSource> =
         std::sync::Arc::new(store.clone());
-    let state = AppState::new(store_arc, registry.clone());
+    let state = AppState::with_pool(store_arc, registry.clone(), pool);
     let context = dashboard::dashboard::build_dashboard_context(None, &[], None);
     *state.sections.write() = state::LazySectionStore::new(context);
     state.live.store(true, Ordering::Relaxed);

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -1,14 +1,13 @@
 //! Path-shaped adapter over the shared `report-save` crate. The
 //! server's `save_with_selection` handler receives a `PathBuf` (the
-//! loaded parquet on disk) and an in-memory `Tsdb`; this module reads
+//! loaded parquet on disk) and a MetricsSource; this module reads
 //! the path into bytes once and delegates the trim/embed/tarball logic
 //! to the shared crate so the WASM static-site viewer can share it.
 
 use std::path::Path;
-use std::sync::Arc;
 
-use metriken_query::{Bytes, Tsdb};
-use parking_lot::RwLock;
+use bytes::Bytes;
+use metriken_query::MetricsSource;
 
 use crate::parquet_metadata::AbContainers;
 
@@ -19,48 +18,41 @@ fn read_path_to_bytes(path: &Path) -> Result<Bytes, Box<dyn std::error::Error>> 
 }
 
 /// HTTP-friendly wrapper: read the source parquet from disk, then
-/// delegate to the shared crate. The original body is embedded
-/// verbatim under `selection` in the output footer so re-opening the
-/// report restores the saved Notebook state.
+/// delegate to the shared crate.
 pub fn save_single_parquet(
     source_path: &Path,
     payload: &ReportPayload,
     selection_json: &str,
-    tsdb: &Arc<RwLock<Tsdb>>,
+    source: &dyn MetricsSource,
     trim_columns: bool,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let bytes = read_path_to_bytes(source_path)?;
-    let tsdb_read = tsdb.read();
-    report_save::save_single_parquet(bytes, payload, selection_json, &tsdb_read, trim_columns)
+    report_save::save_single_parquet(bytes, payload, selection_json, source, trim_columns)
         .map_err(Into::into)
 }
 
-/// Combined-A/B equivalent: reads both per-side parquets from disk,
-/// serializes the manifest, hands off to the shared crate which emits
-/// a `baseline.parquet + experiment.parquet + ab.json` tar.
+/// Combined-A/B equivalent.
 #[allow(clippy::too_many_arguments)]
 pub fn save_combined_ab_tarball(
     baseline_path: &Path,
     experiment_path: &Path,
     payload: &ReportPayload,
     selection_json: &str,
-    baseline_tsdb: &Arc<RwLock<Tsdb>>,
-    experiment_tsdb: &Arc<RwLock<Tsdb>>,
     manifest: &AbContainers,
     trim_columns: bool,
+    baseline_source: &dyn MetricsSource,
+    experiment_source: &dyn MetricsSource,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let baseline_bytes = read_path_to_bytes(baseline_path)?;
     let experiment_bytes = read_path_to_bytes(experiment_path)?;
     let manifest_bytes = serde_json::to_vec_pretty(manifest)?;
-    let baseline_read = baseline_tsdb.read();
-    let experiment_read = experiment_tsdb.read();
     report_save::save_combined_ab_tarball(
         baseline_bytes,
         experiment_bytes,
         payload,
         selection_json,
-        &baseline_read,
-        &experiment_read,
+        baseline_source,
+        experiment_source,
         &manifest_bytes,
         trim_columns,
     )

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -154,9 +154,8 @@ async fn data(State(state): State<Arc<AppState>>, AxumPath(path): AxumPath<Strin
 
     let value = {
         let data = state.baseline_data();
-        let filename = state.captures.filename(CaptureId::Baseline);
         let mut store = state.sections.write();
-        store.get_or_generate(&route, data.as_ref(), filename).cloned()
+        store.get_or_generate(&route, data.as_ref()).cloned()
     };
 
     let Some(mut value) = value else {

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -28,11 +28,11 @@ use tower_http::services::{ServeDir, ServeFile};
 
 use std::sync::atomic::Ordering;
 
+use metriken_query::{QueryError, QueryResult};
+
 use super::actions;
 use super::capture_registry::{self, CaptureId};
-use super::promql::{self, QueryEngine};
 use super::state::{self, ApiResponse, AppState, CaptureParam};
-use super::tsdb::Tsdb;
 
 #[cfg(not(feature = "developer-mode"))]
 static ASSETS: Dir<'_> = include_dir!("src/viewer/assets");
@@ -153,10 +153,10 @@ async fn data(State(state): State<Arc<AppState>>, AxumPath(path): AxumPath<Strin
     let route = format!("/{stem}");
 
     let value = {
-        let tsdb_handle = state.baseline_tsdb();
-        let tsdb = tsdb_handle.read();
+        let data = state.baseline_data();
+        let filename = state.captures.filename(CaptureId::Baseline);
         let mut store = state.sections.write();
-        store.get_or_generate(&route, &tsdb).cloned()
+        store.get_or_generate(&route, data.as_ref(), filename).cloned()
     };
 
     let Some(mut value) = value else {
@@ -285,26 +285,24 @@ struct RangeQueryParams {
     capture: Option<String>,
 }
 
-/// Run `f` against the resolved capture's `QueryEngine`; on a missing
+/// Run `f` against the resolved capture's data source; on a missing
 /// capture, return a `capture_not_found` ApiResponse.
 fn run_query<F>(
     state: &AppState,
     capture: Option<&str>,
     f: F,
-) -> Json<ApiResponse<promql::QueryResult>>
+) -> Json<ApiResponse<QueryResult>>
 where
-    F: FnOnce(&QueryEngine<&Tsdb>) -> Result<promql::QueryResult, promql::QueryError>,
+    F: FnOnce(&dyn metriken_query::MetricsSource) -> Result<QueryResult, QueryError>,
 {
     let capture = CaptureId::parse_opt(capture);
-    let Some(tsdb_handle) = state.captures.get(capture) else {
+    let Some(data) = state.captures.get(capture) else {
         return ApiResponse::err(
             format!("capture '{capture:?}' not attached"),
             "capture_not_found",
         );
     };
-    let tsdb = tsdb_handle.read();
-    let engine = QueryEngine::new(&*tsdb);
-    match f(&engine) {
+    match f(data.as_ref()) {
         Ok(result) => ApiResponse::ok(result),
         Err(e) => ApiResponse::err(e.to_string(), state::promql_error_type(&e)),
     }
@@ -313,18 +311,18 @@ where
 async fn instant_query(
     Query(params): Query<QueryParams>,
     State(state): State<Arc<AppState>>,
-) -> Json<ApiResponse<promql::QueryResult>> {
-    run_query(&state, params.capture.as_deref(), |engine| {
-        engine.query(&params.query, params.time)
+) -> Json<ApiResponse<QueryResult>> {
+    run_query(&state, params.capture.as_deref(), |data| {
+        data.query(&params.query, params.time)
     })
 }
 
 async fn range_query(
     Query(params): Query<RangeQueryParams>,
     State(state): State<Arc<AppState>>,
-) -> Json<ApiResponse<promql::QueryResult>> {
-    run_query(&state, params.capture.as_deref(), |engine| {
-        engine.query_range(&params.query, params.start, params.end, params.step)
+) -> Json<ApiResponse<QueryResult>> {
+    run_query(&state, params.capture.as_deref(), |data| {
+        data.query_range(&params.query, params.start, params.end, params.step)
     })
 }
 
@@ -366,19 +364,21 @@ async fn metadata(
     Query(p): Query<CaptureParam>,
 ) -> Json<ApiResponse<serde_json::Value>> {
     let capture = p.capture_id();
-    let Some(tsdb_handle) = state.captures.get(capture) else {
+    let Some(data) = state.captures.get(capture) else {
         return ApiResponse::err(
             format!("capture {capture:?} not attached"),
             "capture_not_found",
         );
     };
-    let tsdb = tsdb_handle.read();
-    let engine = QueryEngine::new(&*tsdb);
-    let (min_time, max_time) = engine.get_time_range();
+    // time_range is in seconds; metadata endpoint returns seconds too.
+    let (min_time, max_time) = data
+        .time_range()
+        .unwrap_or((0.0, 0.0));
+    let filename = state.captures.filename(capture);
     let mut meta = serde_json::json!({
         "minTime": min_time,
         "maxTime": max_time,
-        "filename": tsdb.filename(),
+        "filename": filename,
     });
     if let Some(alias) = state.captures.alias(capture) {
         meta["alias"] = serde_json::json!(alias);

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -286,11 +286,7 @@ struct RangeQueryParams {
 
 /// Run `f` against the resolved capture's data source; on a missing
 /// capture, return a `capture_not_found` ApiResponse.
-fn run_query<F>(
-    state: &AppState,
-    capture: Option<&str>,
-    f: F,
-) -> Json<ApiResponse<QueryResult>>
+fn run_query<F>(state: &AppState, capture: Option<&str>, f: F) -> Json<ApiResponse<QueryResult>>
 where
     F: FnOnce(&dyn metriken_query::MetricsSource) -> Result<QueryResult, QueryError>,
 {
@@ -370,9 +366,7 @@ async fn metadata(
         );
     };
     // time_range is in seconds; metadata endpoint returns seconds too.
-    let (min_time, max_time) = data
-        .time_range()
-        .unwrap_or((0.0, 0.0));
+    let (min_time, max_time) = data.time_range().unwrap_or((0.0, 0.0));
     let filename = state.captures.filename(capture);
     let mut meta = serde_json::json!({
         "minTime": min_time,

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -14,11 +14,21 @@ use parking_lot::{Mutex, RwLock};
 use reqwest::Client;
 use tracing::error;
 
-use metriken_query::MetricsSource;
+use metriken_query::{BufferPool, MetricsSource};
 
 use super::capture_registry::{CaptureId, CaptureRegistry};
 use super::proxy_allow;
 use ::dashboard::{self, TemplateRegistry};
+
+/// Default buffer pool budget for the server-side viewer: 500 MB.
+///
+/// All `ParquetReader`s share this budget via an LRU-evicted row-group
+/// cache. First-query latency is unchanged; subsequent queries against
+/// the same row groups (the common dashboard workload) are served from
+/// the in-memory cache.
+///
+/// Tune with `REZOLUS_CACHE_MB` (env) or the `--cache-size-mb` flag.
+pub const DEFAULT_CACHE_SIZE_BYTES: usize = 500 * 1024 * 1024;
 
 /// Caches the navigation list (via the owned `DashboardContext`) and
 /// memoizes per-section JSON bodies. `/api/v1/sections` reads the nav
@@ -118,12 +128,26 @@ pub struct AppState {
     pub proxy: ProxyState,
     pub combined_ab_marker: RwLock<Option<crate::parquet_metadata::AbContainers>>,
     pub trimmed_report_marker: RwLock<Option<String>>,
+    /// Shared LRU row-group cache for all `ParquetReader`s in this process.
+    ///
+    /// Readers opened with `Arc::clone(&state.pool)` share the same budget.
+    /// The default is `DEFAULT_CACHE_SIZE_BYTES`; set `REZOLUS_CACHE_MB` or
+    /// pass `--cache-size-mb` to override.
+    pub pool: Arc<BufferPool>,
 }
 
 impl AppState {
     pub fn new(
         data: Arc<dyn MetricsSource>,
         templates: TemplateRegistry,
+    ) -> Self {
+        Self::with_pool(data, templates, BufferPool::new(DEFAULT_CACHE_SIZE_BYTES))
+    }
+
+    pub fn with_pool(
+        data: Arc<dyn MetricsSource>,
+        templates: TemplateRegistry,
+        pool: Arc<BufferPool>,
     ) -> Self {
         Self {
             sections: Default::default(),
@@ -140,6 +164,7 @@ impl AppState {
             proxy: ProxyState::default(),
             combined_ab_marker: RwLock::new(None),
             trimmed_report_marker: RwLock::new(None),
+            pool,
         }
     }
 

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -62,7 +62,7 @@ impl LazySectionStore {
         if !self.cached_bodies.contains_key(&key) {
             let mut view =
                 dashboard::dashboard::generate_section(data, route, &self.context)?;
-            view.set_filename(data.filename().unwrap_or_default());
+            view.set_filename(data.filename_or_default());
             if let Some(size) = self.context.filesize {
                 view.set_filesize(size);
             }
@@ -195,7 +195,7 @@ impl AppState {
         let interval = data.interval();
         let source = data.source();
         let version = data.version();
-        let filename = data.filename().unwrap_or_default();
+        let filename = data.filename_or_default();
         // time_range is now in seconds; convert to milliseconds for the UI.
         let (start_time, end_time) = data
             .time_range()
@@ -204,19 +204,7 @@ impl AppState {
                 (max * 1000.0) as u64,
             ))
             .unwrap_or((0, 0));
-        let num_series = {
-            let mut count = 0usize;
-            for name in data.counter_names() {
-                count += data.counter_labels(&name).len();
-            }
-            for name in data.gauge_names() {
-                count += data.gauge_labels(&name).len();
-            }
-            for name in data.histogram_names() {
-                count += data.histogram_labels(&name).len();
-            }
-            count
-        };
+        let num_series = data.total_series_count();
 
         build_sections_metadata_payload(
             sections_array,

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -57,13 +57,12 @@ impl LazySectionStore {
         &mut self,
         route: &str,
         data: &dyn MetricsSource,
-        filename: String,
     ) -> Option<&serde_json::Value> {
         let key = format!("{}.json", &route[1..]);
         if !self.cached_bodies.contains_key(&key) {
             let mut view =
                 dashboard::dashboard::generate_section(data, route, &self.context)?;
-            view.set_filename(filename);
+            view.set_filename(data.filename().unwrap_or_default());
             if let Some(size) = self.context.filesize {
                 view.set_filesize(size);
             }
@@ -123,13 +122,12 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(
-        data: Arc<dyn MetricsSource + Send + Sync>,
-        filename: String,
+        data: Arc<dyn MetricsSource>,
         templates: TemplateRegistry,
     ) -> Self {
         Self {
             sections: Default::default(),
-            captures: Arc::new(CaptureRegistry::new(data, filename, None, None, None)),
+            captures: Arc::new(CaptureRegistry::new(data, None, None, None)),
             templates,
             snapshots: Arc::new(Mutex::new(VecDeque::new())),
             live: AtomicBool::new(false),
@@ -162,19 +160,16 @@ impl AppState {
     }
 
     /// Shorthand for the baseline data store (clones the Arc).
-    pub fn baseline_data(&self) -> Arc<dyn MetricsSource + Send + Sync> {
+    pub fn baseline_data(&self) -> Arc<dyn MetricsSource> {
         self.captures
             .get(CaptureId::Baseline)
             .expect("baseline capture is always present")
     }
 
     /// Replace the baseline data store (used by upload/connect handlers).
-    pub fn replace_baseline(
-        &self,
-        data: Arc<dyn MetricsSource + Send + Sync>,
-        filename: String,
-    ) {
-        self.captures.set_baseline_data(data, filename);
+    /// The display filename is carried on the data source itself.
+    pub fn replace_baseline(&self, data: Arc<dyn MetricsSource>) {
+        self.captures.set_baseline_data(data);
     }
 
     pub fn combined_ab(&self) -> bool {
@@ -200,7 +195,7 @@ impl AppState {
         let interval = data.interval();
         let source = data.source();
         let version = data.version();
-        let filename = self.captures.filename(CaptureId::Baseline);
+        let filename = data.filename().unwrap_or_default();
         // time_range is now in seconds; convert to milliseconds for the UI.
         let (start_time, end_time) = data
             .time_range()
@@ -339,15 +334,15 @@ mod report_marker_tests {
 
     #[test]
     fn default_is_not_a_trimmed_report() {
-        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn MetricsSource + Send + Sync>;
-        let state = AppState::new(store, String::new(), TemplateRegistry::empty());
+        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn MetricsSource>;
+        let state = AppState::new(store, TemplateRegistry::empty());
         assert!(!state.is_trimmed_report());
     }
 
     #[test]
     fn setting_marker_flips_predicate() {
-        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn MetricsSource + Send + Sync>;
-        let state = AppState::new(store, String::new(), TemplateRegistry::empty());
+        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn MetricsSource>;
+        let state = AppState::new(store, TemplateRegistry::empty());
         *state.trimmed_report_marker.write() = Some("trimmed".to_string());
         assert!(state.is_trimmed_report());
     }

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -14,9 +14,10 @@ use parking_lot::{Mutex, RwLock};
 use reqwest::Client;
 use tracing::error;
 
+use metriken_query::MetricsSource;
+
 use super::capture_registry::{CaptureId, CaptureRegistry};
 use super::proxy_allow;
-use super::tsdb::Tsdb;
 use ::dashboard::{self, TemplateRegistry};
 
 /// Caches the navigation list (via the owned `DashboardContext`) and
@@ -52,10 +53,17 @@ impl LazySectionStore {
     /// Generate (or return the cached body for) `route` (`/cpu`,
     /// `/service/vllm`, …). Returns `None` when the route is unknown or
     /// the section has no data. Applies `context.filesize` uniformly.
-    pub fn get_or_generate(&mut self, route: &str, data: &Tsdb) -> Option<&serde_json::Value> {
+    pub fn get_or_generate(
+        &mut self,
+        route: &str,
+        data: &dyn MetricsSource,
+        filename: String,
+    ) -> Option<&serde_json::Value> {
         let key = format!("{}.json", &route[1..]);
         if !self.cached_bodies.contains_key(&key) {
-            let mut view = dashboard::dashboard::generate_section(data, route, &self.context)?;
+            let mut view =
+                dashboard::dashboard::generate_section(data, route, &self.context)?;
+            view.set_filename(filename);
             if let Some(size) = self.context.filesize {
                 view.set_filesize(size);
             }
@@ -88,7 +96,7 @@ impl ProxyState {
 
 pub struct AppState {
     pub sections: RwLock<LazySectionStore>,
-    /// Per-capture TSDB + metadata. Single-capture callers always target
+    /// Per-capture data store + metadata. Single-capture callers always target
     /// `CaptureId::Baseline`; the experiment slot is empty unless a
     /// compare-mode hand-off has attached one.
     pub captures: Arc<CaptureRegistry>,
@@ -99,14 +107,8 @@ pub struct AppState {
     /// Original parquet file path (file mode only).
     pub parquet_path: RwLock<Option<PathBuf>>,
     /// Temp parquet path for the HTTP-attached experiment capture.
-    /// Owned by the attach handler — deleted on detach. The CLI startup
-    /// path uses `cli_experiment_path` instead so detach never touches
-    /// the user's own file.
     pub experiment_parquet_path: RwLock<Option<PathBuf>>,
-    /// User-supplied experiment parquet path from the CLI. Read-only —
-    /// never deleted on detach. Kept separate from
-    /// `experiment_parquet_path` so `regenerate_dashboards` can find
-    /// the experiment metadata without risking the user's file.
+    /// User-supplied experiment parquet path from the CLI.
     pub cli_experiment_path: RwLock<Option<PathBuf>>,
     /// Active category template name (when `--category` was supplied).
     pub category_name: RwLock<Option<String>>,
@@ -115,23 +117,19 @@ pub struct AppState {
     /// SHA-256 hex digest of the source parquet file (file mode only).
     pub file_checksum: RwLock<Option<String>>,
     pub proxy: ProxyState,
-    /// Set during init_file_mode when the input was a `*.parquet.ab.tar`
-    /// archive. Carries the manifest extracted from the tarball; the
-    /// presence of `Some` is what `/api/v1/mode` exposes as
-    /// `combined_ab: true` so the frontend can pick UX appropriate for
-    /// a single-artifact compare.
     pub combined_ab_marker: RwLock<Option<crate::parquet_metadata::AbContainers>>,
-    /// Footer `KEY_REPORT` value cached at init. `Some("trimmed")`
-    /// flips the viewer into report mode (empty section list, frontend
-    /// defaults to `/report`).
     pub trimmed_report_marker: RwLock<Option<String>>,
 }
 
 impl AppState {
-    pub fn new(tsdb: Tsdb, templates: TemplateRegistry) -> Self {
+    pub fn new(
+        data: Arc<dyn MetricsSource + Send + Sync>,
+        filename: String,
+        templates: TemplateRegistry,
+    ) -> Self {
         Self {
             sections: Default::default(),
-            captures: Arc::new(CaptureRegistry::new(tsdb, None, None, None)),
+            captures: Arc::new(CaptureRegistry::new(data, filename, None, None, None)),
             templates,
             snapshots: Arc::new(Mutex::new(VecDeque::new())),
             live: AtomicBool::new(false),
@@ -147,9 +145,7 @@ impl AppState {
         }
     }
 
-    /// Enable the URL proxy with the given hostname allowlist. Builds a
-    /// dedicated reqwest client so proxy traffic is isolated from the
-    /// live-mode scrape client. No-op when the allowlist is empty.
+    /// Enable the URL proxy with the given hostname allowlist.
     pub fn set_proxy(&mut self, allow: proxy_allow::Allowlist) {
         if allow.is_empty() {
             return;
@@ -165,33 +161,31 @@ impl AppState {
         }
     }
 
-    /// Shorthand for the baseline TSDB handle. The registry guarantees
-    /// the baseline slot is always present.
-    pub fn baseline_tsdb(&self) -> Arc<RwLock<Tsdb>> {
+    /// Shorthand for the baseline data store (clones the Arc).
+    pub fn baseline_data(&self) -> Arc<dyn MetricsSource + Send + Sync> {
         self.captures
             .get(CaptureId::Baseline)
             .expect("baseline capture is always present")
     }
 
-    /// True when the input artifact was a combined-A/B tarball
-    /// (extracted at startup into two per-side TSDBs). The frontend uses
-    /// this to distinguish a single-file compare from a two-file compare
-    /// in download / save flows.
+    /// Replace the baseline data store (used by upload/connect handlers).
+    pub fn replace_baseline(
+        &self,
+        data: Arc<dyn MetricsSource + Send + Sync>,
+        filename: String,
+    ) {
+        self.captures.set_baseline_data(data, filename);
+    }
+
     pub fn combined_ab(&self) -> bool {
         self.combined_ab_marker.read().is_some()
     }
 
-    /// True when the loaded parquet carries `KEY_REPORT` — see
-    /// [`AppState::trimmed_report_marker`] for what that flips.
     pub fn is_trimmed_report(&self) -> bool {
         self.trimmed_report_marker.read().is_some()
     }
 
     /// Build the navigation + global params payload for `/api/v1/sections`.
-    /// When no context has been loaded yet (live mode pre-refresh,
-    /// upload-only mode pre-upload) returns a minimal payload with empty
-    /// sections and zeroed numerics. The `_capture` argument is advisory:
-    /// the same nav list applies to both baseline and experiment.
     pub fn sections_metadata(&self, _capture: CaptureId) -> serde_json::Value {
         let store = self.sections.read();
         let sections_array: Vec<serde_json::Value> = store
@@ -202,28 +196,29 @@ impl AppState {
         let filesize = store.context().filesize.unwrap_or(0);
         drop(store);
 
-        let tsdb_handle = self.baseline_tsdb();
-        let data = tsdb_handle.read();
+        let data = self.baseline_data();
         let interval = data.interval();
-        let source = data.source().to_string();
-        let version = data.version().to_string();
-        let filename = data.filename().to_string();
-        // Tsdb time_range is in nanoseconds; convert to milliseconds to
-        // match the View's convention.
+        let source = data.source();
+        let version = data.version();
+        let filename = self.captures.filename(CaptureId::Baseline);
+        // time_range is now in seconds; convert to milliseconds for the UI.
         let (start_time, end_time) = data
             .time_range()
-            .map(|(min, max)| (min / 1_000_000, max / 1_000_000))
+            .map(|(min, max)| (
+                (min * 1000.0) as u64,
+                (max * 1000.0) as u64,
+            ))
             .unwrap_or((0, 0));
         let num_series = {
             let mut count = 0usize;
             for name in data.counter_names() {
-                count += data.counter_labels(name).map_or(0, |l| l.len());
+                count += data.counter_labels(&name).len();
             }
             for name in data.gauge_names() {
-                count += data.gauge_labels(name).map_or(0, |l| l.len());
+                count += data.gauge_labels(&name).len();
             }
             for name in data.histogram_names() {
-                count += data.histogram_labels(name).map_or(0, |l| l.len());
+                count += data.histogram_labels(&name).len();
             }
             count
         };
@@ -282,8 +277,7 @@ impl CaptureParam {
     }
 }
 
-/// Standard JSON envelope for API endpoints. Matches Prometheus's
-/// `{ status, data?, error?, errorType? }` shape.
+/// Standard JSON envelope for API endpoints.
 #[derive(serde::Serialize)]
 pub struct ApiResponse<T: serde::Serialize> {
     status: String,
@@ -315,7 +309,6 @@ impl<T: serde::Serialize> ApiResponse<T> {
         }
     }
 
-    /// Convenience: build an error response already wrapped in `Json`.
     pub fn err(
         error: impl Into<String>,
         error_type: impl Into<String>,
@@ -328,8 +321,8 @@ impl<T: serde::Serialize> ApiResponse<T> {
     }
 }
 
-pub fn promql_error_type(e: &super::promql::QueryError) -> &'static str {
-    use super::promql::QueryError::*;
+pub fn promql_error_type(e: &metriken_query::QueryError) -> &'static str {
+    use metriken_query::QueryError::*;
     match e {
         ParseError(_) => "bad_data",
         EvaluationError(_) => "execution",
@@ -342,17 +335,19 @@ pub fn promql_error_type(e: &super::promql::QueryError) -> &'static str {
 mod report_marker_tests {
     use super::*;
     use ::dashboard::TemplateRegistry;
-    use metriken_query::Tsdb;
+    use metriken_query::MemoryStore;
 
     #[test]
     fn default_is_not_a_trimmed_report() {
-        let state = AppState::new(Tsdb::default(), TemplateRegistry::empty());
+        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn MetricsSource + Send + Sync>;
+        let state = AppState::new(store, String::new(), TemplateRegistry::empty());
         assert!(!state.is_trimmed_report());
     }
 
     #[test]
     fn setting_marker_flips_predicate() {
-        let state = AppState::new(Tsdb::default(), TemplateRegistry::empty());
+        let store = Arc::new(MemoryStore::builder().build()) as Arc<dyn MetricsSource + Send + Sync>;
+        let state = AppState::new(store, String::new(), TemplateRegistry::empty());
         *state.trimmed_report_marker.write() = Some("trimmed".to_string());
         assert!(state.is_trimmed_report());
     }

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -70,8 +70,7 @@ impl LazySectionStore {
     ) -> Option<&serde_json::Value> {
         let key = format!("{}.json", &route[1..]);
         if !self.cached_bodies.contains_key(&key) {
-            let mut view =
-                dashboard::dashboard::generate_section(data, route, &self.context)?;
+            let mut view = dashboard::dashboard::generate_section(data, route, &self.context)?;
             view.set_filename(data.filename_or_default());
             if let Some(size) = self.context.filesize {
                 view.set_filesize(size);
@@ -137,10 +136,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(
-        data: Arc<dyn MetricsSource>,
-        templates: TemplateRegistry,
-    ) -> Self {
+    pub fn new(data: Arc<dyn MetricsSource>, templates: TemplateRegistry) -> Self {
         Self::with_pool(data, templates, BufferPool::new(DEFAULT_CACHE_SIZE_BYTES))
     }
 
@@ -224,10 +220,7 @@ impl AppState {
         // time_range is now in seconds; convert to milliseconds for the UI.
         let (start_time, end_time) = data
             .time_range()
-            .map(|(min, max)| (
-                (min * 1000.0) as u64,
-                (max * 1000.0) as u64,
-            ))
+            .map(|(min, max)| ((min * 1000.0) as u64, (max * 1000.0) as u64))
             .unwrap_or((0, 0));
         let num_series = data.total_series_count();
 


### PR DESCRIPTION
## Summary

Migrates rezolus to the streaming, Arrow-native query path published in metriken-query 0.11.0 (iopsystems/metriken#113).

## What changed

- Agent: `Tsdb` → `MemoryStore` for live snapshot ingestion. Same query semantics, lower memory.
- Viewer: `Tsdb` → `ParquetReader` (`open_bytes` path) for browser-side parquet reads. WASM bundle reads row groups on demand instead of materializing the full file.
- Both share a process-wide `BufferPool` (500 MB server, 64 MB WASM) so repeated dashboard queries hit a decoded-block cache instead of re-decoding parquet.
- Picks up convenience methods from the trait (`has_counter`, `total_series_count`, `all_names`, `label_values`, …) that replace several hand-rolled helpers.

## Memory + latency

Numbers in the upstream PR (iopsystems/metriken#113). Headline: a 410 MB capture goes from 22.5 s / 1.4 GB resident to 2.3 ms / 0 B at rest.

## Test plan

- [x] `cargo test --workspace` passes
- [x] Native viewer build verified
- [x] WASM viewer build verified
- [x] Dashboard smoke-tested against real captures

🤖 Generated with [Claude Code](https://claude.com/claude-code)