### PR TITLE
docs: GPU hypervisor operator/tenant insights + per-cgroup I/O attribution proposal

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -615,6 +615,54 @@ recording (single iGPU, 55 min at 1 s).
   (`src/agent/sampler_status.rs`) is whole-sampler only; there is no per-metric
   equivalent today. *Reopen:* if per-metric status machinery lands.
 
+## Agent — per-cgroup I/O attribution
+
+Source: [per-cgroup attribution for block I/O and network samplers](journal/2026-06-16-cgroup-io-attribution.md).
+Rezolus attributes CPU, scheduler, syscall and TLB activity per cgroup, but
+`blockio_*` is labeled only by `op` and `network_traffic` only by `direction` —
+so a hypervisor host cannot answer "which guest is doing this I/O?". Nothing is
+built: `blockio/requests/mod.bpf.c` and `network/traffic/mod.bpf.c` contain no
+cgroup references.
+
+- **`cgroup_blockio_operations` / `cgroup_blockio_bytes`** — Open, and first.
+  Cleanest attribution story: completion runs in IRQ/softirq context so
+  `bpf_get_current_cgroup_id()` is wrong; the issuing cgroup comes off the
+  request as `rq → bio → bi_blkg → blkcg → css.id`, a CO-RE read against types
+  already in the checked-in `vmlinux.h`. Add the counters in `blockio/requests`
+  only — `block_rq_complete` is already shared with `blockio/latency` (principle
+  11, and the "Known drift" note in `docs/principles.md`).
+- **`cgroup_network_bytes` / `_packets`, TX first** — Open, after blockio.
+  `skb->sk` is populated for locally originated traffic at
+  `net_dev_start_xmit`, so TX attributes; at `netif_receive_skb` it is typically
+  NULL (pre-demux), so RX does not.
+- **Network RX attribution** — Open, and the decision that gates the network
+  work. Either accept TX-only at the device hook, or move attribution to the
+  socket layer — which overlaps the existing `tcp/*` samplers and so becomes a
+  cross-sampler consolidation (principle 11) covering only TCP.
+- **Interface as the tenant proxy** — Open, and arguably the *primary* network
+  approach rather than cgroup attribution. Each guest already gets a dedicated
+  host-side netdev (tap/macvtap/VF representor/veth), `skb->dev` is populated on
+  both hooks (solving RX), and the chain is 2 derefs rather than blockio's 4.
+  Breaks on kernel-bypass datapaths (OVS-DPDK, vhost-user, SR-IOV passthrough
+  without a representor), shared interfaces, and ifindex reuse. Prefer emitting
+  interface-keyed metrics and joining `ifname → tenant` downstream (principle
+  9). Note `network_interfaces` is global-only today, so this is a real addition
+  rather than a relabel.
+- **Per-cgroup blockio size histograms** — Deferred, deliberately.
+  `MAX_CGROUPS × 496` H2 buckets is ~16 MB per op, ~64 MB for four; that breaks
+  the bounded-memory discipline (principles 8, 13). *Reopen:* only with config
+  gating or a sparse representation, as its own proposal.
+- **Counter layout and metric naming** — Open (minor). Confirm `packed_counters`
+  keyed by cgroup id, matching `cgroup_cpu_usage`; and prefer the distinct
+  `cgroup_`-prefixed metric over adding a `cgroup` label to `blockio_*`.
+- **Size the tax empirically, don't guess** — Open. Every sampler already exports
+  `rezolus_bpf_run_time`/`rezolus_bpf_run_count`; take mean ns per invocation for
+  `cpu_usage` as the fleetwide baseline, then measure `blockio_requests` /
+  `network_traffic` before and after under fio / a packet generator (principle
+  16). Per-event cost is roughly the cgroup tax `cpu/usage` already pays; the
+  axis that actually differs is hook firing rate (Mpps / millions of IOPS vs
+  tick accounting).
+
 ## metriken — measurement uncertainty (arc)
 
 Source: [measurement uncertainty](journal/2026-07-08-measurement-uncertainty.md).

