### PR TITLE
feat(bpf): raw_tp fallback so samplers work without in-kernel BTF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.1-alpha.0"
+version = "5.14.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.1-alpha.0"
+version = "5.14.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -66,6 +66,15 @@ paying — we would build the agent differently. Architecture-specific
 builds are reproducible against a known-good kernel ABI snapshot rather than
 depending on the build host's headers.
 
+**Two distinct BTF requirements.** CO-RE relocations need BTF, but it may be
+kernel-provided *or* supplied as an external file via the `btf_path` config —
+the kernel need not expose its own. In contrast, BTF-typed program/helper
+attach (`tp_btf`, `fentry`/`fexit`, `bpf_get_current_task_btf`) needs the
+*kernel's own* BTF (`/sys/kernel/btf/vmlinux`) and cannot be satisfied by a
+file. On kernels that lack in-kernel BTF (e.g. NVIDIA Tegra/L4T), Rezolus
+detects this at startup (`kernel_has_btf`) and loads `raw_tp` variants of the
+affected hooks instead, keeping CO-RE via the external BTF.
+
 **How to apply.**
 - New BPF code must use CO-RE (`BPF_CORE_READ`, `bpf_core_read`) for kernel
   field access.
@@ -111,6 +120,13 @@ requires BTF, principle 2), substantially lower per-call overhead, and
 `fexit` exposes entry args + return value in one program — often eliminating
 the side-maps that `kprobe`+`kretprobe` or `kprobe`+exit-tracepoint pairs
 need today.
+
+*BTF caveat.* The ordering above assumes in-kernel BTF. On a CO-RE-only kernel
+(external BTF file, no `/sys/kernel/btf/vmlinux`) it collapses to `raw_tp` >
+`tracepoint` > `kprobe`; `tp_btf` and `fentry`/`fexit` are unavailable. Hooks
+that prefer `tp_btf` should ship a `raw_tp` twin sharing one `__always_inline`
+body, selected at runtime via `kernel_has_btf` and
+`BpfBuilder::disabled_programs` (see `cpu/migrations`, `scheduler/runqueue`).
 
 **How to apply.**
 - New samplers default to the highest-preference attach the target supports.

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -234,6 +234,11 @@ pub struct Builder<T: 'static + SkelBuilder<'static>> {
     /// enabled (default behavior). If Some, only the listed programs will have
     /// autoload enabled; all others will be disabled before loading.
     enabled_programs: Option<HashSet<&'static str>>,
+    /// Optional list of program names to disable. Any program named here has
+    /// autoload disabled before load, regardless of `enabled_programs`. Used to
+    /// drop the unused variant when a sampler ships both a `tp_btf` and a
+    /// `raw_tp` version of a hook.
+    disabled_programs: Option<HashSet<&'static str>>,
 }
 
 impl<T: 'static> Builder<T>
@@ -261,6 +266,7 @@ where
             ringbuf_handler: Vec::new(),
             btf_path: config.general().btf_path().map(|s| s.to_string()),
             enabled_programs: None,
+            disabled_programs: None,
         }
     }
 
@@ -331,6 +337,22 @@ where
                         prog.set_autoload(false);
                     } else {
                         debug!("{} enabling program: {}", self.name, prog_name);
+                    }
+                }
+            }
+
+            // If disabled_programs is set, disable autoload for those programs
+            // (leaving all others at their default). Used to drop the unused
+            // tp_btf/raw_tp variant based on in-kernel BTF availability.
+            if let Some(ref disabled) = self.disabled_programs {
+                for mut prog in open_skel.open_object_mut().progs_mut() {
+                    let prog_name = prog.name().to_string_lossy();
+                    if disabled.contains(prog_name.as_ref()) {
+                        debug!(
+                            "{} disabling autoload for program: {}",
+                            self.name, prog_name
+                        );
+                        prog.set_autoload(false);
                     }
                 }
             }
