### PR TITLE
docs: auto-sync site/docs version label to latest stable tag

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -39,19 +39,27 @@ The skill accepts an optional branch name argument:
      ```
    - If already on a feature branch, use the current branch
 
-4. **Stage and commit**:
+4. **Sync docs version label** (idempotent — runs every PR):
+
+   ```bash
+   ./scripts/sync-docs-version.sh
+   ```
+
+   Updates `site/docs/*.html`'s sidebar version label to the latest stable release tag. If it modifies any file, include the change in the same commit. If nothing changes, no-op.
+
+5. **Stage and commit**:
    - Stage the relevant changed files by name (avoid `git add -A`)
    - Write a commit message following the repo's conventional commit style (`type(scope): description`)
    - Common types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
    - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` trailer
    - Use a HEREDOC for the commit message
 
-5. **Push to origin**:
+6. **Push to origin**:
    ```bash
    git push -u origin <branch-name>
    ```
 
-6. **Open PR against upstream**:
+7. **Open PR against upstream**:
    - The upstream repo is `iopsystems/rezolus`
    - The fork remote is `origin` (determine the owner from `git remote -v`)
    - Use `gh pr create` with `--repo iopsystems/rezolus` and `--head <fork-owner>:<branch-name>`
@@ -74,7 +82,7 @@ The skill accepts an optional branch name argument:
    )"
    ```
 
-7. **Report the PR URL** to the user.
+8. **Report the PR URL** to the user.
 
 ## Version bumps
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.1-alpha.2"
+version = "5.14.1-alpha.3"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.1-alpha.2"
+version = "5.14.1-alpha.3"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/scripts/sync-docs-version.sh
+++ b/scripts/sync-docs-version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Update the version label in site/docs/*.html to the latest stable
+# release tag. Run idempotently before opening a PR so deployed docs
+# track the latest release. Pre-release tags (alpha/beta/rc) are
+# ignored — docs reflect what users can actually install.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+VERSION=$(git tag --list 'v[0-9]*' | grep -vE -- '-(alpha|beta|rc)' | sort -V | tail -1)
+if [[ -z "$VERSION" ]]; then
+    echo "no stable version tag found (looked for v[0-9]*, excluding alpha/beta/rc)" >&2
+    exit 1
+fi
+
+# Rewrite the sidebar version div in each docs page. The Tailwind
+# class string is specific enough that only the version label matches.
+VERSION="$VERSION" perl -pi -e \
+    's|(<div class="font-mono text-\[10px\] uppercase tracking-widest text-slate-400">)v[0-9][^<]*(</div>)|$1$ENV{VERSION}$2|' \
+    site/docs/*.html
+
+echo "Synced site/docs/*.html version label to $VERSION"

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -35,7 +35,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.8.3</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -35,7 +35,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.8.3</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -35,7 +35,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.8.3</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -98,10 +98,16 @@
 </div>
 </div>
 <div class="mt-3 space-y-1 text-xs text-slate-500 font-mono">
-<div><span class="text-slate-400">-i, --interval</span> &lt;INTERVAL&gt;  <span class="text-slate-600">Collection interval [default: 1s]</span></div>
-<div><span class="text-slate-400">-d, --duration</span> &lt;DURATION&gt;  <span class="text-slate-600">Collection duration</span></div>
-<div><span class="text-slate-400">-f, --format</span> &lt;FORMAT&gt;      <span class="text-slate-600">parquet|raw [default: parquet]</span></div>
-<div><span class="text-slate-400">-v, --verbose</span>              <span class="text-slate-600">Increase verbosity (stackable)</span></div>
+<div><span class="text-slate-400">-i, --interval</span> &lt;INTERVAL&gt;     <span class="text-slate-600">Collection interval [default: 1s]</span></div>
+<div><span class="text-slate-400">-d, --duration</span> &lt;DURATION&gt;     <span class="text-slate-600">Collection duration</span></div>
+<div><span class="text-slate-400">-f, --format</span> &lt;FORMAT&gt;         <span class="text-slate-600">parquet|raw [default: parquet]</span></div>
+<div><span class="text-slate-400">    --config</span> &lt;FILE&gt;           <span class="text-slate-600">TOML config for multi-endpoint recording</span></div>
+<div><span class="text-slate-400">    --endpoint</span> &lt;URL&gt;          <span class="text-slate-600">Additional endpoint (repeatable)</span></div>
+<div><span class="text-slate-400">    --metadata</span> &lt;KEY=VALUE&gt;    <span class="text-slate-600">Custom metadata (repeatable)</span></div>
+<div><span class="text-slate-400">    --node</span> &lt;NAME&gt;             <span class="text-slate-600">Node name attached to rezolus data</span></div>
+<div><span class="text-slate-400">    --instance</span> &lt;NAME&gt;         <span class="text-slate-600">Instance name attached to service data</span></div>
+<div><span class="text-slate-400">    --separate</span>                <span class="text-slate-600">Write per-endpoint files instead of one combined</span></div>
+<div><span class="text-slate-400">-v, --verbose</span>                 <span class="text-slate-600">Increase verbosity (stackable)</span></div>
 </div>
 <div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden mt-4">
 <div class="p-5 font-mono text-sm">
@@ -127,11 +133,19 @@
 <h3 class="text-base font-bold mb-3">Viewer</h3>
 <div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
 <div class="p-5 font-mono text-sm">
-<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view [OPTIONS] &lt;INPUT&gt; [LISTEN]</code></div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view [OPTIONS] [INPUT] [EXPERIMENT]</code></div>
 </div>
 </div>
 <div class="mt-3 space-y-1 text-xs text-slate-500 font-mono">
-<div><span class="text-slate-400">-v, --verbose</span>  <span class="text-slate-600">Increase verbosity</span></div>
+<div><span class="text-slate-400">INPUT</span>                          <span class="text-slate-600">First capture (parquet path, agent URL, or alias=parquet)</span></div>
+<div><span class="text-slate-400">EXPERIMENT</span>                     <span class="text-slate-600">Optional second capture for A/B comparison</span></div>
+<div><span class="text-slate-400">-l, --listen</span> &lt;ADDR&gt;           <span class="text-slate-600">Viewer listen address (e.g. 127.0.0.1:8080)</span></div>
+<div><span class="text-slate-400">    --templates</span> &lt;DIR&gt;         <span class="text-slate-600">Directory of service-extension template JSON</span></div>
+<div><span class="text-slate-400">    --category</span> &lt;NAME&gt;         <span class="text-slate-600">Activate category mode (e.g. inference-library)</span></div>
+<div><span class="text-slate-400">    --proxy-allow</span> &lt;PATTERN&gt;  <span class="text-slate-600">Whitelist a host pattern for URL proxy (repeatable)</span></div>
+<div><span class="text-slate-400">    --proxy-allow-any</span>         <span class="text-slate-600">Disable proxy allowlist entirely (trust-everyone mode)</span></div>
+<div><span class="text-slate-400">    --cache-size-mb</span> &lt;MB&gt;     <span class="text-slate-600">Row-group buffer cache size [default: 500]</span></div>
+<div><span class="text-slate-400">-v, --verbose</span>                  <span class="text-slate-600">Increase verbosity</span></div>
 </div>
 <div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden mt-4">
 <div class="p-5 font-mono text-sm">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -35,7 +35,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.8.3</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -37,7 +37,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.8.3</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">


### PR DESCRIPTION
## Summary

Stop the version label in `site/docs/*.html` from drifting (it was stuck on `v5.8.3` through multiple minor releases).

- New `scripts/sync-docs-version.sh` rewrites the sidebar version div in all `site/docs/*.html` to the latest stable git tag — pre-release tags (alpha/beta/rc) are excluded so docs reflect what users can actually install. Idempotent.
- `/pr` skill picks it up as a step before staging, so every PR sweeps the value with no manual editing.
- First run included: docs bumped to `v5.14.0`.

## Test plan

- [x] Script runs cleanly: `./scripts/sync-docs-version.sh` → "Synced site/docs/*.html version label to v5.14.0"
- [x] Re-run is idempotent (no diff on second invocation)
- [x] Each of 5 docs files rewritten to v5.14.0
- [ ] After next release tag (say v5.15.0), opening a PR via `/pr` should auto-bump these to v5.15.0 with no manual intervention

Alpha bump: `5.14.1-alpha.2` → `5.14.1-alpha.3`.