--- a/docs/cgroup_io_attribution_proposal.md
+++ b/docs/cgroup_io_attribution_proposal.md
@@ -1,0 +1,228 @@
+# Proposal: Per-cgroup attribution for block I/O and network samplers
+
+## Motivation
+
+Rezolus already attributes CPU, scheduler, syscall, and TLB activity per cgroup
+(see `cgroup_cpu_usage` in `cpu/usage`). On a hypervisor where each guest/tenant
+is a cgroup (e.g. libvirt `machine.slice/machine-qemu-…`), that gives per-tenant
+CPU/scheduling/syscall visibility from the host.
+
+The block I/O and network samplers do **not** yet break down by cgroup —
+`blockio_*` is labeled only by `op`, `network_traffic` only by `direction`. This
+proposal adds per-cgroup variants so an operator can see per-tenant disk and
+network behavior from the host, consistent with the existing per-cgroup CPU
+metrics.
+
+This is the enhancement called out as a gap in
+`docs/gpu_hypervisor_tenant_insights.md`.
+
+## What "good" looks like
+
+New metric groups, mirroring the `cgroup_cpu_usage` naming/shape:
+
+| Metric | Type | Key | Labels |
+|--------|------|-----|--------|
+| `cgroup_blockio_operations` | counter | `MAX_CGROUPS` | `op={read,write,flush,discard}`, `name=<cgroup path>` |
+| `cgroup_blockio_bytes` | counter | `MAX_CGROUPS` | `op={read,write,…}`, `name` |
+| `cgroup_network_bytes` | counter | `MAX_CGROUPS` | `direction={receive,transmit}`, `name` |
+| `cgroup_network_packets` | counter | `MAX_CGROUPS` | `direction={receive,transmit}`, `name` |
+
+Per-cgroup **histograms** (blockio size distribution) are intentionally **out of
+scope for v1** — see "Histograms" below.
+
+## The hard part: whose cgroup? (attribution context)
+
+This is the crux, and it's why the existing hooks can't just call
+`bpf_get_current_cgroup_id()`. Both samplers fire in contexts where `current` is
+**not** the tenant that owns the I/O.
+
+### Block I/O — completion runs in IRQ/softirq context
+
+`block_rq_complete` fires on the completing CPU, long after submission;
+`current` is whatever happened to be running. The issuing cgroup must come from
+the request itself. The kernel carries it on the bio:
+
+```
+struct request *rq → rq->bio (struct bio*) → bio->bi_blkg (struct blkcg_gq*)
+                   → blkg->blkcg (struct blkcg*) → blkcg->css.id
+```
+
+Both `bi_blkg` and `struct blkcg_gq`/`struct blkcg` are present in the checked-in
+`vmlinux.h` (confirmed at `x86_64/vmlinux.h:10817,25069,25103`), so this is a
+CO-RE read with no kernel patch (principle 2).
+
+**Caveats to handle:**
+- `rq->bio` can be NULL (e.g. flushes). Guard and skip — these already contribute
+  no bytes.
+- `bi_blkg` requires `CONFIG_BLK_CGROUP`. If the chain reads NULL, fall back to
+  cgroup id `0` (root) rather than dropping the count, so totals still reconcile.
+- The `css.id` here is the **blkio** controller's css, a *different* id space than
+  the **cpu** controller's `sched_task_group.css.id` used by `cpu/usage`. That's
+  fine — each sampler resolves its own id→name mapping independently via the
+  kernfs node, and every metric carries its own `name` label. We do **not** try
+  to share cgroup ids across samplers.
+
+### Network — RX/TX run in softirq/NAPI context
+
+`netif_receive_skb` (RX) and `net_dev_start_xmit` (TX) also run outside the
+owning task. The cgroup must come from the socket on the skb:
+
+```
+struct sk_buff *skb → skb->sk (struct sock*) → sk->sk_cgrp_data → cgroup id
+```
+
+- **TX** (`net_dev_start_xmit`): `skb->sk` is normally populated for locally
+  originated traffic, so socket-based attribution works.
+- **RX** (`netif_receive_skb`): `skb->sk` is typically **NULL** at this point —
+  the packet hasn't been demuxed to a socket yet. So RX attribution at this hook
+  is unreliable.
+
+**Two options for network; this needs a decision (see "Open questions"):**
+
+1. **Stay at the device hooks, TX-attributed only.** Ship `cgroup_network_bytes`
+   /`_packets` for `direction=transmit` now; leave RX as host-aggregate. Lowest
+   overhead, no new probes, but asymmetric.
+2. **Attribute at the socket layer instead.** Hook `sock_sendmsg`/`tcp_sendmsg`
+   (TX) and `tcp_cleanup_rbuf`/`tcp_recvmsg` (RX), where `current`/`sk` is valid.
+   This gives symmetric RX+TX but **overlaps the existing `tcp/*` samplers** —
+   principle 11 says consolidate rather than add a second attach to a hook
+   another sampler already covers. That makes it a larger, cross-sampler change
+   (fold cgroup attribution into the tcp samplers) and it only covers TCP, not
+   all of `network_traffic`.
+
+My recommendation: **ship blockio first** (cleaner story), and do network as a
+**TX-first** increment (option 1) with RX deferred behind the socket-layer
+consolidation discussion.
+
+## Design (mirrors `cpu/usage`)
+
+The plumbing is already a well-worn path in this codebase; we reuse it wholesale
+(principle 12 — shared headers, no reinvention).
+
+### BPF side (per sampler)
+
+Add to each target `mod.bpf.c`:
+
+1. **cgroup metadata channel** (copy from `cpu/usage`):
+   - `cgroup_info` ringbuf (`RINGBUF_CAPACITY`) — rare new-cgroup metadata only,
+     never per-event (principle 3).
+   - `cgroup_serial_numbers` array (`MAX_CGROUPS`, `BPF_F_MMAPABLE`).
+2. **per-cgroup counter arrays** — `BPF_MAP_TYPE_ARRAY`, `BPF_F_MMAPABLE`,
+   `max_entries = MAX_CGROUPS`, keyed by the bounded cgroup id (principle 5:
+   array over hashmap for a bounded-integer key). One map per (metric, op/dir):
+   e.g. `cgroup_read_ops`, `cgroup_write_ops`, …, or a single packed group of
+   width `MAX_CGROUPS * GROUP_WIDTH` — match whichever the existing per-cgroup
+   metrics use with `packed_counters`.
+3. In the handler, after the existing global counter update, derive `cgroup_id`
+   via the chain above, bounds-check (`if (id >= MAX_CGROUPS) return 0;`), call a
+   new shared helper to emit metadata on first sight, then
+   `array_add(&cgroup_*, id, delta)` with relaxed atomics.
+
+New shared helper in `src/agent/bpf/cgroup.h` (alongside `handle_new_cgroup` /
+`handle_new_cgroup_from_css`):
+
+```c
+// Populate cgroup_info from a blkcg_gq (block I/O completion path, where
+// `current` is not the issuing task).
+static __always_inline int handle_new_cgroup_from_blkg(
+    struct blkcg_gq *blkg, void *serials, void *ringbuf);
+```
+
+This factors the css→name/level/parent walk that already exists in
+`handle_new_cgroup_from_css`; the only difference is where the `css` comes from
+(`blkg->blkcg->css` vs `task->sched_task_group->css`). Refactor the common tail
+into one `__always_inline` body to avoid a third copy of the kernfs walk.
+
+### Userspace side (per sampler `mod.rs` + `stats.rs`)
+
+Copy the `cpu/usage` pattern verbatim:
+- `unsafe impl plain::Plain for bpf::types::cgroup_info {}` + `impl_cgroup_info!`.
+- `CGROUP_METRICS` slice + `handle_cgroup_info` → `process_cgroup_info`.
+- Register maps in `SkelExt::map`, wire `.packed_counters("cgroup_…", &…)` and
+  `.ringbuf_handler("cgroup_info", handle_cgroup_info)` in `init`.
+- `stats.rs`: add `CounterGroup::new(MAX_CGROUPS)` metrics named
+  `cgroup_blockio_*` / `cgroup_network_*`, following the `CGROUP_CPU_USAGE_*`
+  block.
+
+No new userspace refresh cost beyond O(active cgroups) (principle 13): the reader
+is mmap-direct over the `MAX_CGROUPS` array, same as `cgroup_cpu_usage`.
+
+## Histograms (deferred)
+
+Per-cgroup blockio **size distributions** would mean a `MAX_CGROUPS × 496-bucket`
+H2 histogram per op — ~16 MB per op, ~64 MB for four ops, per sampler. That
+violates the bounded-memory discipline (principles 8, 13). v1 ships per-cgroup
+**counters only** (ops + bytes). If distributions are needed later, gate them
+behind config and/or a sparse representation — separate proposal.
+
+## Overhead assessment (principle 1)
+
+- **Per-event work:** one extra pointer-chase (`rq→bio→bi_blkg→blkcg→css.id`) and
+  one `array_add` on the completion/xmit path. No new hot-path probe (we reuse the
+  existing attaches), no helpers from the refused list, O(1) per event.
+- **Ringbuf:** fires only on first observation of each cgroup (serial-number
+  gate), not per I/O — consistent with principle 3.
+- **Memory:** `MAX_CGROUPS (4096) × u64` per counter map. With ~6 new maps that's
+  a few hundred KB — negligible next to the existing per-PID arrays.
+- **Consolidation note:** `block_rq_complete` is already shared logic between
+  `blockio/latency` and `blockio/requests` (flagged in principles "Known drift").
+  Add the cgroup counters in `blockio/requests` only; don't add a second attach.
+
+Net: stays within the always-on fleetwide budget. The one workload to watch is
+millions of IOPS / Mpps (principle 1 caveat) — same ceiling the existing probes
+already have; we add a constant to it.
+
+## File-by-file change list
+
+**Block I/O (do first):**
+- `src/agent/bpf/cgroup.h` — add `handle_new_cgroup_from_blkg` + refactor shared
+  tail.
+- `src/agent/samplers/blockio/linux/requests/mod.bpf.c` — cgroup maps + per-cgroup
+  `array_add` in `handle_block_rq_complete`.
+- `src/agent/samplers/blockio/linux/requests/mod.rs` — cgroup_info plumbing, map
+  registration, `packed_counters`/`ringbuf_handler`.
+- `src/agent/samplers/blockio/linux/requests/stats.rs` — `CGROUP_BLOCKIO_*`
+  metric definitions.
+
+**Network (TX-first increment):**
+- `src/agent/samplers/network/linux/traffic/mod.bpf.c` — cgroup maps + socket→
+  cgroup read on the TX path.
+- `…/traffic/mod.rs`, `…/traffic/stats.rs` — same plumbing as above.
+
+**Docs:**
+- `docs/metrics.md` — document the new `cgroup_blockio_*` / `cgroup_network_*`
+  metrics.
+- `docs/principles.md` — tick the relevant "Known drift" note if applicable.
+
+## Testing
+
+- `cargo build` (triggers `build.rs` BPF compilation) on both `x86_64` and
+  `aarch64` headers.
+- `cargo clippy`, `cargo xtask fmt`.
+- Manual: run the agent under load that exercises a known cgroup (e.g. a
+  container doing `fio` and `iperf`), confirm `cgroup_blockio_*` /
+  `cgroup_network_*` attribute to the expected `name=` path and that summed
+  per-cgroup values reconcile against the existing global `blockio_*` /
+  `network_traffic` totals.
+- Verify graceful behavior when `CONFIG_BLK_CGROUP` is off (falls back to root).
+- Verify the `raw_tp` twins (CO-RE-only kernels, no in-kernel BTF) still load.
+
+## Phasing
+
+1. **PR 1 — blockio counters per cgroup.** Self-contained, clean attribution
+   model, immediately useful for per-tenant disk.
+2. **PR 2 — network TX per cgroup** at the device hook.
+3. **PR 3 (discussion-gated) — network RX** via socket-layer consolidation with
+   the `tcp/*` samplers, if symmetric RX/TX attribution is wanted.
+
+## Open questions (need a decision before coding network)
+
+1. **Network RX attribution:** accept TX-only at the device hook (option 1), or
+   take on the socket-layer consolidation with the tcp samplers (option 2)?
+2. **Counter layout:** `packed_counters` keyed by cgroup id (matches
+   `cgroup_cpu_usage`) — confirm we want the same `PackedCounters` strategy here
+   (principle 7: high-cardinality keyed counters, one natural writer per cgroup).
+3. **Metric naming:** `cgroup_blockio_operations`/`cgroup_blockio_bytes` vs.
+   reusing `blockio_operations` with an added `cgroup` label. The existing
+   convention is a distinct `cgroup_`-prefixed metric (`cgroup_cpu_usage`), so I'd
+   follow that.

