### PR TITLE
docs(cli): make every subcommand `--help` agent-usable

### DIFF
--- a/.claude/skills/document-feature/references/subcommand-help-backlog.md
+++ b/.claude/skills/document-feature/references/subcommand-help-backlog.md
@@ -74,3 +74,17 @@ the most agent-facing surface, so worth polishing once the thinner ones are done
 
 ## Done
 - `record` — PR #983.
+- `view` — `long_about` with worked examples for all four input modes (file, A/B,
+  live, upload-only) + advanced-flag notes (`--proxy-*`, `--category`).
+- `parquet` (+ `metadata`/`annotate`/`combine`/`filter`) — top-level `long_about`
+  and per-subcommand `long_about`s with examples; `combine --ab` now spells out
+  that `baseline=`/`experiment=` take a file's embedded source name, not filename.
+- `exporter`, `hindsight` — `long_about` describing the mode, the config keys, the
+  scrape-interval / ring-buffer + SIGHUP model, pointing at `config/`.
+- top-level `rezolus` + `agent` — root `long_about` overviewing every mode
+  (incl. `status`) and the default no-subcommand agent `CONFIG` form.
+- `mcp` — top-level examples block + remaining subcommand `long_about`s
+  (`describe-recording`, `describe-metrics`, `analyze-correlation`).
+
+Verified with blind user-simulation agents (16 task→command pairs, all passed) and
+fresh-eyes critics per surface; README + CLAUDE.md "Running Modes" synced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,9 @@ target/release/rezolus parquet metadata -i file.parquet --json      # JSON outpu
 target/release/rezolus parquet metadata -i file.parquet --field source
 target/release/rezolus parquet annotate file.parquet                # add service extension KPIs
 target/release/rezolus parquet annotate file.parquet --queries ext.json
-target/release/rezolus parquet combine a.parquet b.parquet -o combined.parquet
+target/release/rezolus parquet combine a.parquet b.parquet -o combined.parquet       # row-merge multi-source
+target/release/rezolus parquet combine a.parquet b.parquet --ab baseline=redis experiment=valkey -o out.parquet.ab.tar  # A/B tarball (values are source names)
+target/release/rezolus parquet filter file.parquet -o slim.parquet   # drop columns not needed by KPIs
 
 # MCP - AI analysis server or CLI commands
 target/release/rezolus mcp                                                    # stdio server
@@ -98,7 +100,7 @@ The binary operates in seven modes via subcommands:
 4. **Hindsight** (`src/hindsight/`) - Maintains rolling ring buffer on disk for post-incident snapshots.
 5. **Viewer** (`src/viewer/`) - Web dashboard with PromQL query engine and TSDB (from `metriken-query` crate). Supports parquet files, live agent connections, and upload-only mode. Generates service KPI dashboards from `ServiceExtension` metadata.
 6. **MCP** (`src/mcp/`) - AI analysis tools (anomaly detection, correlation, PromQL queries). Runs as stdio server or one-shot CLI commands.
-7. **Parquet** (`src/parquet_tools/`) - File operations: `metadata` (inspect), `annotate` (add service extension KPIs), `combine` (merge multi-source files).
+7. **Parquet** (`src/parquet_tools/`) - File operations: `metadata` (inspect), `annotate` (add service extension KPIs), `combine` (merge multi-source files or build an A/B tarball), `filter` (drop columns not needed by KPIs).
 
 ### Sampler Architecture
 

--- a/README.md
+++ b/README.md
@@ -231,12 +231,16 @@ File operations for parquet recordings:
 - **Annotate** — embed service extension KPI definitions for custom viewer
   dashboards.
 - **Combine** — merge a Rezolus parquet with service-level parquet files,
