### PR TITLE
style(site): brand on site/ matches viewer top-nav wordmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.1-alpha.3"
+version = "5.14.1-alpha.4"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.1-alpha.3"
+version = "5.14.1-alpha.4"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -13,6 +13,7 @@
       }
 </script>
 <style>
+    html { scroll-padding-top: 5rem; }
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
 
@@ -65,11 +66,14 @@
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Getting Started</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="installation.html">Installation</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html">Usage</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Core Concepts</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="architecture.html">Architecture</a>
-<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Telemetry Types</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Metrics</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#samplers">Samplers</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#types">Types</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Reference</h4>
@@ -82,7 +86,7 @@
 <!-- Content -->
 <main class="flex-1 px-8 lg:px-16 py-12 min-w-0 max-w-3xl">
 
-<h1 class="text-4xl font-black tracking-tight mb-4">API Reference</h1>
+<h1 class="text-4xl font-extrabold tracking-tight mb-4">API Reference</h1>
 <p class="text-lg text-slate-500 dark:text-slate-400 mb-12">HTTP endpoints exposed by each operating mode.</p>
 
 <!-- Agent -->
@@ -238,7 +242,7 @@
 </section>
 
 <div class="flex justify-between items-center pt-8 border-t border-slate-200 dark:border-slate-800 text-sm">