--- a/docs/cgroup_io_attribution_proposal.md
+++ b/docs/cgroup_io_attribution_proposal.md
@@ -155,22 +155,63 @@ violates the bounded-memory discipline (principles 8, 13). v1 ships per-cgroup
 **counters only** (ops + bytes). If distributions are needed later, gate them
 behind config and/or a sparse representation — separate proposal.
 
-## Overhead assessment (principle 1)
+## Overhead assessment, baselined against `cpu/usage`'s cgroup tax (principle 1)
 
-- **Per-event work:** one extra pointer-chase (`rq→bio→bi_blkg→blkcg→css.id`) and
-  one `array_add` on the completion/xmit path. No new hot-path probe (we reuse the
-  existing attaches), no helpers from the refused list, O(1) per event.
-- **Ringbuf:** fires only on first observation of each cgroup (serial-number
-  gate), not per I/O — consistent with principle 3.
-- **Memory:** `MAX_CGROUPS (4096) × u64` per counter map. With ~6 new maps that's
-  a few hundred KB — negligible next to the existing per-PID arrays.
-- **Consolidation note:** `block_rq_complete` is already shared logic between
-  `blockio/latency` and `blockio/requests` (flagged in principles "Known drift").
-  Add the cgroup counters in `blockio/requests` only; don't add a second attach.
+The right baseline is the **existing per-cgroup CPU sampler** (`cgroup_cpu_usage`),
+which is already deployed always-on fleetwide. The work this proposal adds to the
+blockio/network hooks is the *same cgroup-attribution "tax"* that `cpu/usage`
+already pays on top of its base accounting. Decomposed, that tax is:
 
