### PR TITLE
docs(release): require 'release: prepare v' PR title for tag workflow

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -83,12 +83,21 @@ Example: `/release minor`
    ```
 
 8. **Push and create PR**:
+
+   IMPORTANT: The PR title must start with `release: prepare v` so the
+   `tag-release.yml` workflow fires after merge. When the PR is
+   squash-merged (the repo default), the squash commit takes the PR
+   title as its message, and the workflow guard checks
+   `startsWith(head_commit.message, 'release: prepare v')`. A title like
+   `release: v${NEW_VERSION}` would NOT match and the tag/release would
+   be silently skipped.
+
    ```bash
    git push -u origin release/v${NEW_VERSION}
 
    gh pr create \
      --repo iopsystems/rezolus \
-     --title "release: v${NEW_VERSION}" \
+     --title "release: prepare v${NEW_VERSION}" \
      --body "$(cat <<'EOF'
    ## Release v${NEW_VERSION}
 


### PR DESCRIPTION
## Summary
- Document in the `release` skill that the release PR title must start with `release: prepare v`.
- Explains the why: squash-merge takes the PR title as the commit message, and `tag-release.yml` guards on `startsWith(head_commit.message, 'release: prepare v')`. A `release: v<version>` title would silently skip the tag/release.

## Test plan
- Doc-only change to a Claude Code skill; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)