-  joining on timestamps to produce a unified multi-source recording.
+  joining on timestamps to produce a unified multi-source recording, or package
+  two captures as an A/B tarball for the viewer's compare mode.
+- **Filter** — drop metric columns not referenced by a file's service extension
+  KPIs, shrinking the recording.
 
 ```bash
 rezolus parquet metadata -i rezolus.parquet
 rezolus parquet annotate rezolus.parquet --queries ext.json
 rezolus parquet combine rezolus.parquet service.parquet -o combined.parquet
+rezolus parquet filter rezolus.parquet -o slim.parquet
 ```
 
 ### MCP Server

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -26,10 +26,25 @@ use snapshot::snapshot;
 
 pub fn command() -> Command {
     Command::new("exporter")
-        .about("Exposition of metrics from a Rezolus agent")
+        .about("Serve a Rezolus agent's metrics on a Prometheus-compatible endpoint")
+        .long_about(
+            "Long-running service that pulls from a Rezolus agent's msgpack endpoint and\n\
+             re-exposes the metrics in Prometheus text format for a Prometheus/VictoriaMetrics\n\
+             scraper to collect.\n\n\
+             Configuration is a TOML file (the only argument). It sets the agent to read from\n\
+             ([general] source, default 127.0.0.1:4241), the address to serve `/metrics` on\n\
+             ([general] listen, default 0.0.0.0:4242), and whether to expose full histogram\n\
+             buckets vs. summary percentiles ([prometheus]).\n\n\
+             Set [general] interval (default 1s) to match your Prometheus scrape interval:\n\
+             shorter than the scrape leaves gaps between summary samples, longer serves stale\n\
+             data. See config/exporter.toml for a documented starting point.\n\n\
+             EXAMPLE:\n    \
+             # Expose a local agent to Prometheus using the example config\n    \
+             rezolus exporter config/exporter.toml",
+        )
         .arg(
             clap::Arg::new("CONFIG")
-                .help("Rezolus exporter configuration file")
+                .help("Path to the exporter TOML config (e.g. config/exporter.toml); see that file for the [general]/[prometheus] keys")
                 .value_parser(value_parser!(PathBuf))
                 .action(clap::ArgAction::Set)
                 .required(true)

--- a/src/hindsight/mod.rs
+++ b/src/hindsight/mod.rs
@@ -10,10 +10,26 @@ use state::{DumpToFileRequest, DumpToFileResponse, SharedState, TimeRange};
 
 pub fn command() -> Command {
     Command::new("hindsight")
-        .about("Continuous recording to an on-disk ring buffer")
+        .about("Continuously record to an on-disk ring buffer for after-the-fact snapshots")
+        .long_about(
+            "Long-running daemon that pulls from a Rezolus agent and keeps a rolling,\n\
+             high-resolution ring buffer on disk. When an incident happens you snapshot the\n\
+             buffer to a parquet file — effectively recording the minutes *before* the trigger,\n\
+             at a resolution finer than your normal observability stack keeps.\n\n\
+             Configuration is a TOML file (the only argument). It sets the sampling interval\n\
+             ([general] interval, e.g. 1s), how far back the buffer reaches ([general] duration,\n\
+             e.g. 15m), the agent to read from ([general] source), and the snapshot output path\n\
+             ([general] output). See config/hindsight.toml for a documented starting point.\n\n\
+             TRIGGERING A SNAPSHOT: send SIGHUP to write the buffer to the output file without\n\
+             stopping the daemon. Optionally set [general] listen to enable an HTTP endpoint for\n\
+             remote status/dump requests instead.\n\n\
+             EXAMPLE:\n    \
+             # Run the ring-buffer daemon using the example config\n    \
+             rezolus hindsight config/hindsight.toml",
+        )
         .arg(
             clap::Arg::new("CONFIG")
-                .help("Rezolus Hindsight configuration file")
+                .help("Path to the hindsight TOML config (e.g. config/hindsight.toml); see that file for interval/duration/source/output")
                 .value_parser(value_parser!(PathBuf))
                 .action(clap::ArgAction::Set)
                 .required(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,11 +65,34 @@ fn main() {
 
     let cli = Command::new(env!("CARGO_BIN_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
-        .long_about("Rezolus provides high-resolution systems performance telemetry.")
+        .about("High-resolution systems performance telemetry")
+        .long_about(
+            "Rezolus is a high-resolution systems performance telemetry agent. One binary runs\n\
+             in several roles; the first three are long-running services, the rest are on-demand\n\
+             tools.\n\n\
+             MODES:\n    \
+             agent      (default) Collect system metrics via eBPF/perf and serve them over HTTP.\n\
+             \x20              Run with no subcommand: `rezolus <config.toml>`.\n    \
+             exporter   Re-expose an agent's metrics on a Prometheus-compatible endpoint.\n    \
+             hindsight  Keep an on-disk ring buffer for after-the-fact incident snapshots.\n    \
+             record     Scrape an endpoint to a parquet file (optionally wrapping a command).\n    \
+             view       Serve a web dashboard for a recording or a live agent.\n    \
+             mcp        AI analysis tools (PromQL, anomaly detection, correlation) over a file.\n    \
+             parquet    Inspect and transform parquet recordings (metadata/annotate/combine/filter).\n    \
+             status     Print a running agent's status/sampler health: `rezolus status <endpoint>`.\n\n\
+             The agent is the source everything else reads from; start there, then reach for a\n\
+             tool. Run `rezolus <mode> --help` for a mode's options and examples.\n\n\
+             EXAMPLES:\n    \
+             # Run the agent (needs root for eBPF on Linux)\n    \
+             sudo rezolus config/agent.toml\n\n    \
+             # Record the local agent for 5 minutes, then view it\n    \
+             rezolus record --duration 5m -o out.parquet\n    \
+             rezolus view out.parquet",
+        )
         .subcommand_negates_reqs(true)
         .arg(
             clap::Arg::new("CONFIG")
-                .help("Configuration file")
+                .help("Agent config file (default mode when no subcommand is given), e.g. config/agent.toml")
                 .value_parser(value_parser!(PathBuf))
                 .action(clap::ArgAction::Set)
                 .required(true)

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -574,6 +574,26 @@ impl TryFrom<ArgMatches> for Config {
 pub fn command() -> Command {
     Command::new("mcp")
         .about("Run Rezolus MCP server for AI analysis or execute analysis commands")
+        .long_about(
+            "AI-assisted analysis of a parquet recording. With no subcommand, runs as a Model\n\
+             Context Protocol server over stdio for an LLM client. Each subcommand also runs\n\
+             one-shot from the CLI, printing the same analysis to stdout.\n\n\
+             SUBCOMMANDS:\n    \
+             describe-recording   Summarize a recording (source, version, time range, duration)\n    \
+             describe-metrics     List every metric in a recording with its type and labels\n    \
+             query                Run a PromQL query against a recording\n    \
+             detect-anomalies     Flag anomalies for one metric, or exhaustively across all\n    \
+             analyze-correlation  Correlate two PromQL series over the recording\n\n\
+             A good workflow is describe-metrics (see what's there) → query / detect-anomalies\n\
+             (dig in). Run `rezolus mcp <subcommand> --help` for per-subcommand examples.\n\n\
+             EXAMPLES:\n    \
+             # Run as a stdio MCP server for an LLM client\n    \
+             rezolus mcp\n\n    \
+             # One-shot: list the metrics in a recording\n    \
+             rezolus mcp describe-metrics file.parquet\n\n    \
+             # One-shot: run a PromQL query\n    \
+             rezolus mcp query file.parquet \"sum(rate(cpu_cycles[1m]))\"",
+        )
         .arg(
             clap::Arg::new("VERBOSE")
                 .long("verbose")
@@ -584,6 +604,16 @@ pub fn command() -> Command {
         .subcommand(
             Command::new("analyze-correlation")
                 .about("Analyze correlation between two metrics using the full recording")
+                .long_about(
+                    "Compute how two PromQL series move together across the whole recording\n\
+                     (Pearson correlation plus supporting stats). Useful for testing a hunch\n\
+                     that one metric drives another — e.g. does CPU usage track memory growth.\n\n\
+                     Both arguments are full PromQL expressions, not bare metric names; wrap\n\
+                     counters in rate()/irate() as you would in a query.\n\n\
+                     EXAMPLE:\n    \
+                     rezolus mcp analyze-correlation file.parquet \\\n        \
+                     \"irate(cgroup_cpu_usage[1m])\" \"cgroup_memory_used\"",
+                )
                 .arg(
                     clap::Arg::new("FILE")
                         .help("Parquet file to analyze")
@@ -607,6 +637,13 @@ pub fn command() -> Command {
         .subcommand(
             Command::new("describe-recording")
                 .about("Describe the contents of a recording file")
+                .long_about(
+                    "Print a high-level summary of a recording: source, Rezolus version, the\n\
+                     wall-clock time range it spans, and total duration. Start here to confirm\n\
+                     you have the right file before querying it.\n\n\
+                     EXAMPLE:\n    \
+                     rezolus mcp describe-recording file.parquet",
+                )
                 .arg(
                     clap::Arg::new("FILE")
                         .help("Parquet file to describe")
@@ -618,6 +655,14 @@ pub fn command() -> Command {
         .subcommand(
             Command::new("describe-metrics")
                 .about("List and describe all metrics available in a recording")
+                .long_about(
+                    "List every metric in a recording with its type (counter/gauge/histogram),\n\
+                     help text, and labels. Run this before `query` or `analyze-correlation` to\n\
+                     find exact metric names and see how to phrase a PromQL expression for each\n\
+                     type.\n\n\
+                     EXAMPLE:\n    \
+                     rezolus mcp describe-metrics file.parquet",
+                )
                 .arg(
                     clap::Arg::new("FILE")
                         .help("Parquet file to analyze")

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -15,11 +15,41 @@ use std::sync::Arc;
 
 pub fn command() -> Command {
     Command::new("parquet")
-        .about("Parquet file operations")
+        .about("Inspect and transform Rezolus parquet recordings")
+        .long_about(
+            "Offline operations on parquet recordings produced by `rezolus record` or\n\
+             `rezolus hindsight`.\n\n\
+             SUBCOMMANDS:\n    \
+             metadata   Inspect a file's file-level/column metadata, schema, and geometry\n    \
+             annotate   Embed service-extension KPIs, events, or source/node tags into a file\n    \
+             combine    Merge multiple files (multi-node / multi-instance) or build an A/B tarball\n    \
+             filter     Drop columns not needed by a file's service-extension KPIs (shrink it)\n\n\
+             Run `rezolus parquet <subcommand> --help` for per-subcommand examples.",
+        )
         .subcommand_required(true)
         .subcommand(
             Command::new("annotate")
                 .about("Add service extension metadata to a parquet file")
+                .long_about(
+                    "Rewrite a parquet recording in place, adding metadata the viewer reads.\n\
+                     Use it to attach service-extension KPI dashboards, tag the file's\n\
+                     source/node identity, embed a systeminfo blob, or record timeline events.\n\n\
+                     By default KPIs come from the built-in template matching the file's source;\n\
+                     override with --queries <file.json>. --undo strips a prior annotation.\n\n\
+                     EXAMPLES:\n    \
+                     # Attach KPIs from the built-in template for this file's source\n    \
+                     rezolus parquet annotate rezolus.parquet\n\n    \
+                     # Attach KPIs from a custom service-extension JSON file\n    \
+                     rezolus parquet annotate rezolus.parquet --queries ext.json\n\n    \
+                     # Attach KPIs and also drop columns the KPIs don't need\n    \
+                     rezolus parquet annotate rezolus.parquet --queries ext.json --filter\n\n    \
+                     # Set the source name on a file that has none\n    \
+                     rezolus parquet annotate service.parquet --source vllm\n\n    \
+                     # Add a single timeline event\n    \
+                     rezolus parquet annotate rezolus.parquet --event 'time=2026-05-12T15:23Z,kind=restart,description=\"deploy\"'\n\n    \
+                     # Remove a previously added annotation\n    \
+                     rezolus parquet annotate rezolus.parquet --undo",
+                )
                 .arg(
                     clap::Arg::new("FILE")
                         .help("Parquet file to annotate")
@@ -119,6 +149,27 @@ pub fn command() -> Command {
         .subcommand(
             Command::new("combine")
                 .about("Combine multiple parquet files (multi-node rezolus and/or multi-instance services)")
+                .long_about(
+                    "Merge two or more parquet recordings into a single file. Requires at least\n\
+                     two inputs and an output path (-o).\n\n\
+                     Default (row-merge): joins the inputs on timestamp into one recording — use\n\
+                     it to stitch together multiple rezolus nodes and/or per-instance service\n\
+                     files so the viewer shows them together.\n\n\
+                     --ab (tarball): instead of row-merging, packages exactly two captures\n\
+                     unmodified into a combined-A/B tarball for the viewer's compare mode. The\n\
+                     output should end in `.parquet.ab.tar`, and you map each side with\n\
+                     `baseline=<src> experiment=<src>` where <src> is a file's embedded SOURCE\n\
+                     NAME (not its filename) — set with `annotate --source`, seen with\n\
+                     `parquet metadata --field source`. In the example below a.parquet's source\n\
+                     is `redis` and b.parquet's is `valkey`.\n\n\
+                     EXAMPLES:\n    \
+                     # Row-merge a rezolus agent file with a service file\n    \
+                     rezolus parquet combine rezolus.parquet service.parquet -o combined.parquet\n\n    \
+                     # Merge several rezolus nodes, pinning which one the viewer shows first\n    \
+                     rezolus parquet combine node1.parquet node2.parquet -o cluster.parquet --pinned node1\n\n    \
+                     # Package two captures as an A/B tarball for compare mode\n    \
+                     rezolus parquet combine a.parquet b.parquet --ab baseline=redis experiment=valkey -o out.parquet.ab.tar",
+                )
                 .arg(
                     clap::Arg::new("FILES")
                         .help("Input parquet files (rezolus agent and/or service files)")
@@ -182,6 +233,22 @@ pub fn command() -> Command {
         .subcommand(
             Command::new("metadata")
                 .about("Display file and column metadata for a parquet file")
+                .long_about(
+                    "Print the metadata of a parquet recording: file-level key/values (source,\n\
+                     sampling interval, systeminfo, descriptions, …), the column schema with\n\
+                     each metric's type and labels, and table geometry (row/column counts and\n\
+                     row-group layout).\n\n\
+                     With no filter flag all sections are shown. Narrow with --file, --schema, or\n\
+                     --geometry; pull a single file-level value with --field <KEY>; add --json for\n\
+                     machine-readable output.\n\n\
+                     EXAMPLES:\n    \
+                     # Everything about a recording\n    \
+                     rezolus parquet metadata -i rezolus.parquet\n\n    \
+                     # Only file-level metadata, as JSON\n    \
+                     rezolus parquet metadata -i rezolus.parquet --file --json\n\n    \
+                     # Just the value of one metadata key\n    \
+                     rezolus parquet metadata -i rezolus.parquet --field source",
+                )
                 .arg(
                     clap::Arg::new("input")
                         .short('i')
@@ -225,6 +292,20 @@ pub fn command() -> Command {
         .subcommand(
             Command::new("filter")
                 .about("Filter parquet columns to only those needed by service extension KPIs")
+                .long_about(
+                    "Shrink a parquet recording by dropping every metric column not referenced by\n\
+                     its service-extension KPIs. The KPI set is taken from the file's embedded\n\
+                     annotation (or a matching built-in template); override with --queries.\n\n\
+                     By default the input is rewritten in place; pass -o/--output to write a new\n\
+                     file and leave the original untouched.\n\n\
+                     EXAMPLES:\n    \
+                     # Filter in place using the file's embedded KPIs\n    \
+                     rezolus parquet filter rezolus.parquet\n\n    \
+                     # Write a slimmed copy, keeping the original\n    \
+                     rezolus parquet filter rezolus.parquet -o slim.parquet\n\n    \
+                     # Filter to the columns a custom KPI set needs\n    \
+                     rezolus parquet filter rezolus.parquet --queries ext.json -o slim.parquet",
+                )
                 .arg(
                     clap::Arg::new("FILE")
                         .help("Parquet file to filter")

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -82,7 +82,37 @@ enum Source {
 
 pub fn command() -> Command {
     Command::new("view")
-        .about("View a Rezolus artifact or live agent")
+        .about("Serve an interactive web dashboard for a recording or live agent")
+        .long_about(
+            "Launch a local web dashboard to explore Rezolus metrics. PromQL runs in the\n\
+             browser (WASM), so data stays on your machine. A browser is opened automatically\n\
+             unless REZOLUS_NO_OPEN is set.\n\n\
+             WHAT TO VIEW (pick one input form):\n    \
+             - a parquet recording:      rezolus view rezolus.parquet\n    \
+             - two recordings (A/B):     rezolus view baseline.parquet experiment.parquet\n    \
+             - a live agent:             rezolus view http://host:4241\n    \
+             - nothing (upload-only):    rezolus view    (drag files in from the browser)\n\n\
+             Either positional may be given as alias=path (e.g. redis=./a.parquet) to set the\n\
+             display label; the internal slots stay baseline/experiment. The second positional\n\
+             (A/B experiment) is only honored when the first is a parquet file — live and\n\
+             upload-only modes attach a second capture from the browser instead.\n\n\
+             By default the viewer binds 127.0.0.1 on a random free port; pass --listen to fix\n\
+             the address (e.g. to reach it from another host).\n\n\
+             The --templates/--category flags (service-extension dashboards) and the --proxy-*\n\
+             flags (in-browser 'load from URL' fetching) are advanced; the input forms above\n\
+             need none of them.\n\n\
+             EXAMPLES:\n    \
+             # Open a single recording\n    \
+             rezolus view rezolus.parquet\n\n    \
+             # A/B compare two recordings with display labels\n    \
+             rezolus view redis=baseline.parquet valkey=experiment.parquet\n\n    \
+             # Stream live from a remote agent on a fixed address\n    \
+             rezolus view http://host:4241 --listen 127.0.0.1:8080\n\n    \
+             # Upload-only mode: start with no file, then upload from the browser\n    \
+             rezolus view\n\n    \
+             # A/B compare using a category bridge view (both sources must be category members)\n    \
+             rezolus view a.parquet b.parquet --category inference-library",
+        )
         .arg(
             clap::Arg::new("INPUT")
                 .help(
@@ -133,10 +163,12 @@ pub fn command() -> Command {
                 .long("category")
                 .value_name("NAME")
                 .help(
-                    "Activate category mode using the named category template \
-                     (e.g. `inference-library`). Each capture's detected source \
-                     (from the parquet metadata) must appear in the category \
-                     template's `members` list.",
+                    "Activate the A/B 'category bridge' view using the named category \
+                     template (e.g. `inference-library`). NAME must match a category \
+                     template known to the viewer (built-in, or from --templates). Each \
+                     capture's detected source (from the parquet metadata) must appear in \
+                     that template's `members` list. Only meaningful when comparing two \
+                     captures.",
                 )
                 .action(clap::ArgAction::Set),
         )
@@ -145,11 +177,13 @@ pub fn command() -> Command {
                 .long("proxy-allow")
                 .value_name("HOST_PATTERN")
                 .help(
-                    "Enable the URL proxy and whitelist a host pattern \
+                    "Let the browser's 'load from URL' feature fetch parquet/agent \
+                     URLs through this server, and whitelist a host pattern \
                      (repeatable). Patterns are shell-style with `*` matching \
-                     a single DNS label — e.g. `*.s3.amazonaws.com`, \
-                     `bucket.example.internal`. Without this flag the proxy \
-                     stays disabled and the browser must fetch URLs directly.",
+                     a single DNS label — e.g. `--proxy-allow '*.s3.amazonaws.com'`, \
+                     `--proxy-allow bucket.example.internal`. Without this flag the \
+                     proxy stays disabled and the browser fetches URLs directly. Not \
+                     needed for the file/live/upload input forms.",
                 )
                 .action(clap::ArgAction::Append),
         )


### PR DESCRIPTION
## Problem

Rezolus is increasingly driven by LLM agents, for which `--help` *is* the
interface. `rezolus record --help` was reworked to be agent-usable in #983, but
every other subcommand still had thin help — a bare usage line, no examples, and
unexplained jargon — which produces wrong invocations that fail silently or do the
wrong thing. The `document-feature` handoff
(`.claude/skills/document-feature/references/subcommand-help-backlog.md`) tracked
bringing the rest of the CLI up to the same bar.

## Solution

Applied the `document-feature` loop to each remaining mode: wrote ground-truth
task→command pairs first, then added a `long_about` with worked, copy-pasteable
examples and concrete per-arg value formats. No behavior or arg-graph changes —
help strings only.

- **view** — `long_about` covering all four input forms (parquet file, A/B, live
  agent, upload-only), the `alias=path` label form, the `--listen` default, and
  notes marking `--templates`/`--category` and `--proxy-*` as advanced.
- **parquet** — top-level `long_about` plus per-subcommand `long_about`s and
  examples for `metadata`, `annotate`, `combine`, `filter`. `combine --ab` now
  spells out that `baseline=`/`experiment=` take a file's embedded **source name**
  (set via `annotate --source`, seen via `metadata --field source`), not its
  filename.
- **exporter** / **hindsight** — `long_about` describing the mode, the `[general]`
  config keys, the scrape-interval-must-match-Prometheus constraint (exporter) and
  the ring-buffer + SIGHUP-snapshot model (hindsight), pointing at the example
  config in `config/`.
- **rezolus (root)** + **agent** — replaced the one-sentence root `long_about`
  with an overview of every mode (including `status`) and the default
  no-subcommand agent `CONFIG` form.
- **mcp** — top-level examples block + remaining subcommand `long_about`s
  (`describe-recording`, `describe-metrics`, `analyze-correlation`).
- Synced README + CLAUDE.md "Running Modes" (added `filter` and the A/B tarball
  form) and marked the backlog cleared.

Verified per the skill: rendered each `--help` and fed it to blind
user-simulation agents (16 task→command pairs — all matched ground truth) plus
fresh-eyes critics per surface. The critics' material findings were folded back
in (the `combine --ab` source-name-vs-filename clarification, the `view`
proxy/category jargon, and the missing `status` entry in the root overview).

## Result

Every `rezolus <subcommand> --help` now leads with what the mode is for and shows
concrete example invocations, so an agent (or human) can construct a correct
command on the first try without reading the source. `cargo build`, `cargo fmt`,
and the clap arg-graph test pass; no runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZdkZTmbBpwPwBd4TrpNCX)_