### PR TITLE
feat(record): perf-record-style command wrapping

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -242,6 +242,19 @@ jobs:
           sudo ./target/release/rezolus config/agent.toml & echo $! > agent.pid
           sleep 15
           ./target/release/rezolus record --duration 30s http://127.0.0.1:4241 rezolus.parquet
+          # wrap mode: record a command against the live agent for its lifetime
+          ./target/release/rezolus record --url http://127.0.0.1:4241 -o wrap.parquet -- sleep 3
+          test -s wrap.parquet
+          # exit-code propagation: a wrapped 'false' must exit non-zero
+          code=0
+          ./target/release/rezolus record -o false.parquet -- false || code=$?
+          test "$code" -ne 0
+          # --duration cap: a long command is terminated and record exits 124 quickly
+          start=$(date +%s)
+          code=0
+          ./target/release/rezolus record --duration 2s -o cap.parquet -- sleep 60 || code=$?
+          test "$code" -eq 124
+          test "$(( $(date +%s) - start ))" -lt 10
       - name: smoketest
         if: ${{ matrix.profile == 'debug' }}
         shell: bash
@@ -250,6 +263,19 @@ jobs:
           sudo ./target/debug/rezolus config/agent.toml & echo $! > agent.pid
           sleep 15
           ./target/debug/rezolus record --duration 30s http://127.0.0.1:4241 rezolus.parquet
+          # wrap mode: record a command against the live agent for its lifetime
+          ./target/debug/rezolus record --url http://127.0.0.1:4241 -o wrap.parquet -- sleep 3
+          test -s wrap.parquet
+          # exit-code propagation: a wrapped 'false' must exit non-zero
+          code=0
+          ./target/debug/rezolus record -o false.parquet -- false || code=$?
+          test "$code" -ne 0
+          # --duration cap: a long command is terminated and record exits 124 quickly
+          start=$(date +%s)
+          code=0
+          ./target/debug/rezolus record --duration 2s -o cap.parquet -- sleep 60 || code=$?
+          test "$code" -eq 124
+          test "$(( $(date +%s) - start ))" -lt 10
 
   check-success:
     name: verify all tests pass

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ site/viewer/templates/manifest.json
 **/*.rs.bk
 .worktrees/
 results/
-# default `rezolus record` output file
-rezolus.parquet
+# default `rezolus record` output file (repo root only)
+/rezolus.parquet

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ site/viewer/templates/manifest.json
 **/*.rs.bk
 .worktrees/
 results/