@@ -643,6 +665,30 @@ where
     /// ```
     pub fn enabled_programs(mut self, names: &[&'static str]) -> Self {
         self.enabled_programs = Some(names.iter().copied().collect());
+        self
+    }
+
+    /// Specify BPF programs to disable (autoload off). Unlike
+    /// [`Self::enabled_programs`], which is an allowlist, this is a denylist:
+    /// only the named programs are disabled; everything else loads as usual.
+    ///
+    /// Use this to drop the unused variant when a sampler defines both a
+    /// `tp_btf` and a `raw_tp` version of a hook, selecting at runtime on
+    /// [`crate::agent::bpf::kernel_has_btf`].
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// BpfBuilder::new(...)
+    ///     .disabled_programs(if kernel_has_btf() {
+    ///         &["handle__sched_switch_raw"]
+    ///     } else {
+    ///         &["handle__sched_switch_btf"]
+    ///     })
+    ///     .build()?;
+    /// ```
+    pub fn disabled_programs(mut self, names: &[&'static str]) -> Self {
+        self.disabled_programs = Some(names.iter().copied().collect());
         self
     }
 }

--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -6,9 +6,21 @@ mod sync_primitive;
 pub use builder::Builder as BpfBuilder;
 pub use builder::{BpfProgStats, PerfEvent};
 
+use std::path::Path;
+use std::sync::OnceLock;
+
 use crate::agent::samplers::Sampler;
 use crate::agent::GroupMetadata;
 use crate::*;
+
+/// Returns true if the running kernel exposes its own BTF
+/// (`/sys/kernel/btf/vmlinux`). Programs that need in-kernel BTF — `tp_btf`,
+/// `fentry`/`fexit`, and the `bpf_get_current_task_btf` helper — can only be
+/// attached when this is true. Checked once and cached.
+pub fn kernel_has_btf() -> bool {
+    static HAS_BTF: OnceLock<bool> = OnceLock::new();
+    *HAS_BTF.get_or_init(|| Path::new("/sys/kernel/btf/vmlinux").exists())
+}
 
 pub trait OpenSkelExt {
     /// When called, the SkelBuilder should log instruction counts for each of

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -20,7 +20,7 @@ mod bpf;
 use bpf::*;
 
 #[cfg(target_os = "linux")]
-pub use bpf::{process_cgroup_info, CgroupInfo};
+pub use bpf::{kernel_has_btf, process_cgroup_info, CgroupInfo};
 
 // This is the maximum number of CPUs we track with BPF counters.
 pub const MAX_CPUS: usize = 1024;

--- a/src/agent/samplers/cpu/linux/migrations/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/migrations/mod.bpf.c
@@ -63,8 +63,7 @@ struct {
     __type(value, u32); // cpu
 } last_cpu SEC(".maps");
 
-SEC("tp_btf/sched_switch")
-int handle__sched_switch(u64* ctx) {
+static __always_inline int account__sched_switch(u64* ctx) {
     /* TP_PROTO(bool preempt, struct task_struct *prev, struct task_struct *next) */
     struct task_struct* next = (struct task_struct*)ctx[2];
 
@@ -117,6 +116,16 @@ int handle__sched_switch(u64* ctx) {
     bpf_map_update_elem(&last_cpu, &next_pid, &cpu, BPF_ANY);
 
     return 0;
+}
+
+SEC("tp_btf/sched_switch")
+int handle__sched_switch_btf(u64* ctx) {
+    return account__sched_switch(ctx);
+}
+
+SEC("raw_tp/sched_switch")
+int handle__sched_switch_raw(u64* ctx) {
+    return account__sched_switch(ctx);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/cpu/linux/migrations/mod.rs
+++ b/src/agent/samplers/cpu/linux/migrations/mod.rs
@@ -53,6 +53,11 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .cpu_counters("migrations", migrations)
     .packed_counters("cgroup_cpu_migrations", &CGROUP_CPU_MIGRATIONS)
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
+    .disabled_programs(if kernel_has_btf() {
+        &["handle__sched_switch_raw"]
+    } else {
+        &["handle__sched_switch_btf"]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -72,8 +77,12 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} handle__sched_switch() BPF instruction count: {}",
-            self.progs.handle__sched_switch.insn_cnt()
+            "{NAME} handle__sched_switch_btf() BPF instruction count: {}",
+            self.progs.handle__sched_switch_btf.insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_switch_raw() BPF instruction count: {}",
+            self.progs.handle__sched_switch_raw.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/cpu/linux/perf/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/perf/mod.bpf.c
@@ -92,8 +92,7 @@ struct {
 
 // attach a tracepoint on sched_switch for per-cgroup accounting
 
-SEC("tp_btf/sched_switch")
-int handle__sched_switch(u64* ctx) {
+static __always_inline int account__sched_switch(u64* ctx) {
     /* TP_PROTO(bool preempt, struct task_struct *prev,
      *      struct task_struct *next)
      */
@@ -107,7 +106,7 @@ int handle__sched_switch(u64* ctx) {
     u64 i = bpf_perf_event_read(&instructions, BPF_F_CURRENT_CPU);
 
     if (bpf_core_field_exists(prev->sched_task_group)) {
-        int cgroup_id = prev->sched_task_group->css.id;
+        int cgroup_id = BPF_CORE_READ(prev, sched_task_group, css.id);
 
         if (cgroup_id < MAX_CGROUPS) {
 
@@ -148,6 +147,16 @@ int handle__sched_switch(u64* ctx) {
     bpf_map_update_elem(&instructions_prev, &processor_id, &i, BPF_ANY);
 
     return 0;
+}
+
+SEC("tp_btf/sched_switch")
+int handle__sched_switch_btf(u64* ctx) {
+    return account__sched_switch(ctx);
+}
+
+SEC("raw_tp/sched_switch")
+int handle__sched_switch_raw(u64* ctx) {
+    return account__sched_switch(ctx);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/cpu/linux/perf/mod.rs
+++ b/src/agent/samplers/cpu/linux/perf/mod.rs
@@ -57,6 +57,11 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .packed_counters("cgroup_cycles", &CGROUP_CPU_CYCLES)
     .packed_counters("cgroup_instructions", &CGROUP_CPU_INSTRUCTIONS)
     .ringbuf_handler("cgroup_info", handle_event)
+    .disabled_programs(if kernel_has_btf() {
+        &["handle__sched_switch_raw"]
+    } else {
+        &["handle__sched_switch_btf"]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -78,8 +83,12 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} handle__sched_switch() BPF instruction count: {}",
-            self.progs.handle__sched_switch.insn_cnt()
+            "{NAME} handle__sched_switch_btf() BPF instruction count: {}",
+            self.progs.handle__sched_switch_btf.insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_switch_raw() BPF instruction count: {}",
+            self.progs.handle__sched_switch_raw.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -331,8 +331,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, struct task_struct* task, u32 index
     return 0;
 }
 
-SEC("tp_btf/sched_process_exit")
-int handle__sched_process_exit(u64* ctx) {
+static __always_inline int account__sched_process_exit(u64* ctx) {
     /* TP_PROTO(struct task_struct *p) */
     struct task_struct* task = (struct task_struct*)ctx[0];
 
@@ -400,6 +399,16 @@ int softirq_exit(struct trace_event_raw_softirq* args) {
     *start_ts = 0;
 
     return 0;
+}
+
+SEC("tp_btf/sched_process_exit")
+int handle__sched_process_exit_btf(u64* ctx) {
+    return account__sched_process_exit(ctx);
+}
+
+SEC("raw_tp/sched_process_exit")
+int handle__sched_process_exit_raw(u64* ctx) {
+    return account__sched_process_exit(ctx);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -165,6 +165,11 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .ringbuf_handler("task_info", handle_task_info)
     .ringbuf_handler("task_exit", handle_task_exit)
+    .disabled_programs(if kernel_has_btf() {
+        &["handle__sched_process_exit_raw"]
+    } else {
+        &["handle__sched_process_exit_btf"]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -194,8 +199,12 @@ impl OpenSkelExt for ModSkel<'_> {
             self.progs.cpuacct_account_field_kprobe.insn_cnt()
         );
         debug!(
-            "{NAME} handle__sched_process_exit() BPF instruction count: {}",
-            self.progs.handle__sched_process_exit.insn_cnt()
+            "{NAME} handle__sched_process_exit_btf() BPF instruction count: {}",
+            self.progs.handle__sched_process_exit_btf.insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_process_exit_raw() BPF instruction count: {}",
+            self.progs.handle__sched_process_exit_raw.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -154,24 +154,21 @@ static __always_inline int trace_enqueue(u32 tgid, u32 pid) {
     return 0;
 }
 
-SEC("tp_btf/sched_wakeup")
-int handle__sched_wakeup(u64* ctx) {
+static __always_inline int account__sched_wakeup(u64* ctx) {
     /* TP_PROTO(struct task_struct *p) */
     struct task_struct* p = (void*)ctx[0];
 
-    return trace_enqueue(p->tgid, p->pid);
+    return trace_enqueue(BPF_CORE_READ(p, tgid), BPF_CORE_READ(p, pid));
 }
 
-SEC("tp_btf/sched_wakeup_new")
-int handle__sched_wakeup_new(u64* ctx) {
+static __always_inline int account__sched_wakeup_new(u64* ctx) {
     /* TP_PROTO(struct task_struct *p) */
     struct task_struct* p = (void*)ctx[0];
 
-    return trace_enqueue(p->tgid, p->pid);
+    return trace_enqueue(BPF_CORE_READ(p, tgid), BPF_CORE_READ(p, pid));
 }
 
-SEC("tp_btf/sched_switch")
-int handle__sched_switch(u64* ctx) {
+static __always_inline int account__sched_switch(u64* ctx) {
     /* TP_PROTO(bool preempt, struct task_struct *prev,
      *      struct task_struct *next)
      */
@@ -250,7 +247,7 @@ int handle__sched_switch(u64* ctx) {
             array_incr(&cgroup_ivcsw, cgroup_id);
         }
 
-        pid = prev->pid;
+        pid = BPF_CORE_READ(prev, pid);
 
         bpf_map_update_elem(&enqueued_at, &pid, &ts, 0);
 
@@ -265,14 +262,14 @@ int handle__sched_switch(u64* ctx) {
     }
 
     // for all tasks: track when it went off-cpu
-    pid = prev->pid;
+    pid = BPF_CORE_READ(prev, pid);
 
     bpf_map_update_elem(&offcpu_at, &pid, &ts, 0);
 
     // next task has moved into running
     // - update next->pid running_at with now
     // - calculate how long next task was enqueued, update hist
-    pid = next->pid;
+    pid = BPF_CORE_READ(next, pid);
 
     // read the next task cgroup details and push to ringbuf if new cgroup
     void* next_task_group = BPF_CORE_READ(next, sched_task_group);
@@ -331,6 +328,36 @@ int handle__sched_switch(u64* ctx) {
     }
 
     return 0;
+}
+
+SEC("tp_btf/sched_wakeup")
+int handle__sched_wakeup_btf(u64* ctx) {
+    return account__sched_wakeup(ctx);
+}
+
+SEC("raw_tp/sched_wakeup")
+int handle__sched_wakeup_raw(u64* ctx) {
+    return account__sched_wakeup(ctx);
+}
+
+SEC("tp_btf/sched_wakeup_new")
+int handle__sched_wakeup_new_btf(u64* ctx) {
+    return account__sched_wakeup_new(ctx);
+}
+
+SEC("raw_tp/sched_wakeup_new")
+int handle__sched_wakeup_new_raw(u64* ctx) {
+    return account__sched_wakeup_new(ctx);
+}
+
+SEC("tp_btf/sched_switch")
+int handle__sched_switch_btf(u64* ctx) {
+    return account__sched_switch(ctx);
+}
+
+SEC("raw_tp/sched_switch")
+int handle__sched_switch_raw(u64* ctx) {
+    return account__sched_switch(ctx);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -62,6 +62,19 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .packed_counters("cgroup_offcpu", &CGROUP_SCHEDULER_OFFCPU)
     .packed_counters("cgroup_ivcsw", &CGROUP_SCHEDULER_IVCSW)
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
+    .disabled_programs(if kernel_has_btf() {
+        &[
+            "handle__sched_wakeup_raw",
+            "handle__sched_wakeup_new_raw",
+            "handle__sched_switch_raw",
+        ]
+    } else {
+        &[
+            "handle__sched_wakeup_btf",
+            "handle__sched_wakeup_new_btf",
+            "handle__sched_switch_btf",
+        ]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -86,16 +99,28 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} handle__sched_switch() BPF instruction count: {}",
-            self.progs.handle__sched_switch.insn_cnt()
+            "{NAME} handle__sched_switch_btf() BPF instruction count: {}",
+            self.progs.handle__sched_switch_btf.insn_cnt()
         );
         debug!(
-            "{NAME} handle__sched_wakeup() BPF instruction count: {}",
-            self.progs.handle__sched_wakeup.insn_cnt()
+            "{NAME} handle__sched_switch_raw() BPF instruction count: {}",
+            self.progs.handle__sched_switch_raw.insn_cnt()
         );
         debug!(
-            "{NAME} handle__sched_wakeup_new() BPF instruction count: {}",
-            self.progs.handle__sched_wakeup_new.insn_cnt()
+            "{NAME} handle__sched_wakeup_btf() BPF instruction count: {}",
+            self.progs.handle__sched_wakeup_btf.insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_wakeup_raw() BPF instruction count: {}",
+            self.progs.handle__sched_wakeup_raw.insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_wakeup_new_btf() BPF instruction count: {}",
+            self.progs.handle__sched_wakeup_new_btf.insn_cnt()
+        );
+        debug!(
+            "{NAME} handle__sched_wakeup_new_raw() BPF instruction count: {}",
+            self.progs.handle__sched_wakeup_new_raw.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/agent/samplers/syscall/linux/counts/mod.bpf.c
@@ -221,10 +221,10 @@ int sys_enter(struct trace_event_raw_sys_enter* args) {
     idx = offset + group;
     array_incr(&counters, idx);
 
-    struct task_struct* current = bpf_get_current_task_btf();
+    struct task_struct* current = (struct task_struct*)bpf_get_current_task();
 
     if (bpf_core_field_exists(current->sched_task_group)) {
-        int cgroup_id = current->sched_task_group->css.id;
+        int cgroup_id = BPF_CORE_READ(current, sched_task_group, css.id);
 
         if (cgroup_id < MAX_CGROUPS) {
 


### PR DESCRIPTION
## Summary

Five BPF samplers collect no data on kernels that lack in-kernel BTF (`/sys/kernel/btf/vmlinux`) — e.g. NVIDIA Tegra/L4T, which ships without `CONFIG_DEBUG_INFO_BTF`. An external BTF file (`btf_path`, pahole-generated) satisfies **CO-RE relocations**, so `raw_tp`/`tracepoint`/`kprobe` samplers (blockio, syscall_latency, TCP) work — but it cannot provide the **kernel-side** BTF that `tp_btf` programs and the `bpf_get_current_task_btf` helper need at attach time. Those silently fail (the load error is swallowed at debug level in `builder.rs`).

This makes the affected samplers degrade gracefully on BTF-less kernels:

- Each `tp_btf` hook gains a `raw_tp` twin that shares one `__always_inline` body (CO-RE throughout). At startup, `kernel_has_btf()` selects which variant loads, via a new `BpfBuilder::disabled_programs()` denylist (autoload off for the unused twin) — mirroring the existing per-arch `enabled_programs()` pattern used by `cpu/tlb_flush`.
- `syscall_counts` needs no twin: its tracepoint already attaches on Tegra; it just swaps `bpf_get_current_task_btf()` → `bpf_get_current_task()` + `BPF_CORE_READ`.
- Samplers covered: `cpu_migrations`, `cpu_perf`, `cpu_usage` (incl. softirq, same skeleton), `scheduler_runqueue`, `syscall_counts`.

On stock kernels nothing changes — the `tp_btf` variants load exactly as before (no regression). Design/principles updated to distinguish CO-RE's BTF need (kernel *or* file) from BTF-typed attach (kernel-only).

## Out of scope (separate follow-ups)

- `cpu_tlb_flush` failing on Tegra is a missing `kprobe/tlb_finish_mmu` symbol, not a BTF issue.
- `cpu_perf` will now *load* on Tegra via `raw_tp`, but hardware PMU counter availability there is a distinct question.

## Test plan

- [x] `cargo clippy` clean on x86_64 Linux (compiles both BPF variants, regenerates skeletons, type-checks the `_btf`/`_raw` program fields and `disabled_programs` lists).
- [x] `cargo build --release` clean on x86_64 Linux.
- [x] Review confirmed: all `raw_tp` shared bodies use `BPF_CORE_READ` for every kernel-pointer deref (required — `raw_tp` can't deref trusted pointers); program names consistent across C `SEC`, `disabled_programs`, and `self.progs`; selection branch maps correctly; cpu/usage kprobe + softirq untouched.
- [ ] **Runtime acceptance on aarch64 Jetson (no in-kernel BTF):** confirm `cpu_usage`, `cpu_migrations`, `scheduler_runqueue`, `syscall_counts` (+ softirq) now report non-zero while blockio/syscall_latency still work. *(manual, pending)*
- [ ] Runtime no-regression check on a stock BTF kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)