### PR TITLE
feat(agent): resilient BPF attach + sampler status (/samplers, recording metadata)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.1-alpha.5"
+version = "5.14.1-alpha.6"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.1-alpha.5"
+version = "5.14.1-alpha.6"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -381,7 +381,7 @@ where
             // failures are tolerated here.
             let mut links: Vec<libbpf_rs::Link> = Vec::new();
             let mut prog_status: Vec<crate::agent::sampler_status::ProgramStatus> = Vec::new();
-            for prog in skel.object().progs() {
+            for prog in skel.object().progs_mut() {
                 if !prog.autoload() {
                     continue; // intentionally-disabled tp_btf/raw_tp twin
                 }

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -318,11 +318,18 @@ where
                     }
                     Err(e) => {
                         error!("Failed to load external BTF from {}: {}", btf_path, e);
+                        crate::agent::sampler_status::set_failed(self.name, e.to_string());
                         return Err(e);
                     }
                 }
             } else {
-                (self.skel)().open(open_object)?
+                match (self.skel)().open(open_object) {
+                    Ok(skel) => skel,
+                    Err(e) => {
+                        crate::agent::sampler_status::set_failed(self.name, e.to_string());
+                        return Err(e);
+                    }
+                }
             };
 
             // If enabled_programs is set, disable autoload for programs not in the list
@@ -357,17 +364,65 @@ where
                 }
             }
 
-            let mut skel = open_skel.load()?;
+            let mut skel = match open_skel.load() {
+                Ok(skel) => skel,
+                Err(e) => {
+                    crate::agent::sampler_status::set_failed(self.name, e.to_string());
+                    return Err(e);
+                }
+            };
 
             skel.log_prog_instructions();
 
-            match skel.attach() {
-                Ok(_) => {}
-                Err(e) if e.kind() == libbpf_rs::ErrorKind::NotFound => {
-                    debug!("Some BPF probes skipped due to missing kernel symbols");
+            // Attach each program individually so one failing probe (missing
+            // kernel symbol, no kprobe support, etc.) does not prevent the
+            // others in this skeleton from attaching. Records per-program
+            // status. Load/verify failures above remain fatal; only attach
+            // failures are tolerated here.
+            let mut links: Vec<libbpf_rs::Link> = Vec::new();
+            let mut prog_status: Vec<crate::agent::sampler_status::ProgramStatus> = Vec::new();
+            for prog in skel.object().progs() {
+                if !prog.autoload() {
+                    continue; // intentionally-disabled tp_btf/raw_tp twin
                 }
-                Err(e) => return Err(e),
+                let prog_name = prog.name().to_string_lossy().to_string();
+                match prog.attach() {
+                    Ok(link) => {
+                        links.push(link);
+                        prog_status.push(crate::agent::sampler_status::ProgramStatus {
+                            name: prog_name,
+                            attached: true,
+                            error: None,
+                        });
+                    }
+                    Err(e) if e.kind() == libbpf_rs::ErrorKind::NotFound => {
+                        debug!(
+                            "{} program '{}' not attached (no kernel support): {}",
+                            self.name, prog_name, e
+                        );
+                        prog_status.push(crate::agent::sampler_status::ProgramStatus {
+                            name: prog_name,
+                            attached: false,
+                            error: Some("no kernel support (ENOENT)".to_string()),
+                        });
+                    }
+                    Err(e) => {
+                        warn!(
+                            "{} program '{}' failed to attach, skipping: {}",
+                            self.name, prog_name, e
+                        );
+                        prog_status.push(crate::agent::sampler_status::ProgramStatus {
+                            name: prog_name,
+                            attached: false,
+                            error: Some(e.to_string()),
+                        });
+                    }
+                }
             }
+            crate::agent::sampler_status::set_active_with_programs(self.name, prog_status);
+            // `_links` must outlive the loop for the sampler thread's lifetime;
+            // dropping a Link detaches its program.
+            let _links = links;
 
             let mut counters: Vec<Counters> = self
                 .counters

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -364,7 +364,7 @@ where
                 }
             }
 
