### PR TITLE
fix(bpf): warn when a BPF program fails to attach due to missing kernel symbol

### DIFF
--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -396,7 +396,7 @@ where
                         });
                     }
                     Err(e) if e.kind() == libbpf_rs::ErrorKind::NotFound => {
-                        debug!(
+                        warn!(
                             "{} program '{}' not attached (no kernel support): {}",
                             self.name, prog_name, e
                         );


### PR DESCRIPTION
## Summary

- Upgrades BPF program attach failures caused by a missing kernel symbol (ENOENT) from `debug!` to `warn!` level logging, so they surface in production logs.

## Background

Previously, when a BPF kprobe/tracepoint failed to attach because the target kernel symbol didn't exist, the error was swallowed at `debug!` level. This made it completely invisible in normal deployments.

The concrete trigger: the `cpu_usage` sampler hooks `cpuacct_account_field()` to track user/system/cgroup/task CPU time. On kernels built with `CONFIG_TICK_CPU_ACCOUNTING` that function doesn't exist, so the kprobe never fires — and `cpu_usage`, `cgroup_cpu_usage`, and `task_cpu_usage` all silently produce zero data. With this change, operators see a clear `warn!` line explaining which program failed to attach and why.

Intentionally-disabled programs (via `disabled_programs()`/`set_autoload(false)`) are unaffected — they are excluded from the attach loop before this code path is reached.

Closes #967

---

_Triaged from Slack thread: https://iop-systems.slack.com/archives/D0B9035MTKM/p1781719588124049?thread_ts=1781718813.593899&cid=D0B9035MTKM_

---
_Generated by [Claude Code](https://claude.ai/code/session_015VqzCriXWCCThh5CFdzTrC)_