### PR TITLE
ci: build prerelease packages without publishing to apt/docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-and-push:
-    if: github.repository == 'iopsystems/rezolus'
+    if: ${{ github.repository == 'iopsystems/rezolus' && (github.event_name == 'workflow_dispatch' || (!contains(github.ref_name, '-') && !contains(github.ref_name, '+'))) }}
     name: "Build and push Docker image (${{ matrix.arch }})"
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
@@ -85,7 +85,7 @@ jobs:
           retention-days: 1
 
   merge:
-    if: github.repository == 'iopsystems/rezolus'
+    if: ${{ github.repository == 'iopsystems/rezolus' && (github.event_name == 'workflow_dispatch' || (!contains(github.ref_name, '-') && !contains(github.ref_name, '+'))) }}
     name: Create multi-arch manifest
     runs-on: ubuntu-latest
     needs: build-and-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,15 +349,18 @@ jobs:
           path: target/viewer-static/
           pattern: viewer-static
 
-      # Upload debs to systemslab registry
+      # Upload debs to systemslab registry (stable releases only)
       - uses: google-github-actions/auth@v2
+        if: steps.check-release.outputs.is_stable == 'true'
         id: auth-systemslab
         with:
           credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
 
       - uses: google-github-actions/setup-gcloud@v2
+        if: steps.check-release.outputs.is_stable == 'true'
 
-      - name: upload debs to systemslab registry (all releases)
+      - name: upload debs to systemslab registry (stable releases only)
+        if: steps.check-release.outputs.is_stable == 'true'
         run: |
           gcloud config set artifacts/repository systemslab
           gcloud config set artifacts/location us
@@ -516,7 +519,14 @@ jobs:
 
       - name: create GitHub release
         run: |
+          # Mark non-stable tags (anything with '-' or '+', e.g. -alpha.N) as
+          # GitHub pre-releases so they don't become the "Latest" release.
+          PRERELEASE=""
+          if [ "${{ steps.check-release.outputs.is_stable }}" != "true" ]; then
+            PRERELEASE="--prerelease"
+          fi
           gh release create "${{ github.ref_name }}" \
+            $PRERELEASE \
             --title "${{ github.ref_name }}" \
             --notes-file /tmp/release-notes.md \
             target/release-artifacts/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
   requires Hopper+ and is reported only where the corresponding pipe is
   supported.
 
+### Fixed
+
+- BPF samplers that rely on in-kernel BTF (`cpu_usage`, `cpu_migrations`,
+  `cpu_perf`, `scheduler_runqueue`, `syscall_counts`) now work on kernels
+  built without `/sys/kernel/btf/vmlinux` (e.g. NVIDIA Tegra/L4T). Each
+  `tp_btf` hook gains a `raw_tp` twin selected at runtime via
+  `kernel_has_btf()`, and `syscall_counts` uses `bpf_get_current_task()`
+  instead of `bpf_get_current_task_btf()`. CO-RE still uses the external
+  BTF file (`btf_path`). Stock BTF kernels are unaffected. (#948)
+
 ## [5.14.0] - 2026-06-03
 
 ### Added


### PR DESCRIPTION
## Summary

Makes the release pipeline **prerelease-aware** so `*-alpha.N` / `-beta` / `-rc` tags can be used for field-testing without touching any stable channel. Motivated by wanting to install an aarch64 `.deb` on a Tegra/Jetson to validate #948 before cutting a stable release.

Behavior today for a `v*` tag treats alphas almost like stable: the systemslab apt upload runs for "all releases", `gh release create` has no `--prerelease` flag (alpha shows as "Latest"), and `docker.yml` moves `:latest` to any tag.

Changes:
- **release.yml** — gate the systemslab apt upload on `is_stable` (was unconditional). Non-stable tags now publish to **no** apt registry (public rezolus apt/yum + Homebrew were already stable-only).
- **release.yml** — add `--prerelease` to `gh release create` for non-stable tags, so an alpha becomes a GitHub **pre-release**, not "Latest". Packages are still built and attached as artifacts.
- **docker.yml** — skip the image build/push for prerelease tags (still runs for `workflow_dispatch` and stable tags), so `:latest` never points at an alpha.
- **CHANGELOG** — record the merged BTF-less sampler fix (#948).

Net for `v5.14.1-alpha.1`: builds debs (incl. aarch64), rpms, viewer → attaches them to a GitHub **pre-release** → no apt, no `docker :latest`, no Homebrew.

## Test plan

- [x] `python3 -c yaml.safe_load` parses both workflow files.
- [x] Reviewed `if:` gating: systemslab steps gated on `is_stable == 'true'`; docker jobs run only for `workflow_dispatch` or tags without `-`/`+`.
- [ ] **Live validation:** `release.yml`/`docker.yml` only run on a real tag and are gated to `iopsystems`, so this can't be dry-run. The first `v5.14.1-alpha.1` tag after merge is the live test. Gating reuses the existing `check-release` `is_stable` step; worst case (an alpha landing in the internal systemslab apt repo, or `:latest` moving) is recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)