-Net: stays within the always-on fleetwide budget. The one workload to watch is
-millions of IOPS / Mpps (principle 1 caveat) — same ceiling the existing probes
-already have; we add a constant to it.
+| Step (per event) | Cost | `cpu/usage` today | This proposal |
+|---|---|---|---|
+| Resolve cgroup id (pointer chase to a `css.id`) | a few `BPF_CORE_READ`s | `task → sched_task_group → css.id` (**2 derefs**) | blockio: `rq → bio → bi_blkg → blkcg → css.id` (**4 derefs**); network: `skb → sk → sk_cgrp_data` (**2–3 derefs**) |
+| New-cgroup gate (`handle_new_cgroup*`) | 1 array lookup + serial compare; ringbuf **only on first sighting** | identical (shared `cgroup.h` helper) | identical (shared helper) |
+| Accumulate | 1–2 `array_add` (relaxed atomic) into a `MAX_CGROUPS` array | 2 (`cgroup_user`,`cgroup_system`) | 2 (ops + bytes / packets + bytes) |
+
+So the **marginal per-event cost is essentially the cpu baseline's cgroup
+portion**, with one wrinkle: blockio's id chain is ~2 dereferences longer (each a
+bounded `bpf_probe_read_kernel`), so its tax is modestly higher per event than
+cpu's; network's is comparable to cpu's (plus one NULL-`sk` branch on RX). All
+O(1), no refused helpers, no new probe (we extend existing attaches).
+
+**The axis that actually differs is event rate, not per-event cost.** The cgroup
+tax is constant per event; aggregate overhead = tax × hook firing rate. Ordering
+the three hosts hooks by worst-case rate:
+
+| Sampler | Host hook | Event-rate ceiling |
+|---|---|---|
+| `cpu/usage` (baseline) | `cpuacct_account_field` | ~per-task-per-tick — modest, scales with runnable tasks |
+| `blockio/requests` | `block_rq_complete` | **millions of IOPS** on NVMe under fio |
+| `network/traffic` | `netif_receive_skb` / `net_dev_start_xmit` | **Mpps** at line rate — the highest |
+
+This is exactly principle 1's named ceiling. The conclusion: **per-event, this is
+no worse than a sampler we already run fleetwide; the thing to respect is that the
+completion/packet hooks can fire far more often than tick accounting, so the same
+tax multiplies further on extreme IOPS/pps workloads.** That is an argument about
+*which hook to attribute at* (and how often it fires), not about the cgroup
+machinery itself.
+
+**Memory & userspace:** identical shape to `cpu/usage` — `MAX_CGROUPS (4096) ×
+u64` per counter map (cpu's cgroup maps are 2 × 4096 × 8 = 64 KB; blockio ~256 KB,
+network ~128 KB), plus the shared serial-number array and ringbuf. Userspace
+refresh is the same mmap-direct, O(active cgroups) read the cpu cgroup sampler
+already does (principle 13). Negligible and already-proven.
+
+**Consolidation note:** `block_rq_complete` is already shared logic between
+`blockio/latency` and `blockio/requests` (flagged in principles "Known drift").
+Add the cgroup counters in `blockio/requests` only; don't add a second attach.
+
+### Measure it, don't guess
+
+Every sampler already exports `rezolus_bpf_run_time` and `rezolus_bpf_run_count`
+(see `BPF_RUN_TIME`/`BPF_RUN_COUNT`). The honest way to size this is empirical:
+take `run_time / run_count` (mean ns per probe invocation) for `cpu_usage` as the
+established baseline, then compare the same ratio for `blockio_requests` /
+`network_traffic` **before and after** adding the cgroup path, under a load
+generator that drives the hook hard (fio for blockio, a packet generator for
+network). The delta in mean-ns-per-event is the cgroup tax; multiply by expected
+fleet event rates to bound aggregate cost. This avoids hand-waved cycle counts and
+uses instrumentation that already ships.
 
 ## File-by-file change list
 