-            let mut skel = match open_skel.load() {
+            let skel = match open_skel.load() {
                 Ok(skel) => skel,
                 Err(e) => {
                     crate::agent::sampler_status::set_failed(self.name, e.to_string());

--- a/src/agent/exposition/http/mod.rs
+++ b/src/agent/exposition/http/mod.rs
@@ -41,6 +41,7 @@ fn app(state: Arc<Mutex<SnapshotBuilder>>) -> Router {
         .route("/metrics/json", get(json))
         .route("/metrics/descriptions", get(descriptions))
         .route("/systeminfo", get(system_info))
+        .route("/samplers", get(samplers))
         .with_state(state)
         .layer(
             ServiceBuilder::new()
@@ -82,6 +83,10 @@ async fn descriptions() -> axum::response::Json<std::collections::HashMap<String
         }
     }
     axum::response::Json(result)
+}
+
+async fn samplers() -> axum::response::Json<Vec<crate::agent::sampler_status::SamplerStatus>> {
+    axum::response::Json(crate::agent::sampler_status::snapshot())
 }
 
 async fn system_info() -> axum::response::Response {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -63,9 +63,16 @@ pub fn run(config: PathBuf) {
 
     let mut samplers = Vec::new();
 
-    for init in SAMPLERS {
-        if let Ok(Some(s)) = init(config.clone()) {
-            samplers.push(s);
+    for entry in SAMPLERS {
+        match (entry.init)(config.clone()) {
+            Ok(Some(s)) => {
+                // BPF samplers already recorded active + per-program detail in
+                // the builder; this only fills in non-BPF samplers.
+                crate::agent::sampler_status::set_active_if_absent(entry.name);
+                samplers.push(s);
+            }
+            Ok(None) => crate::agent::sampler_status::set_disabled(entry.name),
+            Err(e) => crate::agent::sampler_status::set_failed(entry.name, e.to_string()),
         }
     }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,6 +4,7 @@ mod config;
 mod exposition;
 mod external_metrics;
 mod metrics;
+pub mod sampler_status;
 mod samplers;
 
 use config::Config;

--- a/src/agent/sampler_status.rs
+++ b/src/agent/sampler_status.rs
@@ -1,0 +1,152 @@
+//! Process-global registry of per-sampler status, populated during agent
+//! initialization and read by the `/samplers` HTTP endpoint and the recorder.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+/// Status of a single sampler.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SamplerStatus {
+    pub name: String,
+    #[serde(flatten)]
+    pub state: SamplerState,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub programs: Vec<ProgramStatus>,
+}
+
+/// Whether a sampler is running, disabled by config, or failed to initialize.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum SamplerState {
+    Active,
+    Disabled,
+    Failed { error: String },
+}
+
+/// Status of a single BPF program within a sampler.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProgramStatus {
+    pub name: String,
+    pub attached: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn registry() -> &'static Mutex<BTreeMap<&'static str, SamplerStatus>> {
+    static REGISTRY: OnceLock<Mutex<BTreeMap<&'static str, SamplerStatus>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Record a sampler as config-disabled.
+pub fn set_disabled(name: &'static str) {
+    registry().lock().unwrap().insert(
+        name,
+        SamplerStatus {
+            name: name.to_string(),
+            state: SamplerState::Disabled,
+            programs: Vec::new(),
+        },
+    );
+}
+
+/// Record a sampler as failed to initialize, with the error message.
+pub fn set_failed(name: &'static str, error: String) {
+    registry().lock().unwrap().insert(
+        name,
+        SamplerStatus {
+            name: name.to_string(),
+            state: SamplerState::Failed { error },
+            programs: Vec::new(),
+        },
+    );
+}
+
+/// Record a sampler as active with its per-program attach detail.
+pub fn set_active_with_programs(name: &'static str, programs: Vec<ProgramStatus>) {
+    registry().lock().unwrap().insert(
+        name,
+        SamplerStatus {
+            name: name.to_string(),
+            state: SamplerState::Active,
+            programs,
+        },
+    );
+}
+
+/// Mark a sampler active only if it has no record yet. Used by the central
+/// init loop so it does not clobber the richer record a BPF sampler already
+/// wrote from the builder.
+pub fn set_active_if_absent(name: &'static str) {
+    registry()
+        .lock()
+        .unwrap()
+        .entry(name)
+        .or_insert_with(|| SamplerStatus {
+            name: name.to_string(),
+            state: SamplerState::Active,
+            programs: Vec::new(),
+        });
+}
+
+/// Snapshot of all sampler statuses, sorted by name (BTreeMap order).
+pub fn snapshot() -> Vec<SamplerStatus> {
+    registry().lock().unwrap().values().cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_serializes_with_flattened_state_and_programs() {
+        let s = SamplerStatus {
+            name: "cpu_usage".into(),
+            state: SamplerState::Active,
+            programs: vec![
+                ProgramStatus {
+                    name: "softirq_enter".into(),
+                    attached: true,
+                    error: None,
+                },
+                ProgramStatus {
+                    name: "cpuacct_account_field_kprobe".into(),
+                    attached: false,
+                    error: Some("no kernel support (ENOENT)".into()),
+                },
+            ],
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains(r#""name":"cpu_usage""#));
+        assert!(json.contains(r#""state":"active""#));
+        assert!(json.contains(r#""attached":true"#));
+        assert!(json.contains(r#""error":"no kernel support (ENOENT)""#));
+        let back: SamplerStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn disabled_omits_programs_and_error() {
+        let json = serde_json::to_string(&SamplerStatus {
+            name: "gpu".into(),
+            state: SamplerState::Disabled,
+            programs: Vec::new(),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"name":"gpu","state":"disabled"}"#);
+    }
+
+    #[test]
+    fn failed_includes_error() {
+        let json = serde_json::to_string(&SamplerStatus {
+            name: "blockio_latency".into(),
+            state: SamplerState::Failed {
+                error: "boom".into(),
+            },
+            programs: Vec::new(),
+        })
+        .unwrap();
+        assert!(json.contains(r#""state":"failed""#));
+        assert!(json.contains(r#""error":"boom""#));
+    }
+}

--- a/src/agent/samplers/blockio/linux/latency/mod.rs
+++ b/src/agent/samplers/blockio/linux/latency/mod.rs
@@ -6,7 +6,7 @@
 //! And produces these stats:
 //! * `blockio_latency`
 
-static NAME: &str = "blockio_latency";
+const NAME: &str = "blockio_latency";
 
 mod bpf {
     include!(concat!(env!("OUT_DIR"), "/blockio_latency.bpf.rs"));
@@ -21,7 +21,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -44,6 +43,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/blockio/linux/requests/mod.rs
+++ b/src/agent/samplers/blockio/linux/requests/mod.rs
@@ -9,7 +9,7 @@
 //! * `blockio_errors`   — labeled by `op` and `error` class
 //! * `blockio_requeues` — labeled by `op`
 
-static NAME: &str = "blockio_requests";
+const NAME: &str = "blockio_requests";
 
 mod bpf {
     include!(concat!(env!("OUT_DIR"), "/blockio_requests.bpf.rs"));
@@ -24,7 +24,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -109,6 +108,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.rs
@@ -60,7 +60,6 @@ fn handle_bandwidth_info(data: &[u8]) -> i32 {
     0
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -92,6 +91,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/cpu/linux/branch/mod.rs
+++ b/src/agent/samplers/cpu/linux/branch/mod.rs
@@ -25,7 +25,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -37,6 +36,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct Branch {
     inner: Mutex<BranchInner>,

--- a/src/agent/samplers/cpu/linux/cores/mod.rs
+++ b/src/agent/samplers/cpu/linux/cores/mod.rs
@@ -10,7 +10,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -22,6 +21,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         file: Mutex::new(File::from_std(file)),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 pub struct Cores {
     file: Mutex<File>,

--- a/src/agent/samplers/cpu/linux/dtlb/mod.rs
+++ b/src/agent/samplers/cpu/linux/dtlb/mod.rs
@@ -29,7 +29,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -41,6 +40,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct Dtlb {
     inner: Mutex<DtlbInner>,

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -27,7 +27,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -39,6 +38,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct Frequency {
     inner: Mutex<FrequencyInner>,

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -24,7 +24,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -36,6 +35,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct CpuL3 {
     inner: Mutex<CpuL3Inner>,

--- a/src/agent/samplers/cpu/linux/migrations/mod.rs
+++ b/src/agent/samplers/cpu/linux/migrations/mod.rs
@@ -33,7 +33,6 @@ fn handle_cgroup_info(data: &[u8]) -> i32 {
     process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -62,6 +61,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/cpu/linux/perf/mod.rs
+++ b/src/agent/samplers/cpu/linux/perf/mod.rs
@@ -37,7 +37,6 @@ fn handle_event(data: &[u8]) -> i32 {
     process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -66,6 +65,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
+++ b/src/agent/samplers/cpu/linux/tlb_flush/mod.rs
@@ -48,7 +48,6 @@ fn handle_cgroup_info(data: &[u8]) -> i32 {
     process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -109,6 +108,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -113,7 +113,6 @@ fn handle_task_exit(data: &[u8]) -> i32 {
     0
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -174,6 +173,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/cpu/macos/usage/mod.rs
+++ b/src/agent/samplers/cpu/macos/usage/mod.rs
@@ -13,7 +13,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -25,6 +24,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: Arc::new(Mutex::new(inner)),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 pub struct Usage {
     inner: Arc<Mutex<UsageInner>>,

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -17,7 +17,6 @@ const KB: i64 = 1024;
 const MB: i64 = 1024 * KB;
 const MHZ: i64 = 1_000_000;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -29,6 +28,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct Nvidia {
     inner: Mutex<NvidiaInner>,

--- a/src/agent/samplers/gpu/macos/apple.rs
+++ b/src/agent/samplers/gpu/macos/apple.rs
@@ -13,7 +13,6 @@ use tokio::sync::Mutex;
 
 use super::stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -25,6 +24,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 pub struct GpuApple {
     inner: Mutex<GpuAppleInner>,

--- a/src/agent/samplers/memory/linux/meminfo/mod.rs
+++ b/src/agent/samplers/memory/linux/meminfo/mod.rs
@@ -13,7 +13,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -25,6 +24,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct Meminfo {
     inner: Mutex<MeminfoInner>,

--- a/src/agent/samplers/memory/linux/vmstat/mod.rs
+++ b/src/agent/samplers/memory/linux/vmstat/mod.rs
@@ -13,7 +13,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -25,6 +24,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct Meminfo {
     inner: Mutex<MeminfoInner>,

--- a/src/agent/samplers/mod.rs
+++ b/src/agent/samplers/mod.rs
@@ -15,8 +15,14 @@ mod scheduler;
 mod syscall;
 mod tcp;
 
+/// A registered sampler: its stable name plus its init function.
+pub struct SamplerEntry {
+    pub name: &'static str,
+    pub init: fn(config: Arc<Config>) -> SamplerResult,
+}
+
 #[distributed_slice]
-pub static SAMPLERS: [fn(config: Arc<Config>) -> SamplerResult] = [..];
+pub static SAMPLERS: [SamplerEntry] = [..];
 
 #[async_trait]
 pub trait Sampler: Send + Sync {

--- a/src/agent/samplers/network/linux/ethtool/mod.rs
+++ b/src/agent/samplers/network/linux/ethtool/mod.rs
@@ -134,7 +134,6 @@ struct TrackedInterface {
     stats: Vec<TrackedStat>,
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -156,6 +155,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
         inner: inner.into(),
     })))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 struct Ethtool {
     inner: Mutex<EthtoolInner>,

--- a/src/agent/samplers/network/linux/interfaces/mod.rs
+++ b/src/agent/samplers/network/linux/interfaces/mod.rs
@@ -19,7 +19,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -46,6 +45,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/network/linux/traffic/mod.rs
+++ b/src/agent/samplers/network/linux/traffic/mod.rs
@@ -24,7 +24,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -51,6 +50,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/rezolus/rusage/mod.rs
+++ b/src/agent/samplers/rezolus/rusage/mod.rs
@@ -6,7 +6,6 @@ mod stats;
 
 use stats::*;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -14,6 +13,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(Rusage {})))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 pub struct Rusage {}
 

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -37,7 +37,6 @@ fn handle_cgroup_info(data: &[u8]) -> i32 {
     process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -79,6 +78,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/syscall/linux/counts/mod.rs
+++ b/src/agent/samplers/syscall/linux/counts/mod.rs
@@ -47,7 +47,6 @@ fn handle_cgroup_info(data: &[u8]) -> i32 {
     process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -104,6 +103,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/syscall/linux/latency/mod.rs
+++ b/src/agent/samplers/syscall/linux/latency/mod.rs
@@ -21,7 +21,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -57,6 +56,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/tcp/linux/connect_latency/mod.rs
+++ b/src/agent/samplers/tcp/linux/connect_latency/mod.rs
@@ -22,7 +22,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -42,6 +41,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/tcp/linux/packet_latency/mod.rs
+++ b/src/agent/samplers/tcp/linux/packet_latency/mod.rs
@@ -21,7 +21,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -41,6 +40,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/tcp/linux/receive/mod.rs
+++ b/src/agent/samplers/tcp/linux/receive/mod.rs
@@ -20,7 +20,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -41,6 +40,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/tcp/linux/retransmit/mod.rs
+++ b/src/agent/samplers/tcp/linux/retransmit/mod.rs
@@ -19,7 +19,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -41,6 +40,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/agent/samplers/tcp/linux/traffic/mod.rs
+++ b/src/agent/samplers/tcp/linux/traffic/mod.rs
@@ -25,7 +25,6 @@ use crate::agent::*;
 
 use std::sync::Arc;
 
-#[distributed_slice(SAMPLERS)]
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
@@ -54,6 +53,10 @@ fn init(config: Arc<Config>) -> SamplerResult {
 
     Ok(Some(Box::new(bpf)))
 }
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry =
+    crate::agent::samplers::SamplerEntry { name: NAME, init };
 
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -90,6 +90,10 @@ pub const NESTED_NODE: &str = "node";
 /// Per-source instance identifier (nested key).
 pub const NESTED_INSTANCE: &str = "instance";
 
+/// Per-source nested key: JSON array of sampler status (from the agent's
+/// `/samplers` endpoint). Present only for Rezolus-agent sources.
+pub const NESTED_SAMPLER_STATUS: &str = "sampler_status";
+
 // ── Viewer hints ─────────────────────────────────────────────────────
 
 /// The default rezolus node to display when the viewer opens a combined

--- a/src/recorder/endpoint.rs
+++ b/src/recorder/endpoint.rs
@@ -51,6 +51,7 @@ pub struct EndpointState {
     pub scrape_url: Option<Url>,
     pub systeminfo: Option<String>,
     pub descriptions: Option<String>,
+    pub sampler_status: Option<String>,
     pub first_success_ns: Option<u64>,
     pub last_success_ns: Option<u64>,
 }
@@ -65,6 +66,7 @@ impl EndpointState {
             scrape_url: None,
             systeminfo: None,
             descriptions: None,
+            sampler_status: None,
             first_success_ns: None,
             last_success_ns: None,
         }

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -161,8 +161,11 @@ async fn probe_endpoint(
     None
 }
 
-/// Fetch systeminfo and descriptions from a Rezolus agent endpoint.
-async fn fetch_agent_metadata(client: &Client, base_url: &Url) -> (Option<String>, Option<String>) {
+/// Fetch systeminfo, descriptions, and sampler status from a Rezolus agent.
+async fn fetch_agent_metadata(
+    client: &Client,
+    base_url: &Url,
+) -> (Option<String>, Option<String>, Option<String>) {
     let mut info_url = base_url.clone();
     info_url.set_path("/systeminfo");
     let systeminfo = match client.get(info_url).send().await {
@@ -177,7 +180,14 @@ async fn fetch_agent_metadata(client: &Client, base_url: &Url) -> (Option<String
         _ => None,
     };
 
-    (systeminfo, descriptions)
+    let mut samplers_url = base_url.clone();
+    samplers_url.set_path("/samplers");
+    let sampler_status = match client.get(samplers_url).send().await {
+        Ok(response) if response.status().is_success() => response.text().await.ok(),
+        _ => None,
+    };
+
+    (systeminfo, descriptions, sampler_status)
 }
 
 async fn scrape_one(client: &Client, url: &Url) -> Result<Vec<u8>, String> {
@@ -321,6 +331,7 @@ fn build_parquet_converter(
         ep.first_success_ns,
         ep.last_success_ns,
         ep.config.role.as_deref(),
+        ep.sampler_status.as_deref(),
     ) {
         converter = converter.metadata("per_source_metadata".to_string(), json);
     }
@@ -341,6 +352,7 @@ fn build_per_source_metadata(
     first_sample_ns: Option<u64>,
     last_sample_ns: Option<u64>,
     role: Option<&str>,
+    sampler_status: Option<&str>,
 ) -> Option<String> {
     let mut source_meta = serde_json::Map::new();
     if let Some(ns) = first_sample_ns {
@@ -360,6 +372,11 @@ fn build_per_source_metadata(
             parquet_metadata::NESTED_ROLE.to_string(),
             serde_json::json!(role),
         );
+    }
+    if let Some(ss) = sampler_status {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(ss) {
+            source_meta.insert(parquet_metadata::NESTED_SAMPLER_STATUS.to_string(), value);
+        }
     }
 
     if source_meta.is_empty() {
@@ -448,9 +465,10 @@ pub fn run(config: RecordingConfig) {
                         protocol
                     );
                     if protocol == Protocol::Msgpack {
-                        let (si, desc) = fetch_agent_metadata(&client, &ep.config.url).await;
+                        let (si, desc, ss) = fetch_agent_metadata(&client, &ep.config.url).await;
                         ep.systeminfo = si;
                         ep.descriptions = desc;
+                        ep.sampler_status = ss;
                     }
                     ep.scrape_url = Some(url);
                     ep.detected_protocol = Some(protocol);
@@ -640,10 +658,11 @@ pub fn run(config: RecordingConfig) {
                         endpoints[idx].config.url
                     );
                     if protocol == Protocol::Msgpack {
-                        let (si, desc) =
+                        let (si, desc, ss) =
                             fetch_agent_metadata(&client, &endpoints[idx].config.url).await;
                         endpoints[idx].systeminfo = si;
                         endpoints[idx].descriptions = desc;
+                        endpoints[idx].sampler_status = ss;
                     }
                     endpoints[idx].scrape_url = Some(url);
                     endpoints[idx].detected_protocol = Some(protocol.clone());
@@ -886,7 +905,8 @@ mod tests {
     #[test]
     fn test_build_per_source_metadata_single_source() {
         let json =
-            build_per_source_metadata("rezolus", Some(100), Some(200), Some("service")).unwrap();
+            build_per_source_metadata("rezolus", Some(100), Some(200), Some("service"), None)
+                .unwrap();
         let psm: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(
             psm["rezolus"]["first_sample_ns"].as_u64(),
@@ -908,6 +928,7 @@ mod tests {
             Some(100),
             Some(200),
             Some("service"),
+            None,
         )
         .unwrap();
         let psm: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -926,18 +947,30 @@ mod tests {
     #[test]
     fn test_build_per_source_metadata_returns_none_when_empty() {
         // No per-source fields at all → no per_source_metadata.
-        assert!(build_per_source_metadata("rezolus", None, None, None).is_none());
+        assert!(build_per_source_metadata("rezolus", None, None, None, None).is_none());
     }
 
     #[test]
     fn test_build_per_source_metadata_array_with_partial_fields() {
         // Array source with only a subset of per-source fields populated.
-        let json = build_per_source_metadata("[\"a\",\"b\",\"c\"]", Some(50), None, None).unwrap();
+        let json =
+            build_per_source_metadata("[\"a\",\"b\",\"c\"]", Some(50), None, None, None).unwrap();
         let psm: serde_json::Value = serde_json::from_str(&json).unwrap();
         for name in ["a", "b", "c"] {
             assert_eq!(psm[name]["first_sample_ns"].as_u64(), Some(50));
             assert!(psm[name].get("last_sample_ns").is_none());
             assert!(psm[name].get("role").is_none());
         }
+    }
+
+    #[test]
+    fn test_build_per_source_metadata_includes_sampler_status() {
+        let ss = r#"[{"name":"cpu_usage","state":"active"}]"#;
+        let json = build_per_source_metadata("rezolus", None, None, None, Some(ss)).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = &v["rezolus"]["sampler_status"];
+        assert!(arr.is_array());
+        assert_eq!(arr[0]["name"], "cpu_usage");
+        assert_eq!(arr[0]["state"], "active");
     }
 }


### PR DESCRIPTION
## Summary

Makes BPF program attach resilient and surfaces per-sampler / per-program health as queryable data, so "why is telemetry X missing?" no longer requires grepping `RUST_LOG=debug` in journald. Motivated by the Tegra/Jetson investigation (no in-kernel BTF, then no kprobe support), where failures were silent.

- **Resilient attach** — the BPF builder now attaches each program individually and tolerates per-program failures (`NotFound`/`-ENOENT` at debug, other errors at warn; load/verify stays fatal) instead of a single all-or-nothing `skel.attach()` that aborted on the first failure. A dead probe (e.g. `cpuacct_account_field` on a kprobe-less kernel) no longer zeroes its sibling programs.
- **Per-sampler go/no-go** — a process-global `sampler_status` registry records each sampler as `active` / `disabled` (by config) / `failed` (error). Names are made compile-mandatory by converting the `SAMPLERS` distributed-slice to a `SamplerEntry { name, init }` struct, so the central init loop records every outcome and a forgotten sampler is a build error, not a silent gap.
- **Per-program detail** — for BPF samplers, each program is reported attached or not-attached with the error; intentionally-disabled `tp_btf`/`raw_tp` twins are excluded.
- **`GET /samplers`** — live JSON dashboard of the above.
- **Recording capture** — the recorder fetches `/samplers` once per session (like `/systeminfo`) and nests it under `per_source_metadata.<source>.sampler_status`, so recordings carry it (per-source, so `combine` keeps each agent's status).

## Out of scope (future)

- Perf-counter (PMU) enable failures (e.g. `cpu_branch`) and other non-BPF diagnostic surfaces.
- Viewer UI for the status (the parquet metadata enables it later).

## Test plan

- [x] Unit tests: `sampler_status` serde (state-tagged enum, program detail) and `build_per_source_metadata` per-source `sampler_status` nesting — pass on macOS.
- [x] `cargo clippy` + `cargo build --release` clean on x86_64 Linux.
- [ ] **Manual Jetson (no-kprobe) acceptance:** `/samplers` shows `cpu_usage` `active` with `cpuacct_account_field*` `attached:false` but `softirq_*`/`sched_process_exit_raw` `attached:true` (resilient attach recovered them); kprobe-only samplers show programs `attached:false`; disabled samplers show `state:disabled`. `rezolus record` parquet carries `per_source_metadata.<source>.sampler_status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)