### PR TITLE
ci(release): build rpm from spec template (fix prerelease rpms)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,9 +98,6 @@ jobs:
         with:
           shared-key: build-rpm-${{ matrix.distro }}-${{ matrix.version}}-${{ matrix.arch }}
 
-      - name: install rpm packaging tool
-        run: cargo install cargo-generate-rpm
-
       - name: build
         shell: bash
         run: |
@@ -109,72 +106,55 @@ jobs:
       - name: package
         shell: bash
         run: |
-          # Build with cargo-generate-rpm
-          cargo generate-rpm --payload-compress gzip
+          # Version from the tag being released (release.yml triggers on tags).
+          FULL_VERSION="${GITHUB_REF_NAME#v}"
 
-          # Install rpm-build for rebuilding with proper headers
+          # RPM arch from the build matrix (arm64 -> aarch64).
+          RPM_ARCH=$([ "${{ matrix.arch }}" = "arm64" ] && echo aarch64 || echo x86_64)
+
+          # Split semver prerelease into RPM Version/Release. The leading 0.
+          # makes prereleases sort before the eventual GA (Release=1).
+          if [[ "$FULL_VERSION" == *"-alpha"* ]]; then
+            RPM_VERSION=$(echo "$FULL_VERSION" | cut -d'-' -f1)
+            ALPHA_VERSION=$(echo "$FULL_VERSION" | sed 's/.*-alpha\.//')
+            RPM_RELEASE="0.1.alpha.${ALPHA_VERSION}"
+          elif [[ "$FULL_VERSION" == *"-beta"* ]]; then
+            RPM_VERSION=$(echo "$FULL_VERSION" | cut -d'-' -f1)
+            BETA_VERSION=$(echo "$FULL_VERSION" | sed 's/.*-beta\.//')
+            RPM_RELEASE="0.2.beta.${BETA_VERSION}"
+          elif [[ "$FULL_VERSION" == *"-rc"* ]]; then
+            RPM_VERSION=$(echo "$FULL_VERSION" | cut -d'-' -f1)
+            RC_VERSION=$(echo "$FULL_VERSION" | sed 's/.*-rc\.//')
+            RPM_RELEASE="0.3.rc.${RC_VERSION}"
+          else
+            RPM_VERSION="$FULL_VERSION"
+            RPM_RELEASE="1"
+          fi
+          echo "Building rpm: Version=$RPM_VERSION Release=$RPM_RELEASE Arch=$RPM_ARCH"
+
+          # rpm-build provides rpmbuild (not in the minimal container image).
           yum install -y rpm-build
 