+# default `rezolus record` output file
+rezolus.parquet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3180,6 +3180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno 0.2.8",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,6 +3505,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.15.1-alpha.3"
+version = "5.15.1-alpha.4"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.15.1-alpha.3"
+version = "5.15.1-alpha.4"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ tokio = { version = "1.52.2", features = [
     "io-util",
     "macros",
     "net",
+    "process",
     "rt-multi-thread",
     "sync",
     "time",

--- a/README.md
+++ b/README.md
@@ -168,13 +168,34 @@ management — see [HTTP Endpoint](#http-endpoint-optional) below.
 
 ### Recorder
 
-Connects to a running agent and records metrics into a Parquet file for
-benchmarking, lab tests, or offline workload characterization. It auto-detects
-Rezolus agent vs Prometheus sources and supports custom file-level metadata.
+Records metrics into a Parquet file for benchmarking, lab tests, or offline
+workload characterization. It auto-detects Rezolus agent vs Prometheus sources
+and supports custom file-level metadata.
+
+Like `perf record`, it can wrap a workload and capture for exactly its lifetime,
+finalizing when the command exits:
 
 ```bash
-rezolus record --interval 1s --duration 15m http://localhost:4241 rezolus.parquet
+rezolus record -- ./my-benchmark --threads 8
 ```
+
+By default this records the local agent (`http://localhost:4241`) into
+`rezolus.parquet`. Override the endpoint with `--url` and the output with `-o`:
+
+```bash
+rezolus record --url http://host:4241 -o run.parquet -- ./driver
+```
+
+Or record a fixed window instead, until `--duration` elapses or you press
+ctrl-c:
+
+```bash
+rezolus record --interval 1s --duration 15m --url http://localhost:4241 -o rezolus.parquet
+```
+
+When wrapping a command, `--duration` also acts as a safety cap: if the command
+outlives it, recording stops and the command is terminated. The positional
+`<URL> <OUTPUT>` form still works but is deprecated in favor of `--url`/`-o`.
 
 ### Viewer
 
@@ -243,8 +264,15 @@ workload and understand what conditions you'd want to replicate in test.
 Collect a per-second recording for 15 minutes, then open it:
 
 ```bash
-rezolus record --interval 1s --duration 15m http://localhost:4241 rezolus.parquet
+rezolus record --interval 1s --duration 15m -o rezolus.parquet
 rezolus view rezolus.parquet
+```
+
+Or wrap a benchmark and capture only while it runs:
+
+```bash
+rezolus record -o run.parquet -- ./my-benchmark
+rezolus view run.parquet
 ```
 
 ### DevOps and SRE troubleshooting
@@ -306,8 +334,8 @@ sudo target/release/rezolus config/agent.toml
 # run the exporter
 sudo target/release/rezolus exporter config/exporter.toml
 
-# record metrics to a parquet file
-target/release/rezolus record http://localhost:4241 rezolus.parquet
+# record metrics to a parquet file (until ctrl-c, or wrap a command with `-- cmd`)
+target/release/rezolus record -o rezolus.parquet
 
 # run hindsight
 target/release/rezolus hindsight config/hindsight.toml

--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ rezolus record --interval 1s --duration 15m --url http://localhost:4241 -o rezol
 ```
 
 When wrapping a command, `--duration` also acts as a safety cap: if the command
-outlives it, recording stops and the command is terminated. The positional
-`<URL> <OUTPUT>` form still works but is deprecated in favor of `--url`/`-o`.
+outlives it, recording stops and the command — along with any worker processes
+it spawned — is terminated. The positional `<URL> <OUTPUT>` form still works but
+is deprecated in favor of `--url`/`-o`.
 
 ### Viewer
 

--- a/src/recorder/child.rs
+++ b/src/recorder/child.rs
@@ -1,6 +1,46 @@
 use std::os::unix::process::ExitStatusExt;
 use std::process::ExitStatus;
+use std::process::Stdio;
 use std::time::Duration;
+
+use tokio::process::Child;
+
+/// Spawn a wrapped command with inherited stdio (stdin/stdout/stderr pass
+/// straight through to the terminal, like `perf record` / `time`).
+pub fn spawn(command: &[String]) -> std::io::Result<Child> {
+    let (program, args) = command
+        .split_first()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "empty command"))?;
+    tokio::process::Command::new(program)
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+}
+
+/// Terminate a running child: SIGTERM, wait up to `grace`, then SIGKILL.
+/// Returns the child's final `ExitStatus`.
+pub async fn terminate(child: &mut Child, grace: Duration) -> ExitStatus {
+    if let Some(pid) = child.id() {
+        // SAFETY: sending a signal to a pid we own; return value ignored
+        // because the child may have already exited between checks.
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+    }
+    match tokio::time::timeout(grace, child.wait()).await {
+        Ok(Ok(status)) => status,
+        _ => {
+            // Grace elapsed or wait errored: force kill and reap.
+            let _ = child.kill().await;
+            child
+                .wait()
+                .await
+                .unwrap_or_else(|_| ExitStatus::from_raw(libc::SIGKILL))
+        }
+    }
+}
 
 /// Grace period between SIGTERM and SIGKILL when capping a wrapped command.
 pub const TERM_GRACE: Duration = Duration::from_secs(2);
@@ -61,5 +101,47 @@ mod tests {
     fn map_exit_code_signal() {
         // raw status 9 == killed by signal 9 (SIGKILL), no exit code
         assert_eq!(map_exit_code(ExitStatus::from_raw(9)), 128 + 9);
+    }
+
+    #[tokio::test]
+    async fn spawn_true_exits_zero() {
+        let mut child = spawn(&["true".to_string()]).unwrap();
+        // Poll like the record loop does.
+        let status = loop {
+            if let Some(s) = child.try_wait().unwrap() {
+                break s;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(map_exit_code(status), 0);
+    }
+
+    #[tokio::test]
+    async fn spawn_false_exits_nonzero() {
+        let mut child = spawn(&["false".to_string()]).unwrap();
+        let status = loop {
+            if let Some(s) = child.try_wait().unwrap() {
+                break s;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(map_exit_code(status), 1);
+    }
+
+    #[tokio::test]
+    async fn terminate_kills_long_sleep() {
+        let mut child = spawn(&["sleep".to_string(), "30".to_string()]).unwrap();
+        // Short grace so the test is fast; sleep ignores SIGTERM? No — default
+        // disposition of SIGTERM terminates sleep, so grace path suffices.
+        let start = std::time::Instant::now();
+        let status = terminate(&mut child, Duration::from_millis(500)).await;
+        assert!(start.elapsed() < Duration::from_secs(5), "terminate hung");
+        // Killed by a signal, so no normal exit code.
+        assert!(status.code().is_none());
+    }
+
+    #[tokio::test]
+    async fn spawn_empty_command_errors() {
+        assert!(spawn(&[]).is_err());
     }
 }

--- a/src/recorder/child.rs
+++ b/src/recorder/child.rs
@@ -7,6 +7,11 @@ use tokio::process::Child;
 
 /// Spawn a wrapped command with inherited stdio (stdin/stdout/stderr pass
 /// straight through to the terminal, like `perf record` / `time`).
+///
+/// The child is made the leader of a new process group (`process_group(0)`, so
+/// its pgid equals its pid) so that [`terminate`] can signal the entire group —
+/// reaching workers a shell or benchmark harness forks, not just the direct
+/// child.
 pub fn spawn(command: &[String]) -> std::io::Result<Child> {
     let (program, args) = command
         .split_first()
@@ -16,24 +21,33 @@ pub fn spawn(command: &[String]) -> std::io::Result<Child> {
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
+        .process_group(0)
         .spawn()
 }
 
-/// Terminate a running child: SIGTERM, wait up to `grace`, then SIGKILL.
-/// Returns the child's final `ExitStatus`.
+/// Terminate a running child's process group: SIGTERM, wait up to `grace`, then
+/// SIGKILL. Signals the whole group (see [`spawn`]) so forked workers are
+/// cleaned up too. Returns the child leader's final `ExitStatus`.
 pub async fn terminate(child: &mut Child, grace: Duration) -> ExitStatus {
-    if let Some(pid) = child.id() {
-        // SAFETY: sending a signal to a pid we own; return value ignored
-        // because the child may have already exited between checks.
+    // The child is its own process group leader, so its pid is the pgid.
+    let pgid = child.id().map(|p| p as libc::pid_t);
+    if let Some(pgid) = pgid {
+        // SAFETY: signalling a process group we created; return value ignored
+        // because members may have already exited between checks.
         unsafe {
-            libc::kill(pid as i32, libc::SIGTERM);
+            libc::killpg(pgid, libc::SIGTERM);
         }
     }
     match tokio::time::timeout(grace, child.wait()).await {
         Ok(Ok(status)) => status,
         _ => {
-            // Grace elapsed or wait errored: force kill and reap.
-            let _ = child.kill().await;
+            // Grace elapsed or wait errored: force-kill the whole group and reap
+            // the leader.
+            if let Some(pgid) = pgid {
+                unsafe {
+                    libc::killpg(pgid, libc::SIGKILL);
+                }
+            }
             child
                 .wait()
                 .await
@@ -143,5 +157,47 @@ mod tests {
     #[tokio::test]
     async fn spawn_empty_command_errors() {
         assert!(spawn(&[]).is_err());
+    }
+
+    #[tokio::test]
+    async fn terminate_kills_forked_grandchild() {
+        use std::io::Read;
+
+        // A shell backgrounds a grandchild `sleep` and records its pid, then
+        // waits. `terminate` must kill the whole process group (shell + the
+        // backgrounded sleep), not just the shell.
+        let pid_file =
+            std::env::temp_dir().join(format!("rz_grandchild_{}.pid", std::process::id()));
+        let _ = std::fs::remove_file(&pid_file);
+        let script = format!("sleep 300 & echo $! > {} ; wait", pid_file.display());
+        let mut child = spawn(&["sh".to_string(), "-c".to_string(), script]).unwrap();
+
+        // Wait for the shell to publish the grandchild pid.
+        let gpid: i32 = loop {
+            if let Ok(mut f) = std::fs::File::open(&pid_file) {
+                let mut s = String::new();
+                let _ = f.read_to_string(&mut s);
+                if let Ok(pid) = s.trim().parse::<i32>() {
+                    break pid;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+
+        terminate(&mut child, Duration::from_millis(500)).await;
+        // Give the kernel a moment to deliver signals and reap.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // kill(pid, 0) probes existence: it fails with ESRCH once the
+        // grandchild is gone.
+        let alive = unsafe { libc::kill(gpid, 0) } == 0;
+        let _ = std::fs::remove_file(&pid_file);
+        if alive {
+            // Cleanup so a failing test doesn't leak the process.
+            unsafe {
+                libc::kill(gpid, libc::SIGKILL);
+            }
+        }
+        assert!(!alive, "grandchild {gpid} survived group terminate");
     }
 }

--- a/src/recorder/child.rs
+++ b/src/recorder/child.rs
@@ -1,0 +1,65 @@
+use std::os::unix::process::ExitStatusExt;
+use std::process::ExitStatus;
+use std::time::Duration;
+
+/// Grace period between SIGTERM and SIGKILL when capping a wrapped command.
+pub const TERM_GRACE: Duration = Duration::from_secs(2);
+/// Exit code emitted when a wrapped command is killed by the --duration cap.
+pub const CAP_EXIT_CODE: i32 = 124;
+
+/// Why a wrapped-command recording ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The command exited on its own; carries the mapped process exit code.
+    Exited(i32),
+    /// The command outlived `--duration` and was killed.
+    Capped,
+}
+
+impl Outcome {
+    /// The process exit code Rezolus should return for this outcome.
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Outcome::Exited(code) => code,
+            Outcome::Capped => CAP_EXIT_CODE,
+        }
+    }
+}
+
+/// Map a child `ExitStatus` to a shell-style process exit code.
+/// Normal exit yields its code; signal death yields `128 + signal`.
+pub fn map_exit_code(status: ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        code
+    } else if let Some(sig) = status.signal() {
+        128 + sig
+    } else {
+        1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::process::ExitStatusExt;
+
+    #[test]
+    fn outcome_exit_codes() {
+        assert_eq!(Outcome::Exited(0).exit_code(), 0);
+        assert_eq!(Outcome::Exited(3).exit_code(), 3);
+        assert_eq!(Outcome::Capped.exit_code(), 124);
+    }
+
+    #[test]
+    fn map_exit_code_normal() {
+        assert_eq!(map_exit_code(ExitStatus::from_raw(0)), 0);
+        // raw status 0x0100 == exit code 1 on Unix wait() encoding
+        assert_eq!(map_exit_code(ExitStatus::from_raw(1 << 8)), 1);
+    }
+
+    #[test]
+    fn map_exit_code_signal() {
+        // raw status 9 == killed by signal 9 (SIGKILL), no exit code
+        assert_eq!(map_exit_code(ExitStatus::from_raw(9)), 128 + 9);
+    }
+}

--- a/src/recorder/config.rs
+++ b/src/recorder/config.rs
@@ -94,6 +94,16 @@ impl RecordingConfig {
             })
             .collect();
 
+        let command: Option<Vec<String>> = args
+            .get_many::<String>("COMMAND")
+            .map(|vals| vals.map(|s| s.to_string()).collect());
+
+        // Resolve output once (used by every mode except --config, which
+        // prefers its TOML output when -o is not given).
+        let out_flag = args.get_one::<PathBuf>("OUTPUT_FLAG").map(|p| p.as_path());
+        let out_pos = args.get_one::<PathBuf>("OUTPUT").map(|p| p.as_path());
+        let (resolved_output, output_deprecated) = resolve_output(out_flag, out_pos)?;
+
         // Mode 1: --config file.toml
         if let Some(config_path) = args.get_one::<PathBuf>("CONFIG_FILE") {
             let contents = std::fs::read_to_string(config_path)
@@ -136,16 +146,22 @@ impl RecordingConfig {
                 return Err("config file must define at least one endpoint".to_string());
             }
 
+            let output = if args.get_one::<PathBuf>("OUTPUT_FLAG").is_some() {
+                resolved_output.clone()
+            } else {
+                PathBuf::from(toml_cfg.recording.output)
+            };
+
             return Ok(RecordingConfig {
                 interval,
                 duration,
                 format,
                 verbose,
-                output: PathBuf::from(toml_cfg.recording.output),
+                output,
                 separate,
                 metadata,
                 endpoints: toml_cfg.endpoints,
-                command: None,
+                command: command.clone(),
             });
         }
 
@@ -159,36 +175,30 @@ impl RecordingConfig {
                 return Err("at least one --endpoint is required".to_string());
             }
 
-            // OUTPUT is required for --endpoint mode
-            let output = args
-                .get_one::<PathBuf>("OUTPUT")
-                .ok_or_else(|| "OUTPUT is required when using --endpoint".to_string())?
-                .to_path_buf();
-
             return Ok(RecordingConfig {
                 interval,
                 duration,
                 format,
                 verbose,
-                output,
+                output: resolved_output.clone(),
                 separate,
                 metadata,
                 endpoints,
-                command: None,
+                command: command.clone(),
             });
         }
 
-        // Mode 3: positional <URL> <OUTPUT> (backward compat)
-        let url = args
-            .get_one::<Url>("URL")
-            .ok_or_else(|| {
-                "must specify one of: <URL> <OUTPUT>, --endpoint, or --config".to_string()
-            })?
-            .clone();
-        let output = args
-            .get_one::<PathBuf>("OUTPUT")
-            .ok_or_else(|| "OUTPUT is required".to_string())?
-            .to_path_buf();
+        // Mode 3: --url / positional <URL>, single endpoint.
+        let url_flag = args.get_one::<Url>("URL_FLAG");
+        let url_pos = args.get_one::<Url>("URL");
+        let (url, url_deprecated) = resolve_url(url_flag, url_pos)?;
+
+        if url_deprecated {
+            eprintln!("note: the positional URL is deprecated, use --url");
+        }
+        if output_deprecated {
+            eprintln!("note: the positional OUTPUT is deprecated, use -o/--output");
+        }
 
         let source = metadata
             .iter()
@@ -207,11 +217,11 @@ impl RecordingConfig {
             duration,
             format,
             verbose,
-            output,
+            output: resolved_output,
             separate,
             metadata,
             endpoints: vec![endpoint],
-            command: None,
+            command,
         })
     }
 }

--- a/src/recorder/config.rs
+++ b/src/recorder/config.rs
@@ -5,6 +5,7 @@ use clap::ArgMatches;
 use reqwest::Url;
 use serde::Deserialize;
 
+use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -33,6 +34,43 @@ pub struct RecordingConfig {
     pub separate: bool,
     pub metadata: Vec<(String, String)>,
     pub endpoints: Vec<EndpointConfig>,
+    /// When set, record only while this command runs (perf-record style).
+    pub command: Option<Vec<String>>,
+}
+
+/// Default endpoint used when neither `--url` nor a positional URL is given.
+const DEFAULT_URL: &str = "http://localhost:4241";
+/// Default output file used when neither `-o` nor a positional OUTPUT is given.
+const DEFAULT_OUTPUT: &str = "rezolus.parquet";
+
+/// Resolve the recording URL from the `--url` flag and the deprecated
+/// positional URL. Returns `(url, positional_was_used)`. Errors if both are
+/// supplied.
+pub fn resolve_url(flag: Option<&Url>, positional: Option<&Url>) -> Result<(Url, bool), String> {
+    match (flag, positional) {
+        (Some(_), Some(_)) => {
+            Err("specify either --url or the positional URL, not both".to_string())
+        }
+        (Some(u), None) => Ok((u.clone(), false)),
+        (None, Some(u)) => Ok((u.clone(), true)),
+        (None, None) => Ok((Url::parse(DEFAULT_URL).unwrap(), false)),
+    }
+}
+
+/// Resolve the output path from `-o/--output` and the deprecated positional
+/// OUTPUT. Returns `(path, positional_was_used)`. Errors if both are supplied.
+pub fn resolve_output(
+    flag: Option<&Path>,
+    positional: Option<&Path>,
+) -> Result<(PathBuf, bool), String> {
+    match (flag, positional) {
+        (Some(_), Some(_)) => {
+            Err("specify either -o/--output or the positional OUTPUT, not both".to_string())
+        }
+        (Some(p), None) => Ok((p.to_path_buf(), false)),
+        (None, Some(p)) => Ok((p.to_path_buf(), true)),
+        (None, None) => Ok((PathBuf::from(DEFAULT_OUTPUT), false)),
+    }
 }
 
 impl RecordingConfig {
@@ -107,6 +145,7 @@ impl RecordingConfig {
                 separate,
                 metadata,
                 endpoints: toml_cfg.endpoints,
+                command: None,
             });
         }
 
@@ -135,6 +174,7 @@ impl RecordingConfig {
                 separate,
                 metadata,
                 endpoints,
+                command: None,
             });
         }
 
@@ -171,6 +211,7 @@ impl RecordingConfig {
             separate,
             metadata,
             endpoints: vec![endpoint],
+            command: None,
         })
     }
 }
@@ -225,6 +266,51 @@ pub fn parse_endpoint_str(s: &str) -> Result<EndpointConfig, String> {
 mod tests {
     use super::*;
     use crate::recorder::endpoint::Protocol;
+
+    #[test]
+    fn resolve_url_defaults_to_localhost() {
+        let (url, deprecated) = resolve_url(None, None).unwrap();
+        assert_eq!(url.as_str(), "http://localhost:4241/");
+        assert!(!deprecated);
+    }
+
+    #[test]
+    fn resolve_url_flag_wins() {
+        let flag = Url::parse("http://example:9090").unwrap();
+        let (url, deprecated) = resolve_url(Some(&flag), None).unwrap();
+        assert_eq!(url.as_str(), "http://example:9090/");
+        assert!(!deprecated);
+    }
+
+    #[test]
+    fn resolve_url_positional_is_deprecated() {
+        let pos = Url::parse("http://host:4241").unwrap();
+        let (url, deprecated) = resolve_url(None, Some(&pos)).unwrap();
+        assert_eq!(url.as_str(), "http://host:4241/");
+        assert!(deprecated);
+    }
+
+    #[test]
+    fn resolve_url_both_is_error() {
+        let a = Url::parse("http://a:1").unwrap();
+        let b = Url::parse("http://b:2").unwrap();
+        assert!(resolve_url(Some(&a), Some(&b)).is_err());
+    }
+
+    #[test]
+    fn resolve_output_default_and_deprecation() {
+        let (out, dep) = resolve_output(None, None).unwrap();
+        assert_eq!(out, PathBuf::from("rezolus.parquet"));
+        assert!(!dep);
+
+        let pos = PathBuf::from("legacy.parquet");
+        let (out, dep) = resolve_output(None, Some(&pos)).unwrap();
+        assert_eq!(out, pos);
+        assert!(dep);
+
+        let flag = PathBuf::from("new.parquet");
+        assert!(resolve_output(Some(&flag), Some(&pos)).is_err());
+    }
 
     #[test]
     fn test_parse_endpoint_str_full() {

--- a/src/recorder/config.rs
+++ b/src/recorder/config.rs
@@ -46,7 +46,7 @@ const DEFAULT_OUTPUT: &str = "rezolus.parquet";
 /// Resolve the recording URL from the `--url` flag and the deprecated
 /// positional URL. Returns `(url, positional_was_used)`. Errors if both are
 /// supplied.
-pub fn resolve_url(flag: Option<&Url>, positional: Option<&Url>) -> Result<(Url, bool), String> {
+fn resolve_url(flag: Option<&Url>, positional: Option<&Url>) -> Result<(Url, bool), String> {
     match (flag, positional) {
         (Some(_), Some(_)) => {
             Err("specify either --url or the positional URL, not both".to_string())
@@ -59,7 +59,7 @@ pub fn resolve_url(flag: Option<&Url>, positional: Option<&Url>) -> Result<(Url,
 
 /// Resolve the output path from `-o/--output` and the deprecated positional
 /// OUTPUT. Returns `(path, positional_was_used)`. Errors if both are supplied.
-pub fn resolve_output(
+fn resolve_output(
     flag: Option<&Path>,
     positional: Option<&Path>,
 ) -> Result<(PathBuf, bool), String> {
@@ -308,17 +308,24 @@ mod tests {
     }
 
     #[test]
-    fn resolve_output_default_and_deprecation() {
+    fn resolve_output_defaults_to_rezolus_parquet() {
         let (out, dep) = resolve_output(None, None).unwrap();
         assert_eq!(out, PathBuf::from("rezolus.parquet"));
         assert!(!dep);
+    }
 
+    #[test]
+    fn resolve_output_positional_is_deprecated() {
         let pos = PathBuf::from("legacy.parquet");
         let (out, dep) = resolve_output(None, Some(&pos)).unwrap();
         assert_eq!(out, pos);
         assert!(dep);
+    }
 
+    #[test]
+    fn resolve_output_both_is_error() {
         let flag = PathBuf::from("new.parquet");
+        let pos = PathBuf::from("legacy.parquet");
         assert!(resolve_output(Some(&flag), Some(&pos)).is_err());
     }
 

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -106,7 +106,7 @@ pub fn command() -> Command {
                 .help("Metrics endpoint to record (default http://localhost:4241)")
                 .action(clap::ArgAction::Set)
                 .value_parser(value_parser!(Url))
-                .conflicts_with_all(["CONFIG_FILE", "ENDPOINT"]),
+                .conflicts_with_all(["CONFIG_FILE", "ENDPOINT", "URL"]),
         )
         .arg(
             clap::Arg::new("OUTPUT_FLAG")
@@ -114,7 +114,8 @@ pub fn command() -> Command {
                 .short('o')
                 .help("Path to the output file (default rezolus.parquet)")
                 .action(clap::ArgAction::Set)
-                .value_parser(value_parser!(PathBuf)),
+                .value_parser(value_parser!(PathBuf))
+                .conflicts_with("OUTPUT"),
         )
         .arg(
             clap::Arg::new("COMMAND")

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -100,6 +100,32 @@ pub fn command() -> Command {
                 .help("Instance name for service data (written to parquet metadata)")
                 .action(clap::ArgAction::Set),
         )
+        .arg(
+            clap::Arg::new("URL_FLAG")
+                .long("url")
+                .help("Metrics endpoint to record (default http://localhost:4241)")
+                .action(clap::ArgAction::Set)
+                .value_parser(value_parser!(Url))
+                .conflicts_with_all(["CONFIG_FILE", "ENDPOINT"]),
+        )
+        .arg(
+            clap::Arg::new("OUTPUT_FLAG")
+                .long("output")
+                .short('o')
+                .help("Path to the output file (default rezolus.parquet)")
+                .action(clap::ArgAction::Set)
+                .value_parser(value_parser!(PathBuf)),
+        )
+        .arg(
+            clap::Arg::new("COMMAND")
+                .help("Command to run; record for its lifetime (everything after --)")
+                .action(clap::ArgAction::Set)
+                .index(3)
+                .num_args(1..)
+                .last(true)
+                .allow_hyphen_values(true)
+                .value_parser(value_parser!(String)),
+        )
 }
 
 /// Probe a single endpoint to detect its protocol and resolve the scrape URL.

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod child;
 mod config;
 mod endpoint;
 mod prometheus;

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -546,19 +546,65 @@ pub fn run(config: RecordingConfig) {
         })
         .collect();
 
-    if config.duration.is_some() {
+    if config.command.is_some() {
+        info!("recording while command runs... ctrl-c to stop early");
+    } else if config.duration.is_some() {
         info!("recording metrics... ctrl-c to terminate early");
     } else {
         info!("recording metrics... ctrl-c to end the recording");
     }
 
-    rt.block_on(async {
+    let wrapped = config.command.is_some();
+
+    let outcome: Option<child::Outcome> = rt.block_on(async {
+        // Spawn the wrapped command only after probing/writers succeeded, so a
+        // failed setup never starts an expensive workload.
+        let mut child = if let Some(ref cmd) = config.command {
+            match child::spawn(cmd) {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    eprintln!("error: failed to start command: {e}");
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            None
+        };
+        let mut outcome: Option<child::Outcome> = None;
+
         let interval_dur: Duration = config.interval.into();
         let start = Instant::now() + interval_dur;
+        let cap_deadline: Option<Instant> =
+            config.duration.map(|d| Instant::now() + Duration::from(d));
         let mut interval = crate::common::aligned_interval(interval_dur);
 
         while STATE.load(Ordering::Relaxed) == RUNNING {
-            if let Some(duration) = config.duration.map(Into::<Duration>::into) {
+            if wrapped {
+                // Poll the wrapped command: exit ends recording, cap kills it.
+                if let Some(c) = child.as_mut() {
+                    match c.try_wait() {
+                        Ok(Some(status)) => {
+                            outcome = Some(child::Outcome::Exited(child::map_exit_code(status)));
+                            child = None;
+                            break;
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            warn!("failed to poll command: {e}");
+                        }
+                    }
+                    if let Some(deadline) = cap_deadline {
+                        if Instant::now() >= deadline {
+                            info!("--duration reached, stopping command");
+                            if let Some(mut c) = child.take() {
+                                child::terminate(&mut c, child::TERM_GRACE).await;
+                            }
+                            outcome = Some(child::Outcome::Capped);
+                            break;
+                        }
+                    }
+                }
+            } else if let Some(duration) = config.duration.map(Into::<Duration>::into) {
                 if start.elapsed() >= duration {
                     break;
                 }
@@ -709,6 +755,15 @@ pub fn run(config: RecordingConfig) {
                         converter,
                     });
                 }
+            }
+        }
+
+        // If the loop ended via ctrl-c (STATE flip) while the wrapped command
+        // is still alive, terminate and reap it so we never orphan the child.
+        if let Some(mut c) = child.take() {
+            let status = child::terminate(&mut c, child::TERM_GRACE).await;
+            if outcome.is_none() {
+                outcome = Some(child::Outcome::Exited(child::map_exit_code(status)));
             }
         }
 
@@ -893,7 +948,13 @@ pub fn run(config: RecordingConfig) {
                 }
             }
         }
+
+        outcome
     });
+
+    if let Some(o) = outcome {
+        std::process::exit(o.exit_code());
+    }
 }
 
 #[cfg(test)]

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -963,6 +963,9 @@ pub fn run(config: RecordingConfig) {
     });
 
     if let Some(o) = outcome {
+        // Flush buffered logs before exiting the process: std::process::exit
+        // skips destructors, so drop the log drain explicitly first.
+        drop(_log_drain);
         std::process::exit(o.exit_code());
     }
 }
@@ -970,6 +973,38 @@ pub fn run(config: RecordingConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_arg_graph_is_valid() {
+        // Catches malformed clap wiring (e.g. positional index collisions)
+        // at test time instead of panicking at runtime.
+        command().debug_assert();
+    }
+
+    #[test]
+    fn from_args_populates_command_from_trailing_args() {
+        let matches = command()
+            .try_get_matches_from(["record", "--", "echo", "hello"])
+            .expect("parse");
+        let config = RecordingConfig::from_args(&matches).expect("config");
+        assert_eq!(
+            config.command,
+            Some(vec!["echo".to_string(), "hello".to_string()])
+        );
+        // Defaults apply when no --url/-o are given.
+        assert_eq!(config.output, PathBuf::from("rezolus.parquet"));
+        assert_eq!(config.endpoints.len(), 1);
+        assert_eq!(config.endpoints[0].url.as_str(), "http://localhost:4241/");
+    }
+
+    #[test]
+    fn from_args_without_command_is_none() {
+        let matches = command()
+            .try_get_matches_from(["record", "--url", "http://host:4241"])
+            .expect("parse");
+        let config = RecordingConfig::from_args(&matches).expect("config");
+        assert!(config.command.is_none());
+    }
 
     #[test]
     fn test_separate_output_path() {

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -574,6 +574,10 @@ pub fn run(config: RecordingConfig) {
 
         let interval_dur: Duration = config.interval.into();
         let start = Instant::now() + interval_dur;
+        // In wrapped mode the cap is intentionally measured from command spawn
+        // (`Instant::now()`), which differs from the non-wrapped path's `start`
+        // reference (now + interval). Do not unify these — they are distinct by
+        // design: the cap bounds the child's lifetime, `start` bounds recording.
         let cap_deadline: Option<Instant> =
             config.duration.map(|d| Instant::now() + Duration::from(d));
         let mut interval = crate::common::aligned_interval(interval_dur);
@@ -584,7 +588,9 @@ pub fn run(config: RecordingConfig) {
                 if let Some(c) = child.as_mut() {
                     match c.try_wait() {
                         Ok(Some(status)) => {
-                            outcome = Some(child::Outcome::Exited(child::map_exit_code(status)));
+                            let code = child::map_exit_code(status);
+                            info!("command exited (code {code}), finalizing recording");
+                            outcome = Some(child::Outcome::Exited(code));
                             child = None;
                             break;
                         }
@@ -779,6 +785,10 @@ pub fn run(config: RecordingConfig) {
             .count();
 
         if active_count == 0 {
+            if wrapped {
+                warn!("command exited before any metrics were recorded");
+                return outcome;
+            }
             eprintln!("error: no data was recorded from any endpoint");
             std::process::exit(1);
         }


### PR DESCRIPTION
## Summary
- `rezolus record -- ./workload` wraps a command, records the local agent for its lifetime, and finalizes when the command exits — the `perf record` / `nsys` idiom. Folded into `record` (no `profile` verb) to honor the "not a profiler" principle.
- `--url` (default `http://localhost:4241`) and `-o/--output` (default `rezolus.parquet`) are now the primary interface; the positional `<URL> <OUTPUT>` form still works but prints a deprecation note. Composes with the existing `--endpoint`/`--config` modes.
- Wrapped-mode semantics: probe-before-spawn (a failed setup never starts the workload), inherited stdio, child exit code propagated (or `124` on the `--duration` cap), ctrl-c reaps without orphaning. `--duration` acts as a safety cap that terminates the command **and its process group** (SIGTERM → 2s grace → SIGKILL), cleaning up workers forked by shell/benchmark wrappers.
- New `src/recorder/child.rs` isolates process lifecycle (spawn / group-terminate / exit-code mapping). The scrape loop body and parquet finalization are unchanged.

## Test plan
- [x] `cargo test -p rezolus recorder` — 35 tests pass (exit-code mapping, spawn/terminate incl. a deterministic forked-grandchild group-kill test, clap arg-graph `debug_assert`, `from_args` round-trip, url/output resolution + deprecation)
- [x] `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean
- [x] End-to-end against a mock endpoint: normal wrap (exit 0 + parquet), non-zero exit propagation (exit 3), `--duration` cap (exit 124, child + forked workers killed), ctrl-c (reaped, no orphan, parquet written, exit 143), fail-before-spawn (probe fails → exit 1, workload never spawned)
- [ ] Verify against a live Rezolus agent on Linux (msgpack path + systeminfo/descriptions/sampler metadata) — not runnable on the macOS dev host

🤖 Generated with [Claude Code](https://claude.com/claude-code)