--- a/docs/cgroup_io_attribution_proposal.md
+++ b/docs/cgroup_io_attribution_proposal.md
@@ -256,6 +256,94 @@ uses instrumentation that already ships.
 3. **PR 3 (discussion-gated) — network RX** via socket-layer consolidation with
    the `tcp/*` samplers, if symmetric RX/TX attribution is wanted.
 
+## Alternative for network: interface as the tenant proxy
+
+Worth serious consideration as the *primary* network approach rather than cgroup
+attribution. In virtualization, each guest already gets a dedicated host-side
+netdev (QEMU/virtio `tap`/`vhost-net`, `macvtap`, an SR-IOV **VF representor** in
+switchdev mode, or a `veth` for containers). So **per-interface == per-tenant by
+construction** on the host, with no in-kernel cgroup bookkeeping.
+
+### Why it's stronger than cgroup attribution for network
+
+- **Solves the RX problem.** `skb->dev` is populated on *both* hooks
+  (`netif_receive_skb` and `net_dev_start_xmit`) — unlike `skb->sk`, which is
+  NULL on RX before demux. Symmetric RX+TX, no NULL-branch.
+- **Cheaper chain.** `skb → dev → ifindex` (2 derefs) vs. blockio's 4.
+- **Matches the operator's mental model.** The thing they provision per tenant
+  *is* the interface.
+
+### Where it breaks (must be documented)
+
+- **Kernel-bypass datapaths**: OVS-DPDK, vhost-user, and SR-IOV VF *passthrough*
+  (no representor) never traverse a host kernel netdev, so the netif hooks never
+  fire — Rezolus cannot see that traffic at all. (SR-IOV in **switchdev** mode
+  does expose a per-VF representor netdev, which the hooks see.)
+- **Shared interfaces**: if several VMs share one host netdev (some macvlan/bridge
+  setups), per-interface ≠ per-tenant.
+- **ifindex reuse/churn**: tap devices are created/destroyed per VM lifecycle and
+  ifindex is reused. Userspace must track link add/del and handle reuse (zero
+  counters, re-stamp name) exactly as the cgroup path handles serial numbers and
+  the task path handles PID start-times.
+
+### BPF + userspace shape
+
+- BPF: key `network/traffic` counters by `BPF_CORE_READ(skb, dev, ifindex)`,
+  bounds-checked against a `MAX_IFINDEX` array (principle 5 — ifindex is a
+  bounded-ish int; document the ceiling like `MAX_CPUS`). No new probe.
+- Userspace: resolve `ifindex → ifname` via the existing sysfs discovery pattern
+  (`read_dir("/sys/class/net")`, as `network/ethtool` already does) or netlink for
+  churn. `ifname` is the stable **join key** for tenant mapping.
+
+> Note: `network_interfaces` today exposes only *global* drop/tx_busy/tx_complete/
+> tx_timeout counters — it is **not** per-interface. So this is a real addition,
+> not a relabel of existing data.
+
+### Finding the tenant ↔ interface mapping (layered, most → least authoritative)
+
+1. **libvirt — authoritative on a libvirt/KVM host.** `virsh domiflist <domain>`
+   gives `(host tap ifname, MAC, source bridge)`; or parse the domain XML
+   (`/run/libvirt/qemu/<domain>.xml`, `<interface><target dev='vnet7'/><mac .../>`).
+   Domain name/UUID = tenant id. Refresh on libvirt lifecycle events. Note: the
+   default `vnetN` names are *sequential*, not tenant-encoding — you must go
+   through libvirt to map them.
+2. **Orchestrator-encoded names (no API call — the name carries the id).**
+   - OpenStack/Neutron: `tapXXXXXXXX-XX` embeds the first 11 chars of the Neutron
+     **port UUID** → join to port → `device_id` (instance) → project/tenant.
+     Hybrid-plug `qvo/qvb` veth pairs encode the same.
+   - Kubernetes/CNI: `cali…`/`veth…`/`lxc…` → pod via CNI host state
+     (`/var/run/calico`, kubelet pod list, etc.).
+3. **sysfs + process attribution (generic fallback, no orchestrator).**
+   `/sys/class/net/<if>/{address,ifindex,master,tun_flags}` identifies tap
+   devices, their MAC and bridge. A tap is an open fd on the owning QEMU process;
+   map that pid → VM via its cgroup path
+   `machine.slice/machine-qemu-\x2d<id>-<name>.scope` — **the cgroup samplers
+   already parse exactly this path**, so the tap→VM join reuses existing logic.
+   `bridge fdb show` cross-references guest MAC ↔ tap.
+4. **Control-plane inventory by MAC / PCI-VF index** (EC2 ENI, Azure NIC) where
+   the host doesn't name interfaces by tenant; MAC or VF index is the join key
+   into the provider's port database.
+
+### Where the mapping should live (principle 9)
+
+Prefer: **agent emits interface-keyed metrics (`ifname`/`ifindex` label); the
+tenant join happens downstream.** Keeps the agent generic and dependency-free (no
+libvirt/Neutron client, no extra privilege/coupling); the operator's relabel/
+metadata layer joins `ifname → tenant` from their own inventory — consistent with
+"agent exposes detail; aggregation/labeling lives downstream" and the parquet
+per-source-metadata model. Optionally offer a **config-gated, source-pluggable
+resolver** in userspace (static map file, name-regex, or libvirt) that stamps a
+`vm`/`tenant` label at discovery time — analogous to today's cgroup_info metadata
+stamping — for operators who want labels applied at the source.
+
+### Symmetry for block I/O
+
+The same "assigned device as tenant proxy" idea applies to disk when each VM has a
+dedicated backing block device/LV: key `blockio` by `dev_t` (`rq → rq_disk →`
+major/minor) and join device → VM downstream. Where VMs share a backing device or
+use file-backed images on a shared filesystem, that breaks down and the `bi_blkg`
+cgroup attribution above is the better signal. The two are complementary.
+
 ## Open questions (need a decision before coding network)
 
 1. **Network RX attribution:** accept TX-only at the device hook (option 1), or