-          # Fix each RPM using rpmbuild to add ARCHIVESIZE
+          mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS} target/generate-rpm
+
+          sed -e "s/@NAME@/rezolus/g" \
+              -e "s/@VERSION@/${RPM_VERSION}/g" \
+              -e "s/@RELEASE@/${RPM_RELEASE}/g" \
+              -e "s/@ARCH@/${RPM_ARCH}/g" \
+              rpm/rezolus.spec.template > ~/rpmbuild/SPECS/rezolus.spec
+
+          rpmbuild -bb \
+            --define "_topdir $HOME/rpmbuild" \
+            --define "_sourcedir $GITHUB_WORKSPACE" \
+            --define "_binary_payload w9.gzdio" \
+            ~/rpmbuild/SPECS/rezolus.spec
+
+          # Keep the output path so the sign + upload-artifact steps are unchanged.
+          mv ~/rpmbuild/RPMS/*/*.rpm target/generate-rpm/
+
+          echo "Built rpms:"
           for rpm in target/generate-rpm/*.rpm; do
-            echo "Fixing $(basename $rpm) for GCP Artifact Registry..."
-
-            # Extract metadata from the existing RPM
-            FULL_VERSION=$(rpm -qp --qf "%{VERSION}" "$rpm")
-            RPM_ARCH=$(rpm -qp --qf "%{ARCH}" "$rpm")
-
-            # Parse version and determine release format
-            if [[ "$FULL_VERSION" == *"-alpha"* ]]; then
-              RPM_VERSION=$(echo "$FULL_VERSION" | cut -d'-' -f1)
-              ALPHA_VERSION=$(echo "$FULL_VERSION" | sed 's/.*-alpha\.//')
-              RPM_RELEASE="0.1.alpha.${ALPHA_VERSION}"
-            elif [[ "$FULL_VERSION" == *"-beta"* ]]; then
-              RPM_VERSION=$(echo "$FULL_VERSION" | cut -d'-' -f1)
-              BETA_VERSION=$(echo "$FULL_VERSION" | sed 's/.*-beta\.//')
-              RPM_RELEASE="0.2.beta.${BETA_VERSION}"
-            elif [[ "$FULL_VERSION" == *"-rc"* ]]; then
-              RPM_VERSION=$(echo "$FULL_VERSION" | cut -d'-' -f1)
-              RC_VERSION=$(echo "$FULL_VERSION" | sed 's/.*-rc\.//')
-              RPM_RELEASE="0.3.rc.${RC_VERSION}"
-            else
-              # Stable release
-              RPM_VERSION="$FULL_VERSION"
-              RPM_RELEASE="1"
-            fi
-
-            echo "  Version: $RPM_VERSION"
-            echo "  Release: $RPM_RELEASE"
-
-            # Setup rpmbuild directory
-            mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-
-            # Create spec from template
-            sed -e "s/@NAME@/rezolus/g" \
-                -e "s/@VERSION@/${RPM_VERSION}/g" \
-                -e "s/@RELEASE@/${RPM_RELEASE}/g" \
-                -e "s/@ARCH@/${RPM_ARCH}/g" \
-                rpm/rezolus.spec.template > ~/rpmbuild/SPECS/rezolus.spec
-
-            # Rebuild the RPM with proper headers
-            rpmbuild -bb \
-              --define "_topdir $HOME/rpmbuild" \
-              --define "_sourcedir $GITHUB_WORKSPACE" \
-              --define "_binary_payload w9.gzdio" \
-              ~/rpmbuild/SPECS/rezolus.spec
-
-            # Replace the original RPM with the fixed one
-            mv ~/rpmbuild/RPMS/*/*.rpm "$rpm"
-
-            # Cleanup for next iteration
-            rm -rf ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-          done
-
-          # Final verification
-          echo ""
-          echo "Verifying ARCHIVESIZE headers:"
-          for rpm in target/generate-rpm/*.rpm; do
-            echo "$(basename $rpm):"
-            rpm -qp --qf "  VERSION: %{VERSION}\n  RELEASE: %{RELEASE}\n  ARCHIVESIZE: %{ARCHIVESIZE}\n" "$rpm"
+            rpm -qp --qf "  %{NAME} %{VERSION} %{RELEASE} %{ARCH} ARCHIVESIZE=%{ARCHIVESIZE}\n" "$rpm"
           done
 
       - name: sign RPM packages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.1-alpha.6"
+version = "5.14.1-alpha.7"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.1-alpha.6"
+version = "5.14.1-alpha.7"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,16 +206,3 @@ assets = [
     ],
 ]
 
-[package.metadata.generate-rpm]
-auto_req = "builtin"
-assets = [
-    { source = "target/release/rezolus", dest = "/usr/bin/", mode = "755" },
-    { source = "config/agent.toml", dest = "/etc/rezolus/", mode = "644" },
-    { source = "config/exporter.toml", dest = "/etc/rezolus/", mode = "644" },
-    { source = "config/hindsight.toml", dest = "/etc/rezolus/", mode = "644" },
-    { source = "debian/rezolus.rezolus.service", dest = "/usr/lib/systemd/system/rezolus.service", mode = "644" },
-    { source = "debian/rezolus.rezolus-exporter.service", dest = "/usr/lib/systemd/system/rezolus-exporter.service", mode = "644" },
-    { source = "debian/rezolus.rezolus-hindsight.service", dest = "/usr/lib/systemd/system/rezolus-hindsight.service", mode = "644" },
-]
-post_install_script = "rpm/systemd-start.sh"
-pre_uninstall_script = "rpm/systemd-stop.sh"

--- a/rpm/systemd-start.sh
+++ b/rpm/systemd-start.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-systemctl enable rezolus
-systemctl start rezolus
-
-systemctl enable rezolus-exporter
-systemctl start rezolus-exporter

--- a/rpm/systemd-stop.sh
+++ b/rpm/systemd-stop.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -eu
-
-systemctl stop rezolus-exporter
-systemctl disable rezolus-exporter
-
-systemctl stop rezolus
-systemctl disable rezolus


### PR DESCRIPTION
## Summary
- `release.yml` `build-rpm` now builds the rpm directly from `rpm/rezolus.spec.template` via `rpmbuild`, deriving Version/Release/Arch from the git tag + matrix. Drops `cargo generate-rpm`, whose output was already discarded and rebuilt by the existing `rpmbuild` step.
- **Fixes prerelease rpm builds:** nothing parses the raw `-alpha.N` anymore (RPM gets `Version=5.14.1, Release=0.1.alpha.N`). This unblocks `Publish` on prerelease tags so GitHub pre-releases get created with debs **and** rpms (currently `alpha.*` tags fail all 4 rpm jobs → `Publish` skipped → no release page).
- Removes the duplicate `[package.metadata.generate-rpm]` config and the now-dead `rpm/systemd-start.sh`/`systemd-stop.sh` (the spec template's inline `%post`/`%preun` are what shipped rpms have always used).

## Test plan
- [x] `release.yml` YAML parses; no `cargo generate-rpm` / `cargo install cargo-generate-rpm` references remain; `target/generate-rpm/` output path (sign + upload) unchanged.
- [x] `cargo metadata` clean after removing the metadata block; `Cargo.lock` unchanged.
- [ ] **Live acceptance:** tag `v5.14.1-alpha.7` after merge → `build-rpm` (rockylinux 9, amazonlinux 2023; x86_64 + arm64) succeeds, `Publish` runs, GitHub **pre-release** created with debs + rpms (incl. aarch64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)