-<a href="telemetry.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">&larr; Telemetry Types</a>
+<a href="telemetry.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">&larr; Metrics</a>
 <a href="cli.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">CLI &amp; Configuration &rarr;</a>
 </div>
 

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -4,7 +4,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>API Reference - Rezolus Docs</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script>
       tailwind.config = {
@@ -15,14 +15,38 @@
 <style>
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
-</style>
+
+        .brand {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.15em;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background: linear-gradient(135deg, #58a6ff 0%, #79c0ff 100%);
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            mask-size: contain;
+            -webkit-mask-size: contain;
+            mask-repeat: no-repeat;
+            -webkit-mask-repeat: no-repeat;
+        }
+    </style>
 </head>
 <body class="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
 
 <!-- Nav -->
 <nav class="fixed top-0 w-full z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200/50 dark:border-slate-800">
 <div class="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
-<a href="/" class="text-2xl font-black tracking-tighter text-slate-900 dark:text-white no-underline">Rezolus</a>
+<a href="/" class="brand text-slate-900 dark:text-white no-underline">REZOLUS</a>
 <div class="hidden md:flex items-center gap-8 text-sm font-medium">
 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline" href="/">Home</a>
 <a class="text-blue-700 dark:text-blue-400 font-bold no-underline" href="installation.html">Docs</a>

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -4,7 +4,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Architecture - Rezolus Docs</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script>
       tailwind.config = {
@@ -15,14 +15,38 @@
 <style>
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
-</style>
+
+        .brand {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.15em;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background: linear-gradient(135deg, #58a6ff 0%, #79c0ff 100%);
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            mask-size: contain;
+            -webkit-mask-size: contain;
+            mask-repeat: no-repeat;
+            -webkit-mask-repeat: no-repeat;
+        }
+    </style>
 </head>
 <body class="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
 
 <!-- Nav -->
 <nav class="fixed top-0 w-full z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200/50 dark:border-slate-800">
 <div class="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
-<a href="/" class="text-2xl font-black tracking-tighter text-slate-900 dark:text-white no-underline">Rezolus</a>
+<a href="/" class="brand text-slate-900 dark:text-white no-underline">REZOLUS</a>
 <div class="hidden md:flex items-center gap-8 text-sm font-medium">
 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline" href="/">Home</a>
 <a class="text-blue-700 dark:text-blue-400 font-bold no-underline" href="installation.html">Docs</a>

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -13,6 +13,7 @@
       }
 </script>
 <style>
+    html { scroll-padding-top: 5rem; }
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
 
@@ -65,11 +66,14 @@
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Getting Started</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="installation.html">Installation</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html">Usage</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Core Concepts</h4>
 <a class="block px-3 py-1.5 text-blue-700 dark:text-blue-400 font-bold bg-blue-50 dark:bg-blue-900/30 rounded-lg no-underline" href="architecture.html">Architecture</a>
-<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Telemetry Types</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Metrics</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#samplers">Samplers</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#types">Types</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Reference</h4>
@@ -82,7 +86,7 @@
 <!-- Content -->
 <main class="flex-1 px-8 lg:px-16 py-12 min-w-0 max-w-3xl">
 
-<h1 class="text-4xl font-black tracking-tight mb-4">Architecture</h1>
+<h1 class="text-4xl font-extrabold tracking-tight mb-4">Architecture</h1>
 <p class="text-lg text-slate-500 dark:text-slate-400 mb-12">How Rezolus is structured and how the pieces fit together.</p>
 
 <!-- Operating Modes -->
@@ -199,7 +203,7 @@
 
 <div class="flex justify-between items-center pt-8 border-t border-slate-200 dark:border-slate-800 text-sm">
 <a href="installation.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">&larr; Installation</a>
-<a href="telemetry.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">Telemetry Types &rarr;</a>
+<a href="telemetry.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">Metrics &rarr;</a>
 </div>
 
 </main>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -13,6 +13,7 @@
       }
 </script>
 <style>
+    html { scroll-padding-top: 5rem; }
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
 
@@ -65,11 +66,14 @@
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Getting Started</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="installation.html">Installation</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html">Usage</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Core Concepts</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="architecture.html">Architecture</a>
-<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Telemetry Types</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Metrics</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#samplers">Samplers</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#types">Types</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Reference</h4>
@@ -82,7 +86,7 @@
 <!-- Content -->
 <main class="flex-1 px-8 lg:px-16 py-12 min-w-0 max-w-3xl">
 
-<h1 class="text-4xl font-black tracking-tight mb-4">CLI &amp; Configuration</h1>
+<h1 class="text-4xl font-extrabold tracking-tight mb-4">CLI &amp; Configuration</h1>
 <p class="text-lg text-slate-500 dark:text-slate-400 mb-12">Commands, flags, and TOML configuration reference.</p>
 
 <!-- CLI Commands -->
@@ -195,6 +199,93 @@
 <div><span class="text-slate-400">describe-metrics</span> &lt;FILE&gt;</div>
 <div><span class="text-slate-400">detect-anomalies</span> &lt;FILE&gt; [QUERY]</div>
 <div><span class="text-slate-400">query</span> &lt;FILE&gt; &lt;QUERY&gt;</div>
+</div>
+</div>
+
+<!-- Parquet Tools -->
+<div>
+<h3 class="text-base font-bold mb-3">Parquet Tools</h3>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm">
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus parquet &lt;SUBCOMMAND&gt; [OPTIONS]</code></div>
+</div>
+</div>
+<p class="text-xs text-slate-400 mt-2">File-level operations on rezolus recordings &mdash; inspect metadata, trim columns, embed service KPI definitions, or merge multi-source captures.</p>
+
+<div class="mt-6 space-y-6">
+
+<!-- metadata -->
+<div>
+<h4 class="text-sm font-bold mb-2"><code>metadata</code></h4>
+<p class="text-xs text-slate-500 dark:text-slate-400 mb-2">Show file-level + column metadata for a recording.</p>
+<div class="space-y-1 text-xs text-slate-500 font-mono">
+<div><span class="text-slate-400">-i, --input</span> &lt;FILE&gt;          <span class="text-slate-600">Input parquet file</span></div>
+<div><span class="text-slate-400">    --schema</span>               <span class="text-slate-600">Show only column-level metadata</span></div>
+<div><span class="text-slate-400">    --file</span>                 <span class="text-slate-600">Show only file-level metadata</span></div>
+<div><span class="text-slate-400">    --geometry</span>             <span class="text-slate-600">Show only table shape + row group layout</span></div>
+<div><span class="text-slate-400">    --field</span> &lt;KEY&gt;          <span class="text-slate-600">Print one file-level metadata key</span></div>
+<div><span class="text-slate-400">    --json</span>                 <span class="text-slate-600">Emit JSON (for scripting)</span></div>
+</div>
+</div>
+
+<!-- annotate -->
+<div>
+<h4 class="text-sm font-bold mb-2"><code>annotate</code></h4>
+<p class="text-xs text-slate-500 dark:text-slate-400 mb-2">Embed service-extension KPI queries (and related metadata) into a recording so the viewer can render them as charts.</p>
+<div class="space-y-1 text-xs text-slate-500 font-mono">
+<div><span class="text-slate-400">FILE</span>                          <span class="text-slate-600">Parquet to annotate (overwritten in place unless &dash;&dash;output)</span></div>
+<div><span class="text-slate-400">    --queries</span> &lt;JSON&gt;        <span class="text-slate-600">Custom service-extension JSON (overrides templates)</span></div>
+<div><span class="text-slate-400">    --templates</span> &lt;DIR&gt;       <span class="text-slate-600">Template directory to resolve KPIs from</span></div>
+<div><span class="text-slate-400">    --source</span> &lt;NAME&gt;         <span class="text-slate-600">Source tag to match against template <code>members</code></span></div>
+<div><span class="text-slate-400">    --node</span> &lt;NAME&gt;           <span class="text-slate-600">Node name attached to rezolus columns</span></div>
+<div><span class="text-slate-400">    --filter</span>                <span class="text-slate-600">Trim columns to only those referenced by KPIs</span></div>
+<div><span class="text-slate-400">    --systeminfo</span> &lt;JSON&gt;     <span class="text-slate-600">Embed/override the recorded systeminfo</span></div>
+<div><span class="text-slate-400">    --add-events</span> &lt;JSON&gt;     <span class="text-slate-600">Append events to the file</span></div>
+<div><span class="text-slate-400">    --event</span> &lt;SPEC&gt;          <span class="text-slate-600">Single event spec (repeatable)</span></div>
+<div><span class="text-slate-400">    --clear-events</span>          <span class="text-slate-600">Drop all existing events</span></div>
+<div><span class="text-slate-400">    --overwrite</span>             <span class="text-slate-600">Allow overwriting existing annotations</span></div>
+<div><span class="text-slate-400">    --undo</span>                  <span class="text-slate-600">Remove previously-applied annotations</span></div>
+</div>
+</div>
+
+<!-- combine -->
+<div>
+<h4 class="text-sm font-bold mb-2"><code>combine</code></h4>
+<p class="text-xs text-slate-500 dark:text-slate-400 mb-2">Merge multiple parquet files into one &mdash; multi-node rezolus, multi-instance services, or compare-mode A/B bundles.</p>
+<div class="space-y-1 text-xs text-slate-500 font-mono">
+<div><span class="text-slate-400">FILES...</span>                      <span class="text-slate-600">Parquet inputs to merge</span></div>
+<div><span class="text-slate-400">-o, --output</span> &lt;FILE&gt;         <span class="text-slate-600">Output parquet path</span></div>
+<div><span class="text-slate-400">    --pinned</span> &lt;NAME&gt;         <span class="text-slate-600">Default rezolus node to display</span></div>
+<div><span class="text-slate-400">    --ab</span> &lt;LABEL=SRC&gt;        <span class="text-slate-600">Bundle as A/B compare tarball (repeatable: <code>baseline=…&nbsp;experiment=…</code>)</span></div>
+<div><span class="text-slate-400">    --category</span> &lt;NAME&gt;       <span class="text-slate-600">Tag the bundle with a category template</span></div>
+<div><span class="text-slate-400">    --bypass-time-check</span>     <span class="text-slate-600">Skip timestamp alignment validation</span></div>
+</div>
+</div>
+
+<!-- filter -->
+<div>
+<h4 class="text-sm font-bold mb-2"><code>filter</code></h4>
+<p class="text-xs text-slate-500 dark:text-slate-400 mb-2">Project a recording down to only the columns referenced by its service-extension KPIs &mdash; useful before sharing a focused report.</p>
+<div class="space-y-1 text-xs text-slate-500 font-mono">
+<div><span class="text-slate-400">FILE</span>                          <span class="text-slate-600">Parquet to filter</span></div>
+<div><span class="text-slate-400">    --queries</span> &lt;JSON&gt;        <span class="text-slate-600">Custom KPI JSON (overrides embedded/template)</span></div>
+<div><span class="text-slate-400">    --templates</span> &lt;DIR&gt;       <span class="text-slate-600">Template directory to resolve KPIs from</span></div>
+<div><span class="text-slate-400">-o, --output</span> &lt;FILE&gt;         <span class="text-slate-600">Output path (defaults to in-place overwrite)</span></div>
+</div>
+</div>
+
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden mt-4">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="text-slate-500 text-xs"># Inspect</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus parquet metadata -i recording.parquet --json</code></div>
+<div class="text-slate-600 text-xs mt-3"># Annotate with KPIs from a template directory</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus parquet annotate recording.parquet --templates ./templates</code></div>
+<div class="text-slate-600 text-xs mt-3"># Combine two captures as an A/B bundle</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus parquet combine before.parquet after.parquet \</code></div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">&nbsp;</span><code class="text-green-400">    --ab baseline=before --ab experiment=after \</code></div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">&nbsp;</span><code class="text-green-400">    -o compare.parquet.ab.tar</code></div>
+</div>
+</div>
 </div>
 </div>
 

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -4,7 +4,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>CLI &amp; Configuration - Rezolus Docs</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script>
       tailwind.config = {
@@ -15,14 +15,38 @@
 <style>
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
-</style>
+
+        .brand {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.15em;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background: linear-gradient(135deg, #58a6ff 0%, #79c0ff 100%);
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            mask-size: contain;
+            -webkit-mask-size: contain;
+            mask-repeat: no-repeat;
+            -webkit-mask-repeat: no-repeat;
+        }
+    </style>
 </head>
 <body class="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
 
 <!-- Nav -->
 <nav class="fixed top-0 w-full z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200/50 dark:border-slate-800">
 <div class="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
-<a href="/" class="text-2xl font-black tracking-tighter text-slate-900 dark:text-white no-underline">Rezolus</a>
+<a href="/" class="brand text-slate-900 dark:text-white no-underline">REZOLUS</a>
 <div class="hidden md:flex items-center gap-8 text-sm font-medium">
 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline" href="/">Home</a>
 <a class="text-blue-700 dark:text-blue-400 font-bold no-underline" href="installation.html">Docs</a>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -4,7 +4,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Installation - Rezolus Docs</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script>
       tailwind.config = {
@@ -15,14 +15,38 @@
 <style>
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
-</style>
+
+        .brand {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.15em;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background: linear-gradient(135deg, #58a6ff 0%, #79c0ff 100%);
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            mask-size: contain;
+            -webkit-mask-size: contain;
+            mask-repeat: no-repeat;
+            -webkit-mask-repeat: no-repeat;
+        }
+    </style>
 </head>
 <body class="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
 
 <!-- Nav -->
 <nav class="fixed top-0 w-full z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200/50 dark:border-slate-800">
 <div class="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
-<a href="/" class="text-2xl font-black tracking-tighter text-slate-900 dark:text-white no-underline">Rezolus</a>
+<a href="/" class="brand text-slate-900 dark:text-white no-underline">REZOLUS</a>
 <div class="hidden md:flex items-center gap-8 text-sm font-medium">
 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline" href="/">Home</a>
 <a class="text-blue-700 dark:text-blue-400 font-bold no-underline" href="installation.html">Docs</a>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -13,6 +13,7 @@
       }
 </script>
 <style>
+    html { scroll-padding-top: 5rem; }
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
 
@@ -65,11 +66,14 @@
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Getting Started</h4>
 <a class="block px-3 py-1.5 text-blue-700 dark:text-blue-400 font-bold bg-blue-50 dark:bg-blue-900/30 rounded-lg no-underline" href="installation.html">Installation</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html">Usage</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Core Concepts</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="architecture.html">Architecture</a>
-<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Telemetry Types</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Metrics</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#samplers">Samplers</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#types">Types</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Reference</h4>
@@ -82,7 +86,7 @@
 <!-- Content -->
 <main class="flex-1 px-8 lg:px-16 py-12 min-w-0 max-w-3xl">
 
-<h1 class="text-4xl font-black tracking-tight mb-4">Installation</h1>
+<h1 class="text-4xl font-extrabold tracking-tight mb-4">Installation</h1>
 <p class="text-lg text-slate-500 dark:text-slate-400 mb-12">Get Rezolus running on your system.</p>
 
 <!-- Platform tabs -->

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -4,7 +4,7 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Telemetry Types - Rezolus Docs</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script>
       tailwind.config = {
@@ -17,14 +17,38 @@
     body { font-family: 'Inter', sans-serif; }
     details summary::-webkit-details-marker { display: none; }
     details summary { list-style: none; }
-</style>
+
+        .brand {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.15em;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background: linear-gradient(135deg, #58a6ff 0%, #79c0ff 100%);
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            mask-size: contain;
+            -webkit-mask-size: contain;
+            mask-repeat: no-repeat;
+            -webkit-mask-repeat: no-repeat;
+        }
+    </style>
 </head>
 <body class="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
 
 <!-- Nav -->
 <nav class="fixed top-0 w-full z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200/50 dark:border-slate-800">
 <div class="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
-<a href="/" class="text-2xl font-black tracking-tighter text-slate-900 dark:text-white no-underline">Rezolus</a>
+<a href="/" class="brand text-slate-900 dark:text-white no-underline">REZOLUS</a>
 <div class="hidden md:flex items-center gap-8 text-sm font-medium">
 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline" href="/">Home</a>
 <a class="text-blue-700 dark:text-blue-400 font-bold no-underline" href="installation.html">Docs</a>

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -2,7 +2,7 @@
 <html class="light" lang="en"><head>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>Telemetry Types - Rezolus Docs</title>
+<title>Metrics - Rezolus Docs</title>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
@@ -13,6 +13,7 @@
       }
 </script>
 <style>
+    html { scroll-padding-top: 5rem; }
     .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
     body { font-family: 'Inter', sans-serif; }
     details summary::-webkit-details-marker { display: none; }
@@ -67,11 +68,14 @@
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Getting Started</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="installation.html">Installation</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html">Usage</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Core Concepts</h4>
 <a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="architecture.html">Architecture</a>
-<a class="block px-3 py-1.5 text-blue-700 dark:text-blue-400 font-bold bg-blue-50 dark:bg-blue-900/30 rounded-lg no-underline" href="telemetry.html">Telemetry Types</a>
+<a class="block px-3 py-1.5 text-blue-700 dark:text-blue-400 font-bold bg-blue-50 dark:bg-blue-900/30 rounded-lg no-underline" href="telemetry.html">Metrics</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#samplers">Samplers</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#types">Types</a>
 </div>
 <div class="space-y-1">
 <h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Reference</h4>
@@ -82,73 +86,77 @@
 </aside>
 
 <!-- Content -->
-<main class="flex-1 px-8 lg:px-16 py-12 min-w-0 max-w-3xl">
+<main class="flex-1 px-8 lg:px-16 py-12 min-w-0 max-w-3xl lg:max-w-4xl">
 
-<h1 class="text-4xl font-black tracking-tight mb-4">Telemetry Types</h1>
-<p class="text-lg text-slate-500 dark:text-slate-400 mb-4">Metrics collected by the Rezolus agent, organized by sampler category.</p>
-<p class="text-sm text-slate-400 mb-12">Each sampler can be individually enabled or disabled in the agent config. Metrics are labeled with dimensions like <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">state</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">op</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">direction</code>, etc. Many metrics are also collected per-cgroup.</p>
+<h1 class="text-4xl font-extrabold tracking-tight mb-12">Metrics</h1>
+
+<!-- Samplers -->
+<section class="mb-8" id="samplers">
+<h2 class="text-xl font-bold mb-2">Samplers</h2>
+<p class="text-sm text-slate-500 dark:text-slate-400">Instrumentation categories grouped by subsystem. Each can be enabled or disabled independently in the agent config.</p>
+</section>
 
 <!-- CPU -->
 <section class="mb-12" id="cpu">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-blue-600" data-icon="memory">memory</span>
-<h2 class="text-xl font-bold">CPU</h2>
+<h3 class="text-xl font-bold">CPU</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Usage</h3><p class="text-xs text-slate-400">CPU time by state, softirq breakdown</p></div>
+<div><h4 class="text-sm font-bold">Usage</h4><p class="text-xs text-slate-400">CPU time by state, softirq breakdown</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_usage</code><span class="text-slate-500">Per-CPU nanoseconds by state: <code>user</code>, <code>system</code></span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">softirq</code><span class="text-slate-500">Per-CPU interrupt count by kind: hi, timer, net_tx, net_rx, block, irq_poll, tasklet, sched, hrtimer, rcu</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">softirq_time</code><span class="text-slate-500">Per-CPU nanoseconds spent in softirq, same kinds</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cgroup_cpu_usage</code><span class="text-slate-500">Per-cgroup nanoseconds by state: <code>user</code>, <code>system</code></span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_usage</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU nanoseconds by state: <code>user</code>, <code>system</code></span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">softirq</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU interrupt count by kind: hi, timer, net_tx, net_rx, block, irq_poll, tasklet, sched, hrtimer, rcu</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">softirq_time</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU nanoseconds spent in softirq, same kinds</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cgroup_cpu_usage</code><span class="text-slate-500 pl-4 md:pl-0">Per-cgroup nanoseconds by state: <code>user</code>, <code>system</code></span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Frequency</h3><p class="text-xs text-slate-400">APERF, MPERF, TSC cycle counters</p></div>
+<div><h4 class="text-sm font-bold">Frequency</h4><p class="text-xs text-slate-400">APERF, MPERF, TSC cycle counters</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_aperf</code><span class="text-slate-500">Per-CPU actual performance cycles</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_mperf</code><span class="text-slate-500">Per-CPU maximum performance cycles</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_tsc</code><span class="text-slate-500">Per-CPU timestamp counter cycles</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_aperf</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU actual performance cycles</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_mperf</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU maximum performance cycles</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_tsc</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU timestamp counter cycles</span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Performance Counters</h3><p class="text-xs text-slate-400">Cycles, instructions, branch predictions, cache, TLB</p></div>
+<div><h4 class="text-sm font-bold">Performance Counters</h4><p class="text-xs text-slate-400">Cycles, instructions, branch predictions, cache, TLB</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_cycles</code><span class="text-slate-500">Per-CPU cycle count</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_instructions</code><span class="text-slate-500">Per-CPU retired instructions</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_branch_instructions</code><span class="text-slate-500">Per-CPU branch instructions</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_branch_misses</code><span class="text-slate-500">Per-CPU branch mispredictions</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_dtlb_miss</code><span class="text-slate-500">Per-CPU data TLB misses (with <code>op</code>: load, store on Intel)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_l3_access</code><span class="text-slate-500">Per-CPU L3 cache accesses</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_l3_miss</code><span class="text-slate-500">Per-CPU L3 cache misses</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_tlb_flush</code><span class="text-slate-500">Per-CPU TLB flush count by reason: task_switch, remote_shootdown, local_shootdown, etc.</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cgroup_cpu_cycles</code><span class="text-slate-500">Per-cgroup cycle count</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cgroup_cpu_instructions</code><span class="text-slate-500">Per-cgroup retired instructions</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_cycles</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU cycle count</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_instructions</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU retired instructions</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_branch_instructions</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU branch instructions</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_branch_misses</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU branch mispredictions</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_dtlb_miss</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU data TLB misses (with <code>op</code>: load, store on Intel)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_l3_access</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU L3 cache accesses</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_l3_miss</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU L3 cache misses</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_tlb_flush</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU TLB flush count by reason: task_switch, remote_shootdown, local_shootdown, etc.</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cgroup_cpu_cycles</code><span class="text-slate-500 pl-4 md:pl-0">Per-cgroup cycle count</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cgroup_cpu_instructions</code><span class="text-slate-500 pl-4 md:pl-0">Per-cgroup retired instructions</span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Bandwidth &amp; Migrations</h3><p class="text-xs text-slate-400">CFS throttling, CPU migration events</p></div>
+<div><h4 class="text-sm font-bold">Bandwidth &amp; Migrations</h4><p class="text-xs text-slate-400">CFS throttling, CPU migration events</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_cores</code><span class="text-slate-500">Number of online logical cores (gauge)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cpu_migrations</code><span class="text-slate-500">Per-CPU migration count with <code>direction</code>: from, to</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cgroup_cpu_bandwidth_*</code><span class="text-slate-500">Per-cgroup CFS quota, period, throttled time, period counts</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cgroup_cpu_migrations</code><span class="text-slate-500">Per-cgroup CPU migration count</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_cores</code><span class="text-slate-500 pl-4 md:pl-0">Number of online logical cores (gauge)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cpu_migrations</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU migration count with <code>direction</code>: from, to</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cgroup_cpu_bandwidth_*</code><span class="text-slate-500 pl-4 md:pl-0">Per-cgroup CFS quota, period, throttled time, period counts</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cgroup_cpu_migrations</code><span class="text-slate-500 pl-4 md:pl-0">Per-cgroup CPU migration count</span></div>
 </div>
 </details>
 </section>
@@ -157,21 +165,21 @@
 <section class="mb-12" id="scheduler">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-green-600" data-icon="schedule">schedule</span>
-<h2 class="text-xl font-bold">Scheduler</h2>
+<h3 class="text-xl font-bold">Scheduler</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Runqueue</h3><p class="text-xs text-slate-400">Scheduling latency, running time, off-CPU time, context switches</p></div>
+<div><h4 class="text-sm font-bold">Runqueue</h4><p class="text-xs text-slate-400">Scheduling latency, running time, off-CPU time, context switches</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">scheduler_runqueue_latency</code><span class="text-slate-500">Histogram of time tasks wait in the runqueue (ns)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">scheduler_running</code><span class="text-slate-500">Histogram of time tasks spend running on CPU (ns)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">scheduler_offcpu</code><span class="text-slate-500">Histogram of time tasks spend off-CPU (ns)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">scheduler_context_switch</code><span class="text-slate-500">Per-CPU involuntary context switches</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">scheduler_runqueue_wait</code><span class="text-slate-500">Per-CPU total nanoseconds spent waiting</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cgroup_scheduler_*</code><span class="text-slate-500">Per-cgroup: runqueue_wait, offcpu, context_switch</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">scheduler_runqueue_latency</code><span class="text-slate-500 pl-4 md:pl-0">Histogram of time tasks wait in the runqueue (ns)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">scheduler_running</code><span class="text-slate-500 pl-4 md:pl-0">Histogram of time tasks spend running on CPU (ns)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">scheduler_offcpu</code><span class="text-slate-500 pl-4 md:pl-0">Histogram of time tasks spend off-CPU (ns)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">scheduler_context_switch</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU involuntary context switches</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">scheduler_runqueue_wait</code><span class="text-slate-500 pl-4 md:pl-0">Per-CPU total nanoseconds spent waiting</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cgroup_scheduler_*</code><span class="text-slate-500 pl-4 md:pl-0">Per-cgroup: runqueue_wait, offcpu, context_switch</span></div>
 </div>
 </details>
 </section>
@@ -180,28 +188,28 @@
 <section class="mb-12" id="blockio">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-purple-600" data-icon="storage">storage</span>
-<h2 class="text-xl font-bold">Block I/O</h2>
+<h3 class="text-xl font-bold">Block I/O</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Latency</h3><p class="text-xs text-slate-400">I/O latency distributions by operation type</p></div>
+<div><h4 class="text-sm font-bold">Latency</h4><p class="text-xs text-slate-400">I/O latency distributions by operation type</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">blockio_latency</code><span class="text-slate-500">Histogram (ns) with <code>op</code>: read, write, flush, discard</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">blockio_latency</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (ns) with <code>op</code>: read, write, flush, discard</span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Requests</h3><p class="text-xs text-slate-400">Operation counts, bytes transferred, size distributions</p></div>
+<div><h4 class="text-sm font-bold">Requests</h4><p class="text-xs text-slate-400">Operation counts, bytes transferred, size distributions</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">blockio_operations</code><span class="text-slate-500">Counter with <code>op</code>: read, write, flush, discard</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">blockio_bytes</code><span class="text-slate-500">Counter (bytes) with <code>op</code>: read, write, flush, discard</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">blockio_size</code><span class="text-slate-500">Histogram (bytes) with <code>op</code>: read, write, flush, discard</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">blockio_operations</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>op</code>: read, write, flush, discard</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">blockio_bytes</code><span class="text-slate-500 pl-4 md:pl-0">Counter (bytes) with <code>op</code>: read, write, flush, discard</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">blockio_size</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (bytes) with <code>op</code>: read, write, flush, discard</span></div>
 </div>
 </details>
 </section>
@@ -210,43 +218,43 @@
 <section class="mb-12" id="network">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-amber-600" data-icon="lan">lan</span>
-<h2 class="text-xl font-bold">Network</h2>
+<h3 class="text-xl font-bold">Network</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Traffic</h3><p class="text-xs text-slate-400">Aggregate bytes and packets</p></div>
+<div><h4 class="text-sm font-bold">Traffic</h4><p class="text-xs text-slate-400">Aggregate bytes and packets</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_bytes</code><span class="text-slate-500">Counter with <code>direction</code>: receive, transmit</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_packets</code><span class="text-slate-500">Counter with <code>direction</code>: receive, transmit</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_bytes</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>direction</code>: receive, transmit</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_packets</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>direction</code>: receive, transmit</span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Interfaces</h3><p class="text-xs text-slate-400">Drops, transmit errors, timeouts</p></div>
+<div><h4 class="text-sm font-bold">Interfaces</h4><p class="text-xs text-slate-400">Drops, transmit errors, timeouts</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_drop</code><span class="text-slate-500">Dropped packets counter</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_transmit_busy</code><span class="text-slate-500">Transmit busy counter</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_transmit_complete</code><span class="text-slate-500">Completed transmissions counter</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_transmit_timeout</code><span class="text-slate-500">Transmit timeout events</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_drop</code><span class="text-slate-500 pl-4 md:pl-0">Dropped packets counter</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_transmit_busy</code><span class="text-slate-500 pl-4 md:pl-0">Transmit busy counter</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_transmit_complete</code><span class="text-slate-500 pl-4 md:pl-0">Completed transmissions counter</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_transmit_timeout</code><span class="text-slate-500 pl-4 md:pl-0">Transmit timeout events</span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Ethtool (ENA)</h3><p class="text-xs text-slate-400">AWS EC2 Elastic Network Adapter allowance counters</p></div>
+<div><h4 class="text-sm font-bold">Ethtool (ENA)</h4><p class="text-xs text-slate-400">AWS EC2 Elastic Network Adapter allowance counters</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_ena_bandwidth_allowance_exceeded</code><span class="text-slate-500">With <code>direction</code>: receive, transmit</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_ena_pps_allowance_exceeded</code><span class="text-slate-500">Packets-per-second limit exceeded</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_ena_conntrack_allowance_exceeded</code><span class="text-slate-500">Connection tracking limit exceeded</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">network_ena_linklocal_allowance_exceeded</code><span class="text-slate-500">Link-local traffic limit exceeded</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_ena_bandwidth_allowance_exceeded</code><span class="text-slate-500 pl-4 md:pl-0">With <code>direction</code>: receive, transmit</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_ena_pps_allowance_exceeded</code><span class="text-slate-500 pl-4 md:pl-0">Packets-per-second limit exceeded</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_ena_conntrack_allowance_exceeded</code><span class="text-slate-500 pl-4 md:pl-0">Connection tracking limit exceeded</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">network_ena_linklocal_allowance_exceeded</code><span class="text-slate-500 pl-4 md:pl-0">Link-local traffic limit exceeded</span></div>
 </div>
 </details>
 </section>
@@ -255,32 +263,32 @@
 <section class="mb-12" id="tcp">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-rose-600" data-icon="cable">cable</span>
-<h2 class="text-xl font-bold">TCP</h2>
+<h3 class="text-xl font-bold">TCP</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Traffic</h3><p class="text-xs text-slate-400">Bytes, packets, and segment size distributions</p></div>
+<div><h4 class="text-sm font-bold">Traffic</h4><p class="text-xs text-slate-400">Bytes, packets, and segment size distributions</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_bytes</code><span class="text-slate-500">Counter with <code>direction</code>: receive, transmit</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_packets</code><span class="text-slate-500">Counter with <code>direction</code>: receive, transmit</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_size</code><span class="text-slate-500">Histogram (bytes) with <code>direction</code>: receive, transmit</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_bytes</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>direction</code>: receive, transmit</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_packets</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>direction</code>: receive, transmit</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_size</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (bytes) with <code>direction</code>: receive, transmit</span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Latency</h3><p class="text-xs text-slate-400">Connection establishment, packet delivery, jitter, RTT</p></div>
+<div><h4 class="text-sm font-bold">Latency</h4><p class="text-xs text-slate-400">Connection establishment, packet delivery, jitter, RTT</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_connect_latency</code><span class="text-slate-500">Histogram (ns) &mdash; time to establish connection</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_packet_latency</code><span class="text-slate-500">Histogram (ns) &mdash; receive-to-read latency</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_jitter</code><span class="text-slate-500">Histogram (ns) &mdash; inter-packet jitter</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_srtt</code><span class="text-slate-500">Histogram (ns) &mdash; smoothed round-trip time</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">tcp_retransmit</code><span class="text-slate-500">Counter &mdash; retransmitted packets</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_connect_latency</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (ns) &mdash; time to establish connection</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_packet_latency</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (ns) &mdash; receive-to-read latency</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_jitter</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (ns) &mdash; inter-packet jitter</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_srtt</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (ns) &mdash; smoothed round-trip time</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">tcp_retransmit</code><span class="text-slate-500 pl-4 md:pl-0">Counter &mdash; retransmitted packets</span></div>
 </div>
 </details>
 </section>
@@ -289,19 +297,19 @@
 <section class="mb-12" id="syscall">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-cyan-600" data-icon="terminal">terminal</span>
-<h2 class="text-xl font-bold">Syscall</h2>
+<h3 class="text-xl font-bold">Syscall</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Counts &amp; Latency</h3><p class="text-xs text-slate-400">Invocation counts and latency distributions by syscall category</p></div>
+<div><h4 class="text-sm font-bold">Counts &amp; Latency</h4><p class="text-xs text-slate-400">Invocation counts and latency distributions by syscall category</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 text-xs border-t border-slate-200 dark:border-slate-800">
 <div class="space-y-2 mb-4">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">syscall</code><span class="text-slate-500">Counter with <code>op</code> label (see categories below)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">syscall_latency</code><span class="text-slate-500">Histogram (ns) with <code>op</code> label (same categories)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">cgroup_syscall</code><span class="text-slate-500">Per-cgroup counters with same <code>op</code> labels</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">syscall</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>op</code> label (see categories below)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">syscall_latency</code><span class="text-slate-500 pl-4 md:pl-0">Histogram (ns) with <code>op</code> label (same categories)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">cgroup_syscall</code><span class="text-slate-500 pl-4 md:pl-0">Per-cgroup counters with same <code>op</code> labels</span></div>
 </div>
 <p class="text-slate-400 mb-2">Syscall categories (<code>op</code> values):</p>
 <div class="flex flex-wrap gap-2">
@@ -330,26 +338,26 @@
 <section class="mb-12" id="memory">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-indigo-600" data-icon="dynamic_form">dynamic_form</span>
-<h2 class="text-xl font-bold">Memory</h2>
+<h3 class="text-xl font-bold">Memory</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Meminfo &amp; VMStat</h3><p class="text-xs text-slate-400">System memory gauges and NUMA allocation counters</p></div>
+<div><h4 class="text-sm font-bold">Meminfo &amp; VMStat</h4><p class="text-xs text-slate-400">System memory gauges and NUMA allocation counters</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_total</code><span class="text-slate-500">Gauge (bytes)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_free</code><span class="text-slate-500">Gauge (bytes)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_available</code><span class="text-slate-500">Gauge (bytes)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_buffers</code><span class="text-slate-500">Gauge (bytes)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_cached</code><span class="text-slate-500">Gauge (bytes)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_numa_hit</code><span class="text-slate-500">Counter &mdash; allocations on intended node</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_numa_miss</code><span class="text-slate-500">Counter &mdash; allocations on non-intended node</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_numa_foreign</code><span class="text-slate-500">Counter &mdash; allocations intended for this node, placed elsewhere</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_numa_interleave</code><span class="text-slate-500">Counter &mdash; interleave policy allocations</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_numa_local</code><span class="text-slate-500">Counter &mdash; allocations on local node</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">memory_numa_other</code><span class="text-slate-500">Counter &mdash; allocations on remote node</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_total</code><span class="text-slate-500 pl-4 md:pl-0">Gauge (bytes)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_free</code><span class="text-slate-500 pl-4 md:pl-0">Gauge (bytes)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_available</code><span class="text-slate-500 pl-4 md:pl-0">Gauge (bytes)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_buffers</code><span class="text-slate-500 pl-4 md:pl-0">Gauge (bytes)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_cached</code><span class="text-slate-500 pl-4 md:pl-0">Gauge (bytes)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_numa_hit</code><span class="text-slate-500 pl-4 md:pl-0">Counter &mdash; allocations on intended node</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_numa_miss</code><span class="text-slate-500 pl-4 md:pl-0">Counter &mdash; allocations on non-intended node</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_numa_foreign</code><span class="text-slate-500 pl-4 md:pl-0">Counter &mdash; allocations intended for this node, placed elsewhere</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_numa_interleave</code><span class="text-slate-500 pl-4 md:pl-0">Counter &mdash; interleave policy allocations</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_numa_local</code><span class="text-slate-500 pl-4 md:pl-0">Counter &mdash; allocations on local node</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">memory_numa_other</code><span class="text-slate-500 pl-4 md:pl-0">Counter &mdash; allocations on remote node</span></div>
 </div>
 </details>
 </section>
@@ -358,41 +366,41 @@
 <section class="mb-12" id="gpu">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-emerald-600" data-icon="developer_board">developer_board</span>
-<h2 class="text-xl font-bold">GPU</h2>
+<h3 class="text-xl font-bold">GPU</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">NVIDIA</h3><p class="text-xs text-slate-400">Memory, power, temperature, clocks, utilization (Linux)</p></div>
+<div><h4 class="text-sm font-bold">NVIDIA</h4><p class="text-xs text-slate-400">Memory, power, temperature, clocks, utilization (Linux)</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_memory</code><span class="text-slate-500">Per-GPU gauge (bytes) with <code>state</code>: free, used</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_power_usage</code><span class="text-slate-500">Per-GPU gauge (milliwatts)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_energy_consumption</code><span class="text-slate-500">Per-GPU counter (millijoules)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_temperature</code><span class="text-slate-500">Per-GPU gauge (Celsius)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_clock</code><span class="text-slate-500">Per-GPU gauge (Hz) with <code>clock</code>: compute, graphics, memory, video</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_utilization</code><span class="text-slate-500">Per-GPU gauge (percentage)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_memory_utilization</code><span class="text-slate-500">Per-GPU gauge (percentage)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_pcie_bandwidth</code><span class="text-slate-500">Per-GPU gauge (bytes/sec) with <code>direction</code>: receive</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_pcie_throughput</code><span class="text-slate-500">Per-GPU gauge (bytes/sec) with <code>direction</code>: receive, transmit</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_sm_utilization</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_sm_occupancy</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_dram_bandwidth_utilization</code><span class="text-slate-500">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_tensor_utilization</code><span class="text-slate-500">Per-GPU gauge (%) with <code>pipe</code>: any, hmma (FP16/BF16/TF32), imma (integer), dfma (FP64) &mdash; Hopper+ only</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_memory</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (bytes) with <code>state</code>: free, used</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_power_usage</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (milliwatts)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_energy_consumption</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU counter (millijoules)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_temperature</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (Celsius)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_clock</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (Hz) with <code>clock</code>: compute, graphics, memory, video</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_utilization</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (percentage)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_memory_utilization</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (percentage)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_pcie_bandwidth</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (bytes/sec) with <code>direction</code>: receive</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_pcie_throughput</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (bytes/sec) with <code>direction</code>: receive, transmit</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_sm_utilization</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_sm_occupancy</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_dram_bandwidth_utilization</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (%) &mdash; Hopper+ only</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_tensor_utilization</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (%) with <code>pipe</code>: any, hmma (FP16/BF16/TF32), imma (integer), dfma (FP64) &mdash; Hopper+ only</span></div>
 </div>
 </details>
 
-<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden">
+<details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Apple Silicon</h3><p class="text-xs text-slate-400">Power, clocks, utilization (macOS)</p></div>
+<div><h4 class="text-sm font-bold">Apple Silicon</h4><p class="text-xs text-slate-400">Power, clocks, utilization (macOS)</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_power_usage</code><span class="text-slate-500">Per-GPU gauge (milliwatts)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_energy_consumption</code><span class="text-slate-500">Per-GPU counter (millijoules)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_clock</code><span class="text-slate-500">Per-GPU gauge (Hz) with <code>clock</code>: graphics</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">gpu_utilization</code><span class="text-slate-500">Per-GPU gauge (percentage)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_power_usage</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (milliwatts)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_energy_consumption</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU counter (millijoules)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_clock</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (Hz) with <code>clock</code>: graphics</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">gpu_utilization</code><span class="text-slate-500 pl-4 md:pl-0">Per-GPU gauge (percentage)</span></div>
 </div>
 </details>
 </section>
@@ -401,29 +409,51 @@
 <section class="mb-12" id="rezolus">
 <div class="flex items-center gap-3 mb-6">
 <span class="material-symbols-outlined text-slate-600" data-icon="speed">speed</span>
-<h2 class="text-xl font-bold">Rezolus (self-monitoring)</h2>
+<h3 class="text-xl font-bold">Rezolus (self-monitoring)</h3>
 </div>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>
 <summary class="flex items-center justify-between px-5 py-3 cursor-pointer bg-slate-50 dark:bg-slate-900/50 hover:bg-slate-100 dark:hover:bg-slate-800/50 transition-colors">
-<div><h3 class="text-sm font-bold">Resource Usage</h3><p class="text-xs text-slate-400">Rezolus process CPU, memory, I/O, and context switches</p></div>
+<div><h4 class="text-sm font-bold">Resource Usage</h4><p class="text-xs text-slate-400">Rezolus process CPU, memory, I/O, and context switches</p></div>
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-xs border-t border-slate-200 dark:border-slate-800">
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">rezolus_cpu_usage</code><span class="text-slate-500">Counter (ns) with <code>state</code>: user, system</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">rezolus_memory_usage_resident_set_size</code><span class="text-slate-500">Gauge (bytes)</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">rezolus_memory_page_reclaims</code><span class="text-slate-500">Counter</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">rezolus_memory_page_faults</code><span class="text-slate-500">Counter</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">rezolus_blockio_operations</code><span class="text-slate-500">Counter with <code>op</code>: read, write</span></div>
-<div class="flex gap-3"><code class="text-blue-600 dark:text-blue-400 shrink-0 w-48">rezolus_context_switch</code><span class="text-slate-500">Counter with <code>kind</code>: voluntary, involuntary</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">rezolus_cpu_usage</code><span class="text-slate-500 pl-4 md:pl-0">Counter (ns) with <code>state</code>: user, system</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">rezolus_memory_usage_resident_set_size</code><span class="text-slate-500 pl-4 md:pl-0">Gauge (bytes)</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">rezolus_memory_page_reclaims</code><span class="text-slate-500 pl-4 md:pl-0">Counter</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">rezolus_memory_page_faults</code><span class="text-slate-500 pl-4 md:pl-0">Counter</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">rezolus_blockio_operations</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>op</code>: read, write</span></div>
+<div class="flex flex-col md:flex-row md:gap-3"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:w-72">rezolus_context_switch</code><span class="text-slate-500 pl-4 md:pl-0">Counter with <code>kind</code>: voluntary, involuntary</span></div>
 </div>
 </details>
 </section>
+
+<!-- Metric Types -->
+<section class="mb-12" id="types">
+<h2 class="text-xl font-bold mb-6">Metric types</h2>
+<p class="text-sm text-slate-500 dark:text-slate-400 mb-6">Every metric in a Rezolus recording is one of these three shapes. Column metadata records the type, and the viewer dispatches chart rendering accordingly.</p>
+<div class="space-y-3">
+<div class="rounded-xl border border-slate-200 dark:border-slate-800 px-5 py-4">
+<div class="flex items-baseline gap-3 mb-2"><code class="text-blue-600 dark:text-blue-400 font-bold">counter</code><span class="text-xs text-slate-400">UInt64, monotonic</span></div>
+<p class="text-sm text-slate-500 dark:text-slate-400">A monotonically non-decreasing total. Rates and deltas are derived at query time via <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">rate()</code> / <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">irate()</code>. Examples: <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">cpu_usage</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">syscall</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">blockio_operations</code>.</p>
+</div>
+<div class="rounded-xl border border-slate-200 dark:border-slate-800 px-5 py-4">
+<div class="flex items-baseline gap-3 mb-2"><code class="text-blue-600 dark:text-blue-400 font-bold">gauge</code><span class="text-xs text-slate-400">Int64, instantaneous</span></div>
+<p class="text-sm text-slate-500 dark:text-slate-400">An instantaneous value that can go up or down. Used as-is &mdash; no rate derivation. Examples: <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">cpu_cores</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">memory_used</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">gpu_utilization</code>.</p>
+</div>
+<div class="rounded-xl border border-slate-200 dark:border-slate-800 px-5 py-4">
+<div class="flex items-baseline gap-3 mb-2"><code class="text-blue-600 dark:text-blue-400 font-bold">histogram</code><span class="text-xs text-slate-400">List&lt;UInt64&gt;, H2 bucketed</span></div>
+<p class="text-sm text-slate-500 dark:text-slate-400">A full bucketed distribution per snapshot, not just summary percentiles. Queryable via <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">histogram_quantiles()</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">histogram_mean()</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">histogram_sum()</code>, etc. Examples: <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">scheduler_runqueue_latency</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">syscall_latency</code>, <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">tcp_packet_latency</code>.</p>
+</div>
+</div>
+</section>
+
 
 <div class="flex justify-between items-center pt-8 border-t border-slate-200 dark:border-slate-800 text-sm">
 <a href="architecture.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">&larr; Architecture</a>
 <a href="api.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">API Reference &rarr;</a>
 </div>
+
 
 </main>
 </div>

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Usage - Rezolus Docs</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script>
+      tailwind.config = {
+        darkMode: "media",
+        theme: { extend: { colors: { "primary": "#0059ba" }, fontFamily: { "body": ["Inter"] } } },
+      }
+</script>
+<style>
+    html { scroll-padding-top: 5rem; }
+    .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; }
+    body { font-family: 'Inter', sans-serif; }
+
+        .brand {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.15em;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background: linear-gradient(135deg, #58a6ff 0%, #79c0ff 100%);
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            mask-size: contain;
+            -webkit-mask-size: contain;
+            mask-repeat: no-repeat;
+            -webkit-mask-repeat: no-repeat;
+        }
+    </style>
+</head>
+<body class="bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
+
+<!-- Nav -->
+<nav class="fixed top-0 w-full z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200/50 dark:border-slate-800">
+<div class="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
+<a href="/" class="brand text-slate-900 dark:text-white no-underline">REZOLUS</a>
+<div class="hidden md:flex items-center gap-8 text-sm font-medium">
+<a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline" href="/">Home</a>
+<a class="text-blue-700 dark:text-blue-400 font-bold no-underline" href="installation.html">Docs</a>
+<a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline" href="https://github.com/iopsystems/rezolus">GitHub</a>
+</div>
+</div>
+</nav>
+
+<div class="flex max-w-6xl mx-auto pt-20">
+<!-- Sidebar -->
+<aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
+<div class="mb-8">
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
+</div>
+<nav class="flex-1 space-y-6 overflow-y-auto text-sm">
+<div class="space-y-1">
+<h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Getting Started</h4>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="installation.html">Installation</a>
+<a class="block px-3 py-1.5 text-blue-700 dark:text-blue-400 font-bold bg-blue-50 dark:bg-blue-900/30 rounded-lg no-underline" href="usage.html">Usage</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html#long-running">Long-running</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html#one-off">One-off</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="usage.html#offline">Offline analysis</a>
+</div>
+<div class="space-y-1">
+<h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Core Concepts</h4>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="architecture.html">Architecture</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html">Metrics</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#samplers">Samplers</a>
+<a class="block pl-7 pr-3 py-1 text-xs text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="telemetry.html#types">Types</a>
+</div>
+<div class="space-y-1">
+<h4 class="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-2">Reference</h4>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="api.html">API Reference</a>
+<a class="block px-3 py-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white transition-colors no-underline" href="cli.html">CLI &amp; Configuration</a>
+</div>
+</nav>
+</aside>
+
+<!-- Content -->
+<main class="flex-1 px-8 lg:px-16 py-12 min-w-0 max-w-3xl lg:max-w-4xl">
+
+<h1 class="text-4xl font-extrabold tracking-tight mb-12">Usage</h1>
+
+<!-- Long-running -->
+<section class="mb-16" id="long-running">
+<h2 class="text-xl font-bold mb-2">Long-running</h2>
+<p class="text-sm text-slate-500 dark:text-slate-400 mb-8">Continuous deployments that observe a system over its lifetime.</p>
+
+<div class="space-y-10">
+
+<!-- Agent + Prometheus -->
+<div>
+<h3 class="text-base font-bold mb-3">Run the agent and scrape with Prometheus</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">Standard always-on monitoring. The agent collects via eBPF and exposes its data to the exporter, which serves Prometheus on <code class="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded text-xs">:4242</code>.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="text-slate-500 text-xs"># systemd-installed: both services are already enabled</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">sudo systemctl start rezolus rezolus-exporter</code></div>
+<div class="mt-3 text-slate-500 text-xs"># Point Prometheus at :4242 and wire Grafana to that source</div>
+</div>
+</div>
+</div>
+
+<!-- Hindsight -->
+<div>
+<h3 class="text-base font-bold mb-3">Keep a rolling buffer with Hindsight</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">For systems where you can't predict when something will go wrong. Hindsight maintains a rolling on-disk ring buffer of high-resolution snapshots; when an incident hits, trigger a snapshot and load the surrounding time window in the viewer.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">sudo systemctl start rezolus-hindsight</code></div>
+<div class="mt-3 text-slate-500 text-xs"># Trigger a snapshot on demand (signal or HTTP)</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">sudo pkill -HUP -f rezolus-hindsight</code></div>
+<div class="mt-3 text-slate-500 text-xs"># Or via the HTTP API for scripted triggers</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">curl -X POST http://localhost:4243/snapshot</code></div>
+</div>
+</div>
+</div>
+
+<!-- OTel ingest -->
+<div>
+<h3 class="text-base font-bold mb-3">Combine your own metrics</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">Pull metrics from your application's OpenTelemetry/Prometheus endpoint into the same recording as the rezolus system metrics. Useful for correlating service-level KPIs (request rate, p99 latency) with kernel-level events.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="flex items-center px-4 py-2 bg-slate-800">
+<span class="text-[10px] font-mono opacity-50 uppercase tracking-widest">rezolus-record.toml</span>
+</div>
+<div class="p-5 font-mono text-sm leading-8">
+<div><span class="text-purple-400">[recording]</span></div>
+<div><span class="text-blue-400">interval</span> = <span class="text-green-400">"1s"</span></div>
+<div><span class="text-blue-400">output</span> = <span class="text-green-400">"combined.parquet"</span></div>
+<div class="mt-3"><span class="text-purple-400">[[endpoints]]</span>  <span class="text-slate-600"># rezolus agent</span></div>
+<div><span class="text-blue-400">url</span> = <span class="text-green-400">"http://127.0.0.1:4241"</span></div>
+<div><span class="text-blue-400">source</span> = <span class="text-green-400">"rezolus"</span></div>
+<div class="mt-3"><span class="text-purple-400">[[endpoints]]</span>  <span class="text-slate-600"># your service's /metrics</span></div>
+<div><span class="text-blue-400">url</span> = <span class="text-green-400">"http://127.0.0.1:9090/metrics"</span></div>
+<div><span class="text-blue-400">source</span> = <span class="text-green-400">"my-service"</span></div>
+<div><span class="text-blue-400">role</span> = <span class="text-green-400">"service"</span></div>
+<div><span class="text-blue-400">protocol</span> = <span class="text-green-400">"prometheus"</span></div>
+</div>
+</div>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden mt-3">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus record --config rezolus-record.toml</code></div>
+</div>
+</div>
+</div>
+
+</div>
+</section>
+
+<!-- One-off -->
+<section class="mb-16" id="one-off">
+<h2 class="text-xl font-bold mb-2">One-off</h2>
+<p class="text-sm text-slate-500 dark:text-slate-400 mb-8">Ad-hoc captures and live connections for a specific investigation.</p>
+
+<div class="space-y-10">
+
+<!-- Single recording -->
+<div>
+<h3 class="text-base font-bold mb-3">Capture a recording for performance analysis</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">Run a workload while recording at a high enough resolution to catch what you're looking for. The output parquet is self-contained &mdash; open it later, share it, archive it.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="text-slate-500 text-xs"># Record 60s at 100ms intervals against a running agent</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus record -i 100ms -d 60s http://localhost:4241 run-1.parquet</code></div>
+<div class="mt-3 text-slate-500 text-xs"># Open it in the viewer</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view run-1.parquet</code></div>
+</div>
+</div>
+</div>
+
+<!-- A/B compare -->
+<div>
+<h3 class="text-base font-bold mb-3">A/B comparison</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">Compare two recordings side-by-side &mdash; before/after a change, baseline vs. experiment, or two different machines. The viewer renders each chart twice and surfaces deltas.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view baseline.parquet experiment.parquet</code></div>
+<div class="mt-3 text-slate-500 text-xs"># Aliases for clearer labels in the UI</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view before=run-a.parquet after=run-b.parquet</code></div>
+</div>
+</div>
+</div>
+
+<!-- Live tail -->
+<div>
+<h3 class="text-base font-bold mb-3">Live-tail a remote agent</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">Skip the recording step and stream straight from an agent into a browser dashboard. Best for quick checks against a remote host where you don't want to save anything to disk.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view http://agent-host:4241</code></div>
+</div>
+</div>
+</div>
+
+</div>
+</section>
+
+<!-- Offline / read-time -->
+<section class="mb-16" id="offline">
+<h2 class="text-xl font-bold mb-2">Offline analysis</h2>
+<p class="text-sm text-slate-500 dark:text-slate-400 mb-8">Things you do after the data is already captured &mdash; in the viewer or via the MCP server.</p>
+
+<div class="space-y-10">
+
+<!-- A/B compare (again) -->
+<div>
+<h3 class="text-base font-bold mb-3">A/B comparison</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">Same workflow as in the one-off case: any two recordings can be compared, regardless of when or how they were captured. Useful when you already have an archive of runs and want to spot regressions between specific pairs.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view 2025-12-01.parquet 2026-01-15.parquet</code></div>
+</div>
+</div>
+</div>
+
+<!-- Per-cgroup -->
+<div>
+<h3 class="text-base font-bold mb-3">Per-cgroup / container drill-down</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">CPU, Scheduler, and Syscall samplers emit per-cgroup metrics. In the viewer, switch the cgroup selector to a specific container to see only its CPU usage, runqueue latency, syscall mix &mdash; isolating one tenant on a noisy host.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus view recording.parquet</code></div>
+<div class="mt-3 text-slate-500 text-xs"># In the viewer: Cgroups section → pick a container → all charts re-scope</div>
+</div>
+</div>
+</div>
+
+<!-- MCP -->
+<div>
+<h3 class="text-base font-bold mb-3">AI-assisted analysis with MCP</h3>
+<p class="text-base text-slate-500 dark:text-slate-400 mb-3">Point the MCP server at a recording and ask an LLM-driven client to investigate. Built-in tools cover anomaly detection (MAD / CUSUM / FFT), metric correlation, and arbitrary PromQL queries against the recording.</p>
+<div class="bg-slate-900 text-slate-300 rounded-xl overflow-hidden">
+<div class="p-5 font-mono text-sm leading-8">
+<div class="text-slate-500 text-xs"># One-shot CLI mode</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus mcp detect-anomalies recording.parquet</code></div>
+<div class="mt-3 text-slate-500 text-xs"># Or run as a stdio server for Claude Desktop / Cursor</div>
+<div class="flex gap-4"><span class="text-slate-600 select-none">$</span><code class="text-green-400">rezolus mcp</code></div>
+</div>
+</div>
+</div>
+
+</div>
+</section>
+
+<div class="flex justify-between items-center pt-8 border-t border-slate-200 dark:border-slate-800 text-sm">
+<a href="installation.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">&larr; Installation</a>
+<a href="architecture.html" class="text-blue-600 dark:text-blue-400 font-bold no-underline hover:underline">Architecture &rarr;</a>
+</div>
+
+</main>
+</div>
+</body></html>

--- a/site/index.html
+++ b/site/index.html
@@ -381,9 +381,9 @@
                 <a href="docs/telemetry.html#cpu"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="memory">memory</span></span></div>
+                                data-icon="memory">memory</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">CPU</h3>
                     </div>
                     <p class="text-base text-slate-400">Usage, frequency, perf counters, cache, TLB</p>
@@ -391,9 +391,9 @@
                 <a href="docs/telemetry.html#gpu"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="developer_board">developer_board</span></span></div>
+                                data-icon="developer_board">developer_board</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">GPU</h3>
                     </div>
                     <p class="text-base text-slate-400">NVIDIA and Apple Silicon metrics</p>
@@ -401,9 +401,9 @@
                 <a href="docs/telemetry.html#memory"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="dynamic_form">dynamic_form</span></span></div>
+                                data-icon="dynamic_form">dynamic_form</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">Memory</h3>
                     </div>
                     <p class="text-base text-slate-400">Usage, vmstat, NUMA allocations</p>
@@ -411,9 +411,9 @@
                 <a href="docs/telemetry.html#network"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="lan">lan</span></span></div>
+                                data-icon="lan">lan</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">Network</h3>
                     </div>
                     <p class="text-base text-slate-400">Traffic, errors, ethtool counters</p>
@@ -421,9 +421,9 @@
                 <a href="docs/telemetry.html#tcp"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="cable">cable</span></span></div>
+                                data-icon="cable">cable</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">TCP</h3>
                     </div>
                     <p class="text-base text-slate-400">Connect latency, jitter, retransmits</p>
@@ -431,9 +431,9 @@
                 <a href="docs/telemetry.html#blockio"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="storage">storage</span></span></div>
+                                data-icon="storage">storage</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">Block I/O</h3>
                     </div>
                     <p class="text-base text-slate-400">Latency distributions, request counts</p>
@@ -441,9 +441,9 @@
                 <a href="docs/telemetry.html#scheduler"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="schedule">schedule</span></span></div>
+                                data-icon="schedule">schedule</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">Scheduler</h3>
                     </div>
                     <p class="text-base text-slate-400">Runqueue latency, context switches</p>
@@ -451,9 +451,9 @@
                 <a href="docs/telemetry.html#syscall"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="terminal">terminal</span></span></div>
+                                data-icon="terminal">terminal</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">Syscall</h3>
                     </div>
                     <p class="text-base text-slate-400">Counts and latency by type</p>
@@ -461,9 +461,9 @@
                 <a href="docs/telemetry.html#rezolus"
                     class="group p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3 mb-2">
-                        <div class="text-2xl"><span
+                        <div class="text-2xl leading-none"><span
                                 class="material-symbols-outlined text-slate-400 group-hover:text-blue-600 transition-colors"
-                                data-icon="speed">speed</span></span></div>
+                                data-icon="speed">speed</span></div>
                         <h3 class="text-base font-bold text-slate-900 dark:text-white">Rezolus</h3>
                     </div>
                     <p class="text-base text-slate-400">Self-monitoring: CPU, memory, I/O</p>
@@ -494,8 +494,8 @@
                         class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                         data-icon="download">download</span>
                     <div>
-                        <h3 class="text-sm font-bold text-slate-900 dark:text-white">Installation</h3>
-                        <p class="text-sm text-slate-400">Packages, source builds, platform support</p>
+                        <h3 class="text-base font-bold text-slate-900 dark:text-white">Installation</h3>
+                        <p class="text-base text-slate-400">Packages, source builds, platform support</p>
                     </div>
                 </a>
                 <a href="docs/architecture.html"
@@ -504,8 +504,8 @@
                         class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                         data-icon="account_tree">account_tree</span>
                     <div>
-                        <h3 class="text-sm font-bold text-slate-900 dark:text-white">Architecture</h3>
-                        <p class="text-sm text-slate-400">Modes, samplers, eBPF integration</p>
+                        <h3 class="text-base font-bold text-slate-900 dark:text-white">Architecture</h3>
+                        <p class="text-base text-slate-400">Modes, samplers, eBPF integration</p>
                     </div>
                 </a>
                 <a href="docs/cli.html"
@@ -514,8 +514,8 @@
                         class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                         data-icon="terminal">terminal</span>
                     <div>
-                        <h3 class="text-sm font-bold text-slate-900 dark:text-white">CLI &amp; Configuration</h3>
-                        <p class="text-sm text-slate-400">Commands, flags, TOML config reference</p>
+                        <h3 class="text-base font-bold text-slate-900 dark:text-white">CLI &amp; Configuration</h3>
+                        <p class="text-base text-slate-400">Commands, flags, TOML config reference</p>
                     </div>
                 </a>
                 <a href="docs/api.html"
@@ -524,8 +524,8 @@
                         class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                         data-icon="api">api</span>
                     <div>
-                        <h3 class="text-sm font-bold text-slate-900 dark:text-white">API Reference</h3>
-                        <p class="text-sm text-slate-400">HTTP endpoints for every mode</p>
+                        <h3 class="text-base font-bold text-slate-900 dark:text-white">API Reference</h3>
+                        <p class="text-base text-slate-400">HTTP endpoints for every mode</p>
                     </div>
                 </a>
             </div>

--- a/site/index.html
+++ b/site/index.html
@@ -9,7 +9,7 @@
         content="Rezolus is a high-resolution systems &amp; performance telemetry agent using eBPF for low-overhead instrumentation on Linux." />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=Jost:wght@100..900&amp;display=swap"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=Jost:wght@100..900&amp;family=JetBrains+Mono:wght@700&amp;display=swap"
         rel="stylesheet" />
     <link
         href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
@@ -49,10 +49,33 @@
         }
 
         .hero-title,
-        .brand,
         h2 {
             font-family: 'Jost', sans-serif;
             font-weight: 650;
+        }
+    
+        .brand {
+            font-family: 'JetBrains Mono', monospace;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.15em;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .brand::before {
+            content: '';
+            display: inline-block;
+            width: 24px;
+            height: 24px;
+            background: linear-gradient(135deg, #58a6ff 0%, #79c0ff 100%);
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M2 12h4l3-9 6 18 3-9h4' fill='none' stroke='white' stroke-width='2' stroke-linejoin='miter'/%3E%3C/svg%3E");
+            mask-size: contain;
+            -webkit-mask-size: contain;
+            mask-repeat: no-repeat;
+            -webkit-mask-repeat: no-repeat;
         }
     </style>
 </head>
@@ -63,7 +86,7 @@
     <nav
         class="fixed top-0 w-full z-50 bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-slate-200/50 dark:border-slate-800">
         <div class="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
-            <a href="/" class="brand text-2xl tracking-tighter text-slate-800 dark:text-white no-underline">Rezolus</a>
+            <a href="/" class="brand text-slate-800 dark:text-white no-underline">REZOLUS</a>
             <div class="hidden md:flex items-center gap-8 text-sm font-medium">
                 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline"
                     href="#features">Features</a>


### PR DESCRIPTION
## Summary

Marketing site brand was visually inconsistent with the viewer's top nav. This aligns them: same JetBrains Mono wordmark, same waveform glyph, same uppercase "REZOLUS" letterforms.

Concretely:

- `.brand` class in each of the 6 site pages (landing + 5 docs) now sets `JetBrains Mono`, weight 700, 0.15em letter-spacing, 1rem, with a `::before` pseudo-element rendering the same 24px waveform SVG as `#topnav .logo::before` in `src/viewer/assets/lib/style.css`, masked over the viewer's accent gradient (`#58a6ff → #79c0ff`).
- Wordmark text changed `Rezolus` → `REZOLUS`.
- JetBrains Mono added to the Google Fonts loader on each page.
- On the landing page, `.brand` was previously grouped with `.hero-title, h2` for the Jost weight rule — pulled out so the new mono styling isn't shadowed.

Alpha bump: `5.14.1-alpha.3` → `5.14.1-alpha.4`.

## Test plan

- [x] Visual check on landing + each docs page locally; brand matches the viewer's nav at the same scale.
- [x] Dark-mode rendering checked (glyph gradient + text colors).
- [x] `./scripts/sync-docs-version.sh` re-run as part of the /pr workflow — no-op (v5.14.0 already current).