--- a/docs/gpu_hypervisor_tenant_insights.md
+++ b/docs/gpu_hypervisor_tenant_insights.md
@@ -1,0 +1,122 @@
+# Rezolus on GPU Servers: What an Operator and Tenants Can Learn From Each Other
+
+This note sketches the two-way value of running **Rezolus inside the guest OS**
+on a GPU server fleet. The operator owns the hypervisor and the physical hosts;
+tenants run their workloads (training, fine-tuning, inference, data prep) inside
+guest VMs. Rezolus is a low-overhead, high-resolution telemetry agent that uses
+eBPF for in-kernel aggregation, so it is cheap enough to leave running on
+production guests fleet-wide.
+
+The key idea: the operator already sees the *host* side. Putting Rezolus on the
+guest closes the loop by exposing the *workload* side at high resolution — and
+that benefits both parties.
+
+---
+
+## What the operator can offer tenants as insight
+
+These are things a tenant usually struggles to see on their own, but which
+become straightforward once Rezolus is collecting guest-side telemetry.
+
+### GPU efficiency and utilization quality
+- **Real GPU utilization vs. "allocation."** `gpu_utilization` and
+  `gpu_memory_utilization` show how much of a paid-for GPU is actually doing
+  work. A GPU pinned at 100% allocation but 30% utilization is money on the
+  floor — the operator can show tenants exactly when and where.
+- **Power and thermal headroom.** `gpu_power_usage`, `gpu_energy_consumption`,
+  `gpu_temperature`, and `gpu_clock` reveal whether kernels are power- or
+  thermally throttled, or running below their clock ceiling.
+- **PCIe pressure.** `gpu_pcie_throughput` / `gpu_pcie_bandwidth` highlight
+  host-to-device transfer bottlenecks — a classic cause of "the GPU is idle but
+  my job is slow."
+
+### Where the GPU is *waiting* (the host-side context the tenant can't see)
+- **Data-loading and I/O stalls.** `blockio_latency`, `blockio_requests`, and
+  `blockio_size` expose storage as the reason GPUs sit idle between steps.
+- **CPU starvation feeding the GPU.** `cpu_usage`, `scheduler_runqueue` (runqueue
+  latency), and `cpu_migrations` show when the data pipeline (augmentation,
+  tokenization, collation) is CPU-bound and can't keep the accelerator fed.
+- **Network bottlenecks for distributed jobs.** `tcp_traffic`,
+  `tcp_retransmit`, `tcp_connect_latency`, and `tcp_packet_latency` surface
+  collective-communication (all-reduce) stalls, NIC saturation, and retransmits
+  that throttle multi-node training.
+
+### Efficiency and right-sizing guidance
+- **"You are paying for a GPU box but bottlenecked on CPU/IO/network."** The
+  combination above lets the operator give concrete, evidence-backed advice:
+  add data-loader workers, move to faster storage, change instance shape, batch
+  differently.
+- **Syscall and scheduler behavior.** `syscall_counts` / `syscall_latency` and
+  runqueue depth can point at pathological behavior (excessive `futex`, lock
+  contention, oversubscribed vCPUs) the tenant would never attribute correctly.
+
+### Incident and regression support
+- **High-resolution post-incident analysis.** With Rezolus Hindsight's rolling
+  ring buffer, the operator can hand a tenant a second-by-second picture of what
+  the guest was doing during a slowdown, OOM, or throttling event.
+- **Before/after comparisons.** The viewer's A/B mode lets a tenant compare two
+  runs (e.g., before vs. after a code change or instance migration) on identical
+  axes.
+
+---
+
+## What the operator can learn from tenants
+
+Guest-side telemetry also makes the *fleet* more legible to the operator — for
+capacity planning, oversubscription decisions, and fairness.
+
+### True demand vs. provisioned capacity
+- **Real utilization distributions across the fleet.** Aggregated
+  `gpu_utilization` / `gpu_memory_utilization` tell the operator how much
+  GPU capacity is genuinely consumed vs. reserved — the basis for
+  oversubscription and bin-packing policy.
+- **Workload shapes.** Block IO sizes, network traffic patterns, and CPU/GPU
+  ratios let the operator classify tenants (IO-bound prep, compute-bound
+  training, latency-bound inference) and place them on suitable hardware.
+
+### Noisy-neighbor and contention detection
+- **Cross-tenant interference.** Correlating guest-side `scheduler_runqueue`
+  latency, `cpu_migrations`, `blockio_latency`, and `tcp_retransmit` with host
+  occupancy reveals when one tenant's behavior degrades a co-located tenant —
+  something invisible from host counters alone.
+- **vCPU oversubscription health.** Runqueue latency on the guest is a direct
+  signal that the host is overcommitted relative to what tenants actually need.
+
+### Capacity planning and hardware ROI
+- **Bottleneck inventory across the fleet.** If many guests are PCIe- or
+  storage-bound rather than compute-bound, that argues for faster NVMe, more
+  host CPU, or better NIC provisioning — not more GPUs.
+- **Power and thermal envelopes.** Fleet-wide `gpu_power_usage` and
+  `gpu_temperature` inform datacenter power budgeting and cooling, and flag
+  hosts that throttle under load.
+
+### Anomaly detection at fleet scale
+- Rezolus recordings (parquet) plus the MCP analysis tools
+  (`detect-anomalies`, `analyze-correlation`, PromQL `query`) let the operator
+  run automated regression and anomaly sweeps across many tenants without
+  manual dashboard-watching.
+
+---
+
+## Why guest-side Rezolus specifically
+
+- **Low overhead, always-on.** eBPF in-kernel aggregation read via mmap means it
+  is cheap enough to run continuously on production guests, not just during
+  debugging.
+- **High resolution.** Sub-second visibility catches micro-stalls (step-to-step
+  GPU idle, all-reduce hiccups) that minute-resolution monitoring averages away.
+- **Workload-side truth.** The host sees physical counters; the guest sees what
+  the *application kernel* actually experiences (runqueue latency, syscall
+  latency, TCP latency). Together they tell a complete story neither side has
+  alone.
+
+---
+
+## A reasonable privacy/trust boundary
+
+Rezolus collects *systems performance* signals (utilization, latencies,
+counters), not application payloads or model data. That makes it a comfortable
+shared layer: tenants get expert efficiency insight and faster incident
+resolution, and the operator gets the demand signal needed to run a denser,
+fairer, better-provisioned fleet — without either side exposing proprietary
+workload contents.

