### PR TITLE
fix(agent): correctness fixes for BPF samplers from code review

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.14.1-alpha.7"
+version = "5.14.1-alpha.8"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.14.1-alpha.7"
+version = "5.14.1-alpha.8"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -63,7 +63,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.14.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/src/agent/bpf/cgroup.h
+++ b/src/agent/bpf/cgroup.h
@@ -31,7 +31,8 @@ struct cgroup_info {
  * Returns:
  *  - 0 on success
  *  - 1 if not a new cgroup (serial number matches)
- *  - -1 on error (invalid cgroup_id, lookup failure, etc.)
+ *  - -1 on error (invalid cgroup_id, lookup failure, or ringbuf full —
+ *    the serial number is left unchanged so the next event retries)
  */
 static __always_inline int handle_new_cgroup(struct task_struct* task, void* cgroup_serial_numbers,
                                              void* cgroup_info_ringbuf) {
@@ -58,9 +59,10 @@ static __always_inline int handle_new_cgroup(struct task_struct* task, void* cgr
     struct cgroup_info* cginfo =
         bpf_ringbuf_reserve(cgroup_info_ringbuf, sizeof(struct cgroup_info), 0);
     if (!cginfo) {
-        // Still update serial number even if ringbuf is full
-        bpf_map_update_elem(cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
-        return 0;
+        // The ringbuf is full. Leave the serial number unchanged so the next
+        // event for this cgroup retries the send — updating it here would
+        // permanently suppress the cgroup's name/hierarchy in userspace.
+        return -1;
     }
 
     __builtin_memset(cginfo, 0, sizeof(struct cgroup_info));
@@ -112,7 +114,8 @@ static __always_inline int handle_new_cgroup(struct task_struct* task, void* cgr
  * Returns:
  *  - 0 on success
  *  - 1 if not a new cgroup (serial number matches)
- *  - -1 on error (invalid cgroup_id, lookup failure, etc.)
+ *  - -1 on error (invalid cgroup_id, lookup failure, or ringbuf full —
+ *    the serial number is left unchanged so the next event retries)
  */
 static __always_inline int handle_new_cgroup_from_css(struct cgroup_subsys_state* css,
                                                       void* cgroup_serial_numbers,
@@ -140,9 +143,10 @@ static __always_inline int handle_new_cgroup_from_css(struct cgroup_subsys_state
     struct cgroup_info* cginfo =
         bpf_ringbuf_reserve(cgroup_info_ringbuf, sizeof(struct cgroup_info), 0);
     if (!cginfo) {
-        // Still update serial number even if ringbuf is full
-        bpf_map_update_elem(cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
-        return 0;
+        // The ringbuf is full. Leave the serial number unchanged so the next
+        // event for this cgroup retries the send — updating it here would
+        // permanently suppress the cgroup's name/hierarchy in userspace.
+        return -1;
     }
 
     __builtin_memset(cginfo, 0, sizeof(struct cgroup_info));

--- a/src/agent/bpf/core_fixes.h
+++ b/src/agent/bpf/core_fixes.h
@@ -6,6 +6,7 @@
 
 #include "vmlinux.h"
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
 
 /**
  * commit 2f064a59a1 ("sched: Change task_struct::state") changes
@@ -97,6 +98,28 @@ static __always_inline bool renamedata_has_old_mnt_userns_field(void) {
     if (bpf_core_field_exists(struct renamedata___x, old_mnt_userns))
         return true;
     return false;
+}
+
+/**
+ * commit a54895fa057c ("block: remove the request_queue argument to the block
+ * tracepoints") drops the leading `struct request_queue *` argument from the
+ * block_rq_insert, block_rq_issue, and block_rq_requeue tracepoints in kernel
+ * v5.11+. On older kernels the `struct request *` is the second raw
+ * tracepoint argument. LINUX_KERNEL_VERSION is resolved to a constant at load
+ * time, so the verifier prunes the dead branch.
+ * see:
+ *     https://github.com/torvalds/linux/commit/a54895fa057c
+ */
+extern int LINUX_KERNEL_VERSION __kconfig;
+
+#ifndef KERNEL_VERSION
+#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c)))
+#endif
+
+static __always_inline struct request* block_rq_tp_request(__u64* ctx) {
+    if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
+        return (struct request*)ctx[1];
+    return (struct request*)ctx[0];
 }
 
 /**

--- a/src/agent/bpf/histogram.h
+++ b/src/agent/bpf/histogram.h
@@ -218,8 +218,11 @@ static u32 value_to_index(u64 value, u8 grouping_power) {
     } else {
         u64 power = 63 - clz(value);
         u64 bin = power - grouping_power + 1;
-        u64 offset = (value - (1 << power)) >> (power - grouping_power);
+        // the shift bases must be 64-bit: power can be up to 63, and `1 <<
+        // power` (int) is UB for power >= 31, which mis-bucketed all values
+        // >= 2^31 (~2.15s for nanosecond latencies)
+        u64 offset = (value - (1ULL << power)) >> (power - grouping_power);
 
-        return (bin * (1 << grouping_power) + offset);
+        return (bin * (1ULL << grouping_power) + offset);
     }
 }

--- a/src/agent/samplers/blockio/linux/latency/mod.bpf.c
+++ b/src/agent/samplers/blockio/linux/latency/mod.bpf.c
@@ -3,12 +3,11 @@
 // Copyright (c) 2023 The Rezolus Authors
 
 #include <vmlinux.h>
+#include "../../../agent/bpf/core_fixes.h"
 #include "../../../agent/bpf/helpers.h"
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
-
-extern int LINUX_KERNEL_VERSION __kconfig;
 
 #define COUNTER_GROUP_WIDTH 8
 #define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
@@ -63,22 +62,15 @@ struct {
     __uint(max_entries, HISTOGRAM_BUCKETS);
 } discard_latency SEC(".maps");
 
-static int __always_inline trace_rq_start(struct request* rq, int issue) {
+static int __always_inline trace_rq_start(struct request* rq) {
     u64 ts = bpf_ktime_get_ns();
 
     bpf_map_update_elem(&start, &rq, &ts, 0);
     return 0;
 }
 
-static int handle_block_rq_insert(__u64* ctx) {
-    return trace_rq_start((void*)ctx[0], false);
-}
-
-static int handle_block_rq_issue(__u64* ctx) {
-    return trace_rq_start((void*)ctx[0], true);
-}
-
-static int handle_block_rq_complete(struct request* rq, int error, unsigned int nr_bytes) {
+static int __always_inline handle_block_rq_complete(struct request* rq, int error,
+                                                    unsigned int nr_bytes) {
     u64 delta, *tsp, ts = bpf_ktime_get_ns();
     u32 idx, op;
     unsigned int cmd_flags;
@@ -116,18 +108,39 @@ static int handle_block_rq_complete(struct request* rq, int error, unsigned int 
     return 0;
 }
 
+// tp_btf and raw_tp twins share the handlers above; the unused variant is
+// disabled at load time based on whether the kernel has its own BTF (see
+// disabled_programs in mod.rs). The request pointer goes through
+// block_rq_tp_request() because kernels before v5.11 pass a leading
+// struct request_queue* argument to insert/issue.
+
+SEC("tp_btf/block_rq_insert")
+int BPF_PROG(block_rq_insert_btf) {
+    return trace_rq_start(block_rq_tp_request(ctx));
+}
+
 SEC("raw_tp/block_rq_insert")
-int BPF_PROG(block_rq_insert) {
-    return handle_block_rq_insert(ctx);
+int BPF_PROG(block_rq_insert_raw) {
+    return trace_rq_start(block_rq_tp_request(ctx));
+}
+
+SEC("tp_btf/block_rq_issue")
+int BPF_PROG(block_rq_issue_btf) {
+    return trace_rq_start(block_rq_tp_request(ctx));
 }
 
 SEC("raw_tp/block_rq_issue")
-int BPF_PROG(block_rq_issue) {
-    return handle_block_rq_issue(ctx);
+int BPF_PROG(block_rq_issue_raw) {
+    return trace_rq_start(block_rq_tp_request(ctx));
+}
+
+SEC("tp_btf/block_rq_complete")
+int BPF_PROG(block_rq_complete_btf, struct request* rq, int error, unsigned int nr_bytes) {
+    return handle_block_rq_complete(rq, error, nr_bytes);
 }
 
 SEC("raw_tp/block_rq_complete")
-int BPF_PROG(block_rq_complete, struct request* rq, int error, unsigned int nr_bytes) {
+int BPF_PROG(block_rq_complete_raw, struct request* rq, int error, unsigned int nr_bytes) {
     return handle_block_rq_complete(rq, error, nr_bytes);
 }
 

--- a/src/agent/samplers/blockio/linux/latency/mod.rs
+++ b/src/agent/samplers/blockio/linux/latency/mod.rs
@@ -39,6 +39,19 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .histogram("write_latency", &BLOCKIO_WRITE_LATENCY)
     .histogram("flush_latency", &BLOCKIO_FLUSH_LATENCY)
     .histogram("discard_latency", &BLOCKIO_DISCARD_LATENCY)
+    .disabled_programs(if kernel_has_btf() {
+        &[
+            "block_rq_insert_raw",
+            "block_rq_issue_raw",
+            "block_rq_complete_raw",
+        ]
+    } else {
+        &[
+            "block_rq_insert_btf",
+            "block_rq_issue_btf",
+            "block_rq_complete_btf",
+        ]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -63,16 +76,16 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} block_rq_insert() BPF instruction count: {}",
-            self.progs.block_rq_insert.insn_cnt()
+            "{NAME} block_rq_insert_btf() BPF instruction count: {}",
+            self.progs.block_rq_insert_btf.insn_cnt()
         );
         debug!(
-            "{NAME} block_rq_issue() BPF instruction count: {}",
-            self.progs.block_rq_issue.insn_cnt()
+            "{NAME} block_rq_issue_btf() BPF instruction count: {}",
+            self.progs.block_rq_issue_btf.insn_cnt()
         );
         debug!(
-            "{NAME} block_rq_complete() BPF instruction count: {}",
-            self.progs.block_rq_complete.insn_cnt()
+            "{NAME} block_rq_complete_btf() BPF instruction count: {}",
+            self.progs.block_rq_complete_btf.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/blockio/linux/requests/mod.bpf.c
+++ b/src/agent/samplers/blockio/linux/requests/mod.bpf.c
@@ -3,12 +3,11 @@
 // Copyright (c) 2023 The Rezolus Authors
 
 #include <vmlinux.h>
+#include "../../../agent/bpf/core_fixes.h"
 #include "../../../agent/bpf/helpers.h"
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
-
-extern int LINUX_KERNEL_VERSION __kconfig;
 
 #define COUNTER_GROUP_WIDTH 8
 #define HISTOGRAM_BUCKETS HISTOGRAM_BUCKETS_POW_3
@@ -145,7 +144,8 @@ static __always_inline int classify_status(int status) {
     }
 }
 
-static int handle_block_rq_complete(struct request* rq, int error, unsigned int nr_bytes) {
+static int __always_inline handle_block_rq_complete(struct request* rq, int error,
+                                                    unsigned int nr_bytes) {
     u32 idx, op;
     unsigned int cmd_flags;
 
@@ -160,21 +160,25 @@ static int handle_block_rq_complete(struct request* rq, int error, unsigned int 
         idx = idx + COUNTER_GROUP_WIDTH / 2;
         array_add(&counters, idx, nr_bytes);
 
-        idx = value_to_index(nr_bytes, HISTOGRAM_POWER);
+        // flush completions transfer no data (nr_bytes is always 0), so a
+        // size observation would just pile zeros into the first bucket
+        if (nr_bytes > 0) {
+            idx = value_to_index(nr_bytes, HISTOGRAM_POWER);
 
-        switch (op) {
-        case REQ_OP_READ:
-            array_incr(&read_size, idx);
-            break;
-        case REQ_OP_WRITE:
-            array_incr(&write_size, idx);
-            break;
-        case REQ_OP_FLUSH:
-            array_incr(&flush_size, idx);
-            break;
-        case REQ_OP_DISCARD:
-            array_incr(&discard_size, idx);
-            break;
+            switch (op) {
+            case REQ_OP_READ:
+                array_incr(&read_size, idx);
+                break;
+            case REQ_OP_WRITE:
+                array_incr(&write_size, idx);
+                break;
+            case REQ_OP_FLUSH:
+                array_incr(&flush_size, idx);
+                break;
+            case REQ_OP_DISCARD:
+                array_incr(&discard_size, idx);
+                break;
+            }
         }
 
         // Error path: bucket non-OK completions by class. Falls inside
@@ -189,13 +193,7 @@ static int handle_block_rq_complete(struct request* rq, int error, unsigned int 
     return 0;
 }
 
-SEC("raw_tp/block_rq_complete")
-int BPF_PROG(block_rq_complete, struct request* rq, int error, unsigned int nr_bytes) {
-    return handle_block_rq_complete(rq, error, nr_bytes);
-}
-
-SEC("raw_tp/block_rq_requeue")
-int BPF_PROG(block_rq_requeue, struct request* rq) {
+static int __always_inline handle_block_rq_requeue(struct request* rq) {
     unsigned int cmd_flags = BPF_CORE_READ(rq, cmd_flags);
     u32 op = cmd_flags & REQ_OP_MASK;
     if (op >= OP_BUCKETS)
@@ -204,6 +202,32 @@ int BPF_PROG(block_rq_requeue, struct request* rq) {
     u32 idx = bpf_get_smp_processor_id() * REQ_BANK_WIDTH + op;
     array_incr(&requeues, idx);
     return 0;
+}
+
+// tp_btf and raw_tp twins share the handlers above; the unused variant is
+// disabled at load time based on whether the kernel has its own BTF (see
+// disabled_programs in mod.rs). The requeue request pointer goes through
+// block_rq_tp_request() because kernels before v5.11 pass a leading
+// struct request_queue* argument.
+
+SEC("tp_btf/block_rq_complete")
+int BPF_PROG(block_rq_complete_btf, struct request* rq, int error, unsigned int nr_bytes) {
+    return handle_block_rq_complete(rq, error, nr_bytes);
+}
+
+SEC("raw_tp/block_rq_complete")
+int BPF_PROG(block_rq_complete_raw, struct request* rq, int error, unsigned int nr_bytes) {
+    return handle_block_rq_complete(rq, error, nr_bytes);
+}
+
+SEC("tp_btf/block_rq_requeue")
+int BPF_PROG(block_rq_requeue_btf) {
+    return handle_block_rq_requeue(block_rq_tp_request(ctx));
+}
+
+SEC("raw_tp/block_rq_requeue")
+int BPF_PROG(block_rq_requeue_raw) {
+    return handle_block_rq_requeue(block_rq_tp_request(ctx));
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/blockio/linux/requests/mod.rs
+++ b/src/agent/samplers/blockio/linux/requests/mod.rs
@@ -104,6 +104,11 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .histogram("write_size", &BLOCKIO_WRITE_SIZE)
     .histogram("flush_size", &BLOCKIO_FLUSH_SIZE)
     .histogram("discard_size", &BLOCKIO_DISCARD_SIZE)
+    .disabled_programs(if kernel_has_btf() {
+        &["block_rq_complete_raw", "block_rq_requeue_raw"]
+    } else {
+        &["block_rq_complete_btf", "block_rq_requeue_btf"]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -131,12 +136,12 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} block_rq_complete() BPF instruction count: {}",
-            self.progs.block_rq_complete.insn_cnt()
+            "{NAME} block_rq_complete_btf() BPF instruction count: {}",
+            self.progs.block_rq_complete_btf.insn_cnt()
         );
         debug!(
-            "{NAME} block_rq_requeue() BPF instruction count: {}",
-            self.progs.block_rq_requeue.insn_cnt()
+            "{NAME} block_rq_requeue_btf() BPF instruction count: {}",
+            self.progs.block_rq_requeue_btf.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
@@ -219,6 +219,10 @@ int unthrottle_cfs_rq(struct pt_regs* ctx) {
     int nr_periods = BPF_CORE_READ(cfs_rq, tg, cfs_bandwidth.nr_periods);
     int nr_throttled = BPF_CORE_READ(cfs_rq, tg, cfs_bandwidth.nr_throttled);
     u64 cgroup_throttled_time = BPF_CORE_READ(cfs_rq, tg, cfs_bandwidth.throttled_time);
+
+    // benign race: these kernel counters are monotone, so the non-atomic
+    // load+compare+store in array_set_if_larger can lose an occasional
+    // concurrent update and the next observation self-heals
     array_set_if_larger(&bandwidth_periods, (u32)cgroup_id, (u64)nr_periods);
     array_set_if_larger(&bandwidth_throttled_periods, (u32)cgroup_id, (u64)nr_throttled);
     array_set_if_larger(&bandwidth_throttled_time, (u32)cgroup_id, cgroup_throttled_time);

--- a/src/agent/samplers/cpu/linux/migrations/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/migrations/mod.bpf.c
@@ -92,8 +92,10 @@ static __always_inline int account__sched_switch(u64* ctx) {
             array_incr(&migrations, to_idx);
 
             // handle per-cgroup accounting
-            if (bpf_core_field_exists(next->sched_task_group)) {
-                int cgroup_id = BPF_CORE_READ(next, sched_task_group, css.id);
+            // runtime NULL check (bpf_core_field_exists is compile-time only)
+            void* task_group = BPF_CORE_READ(next, sched_task_group);
+            if (task_group) {
+                u32 cgroup_id = BPF_CORE_READ(next, sched_task_group, css.id);
 
                 if (cgroup_id < MAX_CGROUPS) {
                     int ret = handle_new_cgroup(next, &cgroup_serial_numbers, &cgroup_info);

--- a/src/agent/samplers/cpu/linux/perf/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/perf/mod.bpf.c
@@ -57,10 +57,10 @@ struct {
 } cgroup_instructions SEC(".maps");
 
 // previous readings for various events
+// (BPF-internal state, not read by userspace, so not mmapable)
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
-    __uint(map_flags, BPF_F_MMAPABLE);
     __type(key, u32);
     __type(value, u64);
     __uint(max_entries, MAX_CGROUPS);
@@ -68,7 +68,6 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
-    __uint(map_flags, BPF_F_MMAPABLE);
     __type(key, u32);
     __type(value, u64);
     __uint(max_entries, MAX_CGROUPS);

--- a/src/agent/samplers/cpu/linux/tlb_flush/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/tlb_flush/mod.bpf.c
@@ -111,6 +111,12 @@ SEC("raw_tp/tlb_flush")
 int BPF_PROG(tlb_flush, int reason, u64 pages) {
     u32 offset, idx;
 
+    // defensive bounds check: a future kernel could add reason codes beyond
+    // the slots in this CPU's counter bank
+    if (reason < 0 || reason >= COUNTER_GROUP_WIDTH) {
+        return 0;
+    }
+
     offset = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id();
 
     idx = reason + offset;

--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -102,6 +102,10 @@ struct {
  */
 
 // track the start time of softirq
+//
+// one slot per CPU (softirqs do not nest on a CPU), padded out to a whole
+// cacheline (* 8) to avoid false sharing between cores; the index is always
+// cpu * 8
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __uint(max_entries, MAX_CPUS * 8);
@@ -265,7 +269,11 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, struct task_struct* task, u32 index
     u64 delta_utime = 0;
     u64 delta_stime = 0;
 
-    // Only calculate delta if we have valid previous values
+    // Only calculate delta if we have valid previous values. A zero previous
+    // value means this is the first observation of the task: skipping the
+    // delta intentionally drops CPU time accrued before we started watching,
+    // otherwise an agent restart would dump every task's accumulated time
+    // into one tick and spike any rate() over these counters.
     if (*last_utime != 0 && curr_utime >= *last_utime) {
         delta_utime = curr_utime - *last_utime;
     }

--- a/src/agent/samplers/network/linux/interfaces/stats.rs
+++ b/src/agent/samplers/network/linux/interfaces/stats.rs
@@ -7,14 +7,14 @@ use metriken::*;
 #[metric(
     name = "rezolus_bpf_run_count",
     description = "The number of times Rezolus BPF programs have been run",
-    metadata = { sampler = "network_traffic"}
+    metadata = { sampler = "network_interfaces"}
 )]
 pub static BPF_RUN_COUNT: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "rezolus_bpf_run_time",
     description = "The amount of time Rezolus BPF programs have been executing",
-    metadata = { unit = "nanoseconds", sampler = "network_traffic"}
+    metadata = { unit = "nanoseconds", sampler = "network_interfaces"}
 )]
 pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
 

--- a/src/agent/samplers/network/linux/traffic/mod.bpf.c
+++ b/src/agent/samplers/network/linux/traffic/mod.bpf.c
@@ -48,7 +48,8 @@ int BPF_PROG(netif_receive_skb, struct sk_buff* skb) {
 }
 
 SEC("raw_tp/net_dev_start_xmit")
-int BPF_PROG(tcp_cleanup_rbuf, struct sk_buff* skb, struct net_device* dev, void* txq, bool more) {
+int BPF_PROG(net_dev_start_xmit, struct sk_buff* skb, struct net_device* dev, void* txq,
+             bool more) {
     u64 len;
     u32 idx;
 

--- a/src/agent/samplers/network/linux/traffic/mod.rs
+++ b/src/agent/samplers/network/linux/traffic/mod.rs
@@ -71,8 +71,8 @@ impl OpenSkelExt for ModSkel<'_> {
             self.progs.netif_receive_skb.insn_cnt()
         );
         debug!(
-            "{NAME} tcp_cleanup_rbuf() BPF instruction count: {}",
-            self.progs.tcp_cleanup_rbuf.insn_cnt()
+            "{NAME} net_dev_start_xmit() BPF instruction count: {}",
+            self.progs.net_dev_start_xmit.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -176,8 +176,12 @@ static __always_inline int account__sched_switch(u64* ctx) {
     struct task_struct* next = (struct task_struct*)ctx[2];
 
     u32 pid, idx;
-    u32 cgroup_id = 0;
-    u64 *tsp, delta_ns, offcpu_ns, *elem;
+    // prev and next can belong to different cgroups; track each separately so
+    // runqueue wait and off-cpu time are never charged to prev's cgroup.
+    // MAX_CGROUPS is the "no attribution" sentinel.
+    u32 prev_cgroup_id = MAX_CGROUPS;
+    u32 next_cgroup_id = MAX_CGROUPS;
+    u64 *tsp, delta_ns, offcpu_ns;
 
     u32 processor_id = bpf_get_smp_processor_id();
     u64 ts = bpf_ktime_get_ns();
@@ -185,49 +189,19 @@ static __always_inline int account__sched_switch(u64* ctx) {
     // read the prev task cgroup details and push to ringbuf if new cgroup
     void* prev_task_group = BPF_CORE_READ(prev, sched_task_group);
     if (prev_task_group) {
-        cgroup_id = BPF_CORE_READ(prev, sched_task_group, css.id);
-        u64 serial_nr = BPF_CORE_READ(prev, sched_task_group, css.serial_nr);
+        u32 id = BPF_CORE_READ(prev, sched_task_group, css.id);
 
-        if (cgroup_id < MAX_CGROUPS) {
+        if (id < MAX_CGROUPS) {
+            prev_cgroup_id = id;
 
-            // we check to see if this is a new cgroup by checking the serial number
+            int ret = handle_new_cgroup(prev, &cgroup_serial_numbers, &cgroup_info);
 
-            elem = bpf_map_lookup_elem(&cgroup_serial_numbers, &cgroup_id);
-
-            if (elem && *elem != serial_nr) {
-                // zero the counters, they will not be exported until they are non-zero
+            if (ret == 0) {
+                // New cgroup detected, zero the counters
                 u64 zero = 0;
-                bpf_map_update_elem(&cgroup_ivcsw, &cgroup_id, &zero, BPF_ANY);
-                bpf_map_update_elem(&cgroup_runq_wait, &cgroup_id, &zero, BPF_ANY);
-                bpf_map_update_elem(&cgroup_offcpu, &cgroup_id, &zero, BPF_ANY);
-
-                // reserve ringbuf space to avoid stack allocation of cgroup_info
-                struct cgroup_info* cginfo =
-                    bpf_ringbuf_reserve(&cgroup_info, sizeof(struct cgroup_info), 0);
-                if (!cginfo) {
-                    bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
-                } else {
-                    __builtin_memset(cginfo, 0, sizeof(struct cgroup_info));
-                    cginfo->id = cgroup_id;
-                    cginfo->level = BPF_CORE_READ(prev, sched_task_group, css.cgroup, level);
-
-                    bpf_probe_read_kernel_str(
-                        &cginfo->name, CGROUP_NAME_LEN,
-                        BPF_CORE_READ(prev, sched_task_group, css.cgroup, kn, name));
-
-                    struct kernfs_node* kn = BPF_CORE_READ(prev, sched_task_group, css.cgroup, kn);
-                    struct kernfs_node* parent = get_kernfs_node_parent(kn);
-                    bpf_probe_read_kernel_str(&cginfo->pname, CGROUP_NAME_LEN,
-                                              BPF_CORE_READ(parent, name));
-
-                    struct kernfs_node* grandparent = get_kernfs_node_parent(parent);
-                    bpf_probe_read_kernel_str(&cginfo->gpname, CGROUP_NAME_LEN,
-                                              BPF_CORE_READ(grandparent, name));
-
-                    bpf_ringbuf_submit(cginfo, 0);
-
-                    bpf_map_update_elem(&cgroup_serial_numbers, &cgroup_id, &serial_nr, BPF_ANY);
-                }
+                bpf_map_update_elem(&cgroup_ivcsw, &prev_cgroup_id, &zero, BPF_ANY);
+                bpf_map_update_elem(&cgroup_runq_wait, &prev_cgroup_id, &zero, BPF_ANY);
+                bpf_map_update_elem(&cgroup_offcpu, &prev_cgroup_id, &zero, BPF_ANY);
             }
         }
     }
@@ -243,8 +217,8 @@ static __always_inline int account__sched_switch(u64* ctx) {
         idx = COUNTER_GROUP_WIDTH * processor_id + IVCSW;
         array_incr(&counters, idx);
 
-        if (cgroup_id < MAX_CGROUPS) {
-            array_incr(&cgroup_ivcsw, cgroup_id);
+        if (prev_cgroup_id < MAX_CGROUPS) {
+            array_incr(&cgroup_ivcsw, prev_cgroup_id);
         }
 
         pid = BPF_CORE_READ(prev, pid);
@@ -274,18 +248,19 @@ static __always_inline int account__sched_switch(u64* ctx) {
     // read the next task cgroup details and push to ringbuf if new cgroup
     void* next_task_group = BPF_CORE_READ(next, sched_task_group);
     if (next_task_group) {
-        cgroup_id = BPF_CORE_READ(next, sched_task_group, css.id);
+        u32 id = BPF_CORE_READ(next, sched_task_group, css.id);
 
-        if (cgroup_id < MAX_CGROUPS) {
+        if (id < MAX_CGROUPS) {
+            next_cgroup_id = id;
 
             int ret = handle_new_cgroup(next, &cgroup_serial_numbers, &cgroup_info);
 
             if (ret == 0) {
                 // New cgroup detected, zero the counters
                 u64 zero = 0;
-                bpf_map_update_elem(&cgroup_ivcsw, &cgroup_id, &zero, BPF_ANY);
-                bpf_map_update_elem(&cgroup_runq_wait, &cgroup_id, &zero, BPF_ANY);
-                bpf_map_update_elem(&cgroup_offcpu, &cgroup_id, &zero, BPF_ANY);
+                bpf_map_update_elem(&cgroup_ivcsw, &next_cgroup_id, &zero, BPF_ANY);
+                bpf_map_update_elem(&cgroup_runq_wait, &next_cgroup_id, &zero, BPF_ANY);
+                bpf_map_update_elem(&cgroup_offcpu, &next_cgroup_id, &zero, BPF_ANY);
             }
         }
     }
@@ -301,8 +276,8 @@ static __always_inline int account__sched_switch(u64* ctx) {
         idx = COUNTER_GROUP_WIDTH * processor_id + RUNQ_WAIT;
         array_add(&counters, idx, delta_ns);
 
-        if (cgroup_id < MAX_CGROUPS) {
-            array_add(&cgroup_runq_wait, cgroup_id, delta_ns);
+        if (next_cgroup_id < MAX_CGROUPS) {
+            array_add(&cgroup_runq_wait, next_cgroup_id, delta_ns);
         }
 
         *tsp = 0;
@@ -318,8 +293,8 @@ static __always_inline int account__sched_switch(u64* ctx) {
 
                 histogram_incr(&offcpu, HISTOGRAM_POWER, offcpu_ns);
 
-                if (cgroup_id < MAX_CGROUPS) {
-                    array_add(&cgroup_offcpu, cgroup_id, offcpu_ns);
+                if (next_cgroup_id < MAX_CGROUPS) {
+                    array_add(&cgroup_offcpu, next_cgroup_id, offcpu_ns);
                 }
             }
 

--- a/src/agent/samplers/syscall/linux/counts/mod.bpf.c
+++ b/src/agent/samplers/syscall/linux/counts/mod.bpf.c
@@ -223,8 +223,10 @@ int sys_enter(struct trace_event_raw_sys_enter* args) {
 
     struct task_struct* current = (struct task_struct*)bpf_get_current_task();
 
-    if (bpf_core_field_exists(current->sched_task_group)) {
-        int cgroup_id = BPF_CORE_READ(current, sched_task_group, css.id);
+    // runtime NULL check (bpf_core_field_exists is a compile-time BTF check)
+    void* task_group = BPF_CORE_READ(current, sched_task_group);
+    if (task_group) {
+        u32 cgroup_id = BPF_CORE_READ(current, sched_task_group, css.id);
 
         if (cgroup_id < MAX_CGROUPS) {
 

--- a/src/agent/samplers/syscall/linux/latency/mod.bpf.c
+++ b/src/agent/samplers/syscall/linux/latency/mod.bpf.c
@@ -186,8 +186,6 @@ int sys_exit(struct trace_event_raw_sys_exit* args) {
     u64 *start_ts, lat = 0;
     u32 tid = id, group = 0;
 
-    u32 idx;
-
     if (args->id < 0) {
         return 0;
     }
@@ -205,8 +203,6 @@ int sys_exit(struct trace_event_raw_sys_exit* args) {
 
     *start_ts = 0;
 
-    idx = value_to_index(lat, HISTOGRAM_POWER);
-
     // increment latency histogram for the syscall family
     if (syscall_id < MAX_SYSCALL_ID) {
         u32* counter_offset = bpf_map_lookup_elem(&syscall_lut, &syscall_id);
@@ -218,52 +214,52 @@ int sys_exit(struct trace_event_raw_sys_exit* args) {
 
     switch (group) {
     case 1:
-        array_incr(&read_latency, idx);
+        histogram_incr(&read_latency, HISTOGRAM_POWER, lat);
         break;
     case 2:
-        array_incr(&write_latency, idx);
+        histogram_incr(&write_latency, HISTOGRAM_POWER, lat);
         break;
     case 3:
-        array_incr(&poll_latency, idx);
+        histogram_incr(&poll_latency, HISTOGRAM_POWER, lat);
         break;
     case 4:
-        array_incr(&lock_latency, idx);
+        histogram_incr(&lock_latency, HISTOGRAM_POWER, lat);
         break;
     case 5:
-        array_incr(&time_latency, idx);
+        histogram_incr(&time_latency, HISTOGRAM_POWER, lat);
         break;
     case 6:
-        array_incr(&sleep_latency, idx);
+        histogram_incr(&sleep_latency, HISTOGRAM_POWER, lat);
         break;
     case 7:
-        array_incr(&socket_latency, idx);
+        histogram_incr(&socket_latency, HISTOGRAM_POWER, lat);
         break;
     case 8:
-        array_incr(&yield_latency, idx);
+        histogram_incr(&yield_latency, HISTOGRAM_POWER, lat);
         break;
     case 9:
-        array_incr(&filesystem_latency, idx);
+        histogram_incr(&filesystem_latency, HISTOGRAM_POWER, lat);
         break;
     case 10:
-        array_incr(&memory_latency, idx);
+        histogram_incr(&memory_latency, HISTOGRAM_POWER, lat);
         break;
     case 11:
-        array_incr(&process_latency, idx);
+        histogram_incr(&process_latency, HISTOGRAM_POWER, lat);
         break;
     case 12:
-        array_incr(&query_latency, idx);
+        histogram_incr(&query_latency, HISTOGRAM_POWER, lat);
         break;
     case 13:
-        array_incr(&ipc_latency, idx);
+        histogram_incr(&ipc_latency, HISTOGRAM_POWER, lat);
         break;
     case 14:
-        array_incr(&timer_latency, idx);
+        histogram_incr(&timer_latency, HISTOGRAM_POWER, lat);
         break;
     case 15:
-        array_incr(&event_latency, idx);
+        histogram_incr(&event_latency, HISTOGRAM_POWER, lat);
         break;
     default:
-        array_incr(&other_latency, idx);
+        histogram_incr(&other_latency, HISTOGRAM_POWER, lat);
         break;
     }
 

--- a/src/agent/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/receive/mod.bpf.c
@@ -42,8 +42,8 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock* sk) {
     u64 mdev_ns, srtt_ns;
 
     ts = (struct tcp_sock*)(sk);
-    bpf_probe_read_kernel(&srtt_us, sizeof(srtt_us), &ts->srtt_us);
-    bpf_probe_read_kernel(&mdev_us, sizeof(mdev_us), &ts->mdev_us);
+    srtt_us = BPF_CORE_READ(ts, srtt_us);
+    mdev_us = BPF_CORE_READ(ts, mdev_us);
 
     // NOTE: srtt is stored as 8x the value in microseconds but we want to
     // record nanoseconds.

--- a/src/agent/samplers/tcp/linux/retransmit/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/retransmit/mod.bpf.c
@@ -25,7 +25,11 @@ struct {
 SEC("kprobe/tcp_retransmit_skb")
 int BPF_KPROBE(tcp_retransmit_skb, struct sock* sk, struct sk_buff* skb, int segs) {
     u32 idx = COUNTER_GROUP_WIDTH * bpf_get_smp_processor_id();
-    array_incr(&counters, idx);
+
+    // segs is the number of TCP segments in the skb, which is greater than
+    // one when TSO/GSO is in use; counting calls would undercount
+    // retransmitted packets
+    array_add(&counters, idx, (u64)(segs > 0 ? segs : 1));
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Fixes from a full review of the BPF samplers against `docs/principles.md`. Highlights:

- **histogram.h**: `1 << power` used `int` shifts (UB for `power >= 31`), mis-bucketing every histogram value ≥ 2³¹ — ~2.15 s for nanosecond latencies, so off-cpu time, blockio latency, connect latency, etc. misreported their long tails (verified empirically: a 3 s value landed ~4× too high). Fixed with `1ULL`.
- **blockio**: on kernels < 5.11 the `block_rq_insert`/`issue`/`requeue` tracepoints have a leading `request_queue*` argument, so `ctx[0]` was the queue pointer and latency tracking silently dropped everything; added a version-gated accessor in `core_fixes.h`. Both samplers also migrate `raw_tp` → `tp_btf` with `raw_tp` fallback twins (principle 4 drift, same pattern as `cpu/migrations`).
- **scheduler/runqueue**: runqueue-wait and off-cpu time could be charged to *prev*'s cgroup when *next*'s task group was unavailable; prev/next cgroup ids are now tracked separately. The prev-path inline cgroup walk (which lacked the level guards) is replaced with the shared `handle_new_cgroup`.
- **cgroup.h**: a full ringbuf no longer permanently suppresses a cgroup's name — the serial number is left unchanged so the send retries on the next event.
- **tcp/retransmit**: count `segs` instead of calls (undercounted with TSO/GSO).
- Smaller fixes: network/traffic TX program renamed from `tcp_cleanup_rbuf` (copy-paste), network/interfaces BPF prog-stats metadata collided with the traffic sampler, flush ops no longer pollute the size histograms with zeros, defensive bounds/NULL checks (`tlb_flush` reason, `sched_task_group`), `BPF_F_MMAPABLE` dropped from BPF-internal maps, shared-helper and style consistency, and comments documenting the benign-race / first-observation-skip / cacheline-padding contracts.

## Test plan

- [x] All modified BPF programs compile clean with `-Wall -Werror` for both x86_64 and aarch64 (replicated build.rs's clang invocation locally)
- [x] `value_to_index` fix verified empirically against the buggy version for values spanning 2³¹
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test` (162 passed) on macOS
- [ ] CI: Linux build (validates generated skeleton references) + BPF program load
- [ ] Smoke-run the agent on a Linux host and check blockio/runqueue/tcp metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)