### PR TITLE
feat(gpu): break out tensor utilization by data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### Added
+
+- GPU (NVIDIA): `gpu_tensor_utilization` now breaks out tensor-pipe
+  activity by data type via a `precision` label — `fp16` (HMMA),
+  `int8` (IMMA), and `fp64` (DFMA) — alongside the existing aggregate
+  (`precision=any`). Collected from NVML GPM, so it requires Hopper+
+  and is reported only where the corresponding pipe is supported.
+
 ## [5.14.0] - 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### Added
 
-- GPU (NVIDIA): `gpu_tensor_utilization` now breaks out tensor-pipe
-  activity by data type via a `precision` label — `fp16` (HMMA),
-  `int8` (IMMA), and `fp64` (DFMA) — alongside the existing aggregate
-  (`precision=any`). Collected from NVML GPM, so it requires Hopper+
-  and is reported only where the corresponding pipe is supported.
+- GPU (NVIDIA): `gpu_tensor_utilization` now breaks out per-tensor-pipe
+  activity via a `pipe` label — `hmma` (FP16/BF16, and FP32 matmul that
+  runs as TF32), `imma` (integer), and `dfma` (FP64) — alongside the
+  existing aggregate (`pipe=any`). Collected from NVML GPM, so it
+  requires Hopper+ and is reported only where the corresponding pipe is
+  supported.
 
 ## [5.14.0] - 2026-06-03
 

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -355,7 +355,7 @@
 <div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_sm_utilization</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
 <div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_sm_occupancy</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
 <div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_dram_bandwidth_utilization</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_tensor_utilization</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
+<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_tensor_utilization</code><span class="text-slate-500">Per-GPU gauge (%) with <code>precision</code>: any, fp16, int8, fp64 &mdash; Hopper+ only</span></div>
 </div>
 </details>
 

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -355,7 +355,7 @@
 <div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_sm_utilization</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
 <div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_sm_occupancy</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
 <div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_dram_bandwidth_utilization</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_tensor_utilization</code><span class="text-slate-500">Per-GPU gauge (%) with <code>precision</code>: any, fp16, int8, fp64 &mdash; Hopper+ only</span></div>
+<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_tensor_utilization</code><span class="text-slate-500">Per-GPU gauge (%) with <code>pipe</code>: any, hmma (FP16/BF16/TF32), imma (integer), dfma (FP64) &mdash; Hopper+ only</span></div>
 </div>
 </details>
 

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -237,15 +237,15 @@ impl NvidiaInner {
                                                 GPU_TENSOR_UTILIZATION.set(id, result.value as i64);
                                         }
                                         GpmMetricId::HmmaTensorUtil => {
-                                            let _ = GPU_TENSOR_UTILIZATION_FP16
+                                            let _ = GPU_TENSOR_UTILIZATION_HMMA
                                                 .set(id, result.value as i64);
                                         }
                                         GpmMetricId::ImmaTensorUtil => {
-                                            let _ = GPU_TENSOR_UTILIZATION_INT8
+                                            let _ = GPU_TENSOR_UTILIZATION_IMMA
                                                 .set(id, result.value as i64);
                                         }
                                         GpmMetricId::DfmaTensorUtil => {
-                                            let _ = GPU_TENSOR_UTILIZATION_FP64
+                                            let _ = GPU_TENSOR_UTILIZATION_DFMA
                                                 .set(id, result.value as i64);
                                         }
                                         _ => {}

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -215,6 +215,9 @@ impl NvidiaInner {
                                     GpmMetricId::SmOccupancy,
                                     GpmMetricId::DramBwUtil,
                                     GpmMetricId::AnyTensorUtil,
+                                    GpmMetricId::HmmaTensorUtil,
+                                    GpmMetricId::ImmaTensorUtil,
+                                    GpmMetricId::DfmaTensorUtil,
                                 ],
                             ) {
                                 for result in results.into_iter().flatten() {
@@ -232,6 +235,18 @@ impl NvidiaInner {
                                         GpmMetricId::AnyTensorUtil => {
                                             let _ =
                                                 GPU_TENSOR_UTILIZATION.set(id, result.value as i64);
+                                        }
+                                        GpmMetricId::HmmaTensorUtil => {
+                                            let _ = GPU_TENSOR_UTILIZATION_FP16
+                                                .set(id, result.value as i64);
+                                        }
+                                        GpmMetricId::ImmaTensorUtil => {
+                                            let _ = GPU_TENSOR_UTILIZATION_INT8
+                                                .set(id, result.value as i64);
+                                        }
+                                        GpmMetricId::DfmaTensorUtil => {
+                                            let _ = GPU_TENSOR_UTILIZATION_FP64
+                                                .set(id, result.value as i64);
                                         }
                                         _ => {}
                                     }

--- a/src/agent/samplers/gpu/linux/nvidia/stats.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/stats.rs
@@ -138,6 +138,27 @@ pub static GPU_DRAM_BW_UTILIZATION: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 #[metric(
     name = "gpu_tensor_utilization",
     description = "The percentage of time the GPU's SMs were doing any tensor operations. (0-100). Requires Hopper+ GPU.",
-    metadata = { unit = "percentage" }
+    metadata = { precision = "any", unit = "percentage" }
 )]
 pub static GPU_TENSOR_UTILIZATION: GaugeGroup = GaugeGroup::new(MAX_GPUS);
