### PR TITLE
fix(viewer): live mode refreshes metadata so chart window tracks TSDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.15.1-alpha.0"
+version = "5.15.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.15.1-alpha.0"
+version = "5.15.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -393,7 +393,12 @@ const createDataApi = ({
         return q;
     };
 
-    const processDashboardData = async (data, activeCgroupPattern, sectionRoute) => {
+    // freshMetadata: bypass the module-level metadata cache (forces the
+    // query window's maxTime to track the live TSDB instead of freezing
+    // at first-fetch). Live-mode auto-refresh sets this; file-mode and
+    // initial loads leave it off so the cache still saves a round-trip.
+    const processDashboardData = async (data, activeCgroupPattern, sectionRoute, { freshMetadata = false } = {}) => {
+        if (freshMetadata) cachedMetadata = null;
         const metadata = cachedMetadata || await fetchMetadata();
         cachedMetadata = metadata;
 

--- a/src/viewer/assets/lib/script.js
+++ b/src/viewer/assets/lib/script.js
@@ -168,7 +168,11 @@ const refreshCurrentSection = async () => {
     try {
         const data = await ViewerApi.getSection(section, true);
 
-        const promises = [processDashboardData(data, getActiveCgroupPattern(), currentRoute)];
+        // freshMetadata: TSDB grows continuously in live mode; without
+        // this the query window stays frozen at first-fetch maxTime and
+        // charts visibly stop updating even though /api/v1/query_range
+        // would serve fresh data if asked.
+        const promises = [processDashboardData(data, getActiveCgroupPattern(), currentRoute, { freshMetadata: true })];
         if (getHeatmapEnabled()) {
             promises.push(fetchSectionHeatmapData(currentRoute, data.groups));
         }

--- a/tests/live_metadata_refresh.test.mjs
+++ b/tests/live_metadata_refresh.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createDataApi } from '../src/viewer/assets/lib/data.js';
+
+// Live-mode auto-refresh advances the query window with the growing TSDB.
+// processDashboardData accepts a `freshMetadata` option that bypasses
+// cachedMetadata so the next query uses the current maxTime, not the
+// frozen one from initial page load.
+
+const makeSectionPayload = () => ({
+    groups: [
+        {
+            name: 'g',
+            subgroups: [
+                {
+                    name: 'sg',
+                    plots: [{ promql_query: 'm', opts: { type: 'gauge' } }],
+                },
+            ],
+        },
+    ],
+});
+
+const matrixOk = {
+    status: 'success',
+    data: {
+        resultType: 'matrix',
+        result: [{ metric: { __name__: 'm' }, values: [[0, '1'], [1, '2']] }],
+    },
+};
+
+const makeApi = (metaSeq, queryRangeCalls) => createDataApi({
+    getMetadata: async () => {
+        const next = metaSeq.shift() ?? metaSeq[metaSeq.length - 1];
+        return next ?? { status: 'success', data: { minTime: 0, maxTime: 0 } };
+    },
+    queryRange: async (query, start, end, step) => {
+        queryRangeCalls.push({ query, start, end, step });
+        return matrixOk;
+    },
+    logHeatmapErrors: false,
+});
+
+test('processDashboardData: default behavior caches metadata across calls', async () => {
+    const metas = [
+        { status: 'success', data: { minTime: 1000, maxTime: 2000 } },
+        { status: 'success', data: { minTime: 1000, maxTime: 3000 } },
+    ];
+    const calls = [];
+    const api = makeApi(metas, calls);
+
+    await api.processDashboardData(makeSectionPayload(), null, '/cpu');
+    await api.processDashboardData(makeSectionPayload(), null, '/cpu');
+
+    assert.equal(calls.length, 2, 'two queryRange calls (one per processDashboardData)');
+    assert.equal(calls[0].end, 2000, 'first call uses initial maxTime');
+    assert.equal(calls[1].end, 2000, 'second call reuses cached maxTime (existing behavior)');
+});
+
+test('processDashboardData: { freshMetadata: true } refetches metadata, advances query window', async () => {
+    const metas = [
+        { status: 'success', data: { minTime: 1000, maxTime: 2000 } },
+        { status: 'success', data: { minTime: 1000, maxTime: 3000 } },
+    ];
+    const calls = [];
+    const api = makeApi(metas, calls);
+
+    await api.processDashboardData(makeSectionPayload(), null, '/cpu');
+    await api.processDashboardData(makeSectionPayload(), null, '/cpu', { freshMetadata: true });
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].end, 2000, 'first call uses initial maxTime');
+    assert.equal(calls[1].end, 3000, 'second call (with freshMetadata) uses new maxTime');
+});


### PR DESCRIPTION
## Summary

- Live-mode auto-refresh was running every 5s but every poll re-queried the same fixed `[T0 - window, T0]` time slice against the growing TSDB. Charts visibly froze even though `/api/v1/query_range` would have returned fresh data if asked. Only a full page reload caught up.
- Root cause: `processDashboardData` in [src/viewer/assets/lib/data.js](src/viewer/assets/lib/data.js) fetches metadata once and caches it forever; the cache is only cleared on `uploadParquet`. The cached `maxTime` froze the query window.
- Fix: `processDashboardData` gets an opt-in `{ freshMetadata: true }` option that invalidates the cache before the fetch. `refreshCurrentSection` passes it; other callers (initial load, file mode, single-chart view, compare attach/detach) leave the default behavior intact so the cache still saves a round-trip.

## Reported by

Crusoe SRE during Yao's site visit ("bug: live view no longer update"). User confirmed the symptom: auto-refresh stops updating the view; reloading the page fetches more data and the chart catches up.

## Test plan

- [x] New node test in [tests/live_metadata_refresh.test.mjs](tests/live_metadata_refresh.test.mjs) covers both paths:
  - Default behavior (no option) caches metadata across calls — existing contract preserved.
  - `{ freshMetadata: true }` re-fetches metadata, advances the query window to the new `maxTime`.
  - Test 2 red-phased before the fix (option didn't exist), green after.
- [x] All 124 node tests green
- [x] All 162 Rust tests green
- [x] clippy / fmt clean
- [x] **Manually verified against a Linux agent** — live charts now update continuously without page reloads.

## Out of scope

A separate, latent bug was found during investigation but NOT fixed here: `LazySectionStore::get_or_generate` in [src/viewer/state.rs](src/viewer/state.rs) memoizes section JSON forever in live mode, so the section *structure* (groups/plots/KPIs) can't update mid-session. Chart *data* is fetched separately via `/api/v1/query_range` and is unaffected — this is why the structure-cache bug never surfaced as the reported symptom. Filed for a follow-up PR.