--- a/docs/gpu_hypervisor_tenant_insights.md
+++ b/docs/gpu_hypervisor_tenant_insights.md
@@ -91,7 +91,7 @@ capacity planning, oversubscription decisions, and fairness.
   hosts that throttle under load.
 
 ### Anomaly detection at fleet scale
-- Rezolus recordings (parquet) plus the MCP analysis tools
+- Rezolus recordings (`.rez` archives, or parquet) plus the MCP analysis tools
   (`detect-anomalies`, `analyze-correlation`, PromQL `query`) let the operator
   run automated regression and anomaly sweeps across many tenants without
   manual dashboard-watching.

--- a/docs/journal/2026-06-16-cgroup-io-attribution.md
+++ b/docs/journal/2026-06-16-cgroup-io-attribution.md
@@ -1,4 +1,15 @@
-# Proposal: Per-cgroup attribution for block I/O and network samplers
+# Per-cgroup attribution for block I/O and network samplers
+
+- **Opened:** 2026-06-16
+- **Status:** OPEN — proposal, pre-build. Nothing is implemented: as of `main`
+  today, `blockio/requests/mod.bpf.c` and `network/traffic/mod.bpf.c` contain no
+  cgroup references at all. Three open questions below (network RX attribution,
+  counter layout, metric naming) need a decision before coding.
+- **Driver:** [Rezolus on GPU servers — operator/tenant insights](../gpu_hypervisor_tenant_insights.md),
+  which names per-tenant disk and network attribution as the gap that keeps the
+  host from answering "which guest is doing this I/O?".
+- **Tracked in:** [`docs/backlog.md`](../backlog.md) → "Agent — per-cgroup I/O
+  attribution".
 
 ## Motivation
 
@@ -14,7 +25,7 @@ network behavior from the host, consistent with the existing per-cgroup CPU
 metrics.
 
 This is the enhancement called out as a gap in
-`docs/gpu_hypervisor_tenant_insights.md`.
+[`docs/gpu_hypervisor_tenant_insights.md`](../gpu_hypervisor_tenant_insights.md).
 
 ## What "good" looks like
 

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -26,6 +26,7 @@ merged PRs, and project notes; each is grounded in real commits/PRs.
 | 2026-04-19 | [Viewer chart & heatmap UX](2026-04-19-viewer-chart-ux.md) | Shipped (merged) |
 | 2026-04-21 | [A/B compare mode for the viewer](2026-04-21-ab-compare-mode.md) | Shipped (merged) |
 | 2026-05-10 | [Selection → Notebook → Report](2026-05-10-selection-notebook-report.md) | Shipped (merged) |