+
+#[metric(
+    name = "gpu_tensor_utilization",
+    description = "The percentage of time the GPU's SMs were doing HMMA (FP16/BF16) tensor operations. (0-100). Requires Hopper+ GPU.",
+    metadata = { precision = "fp16", unit = "percentage" }
+)]
+pub static GPU_TENSOR_UTILIZATION_FP16: GaugeGroup = GaugeGroup::new(MAX_GPUS);
+
+#[metric(
+    name = "gpu_tensor_utilization",
+    description = "The percentage of time the GPU's SMs were doing IMMA (integer) tensor operations. (0-100). Requires Hopper+ GPU.",
+    metadata = { precision = "int8", unit = "percentage" }
+)]
+pub static GPU_TENSOR_UTILIZATION_INT8: GaugeGroup = GaugeGroup::new(MAX_GPUS);
+
+#[metric(
+    name = "gpu_tensor_utilization",
+    description = "The percentage of time the GPU's SMs were doing DFMA (FP64) tensor operations. (0-100). Requires Hopper+ GPU.",
+    metadata = { precision = "fp64", unit = "percentage" }
+)]
+pub static GPU_TENSOR_UTILIZATION_FP64: GaugeGroup = GaugeGroup::new(MAX_GPUS);

--- a/src/agent/samplers/gpu/linux/nvidia/stats.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/stats.rs
@@ -138,27 +138,27 @@ pub static GPU_DRAM_BW_UTILIZATION: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 #[metric(
     name = "gpu_tensor_utilization",
     description = "The percentage of time the GPU's SMs were doing any tensor operations. (0-100). Requires Hopper+ GPU.",
-    metadata = { precision = "any", unit = "percentage" }
+    metadata = { pipe = "any", unit = "percentage" }
 )]
 pub static GPU_TENSOR_UTILIZATION: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_tensor_utilization",
-    description = "The percentage of time the GPU's SMs were doing HMMA (FP16/BF16) tensor operations. (0-100). Requires Hopper+ GPU.",
-    metadata = { precision = "fp16", unit = "percentage" }
+    description = "The percentage of time the GPU's SMs were doing HMMA tensor operations (FP16/BF16, and FP32 matmul which runs as TF32). (0-100). Requires Hopper+ GPU.",
+    metadata = { pipe = "hmma", unit = "percentage" }
 )]
