### PR TITLE
chore: begin next development iteration (5.14.1-alpha.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.0"
+version = "5.14.1-alpha.0"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.0"
+version = "5.14.1-alpha.0"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
Bumps `main` to the next development version `5.14.1-alpha.0`.

This is normally done automatically by `tag-release.yml`, but that job
was **skipped** for v5.14.0: the release PR (#944) was squash-merged, so
the head commit message became the PR title `release: v5.14.0` instead
of `release: prepare v5.14.0`, which no longer matched the workflow's
`startsWith(..., 'release: prepare v')` guard. The `v5.14.0` tag was
pushed manually to trigger `release.yml`; this PR completes the cycle by
applying the dev-version bump.

A follow-up fixes the `/release` skill so future squash-merges keep the
workflow trigger intact.