+| 2026-06-16 | [Per-cgroup attribution for block I/O and network samplers](2026-06-16-cgroup-io-attribution.md) | OPEN — proposal, pre-build. Per-tenant disk/network from the host, mirroring `cgroup_cpu_usage`. Attribution context is the crux: blockio reads `rq → bio → bi_blkg → blkcg → css.id` (present in the checked-in `vmlinux.h`); network TX can use `skb->sk` but RX cannot (NULL before demux), so an **interface-as-tenant-proxy** alternative (`skb->dev->ifindex`, symmetric, 2 derefs) is recorded as the likely primary for network. Per-cgroup histograms explicitly out of scope (MAX_CGROUPS × 496 buckets ≈ 64 MB). Overhead framed as the cgroup "tax" `cpu/usage` already pays fleetwide, with event rate — not per-event cost — as the axis that differs. Three open questions gate coding |
 | 2026-07-02 | [`document-feature` skill — agent-verified CLI help](2026-07-02-document-feature-skill.md) | Shipped (merged) |
 | 2026-07-03 | [Viewer support for "simple capture" parquets](2026-07-03-simple-capture-viewer.md) | Shipped (PR #989) |
 | 2026-07-04 | [Per-source metric descriptions in combined parquets](2026-07-04-per-source-descriptions.md) | Shipped (PR #989) |


### PR DESCRIPTION
## Summary

Two docs on running Rezolus **inside the guest OS** on GPU/hypervisor fleets, and the sampler gap that idea exposes. Docs only — no code, no version bump.

### 1. `docs/gpu_hypervisor_tenant_insights.md` (new)

The two-way value of guest-side Rezolus. The operator already sees the *host* side; the guest closes the loop.

- **What the operator can offer tenants** — real GPU utilization vs. allocation, power/thermal headroom, PCIe pressure; where the GPU is *waiting* (`blockio_*`, `cpu_usage`, `scheduler_runqueue`, `tcp_*`); right-sizing guidance; incident and regression support via Hindsight and the viewer's A/B mode.
- **What the operator can learn from tenants** — true demand vs. provisioned capacity, noisy-neighbor and vCPU-oversubscription detection, capacity planning / hardware ROI, and fleet-scale anomaly sweeps via the MCP tools.
- **Why guest-side specifically**, plus a privacy/trust boundary note: Rezolus collects systems-performance signals, not application payloads.

Grounded in real samplers (`gpu_nvidia`, `cpu_*`, `scheduler_runqueue`, `blockio_*`, `tcp_*`, `syscall_*`) and tooling (Hindsight, viewer A/B, MCP).

### 2. `docs/journal/2026-06-16-cgroup-io-attribution.md` (new)

The GPU note names per-tenant disk and network attribution as the gap. This is the pre-build proposal for closing it — **not in the original description of this PR**, added in later commits.

Rezolus attributes CPU, scheduler, syscall and TLB per cgroup, but `blockio_*` is labeled only by `op` and `network_traffic` only by `direction`, so a host cannot answer "which guest is doing this I/O?".

- **The crux is attribution context.** Both hooks fire where `current` is not the owning tenant, so `bpf_get_current_cgroup_id()` is wrong. Blockio takes the cgroup off the request (`rq → bio → bi_blkg → blkcg → css.id`); network can use `skb->sk` on TX but not on RX, where it is NULL before demux.
- **Interface as the tenant proxy** is recorded as the likely *primary* approach for network: `skb->dev->ifindex` is populated on both hooks, is 2 derefs rather than 4, and matches what an operator actually provisions per tenant. Its failure modes (kernel-bypass datapaths, shared interfaces, ifindex reuse) and the tenant↔interface mapping sources (libvirt, orchestrator-encoded names, sysfs+cgroup fallback, control-plane inventory) are written down.
- **Per-cgroup histograms are deliberately out of scope** — `MAX_CGROUPS × 496` H2 buckets is ~64 MB for four ops, which breaks the bounded-memory discipline.
- **Overhead is framed as the cgroup "tax" `cpu/usage` already pays fleetwide**, with the honest observation that the axis which differs is *hook firing rate* (Mpps / millions of IOPS vs. tick accounting), not per-event cost — and a measurement recipe using the `rezolus_bpf_run_time`/`run_count` metrics that already ship.
- **Three open questions gate coding:** network RX attribution, counter layout, metric naming.

### Housekeeping in this update

- Filed the proposal as a **journal entry** with the standard Opened/Status/Driver header and a README index row, rather than a loose top-level doc — it is a pre-build spec with open questions, which is what the journal is for. The GPU note stays top-level as a positioning/reference doc.
- Added a **`docs/backlog.md` section** ("Agent — per-cgroup I/O attribution") so the open items are tracked where the rest of the backlog lives.
- Fixed one stale phrase in the GPU note: recordings default to `.rez` archives now, not only parquet.
- Rebased onto `main` (was 131 commits behind; clean).

## Test plan

- [x] Docs only; no code, no `Cargo.toml` change, no build/test impact
- [x] Every metric name cited in the GPU note verified present in `docs/metrics.md` and the samplers (19 checked)
- [x] Proposal claims re-verified against current `main`: `handle_new_cgroup_from_css` (`src/agent/bpf/cgroup.h:120`), `MAX_CGROUPS 4096` (`cgroup.h:10`), `bi_blkg`/`blkcg_gq`/`blkcg` at the cited `x86_64/vmlinux.h` lines (10817/25069/25103), the shared-`block_rq_complete` drift note (`docs/principles.md:741`), and **zero** cgroup references in `blockio/requests/mod.bpf.c` / `network/traffic/mod.bpf.c` — the gap is real and unimplemented
- [x] All relative links in the touched docs resolve
- [ ] Review of the network RX decision and the interface-vs-cgroup choice — the two open questions worth an opinion before anyone codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
