### PR TITLE
release: v5.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 ## [Unreleased]
 
+## [5.14.0] - 2026-06-03
+
+### Added
+
+- Viewer: Notebook / Selection / Report rework — Markdown notes,
+  preamble, and editable titles; report-mode load with column-trim;
+  SelectionView mirrors live compare mode. (#908 #909 #919 #931)
+- Viewer: event annotations — add from chart tooltips, plus one-off
+  event annotations baked into recordings. (#914 #929)
+- Viewer: `<rezolus-chart>` embed component for charts with exact
+  viewer parity. (#915)
+- Dashboard: histogram rate|mean card pair and additional vLLM
+  metrics. (#918 #938)
+- WASM viewer: Save as Report works offline; restored Load Parquet
+  upload affordance. (#923 #924)
+- Parquet: combined A/B tarball artifact. (#912)
+
+### Changed
+
+- Adopt `metriken-query` 0.11 streaming `ParquetReader`. (#943)
+- Refresh cargo dependencies. (#930)
+- Viewer: refactor JS into domain subdirectories, trim redundant
+  JS/Rust comments, and a Lit chart spike with CSS tokens /
+  `charts.css` extraction. (#913 #932 #933)
+- Trim parquet codecs to zstd-only and drop brotli. (#907)
+- CI: drop release-profile builds from PR CI; generate A/B smoke
+  fixtures on demand instead of checking them in. (#916 #917)
+
+### Fixed
+
+- Viewer: compare-mode bridge KPIs render both arms in section +
+  Notebook. (#910)
+- Viewer: narrow-screen fixes — topnav cleanup, and chart title-row +
+  spectrum controls. (#925 #926)
+- Viewer: add missing vllm-prefill / vllm-decode template symlinks.
+  (#928)
+- CI: locate the viewer tarball regardless of download nesting. (#905)
+
 ## [5.13.0] - 2026-05-10
 
 ### Added
@@ -794,7 +832,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.13.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.14.0...HEAD
+[5.14.0]: https://github.com/iopsystems/rezolus/compare/v5.13.0...v5.14.0
 [5.13.0]: https://github.com/iopsystems/rezolus/compare/v5.12.1...v5.13.0
 [5.12.1]: https://github.com/iopsystems/rezolus/compare/v5.12.0...v5.12.1
 [5.12.0]: https://github.com/iopsystems/rezolus/compare/v5.11.0...v5.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.13.1-alpha.13"
+version = "5.14.0"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.13.1-alpha.13"
+version = "5.14.0"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -193,13 +193,13 @@ fn run_exhaustive_detection(reader: Arc<ParquetReader>) {
     let mut metrics_to_analyze = Vec::new();
 
     for name in reader.counter_names() {
-        if !skip_metrics.iter().any(|n| *n == name.as_str()) {
+        if !skip_metrics.contains(&name.as_str()) {
             metrics_to_analyze.push((name.to_string(), "counter", None));
         }
     }
 
     for name in reader.gauge_names() {
-        if !skip_metrics.iter().any(|n| *n == name.as_str()) {
+        if !skip_metrics.contains(&name.as_str()) {
             metrics_to_analyze.push((name.to_string(), "gauge", None));
         }
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-use metriken_query::{BufferPool, MetricsSource, ParquetReader};
+use metriken_query::{BufferPool, ParquetReader};
 
 /// MCP protocol methods
 #[derive(Debug)]

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -136,6 +136,7 @@ pub struct AppState {
 }
 
 impl AppState {
+    #[cfg(test)]
     pub fn new(data: Arc<dyn MetricsSource>, templates: TemplateRegistry) -> Self {
         Self::with_pool(data, templates, BufferPool::new(DEFAULT_CACHE_SIZE_BYTES))
     }


### PR DESCRIPTION
## Release v5.14.0

This PR prepares the release of v5.14.0.

### Changes
- Version bump in Cargo.toml (`5.13.1-alpha.13` → `5.14.0`)
- CHANGELOG.md: populated `[5.14.0]` from PRs merged since v5.13.0; new empty `[Unreleased]`; comparison links updated
- Pre-release clippy cleanup (separate commit): unused import, `manual_contains`, and a test-only `AppState::new` gated behind `cfg(test)`

### After Merge
The release workflows will automatically:
1. Create git tag `v5.14.0` and bump to the next dev version
2. Build and publish packages (deb, rpm, Homebrew)
3. Create the GitHub release with all artifacts
4. Publish to crates.io

---
See CHANGELOG.md for details.