-pub static GPU_TENSOR_UTILIZATION_FP16: GaugeGroup = GaugeGroup::new(MAX_GPUS);
+pub static GPU_TENSOR_UTILIZATION_HMMA: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_tensor_utilization",
-    description = "The percentage of time the GPU's SMs were doing IMMA (integer) tensor operations. (0-100). Requires Hopper+ GPU.",
-    metadata = { precision = "int8", unit = "percentage" }
+    description = "The percentage of time the GPU's SMs were doing IMMA tensor operations (integer, e.g. INT8). (0-100). Requires Hopper+ GPU.",
+    metadata = { pipe = "imma", unit = "percentage" }
 )]
-pub static GPU_TENSOR_UTILIZATION_INT8: GaugeGroup = GaugeGroup::new(MAX_GPUS);
+pub static GPU_TENSOR_UTILIZATION_IMMA: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_tensor_utilization",
-    description = "The percentage of time the GPU's SMs were doing DFMA (FP64) tensor operations. (0-100). Requires Hopper+ GPU.",
-    metadata = { precision = "fp64", unit = "percentage" }
+    description = "The percentage of time the GPU's SMs were doing DFMA tensor operations (FP64). (0-100). Requires Hopper+ GPU.",
+    metadata = { pipe = "dfma", unit = "percentage" }
 )]
-pub static GPU_TENSOR_UTILIZATION_FP64: GaugeGroup = GaugeGroup::new(MAX_GPUS);
+pub static GPU_TENSOR_UTILIZATION_DFMA: GaugeGroup = GaugeGroup::new(MAX_GPUS);


### PR DESCRIPTION
## Summary

Previously the NVIDIA GPU sampler reported only a single aggregate tensor metric — `gpu_tensor_utilization`, populated from NVML GPM's `AnyTensorUtil` — so you couldn't tell *which* tensor pipe the cores were running.

This adds a `pipe` label so tensor activity is broken out per GPM tensor pipe, mirroring the existing label-multiplexing pattern used by `gpu_clock` and `gpu_memory`:

| `pipe` | GPM metric | data types |
|---|---|---|
| `any` | `AnyTensorUtil` | aggregate (existing behavior) |
| `hmma` | `HmmaTensorUtil` | FP16 / BF16, and FP32 matmul (runs as TF32) |
| `imma` | `ImmaTensorUtil` | integer (e.g. INT8) |
| `dfma` | `DfmaTensorUtil` | FP64 |

All four share the metric name `gpu_tensor_utilization` and are distinguished by the `pipe` label; the aggregate keeps its existing meaning, now tagged `pipe=any`.

### Why pipe names rather than data types

Each GPM counter is a *pipe*, not a data type — a single HMMA counter covers FP16, BF16, and TF32, so a data-type label like `fp16` would misattribute BF16/TF32 work. There is deliberately **no FP32 tensor pipe**: tensor-core "FP32" matmul executes as TF32 on HMMA (noted in the metric description). The non-tensor CUDA-core `Fp32Util` pipe is a different signal and intentionally out of scope here.

## Details

- `stats.rs` — adds `GPU_TENSOR_UTILIZATION_HMMA/IMMA/DFMA` gauge groups and tags the existing aggregate with `pipe=any`.
- `mod.rs` — requests the three additional GPM metric IDs and routes them in the result match. The existing `into_iter().flatten()` handling means pipes unsupported on a given SKU/driver are simply not reported, consistent with the rest of the sampler.

Like the other GPM metrics, this requires **Hopper+** and is only emitted where GPM and the relevant pipe are supported.

## Notes

- Docs (`site/docs/telemetry.html`) and `CHANGELOG.md` updated.
- The unrelated `Cargo.lock` version bump (alpha.11 → alpha.12) reconciles the lock with `Cargo.toml`, which was already at alpha.12.

## Testing

- `cargo check -p rezolus` — clean.
- `cargo clippy -p rezolus` — no new warnings from this change (pre-existing warnings only).
- Not run against live hardware (no Hopper+ GPU in this environment); the collection path is gated behind GPM support and degrades to "unreported" when pipes are unavailable.