### PR TITLE
feat(site,viewer): tab title, favicon, nav polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.1-alpha.4"
+version = "5.14.1-alpha.5"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.1-alpha.4"
+version = "5.14.1-alpha.5"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -3,6 +3,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>API Reference - Rezolus Docs</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -3,6 +3,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Architecture - Rezolus Docs</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -3,6 +3,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>CLI &amp; Configuration - Rezolus Docs</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -3,6 +3,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Installation - Rezolus Docs</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -3,6 +3,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Metrics - Rezolus Docs</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -3,6 +3,7 @@
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Usage - Rezolus Docs</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&amp;family=JetBrains+Mono:wght@700&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#58a6ff"/>
+      <stop offset="1" stop-color="#79c0ff"/>
+    </linearGradient>
+  </defs>
+  <path d="M2 12h4l3-9 6 18 3-9h4" fill="none" stroke="url(#g)" stroke-width="2.5" stroke-linejoin="miter" stroke-linecap="round"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     <title>Rezolus - High-Resolution Systems &amp; Performance Telemetry</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
     <meta name="description"
         content="Rezolus is a high-resolution systems &amp; performance telemetry agent using eBPF for low-overhead instrumentation on Linux." />
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
@@ -93,13 +94,13 @@
                 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline"
                     href="#quickstart">Quick Start</a>
                 <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline"
-                    href="viewer/">Viewer</a>
-                <a class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline"
                     href="docs/installation.html">Docs</a>
+                <a class="inline-flex items-center gap-1 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors no-underline"
+                    href="viewer/" target="_blank" rel="noopener">Viewer<span class="material-symbols-outlined text-[14px] opacity-70" data-icon="open_in_new">open_in_new</span></a>
             </div>
-            <a href="https://github.com/iopsystems/rezolus"
-                class="bg-primary dark:bg-blue-600 text-white px-5 py-2 rounded-lg text-sm font-bold no-underline hover:opacity-90 transition-opacity">
-                GitHub
+            <a href="https://github.com/iopsystems/rezolus" target="_blank" rel="noopener"
+                class="inline-flex items-center gap-1 bg-primary dark:bg-blue-600 text-white px-5 py-2 rounded-lg text-sm font-bold no-underline hover:opacity-90 transition-opacity">
+                GitHub<span class="material-symbols-outlined text-[14px] opacity-80" data-icon="open_in_new">open_in_new</span>
             </a>
         </div>
     </nav>

--- a/site/viewer/index.html
+++ b/site/viewer/index.html
@@ -8,6 +8,7 @@
     <meta name="theme-color" content="#0a0e14" />
 
     <title>Rezolus Viewer</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/site/viewer/lib/script.js
+++ b/site/viewer/lib/script.js
@@ -113,6 +113,11 @@ async function loadParquet(data, filename) {
     // outside the new file.
     clearMetadataCache();
     const state = await fetchInitialState();
+    // WASM's file_metadata_json only emits the parquet's embedded
+    // metadata; filename is a runtime TSDB field. Inject it so the
+    // tab title and other UI hooks see it the same way the server
+    // viewer does.
+    state.fileMetadata = { ...(state.fileMetadata || {}), filename };
     // initWasmViewer already called setStorageScope, so a persisted
     // working set (if any) has been restored; this only seeds the
     // footer events when nothing was persisted.

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -33,6 +33,29 @@ import {
 } from './sections/section_cache.js';
 
 let activeSectionRoute = null;
+
+// Captured at mount-time from the HTML <title> so we can fall back to
+// it when neither section nor filename is known yet (e.g. initial load).
+const DEFAULT_DOCUMENT_TITLE = (typeof document !== 'undefined' && document.title) || 'Rezolus';
+
+// Update browser tab title to reflect the active section + loaded file
+// so pasted URLs (e.g. .../viewer/?demo=vllm.parquet#/gpu) preview
+// usefully in link-unfurling and tab strips.
+const updateDocumentTitle = (sectionKey) => {
+    if (typeof document === 'undefined') return;
+    const section = getCachedSections().find(s => s.route === `/${sectionKey}`);
+    const sectionName = section?.name;
+    const filename = fileMetadata?.filename;
+    if (sectionName && filename) {
+        document.title = `${sectionName} (${filename}) — Rezolus`;
+    } else if (sectionName) {
+        document.title = `${sectionName} — Rezolus`;
+    } else if (filename) {
+        document.title = `${filename} — Rezolus`;
+    } else {
+        document.title = DEFAULT_DOCUMENT_TITLE;
+    }
+};
 let systemInfoData = null;
 let fileChecksum = null;
 let fileMetadata = null;
@@ -844,6 +867,8 @@ const initDashboard = (config = {}) => {
                     window.scrollTo(0, 0);
                 }
 
+                updateDocumentTitle(params.section);
+
                 if (params.section === 'systeminfo') {
                     bootstrapCacheIfNeeded();
                     return buildClientOnlySectionView(
@@ -966,6 +991,13 @@ const initDashboard = (config = {}) => {
             },
         },
     });
+
+    // Initial title refresh — m.route's onmatch may resolve before
+    // fileMetadata is set on first load, and same-path reload (Load
+    // Parquet) suppresses onmatch entirely. Force-refresh once
+    // fileMetadata is in hand.
+    const currentRoute = (m.route.get() || '').split('/')[1] || '';
+    updateDocumentTitle(currentRoute);
 };
 
 // Double-click anywhere resets zoom and clears all pin selections

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -393,6 +393,7 @@ body::after {
     font-size: var(--font-size-lg);
     font-weight: 700;
     letter-spacing: 0.15em;
+    margin-right: 1rem;
     color: var(--fg);
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Three small UX improvements bundled.

### Viewer

- **Dynamic browser tab title**: shows `Section (filename) — Rezolus` (e.g. `GPU (vllm.parquet) — Rezolus`) so pasted/shared URLs unfurl with useful previews and open tabs are distinguishable. Hooked into the `/:section` route's `onmatch` handler, plus a force-refresh at the end of `initDashboard` to cover the same-route Load-Parquet reload case where `onmatch` is suppressed.
- **WASM filename injection**: `getFileMetadata()` on the WASM side only emits the parquet's embedded metadata; the runtime filename lives on the TSDB (`getInfo`). `loadParquet` now merges the filename into `fileMetadata` before handing it to `initDashboard`, so the new tab-title logic sees it the same way the server viewer does.
- **Brand / filename gap**: `#topnav .logo` picked up `margin-right: 1rem` so the REZOLUS wordmark stops touching the filename box border.

### Marketing site

- **Top nav order swap**: Docs / Viewer (was Viewer / Docs).
- **External-link affordance**: Viewer and the GitHub CTA now open in a new tab (`target="_blank" rel="noopener"`) with a small `open_in_new` material-symbols glyph at 14px as the visual cue.
- **Favicon**: new `site/favicon.svg` using the waveform brand glyph in the viewer's accent gradient (`#58a6ff → #79c0ff`); linked from every site HTML page (landing, 6 docs pages, viewer).

Alpha bump: `5.14.1-alpha.4` → `5.14.1-alpha.5`.

## Test plan

- [x] `cargo build` — clean
- [x] WASM viewer hard-reloaded — tab title reflects current section + filename, updates on nav and on Load Parquet
- [x] Landing page hard-reloaded — Viewer/GitHub open in new tabs, glyph visible, nav order swapped
- [x] Favicon visible at `/favicon.svg`; linked from every page
- [x] Brand/filename gap visible on the viewer's topnav