### PR TITLE
feat(viewer): Save as Report in two-file A/B compare mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.15.1-alpha.1"
+version = "5.15.1-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.15.1-alpha.1"
+version = "5.15.1-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -63,7 +63,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.13.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/viewer/lib/selection/ab_filename.js
+++ b/site/viewer/lib/selection/ab_filename.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/selection/ab_filename.js

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -158,3 +158,138 @@ pub const KEY_REPORT: &str = "report";
 
 /// Canonical `KEY_REPORT` value written by the current writer.
 pub const REPORT_VALUE_TRIMMED: &str = "trimmed";
+
+/// Server-side mirror of the WASM `synthesize_manifest` in
+/// `crates/viewer/src/lib.rs` — needed so compare-mode Save-as-Report
+/// works when the manifest wasn't carried in from a pre-built A/B tar.
+pub fn synthesize_ab_manifest(
+    baseline_alias: Option<&str>,
+    baseline_filename: &str,
+    baseline_sources: &[String],
+    experiment_alias: Option<&str>,
+    experiment_filename: &str,
+    experiment_sources: &[String],
+    category: Option<&str>,
+) -> AbContainers {
+    fn resolve_alias(alias: Option<&str>, filename: &str, fallback: &str) -> String {
+        if let Some(a) = alias {
+            if !a.is_empty() {
+                return a.to_string();
+            }
+        }
+        let base = std::path::Path::new(filename)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        if !base.is_empty() {
+            base.to_string()
+        } else {
+            fallback.to_string()
+        }
+    }
+    AbContainers {
+        version: AbContainers::SCHEMA_VERSION,
+        baseline: AbSide {
+            alias: resolve_alias(baseline_alias, baseline_filename, "baseline"),
+            sources: baseline_sources.to_vec(),
+        },
+        experiment: AbSide {
+            alias: resolve_alias(experiment_alias, experiment_filename, "experiment"),
+            sources: experiment_sources.to_vec(),
+        },
+        category: category.map(|s| s.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod synthesize_tests {
+    use super::*;
+
+    fn srcs(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn uses_explicit_aliases_when_set() {
+        let m = synthesize_ab_manifest(
+            Some("before"),
+            "baseline.parquet",
+            &srcs(&["rezolus"]),
+            Some("after"),
+            "experiment.parquet",
+            &srcs(&["rezolus"]),
+            None,
+        );
+        assert_eq!(m.version, AbContainers::SCHEMA_VERSION);
+        assert_eq!(m.baseline.alias, "before");
+        assert_eq!(m.experiment.alias, "after");
+        assert_eq!(m.baseline.sources, vec!["rezolus".to_string()]);
+        assert_eq!(m.experiment.sources, vec!["rezolus".to_string()]);
+        assert_eq!(m.category, None);
+    }
+
+    #[test]
+    fn falls_back_to_filename_basename_when_no_alias() {
+        let m = synthesize_ab_manifest(
+            None,
+            "/tmp/foo/baseline.parquet",
+            &srcs(&["rezolus"]),
+            None,
+            "experiment.parquet",
+            &srcs(&["rezolus"]),
+            None,
+        );
+        assert_eq!(m.baseline.alias, "baseline.parquet");
+        assert_eq!(m.experiment.alias, "experiment.parquet");
+    }
+
+    #[test]
+    fn empty_filename_falls_back_to_baseline_experiment_literal() {
+        let m = synthesize_ab_manifest(
+            None,
+            "",
+            &srcs(&["rezolus"]),
+            None,
+            "",
+            &srcs(&["rezolus"]),
+            None,
+        );
+        assert_eq!(m.baseline.alias, "baseline");
+        assert_eq!(m.experiment.alias, "experiment");
+    }
+
+    #[test]
+    fn passes_category_through() {
+        let m = synthesize_ab_manifest(
+            Some("a"),
+            "a.parquet",
+            &srcs(&["rezolus"]),
+            Some("b"),
+            "b.parquet",
+            &srcs(&["rezolus"]),
+            Some("inference-library"),
+        );
+        assert_eq!(m.category, Some("inference-library".to_string()));
+    }
+
+    #[test]
+    fn multi_source_each_side_independent() {
+        let m = synthesize_ab_manifest(
+            Some("a"),
+            "a.parquet",
+            &srcs(&["rezolus", "vllm"]),
+            Some("b"),
+            "b.parquet",
+            &srcs(&["rezolus", "sglang"]),
+            None,
+        );
+        assert_eq!(
+            m.baseline.sources,
+            vec!["rezolus".to_string(), "vllm".to_string()]
+        );
+        assert_eq!(
+            m.experiment.sources,
+            vec!["rezolus".to_string(), "sglang".to_string()]
+        );
+    }
+}

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -237,7 +237,97 @@ pub async fn upload_parquet(
     if let Err(e) = std::fs::write(&temp_path, &body) {
         return ApiResponse::err(format!("failed to store upload: {e}"), "io_error");
     }
+    if super::ab_extract::looks_like_ab_tarball(&temp_path) {
+        return ingest_combined_ab_from_path(&state, temp_path, filename);
+    }
     ingest_baseline_from_path(&state, temp_path, filename)
+}
+
+/// Runtime-upload version of `init_file_mode_combined_ab` (mod.rs).
+/// Mirrors the CLI state-mutation but returns an HTTP envelope instead
+/// of exiting on failure, and skips strict `--category` validation
+/// (manifest's category, if any, is applied as-is).
+fn ingest_combined_ab_from_path(
+    state: &AppState,
+    tar_path: PathBuf,
+    display_filename: String,
+) -> Json<ApiResponse<serde_json::Value>> {
+    let extracted = match super::ab_extract::extract_ab_tarball(&tar_path) {
+        Ok(e) => e,
+        Err(e) => {
+            let _ = std::fs::remove_file(&tar_path);
+            return ApiResponse::err(
+                format!("failed to extract combined-A/B tarball: {e}"),
+                "invalid_parquet",
+            );
+        }
+    };
+    let manifest = extracted.manifest.clone();
+
+    let open = |label: &str, path: &std::path::Path| -> Result<Arc<dyn MetricsSource>, String> {
+        ParquetReader::open_with_pool(path, Arc::clone(&state.pool))
+            .map(|r| Arc::new(r.with_filename(display_filename.clone())) as Arc<dyn MetricsSource>)
+            .map_err(|e| format!("failed to load {label} parquet from tarball: {e}"))
+    };
+    let baseline_reader = match open("baseline", &extracted.baseline_path) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = std::fs::remove_file(&tar_path);
+            return ApiResponse::err(e, "invalid_parquet");
+        }
+    };
+    let experiment_reader = match open("experiment", &extracted.experiment_path) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = std::fs::remove_file(&tar_path);
+            return ApiResponse::err(e, "invalid_parquet");
+        }
+    };
+
+    let (baseline_systeminfo, baseline_selection, baseline_file_meta) =
+        extract_parquet_metadata(&extracted.baseline_path);
+    let baseline_multinode = build_multinode_systeminfo(&extracted.baseline_path);
+    let (experiment_systeminfo, _experiment_selection, experiment_file_meta) =
+        extract_parquet_metadata(&extracted.experiment_path);
+    let experiment_multinode = build_multinode_systeminfo(&extracted.experiment_path);
+    let file_checksum = compute_file_checksum(&tar_path);
+
+    state.replace_baseline(baseline_reader);
+    *state.parquet_path.write() = Some(extracted.baseline_path.clone());
+    *state.cli_experiment_path.write() = Some(extracted.experiment_path.clone());
+    *state.experiment_parquet_path.write() = None;
+    state
+        .captures
+        .set_baseline_systeminfo(baseline_multinode.or(baseline_systeminfo));
+    *state.selection.write() = baseline_selection;
+    *state.file_checksum.write() = file_checksum;
+    state
+        .captures
+        .set_baseline_file_metadata(baseline_file_meta);
+    *state.trimmed_report_marker.write() = super::read_footer_kv(
+        &extracted.baseline_path,
+        crate::parquet_metadata::KEY_REPORT,
+    );
+    state
+        .captures
+        .set_baseline_alias(Some(manifest.baseline.alias.clone()));
+    state.captures.attach_experiment(
+        experiment_reader,
+        experiment_multinode.or(experiment_systeminfo),
+        experiment_file_meta,
+        Some(manifest.experiment.alias.clone()),
+    );
+    *state.category_name.write() = manifest.category.clone();
+    *state.combined_ab_marker.write() = Some(manifest);
+
+    // Keep the extracted tempdir alive — both per-side parquet paths
+    // reference it. CLI does the same in `init_file_mode_combined_ab`.
+    std::mem::forget(extracted);
+
+    regenerate_dashboards(state);
+
+    let _ = std::fs::remove_file(&tar_path);
+    ApiResponse::ok(serde_json::json!({ "filename": display_filename }))
 }
 
 /// Shared baseline-ingest path used by upload and load_url. Takes

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -28,6 +28,11 @@ use super::report_save;
 use super::state::{ApiResponse, AppState, LazySectionStore};
 use ::dashboard;
 
+// MetricsSource::source() may be a JSON array (multi-source) or a single label.
+fn parse_source_field(raw: &str) -> Vec<String> {
+    serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|_| vec![raw.to_string()])
+}
+
 // ── Snapshot ingest (live mode) ───────────────────────────────────────
 
 /// Background task that polls a live agent and ingests snapshots.
@@ -595,24 +600,31 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
         let trim_columns = payload.trim_columns;
         // Bind to a local so the temporary read guard from .read() doesn't
         // extend through the `if let` body and trip Send across the await.
-        let ab_manifest = state.combined_ab_marker.read().clone();
+        let ab_manifest_runtime = state.combined_ab_marker.read().clone();
+        let experiment_path = state.resolve_experiment_parquet_path();
+        let experiment_data = state.captures.get(CaptureId::Experiment);
 
-        if let Some(manifest) = ab_manifest {
-            // parquet_path here is the EXTRACTED baseline parquet (set by
-            // init_file_mode_combined_ab); the experiment side lives at
-            // cli_experiment_path. Both paths outlive the process via the
-            // mem::forget'd extractor handle.
-            let Some(experiment_path) = state.cli_experiment_path.read().clone() else {
-                return ApiResponse::<()>::err(
-                    "combined-A/B state missing experiment_path",
-                    "internal_error",
+        // Compare mode: experiment attached -> tarball with manifest
+        // (loaded or synthesized from per-slot runtime state).
+        if let (Some(experiment_path), Some(experiment_data)) = (experiment_path, experiment_data) {
+            let manifest = ab_manifest_runtime.unwrap_or_else(|| {
+                let baseline_alias = state.captures.alias(CaptureId::Baseline);
+                let experiment_alias = state.captures.alias(CaptureId::Experiment);
+                let baseline_filename = state.captures.filename(CaptureId::Baseline);
+                let experiment_filename = state.captures.filename(CaptureId::Experiment);
+                let baseline_sources = parse_source_field(&baseline_data.source());
+                let experiment_sources = parse_source_field(&experiment_data.source());
+                let category = state.category_name.read().clone();
+                crate::parquet_metadata::synthesize_ab_manifest(
+                    baseline_alias.as_deref(),
+                    &baseline_filename,
+                    &baseline_sources,
+                    experiment_alias.as_deref(),
+                    &experiment_filename,
+                    &experiment_sources,
+                    category.as_deref(),
                 )
-                .into_response();
-            };
-            let experiment_data = state
-                .captures
-                .get(CaptureId::Experiment)
-                .expect("experiment slot must be attached in combined-A/B mode");
+            });
             let result = tokio::task::spawn_blocking({
                 let baseline_path = path.clone();
                 let body = selection_json.clone();
@@ -634,6 +646,7 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
             return finalize_report_attachment_tarball(result);
         }
 
+        // Single-capture save.
         let result = tokio::task::spawn_blocking({
             let body = selection_json.clone();
             move || {

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -528,6 +528,7 @@ const SectionContent = {
                 experimentQueryRange,
                 baselineAlias,
                 experimentAlias,
+                experimentFilename,
                 combinedAB,
             });
         }

--- a/src/viewer/assets/lib/selection/ab_filename.js
+++ b/src/viewer/assets/lib/selection/ab_filename.js
@@ -1,0 +1,28 @@
+// Compose the default download filename prefix for an A/B Report save.
+// Caller appends the `.parquet.ab.tar` extension via the save modal.
+
+const PARQUET_SUFFIXES = ['.parquet.ab.tar', '.parquet', '.ab.tar', '.tar'];
+
+const stripKnownSuffix = (label) => {
+    for (const suffix of PARQUET_SUFFIXES) {
+        if (label.endsWith(suffix)) {
+            return label.slice(0, -suffix.length);
+        }
+    }
+    return label;
+};
+
+const sanitize = (raw, fallback) => {
+    if (raw == null) return fallback;
+    const basename = String(raw).split(/[/\\]/).pop();
+    const stripped = stripKnownSuffix(basename).trim();
+    if (!stripped) return fallback;
+    const safe = stripped.replace(/[^A-Za-z0-9._-]+/g, '_').replace(/_+/g, '_');
+    return safe || fallback;
+};
+
+export const composeAbReportPrefix = (baselineLabel, experimentLabel) => {
+    const a = sanitize(baselineLabel, 'baseline');
+    const b = sanitize(experimentLabel, 'experiment');
+    return `${a}_vs_${b}`;
+};

--- a/src/viewer/assets/lib/selection/selection.js
+++ b/src/viewer/assets/lib/selection/selection.js
@@ -869,7 +869,6 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
         const hasChartSelection = cs?.hasActiveSelection();
         const hasHistograms = notebookStore.entries.some(e => isHistogramPlot(e));
         const hasAnyNote = notebookStore.entries.some(e => e.note && e.note.length > 0);
-        const inTwoFileCompare = attrs.compareMode && !attrs.combinedAB;
         const downloadIcon = m.trust('<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2"/><path d="M8 10V2m0 8l-3-3m3 3l3-3"/></svg>');
 
         const header = m('div.selection-header', [
@@ -908,10 +907,7 @@ Object.assign(NotebookView, chartLoaderMixin(notebookStore, NotebookView), {
 
             m('div.selection-actions', [
                 m('button.selection-btn', {
-                    disabled: inTwoFileCompare,
-                    title: inTwoFileCompare
-                        ? 'Two-file A/B mode has no single parquet to embed in. Use `parquet combine --ab` first.'
-                        : 'Embed selection + notes in the loaded parquet',
+                    title: 'Embed selection + notes in the loaded parquet',
                     onclick: () => saveToParquet(notebookStore, attrs),
                 }, [
                     'Save as Report (parquet, Selection & Notes) ',

--- a/src/viewer/assets/lib/selection/selection.js
+++ b/src/viewer/assets/lib/selection/selection.js
@@ -618,7 +618,13 @@ const buildPayload = (store, attrs, { includeNotes = true } = {}) => ({
 });
 
 const exportJSON = async (store, attrs) => {
-    const defaultPrefix = (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-selection';
+    const isCompare = !!attrs.compareMode;
+    const defaultPrefix = isCompare
+        ? composeAbReportPrefix(
+            attrs.baselineAlias || attrs.filename,
+            attrs.experimentAlias || attrs.experimentFilename,
+        ) + '-selection'
+        : (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-selection';
     const result = await showSaveModal(defaultPrefix, '.json');
     if (!result) return;
     const filename = result.filename;

--- a/src/viewer/assets/lib/selection/selection.js
+++ b/src/viewer/assets/lib/selection/selection.js
@@ -9,6 +9,7 @@ import { executePromQLRangeQuery, applyResultToPlot, buildEffectiveQuery, CAPTUR
 import { notify, showSaveModal } from '../ui/overlays.js';
 import { isHistogramPlot } from '../charts/metric_types.js';
 import { migrateSelection, SELECTION_SCHEMA_VERSION } from './selection_migration.js';
+import { composeAbReportPrefix } from './ab_filename.js';
 import { ViewerApi } from '../viewer_api.js';
 import { eventsStore } from '../events/events_store.js';
 import { renderMarkdown, renderMarkdownInline } from '../ui/markdown.js';
@@ -716,7 +717,17 @@ const loadJsonIntoSelection = (json, filename) => {
 };
 
 const saveToParquet = async (store, attrs) => {
-    const defaultPrefix = (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-report';
+    const isCompare = !!attrs.compareMode;
+    // Compare mode produces an A/B tarball — modal default uses both
+    // sides' labels so the user sees `<a>_vs_<b>.parquet.ab.tar`
+    // instead of `<baseline>-report.parquet.ab.tar`.
+    const defaultPrefix = isCompare
+        ? composeAbReportPrefix(
+            attrs.baselineAlias || attrs.filename,
+            attrs.experimentAlias || attrs.experimentFilename,
+        )
+        : (attrs.filename || 'rezolus-capture').replace(/\.parquet$/, '') + '-report';
+    const defaultExt = isCompare ? '.parquet.ab.tar' : '.parquet';
     const cs = attrs.chartsState;
     const hasZoom = cs && !cs.isDefaultZoom();
     const checkboxes = [
@@ -725,7 +736,7 @@ const saveToParquet = async (store, attrs) => {
     if (hasZoom) {
         checkboxes.push({ key: 'trim', label: 'Trim to selected time range', checked: false });
     }
-    const result = await showSaveModal(defaultPrefix, '.parquet', checkboxes);
+    const result = await showSaveModal(defaultPrefix, defaultExt, checkboxes);
     if (!result) return;
     const filename = result.filename;
     const trimToSelection = result.trim;
@@ -749,12 +760,20 @@ const saveToParquet = async (store, attrs) => {
         // /api/v1/save_with_selection; the WASM adapter projects the
         // source bytes locally. Both return { bytes, mime, extension }.
         const { bytes, mime, extension } = await ViewerApi.saveWithSelection(payload);
-        // If the user accepted the default `.parquet` filename, swap the
-        // extension to whatever the adapter reported (AB tarballs come
-        // back with `.parquet.ab.tar`).
-        const finalName = extension && filename.endsWith('.parquet') && extension !== '.parquet'
-            ? filename.slice(0, -'.parquet'.length) + extension
-            : filename;
+        // Replace any default modal extension with what the adapter
+        // actually produced (handles users keeping the default in either
+        // mode + handles users editing the prefix without re-typing the
+        // extension). Skips swap if the user typed a custom extension.
+        const knownExts = ['.parquet.ab.tar', '.ab.tar', '.parquet'];
+        let finalName = filename;
+        if (extension) {
+            for (const ext of knownExts) {
+                if (filename.endsWith(ext)) {
+                    finalName = filename.slice(0, -ext.length) + extension;
+                    break;
+                }
+            }
+        }
         const blob = new Blob([bytes], { type: mime });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');

--- a/src/viewer/assets/lib/ui/layout.js
+++ b/src/viewer/assets/lib/ui/layout.js
@@ -18,11 +18,12 @@ const FILE_ICON_SVG = '<svg width="14" height="14" viewBox="0 0 16 16" fill="non
 
 // Open a one-shot hidden <input type=file> and forward the selected
 // file to the caller's onPick. Returns an onclick handler so the site
-// can wire it directly to a button.
+// can wire it directly to a button. Accepts both bare parquets and
+// combined-A/B tarballs (`.parquet.ab.tar`).
 export const openParquetPicker = (onPick) => () => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.parquet,application/octet-stream';
+    input.accept = '.parquet,.ab.tar,.tar,application/octet-stream,application/x-tar';
     input.onchange = async () => {
         const file = input.files && input.files[0];
         if (file && onPick) await onPick(file);
@@ -130,9 +131,11 @@ const TopNav = {
                         ]),
                     ]);
                 })(),
-                attrs.onUploadParquet && !liveMode && !compareMode && m('button.transport-btn.import-btn', {
+                attrs.onUploadParquet && !liveMode && m('button.transport-btn.import-btn', {
                     onclick: openParquetPicker(attrs.onUploadParquet),
-                    title: 'Upload parquet file',
+                    title: compareMode
+                        ? 'Replace current view (parquet or combined-A/B tarball)'
+                        : 'Upload parquet or combined-A/B tarball',
                 }, [
                     m('span', 'Load Parquet'),
                     m.trust(UPLOAD_ICON_SVG),

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -198,6 +198,14 @@ impl AppState {
         self.combined_ab_marker.read().is_some()
     }
 
+    /// Single lookup that hides the CLI-vs-HTTP-attach split; CLI wins.
+    pub fn resolve_experiment_parquet_path(&self) -> Option<std::path::PathBuf> {
+        self.cli_experiment_path
+            .read()
+            .clone()
+            .or_else(|| self.experiment_parquet_path.read().clone())
+    }
+
     pub fn is_trimmed_report(&self) -> bool {
         self.trimmed_report_marker.read().is_some()
     }

--- a/tests/ab_filename.test.mjs
+++ b/tests/ab_filename.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { composeAbReportPrefix } from '../src/viewer/assets/lib/selection/ab_filename.js';
+
+test('joins two simple aliases', () => {
+    assert.equal(composeAbReportPrefix('before', 'after'), 'before_vs_after');
+});
+
+test('strips trailing .parquet from each side', () => {
+    assert.equal(
+        composeAbReportPrefix('cachecannon.parquet', 'AB_base_pin.parquet'),
+        'cachecannon_vs_AB_base_pin',
+    );
+});
+
+test('strips trailing .parquet.ab.tar', () => {
+    assert.equal(
+        composeAbReportPrefix('foo.parquet.ab.tar', 'bar.parquet.ab.tar'),
+        'foo_vs_bar',
+    );
+});
+
+test('strips trailing .ab.tar without .parquet middle', () => {
+    assert.equal(composeAbReportPrefix('foo.ab.tar', 'bar.ab.tar'), 'foo_vs_bar');
+});
+
+test('strips directory components, keeps basename', () => {
+    assert.equal(
+        composeAbReportPrefix('/tmp/foo/baseline.parquet', 'C:\\runs\\exp.parquet'),
+        'baseline_vs_exp',
+    );
+});
+
+test('falls back to slot literals on empty / nullish input', () => {
+    assert.equal(composeAbReportPrefix(null, undefined), 'baseline_vs_experiment');
+    assert.equal(composeAbReportPrefix('', ''), 'baseline_vs_experiment');
+    assert.equal(composeAbReportPrefix('  ', '\t'), 'baseline_vs_experiment');
+});
+
+test('replaces whitespace and unsafe chars with underscores', () => {
+    assert.equal(
+        composeAbReportPrefix('my run 01', 'exp v2'),
+        'my_run_01_vs_exp_v2',
+    );
+});
+
+test('collapses runs of underscores after sanitization', () => {
+    assert.equal(composeAbReportPrefix('a  b', 'c__d'), 'a_b_vs_c_d');
+});

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -192,6 +192,40 @@ eq "two-file compare save: manifest version" \
 [ -n "$(echo "$ab_manifest" | jq -r .experiment.alias)" ] \
     || fail "two-file compare save: empty experiment.alias" "" "non-empty" "$LOGDIR/file.log"
 
+echo "==> reload the saved tarball, save again, manifest survives round-trip"
+PORT_ROUNDTRIP=18506
+./target/debug/rezolus view "$SAVE_RESP" \
+    --listen 127.0.0.1:$PORT_ROUNDTRIP \
+    > "$LOGDIR/roundtrip.log" 2>&1 &
+PID_ROUNDTRIP=$!
+trap 'kill $PID_UPLOAD $PID_FILE $PID_AB $PID_PROXY $PID_ROUNDTRIP 2>/dev/null || true; wait 2>/dev/null || true' EXIT
+
+wait_for_port $PORT_ROUNDTRIP || {
+    echo "--- log for round-trip viewer ---"
+    cat "$LOGDIR/roundtrip.log"
+    exit 1
+}
+
+ROUNDTRIP_RESP="$LOGDIR/two-file-save-2.parquet.ab.tar"
+curl -fsS -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"entries":[{"chartId":"smoke","section":"overview","sectionName":"Overview","groupName":"smoke","promql_query":"cpu_cores","chartOpts":{}}],"trim_columns":false}' \
+    "http://127.0.0.1:$PORT_ROUNDTRIP/api/v1/save_with_selection" \
+    -o "$ROUNDTRIP_RESP"
+
+# Reload-then-save should carry the synthesizer's first-pass aliases.
+first_baseline_alias=$(tar xfO "$SAVE_RESP" ab.json | jq -r .baseline.alias)
+first_experiment_alias=$(tar xfO "$SAVE_RESP" ab.json | jq -r .experiment.alias)
+roundtrip_baseline_alias=$(tar xfO "$ROUNDTRIP_RESP" ab.json | jq -r .baseline.alias)
+roundtrip_experiment_alias=$(tar xfO "$ROUNDTRIP_RESP" ab.json | jq -r .experiment.alias)
+eq "round-trip baseline alias preserved" \
+    "$roundtrip_baseline_alias" "$first_baseline_alias" "$LOGDIR/roundtrip.log"
+eq "round-trip experiment alias preserved" \
+    "$roundtrip_experiment_alias" "$first_experiment_alias" "$LOGDIR/roundtrip.log"
+
+kill $PID_ROUNDTRIP 2>/dev/null || true
+wait $PID_ROUNDTRIP 2>/dev/null || true
+
 echo "==> DELETE /api/v1/captures/experiment detaches"
 curl -fsS -X DELETE "http://127.0.0.1:$PORT_FILE/api/v1/captures/experiment" >/dev/null
 sleep 1

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -170,6 +170,28 @@ sleep 1
 mode=$(mode_at $PORT_FILE)
 eq "experiment attached → compare_mode" "$(echo "$mode" | jq -r .compare_mode)" "true" "$LOGDIR/file.log"
 
+echo "==> POST /api/v1/save_with_selection in two-file compare returns a tarball"
+SAVE_RESP="$LOGDIR/two-file-save.parquet.ab.tar"
+curl -fsS -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"entries":[{"chartId":"smoke","section":"overview","sectionName":"Overview","groupName":"smoke","promql_query":"cpu_cores","chartOpts":{}}],"trim_columns":false}' \
+    "http://127.0.0.1:$PORT_FILE/api/v1/save_with_selection" \
+    -o "$SAVE_RESP"
+
+ab_listing=$(tar tf "$SAVE_RESP" 2>&1 | tr '\n' ' ')
+case "$ab_listing" in
+    *baseline.parquet*experiment.parquet*ab.json*|*baseline.parquet*ab.json*experiment.parquet*|*experiment.parquet*baseline.parquet*ab.json*|*experiment.parquet*ab.json*baseline.parquet*|*ab.json*baseline.parquet*experiment.parquet*|*ab.json*experiment.parquet*baseline.parquet*) : ;;
+    *) fail "two-file compare save: tarball missing expected entries" "$ab_listing" "baseline.parquet, experiment.parquet, ab.json" "$LOGDIR/file.log" ;;
+esac
+
+ab_manifest=$(tar xfO "$SAVE_RESP" ab.json)
+eq "two-file compare save: manifest version" \
+    "$(echo "$ab_manifest" | jq -r .version)" "1" "$LOGDIR/file.log"
+[ -n "$(echo "$ab_manifest" | jq -r .baseline.alias)" ] \
+    || fail "two-file compare save: empty baseline.alias" "" "non-empty" "$LOGDIR/file.log"
+[ -n "$(echo "$ab_manifest" | jq -r .experiment.alias)" ] \
+    || fail "two-file compare save: empty experiment.alias" "" "non-empty" "$LOGDIR/file.log"
+
 echo "==> DELETE /api/v1/captures/experiment detaches"
 curl -fsS -X DELETE "http://127.0.0.1:$PORT_FILE/api/v1/captures/experiment" >/dev/null
 sleep 1


### PR DESCRIPTION
## Summary

- Two-file A/B compare mode can now produce a `.parquet.ab.tar` Report — previously the button was disabled with a "use `parquet combine --ab` first" tooltip.
- Server save path unifies compare-mode dispatch: any compare-mode save (combined-A/B or two-file) routes through `save_combined_ab_tarball`, synthesizing the `AbContainers` manifest from runtime state when no `combined_ab_marker` exists. WASM viewer already worked via its own synthesizer; backend gap is closed.
- Round-trip preserves aliases: reload a saved tarball, save again, manifest matches byte-for-byte.

## Implementation

- New pure helper `parquet_metadata::synthesize_ab_manifest()` mirrors the WASM-side `synthesize_manifest`, with server-only filename-basename fallback and `--category` passthrough.
- New accessor `AppState::resolve_experiment_parquet_path()` hides the CLI-vs-HTTP-attach split (CLI wins).
- `save_with_selection` rewired: `if let (Some(experiment_path), Some(experiment_data))` → tarball path with `combined_ab_marker.unwrap_or_else(|| synthesize_ab_manifest(...))`. The old `expect("experiment slot must be attached…")` panic path is gone.
- JS button enable: drop the `inTwoFileCompare = compareMode && !combinedAB` short-circuit at `selection.js:872`. No UI affordance changes beyond the disable removal.

## Test plan

- [x] 5 unit tests for `synthesize_ab_manifest` (alias presence/absence, filename fallback, empty-string fallback, category passthrough, multi-source independence)
- [x] Smoke test extension: HTTP-attach experiment, POST `/api/v1/save_with_selection`, assert response is a valid tarball with `version=1` and non-empty aliases
- [x] Round-trip smoke: reload the saved tarball in a fresh viewer, save again, assert both aliases match the first save
- [x] `cargo test` 167 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `bash tests/viewer_smoke.sh` passes including both new assertions

## Notes

- WASM viewer (`crates/viewer/`) is intentionally untouched — its existing `synthesize_manifest` already handles the two-file case and the JS button enable unlocks the WASM save path too.
- Behavior change worth noting: the old code returned `internal_error` when `combined_ab_marker` was set but `cli_experiment_path` was unset. New code silently falls through to single-parquet save in that state. Plan accepts this — the state is unreachable in practice (extractor always sets both).
- Alpha bump: `5.15.1-alpha.0` → `5.15.1-alpha.1`.