### PR TITLE
docs(journal): establish journal; open drive-health Phase 1

### DIFF
--- a/.claude/skills/engineering-journal/SKILL.md
+++ b/.claude/skills/engineering-journal/SKILL.md
@@ -3,7 +3,7 @@ name: engineering-journal
 description: Use when starting or picking up a non-trivial effort (feature, investigation, perf probe, refactor, migration) in a shared repo where teammates or future agents must coordinate or hand off; when a repo has no durable in-tree record of decisions and dead-ends; when you're about to drop a well-measured negative result; or when bootstrapping a journal from a repo's commit history.
 ---
 
-# Keeping an Engineering Journal
+# Engineering Journal
 
 ## Overview
 

--- a/.claude/skills/engineering-journal/SKILL.md
+++ b/.claude/skills/engineering-journal/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: keeping-an-engineering-journal
+name: engineering-journal
 description: Use when starting or picking up a non-trivial effort (feature, investigation, perf probe, refactor, migration) in a shared repo where teammates or future agents must coordinate or hand off; when a repo has no durable in-tree record of decisions and dead-ends; when you're about to drop a well-measured negative result; or when bootstrapping a journal from a repo's commit history.
 ---
 

--- a/.claude/skills/engineering-journal/SKILL.md
+++ b/.claude/skills/engineering-journal/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: keeping-an-engineering-journal
+description: Use when starting or picking up a non-trivial effort (feature, investigation, perf probe, refactor, migration) in a shared repo where teammates or future agents must coordinate or hand off; when a repo has no durable in-tree record of decisions and dead-ends; when you're about to drop a well-measured negative result; or when bootstrapping a journal from a repo's commit history.
+---
+
+# Keeping an Engineering Journal
+
+## Overview
+
+An engineering journal is an **in-repo markdown record of efforts** — what you set out to do, the decision to proceed or not, what happened, and what was learned. It lives in the tree (`docs/journal/` or the repo's docs dir), lands on `main` via PR, and is grounded in code (real commits, files, specs).
+
+**Core principle: an effort's *record* is a deliverable, landed alongside the code — not a closed issue, not notes in your head.** A well-measured dead-end is the most valuable entry: an unrecorded NO-GO is the one the team re-pays to rediscover.
+
+## When to use
+
+- Starting a non-trivial effort a teammate or future agent might need to understand or continue.
+- Picking up someone's in-progress work — read their entry to continue.
+- A repo with no decision/dead-end record — establish the journal as the convention.
+- Bootstrapping from a repo's commit history (retrospective mode, below).
+
+Not for trivial one-liners.
+
+## Journal vs. issues (use both)
+
+Issues/PRs are the *task* layer — discrete units, assignment, notifications. The journal is the *narrative/decision* layer — why, the dead-ends, current state, how to continue. It must be in-repo: versioned with the code, greppable, code-grounded, and readable by the next agent without leaving the tree. Link the journal to issues/PRs; don't let an issue be the only record of a non-trivial effort.
+
+## The lifecycle (per effort)
+
+1. **Pick & scope.** Gather requirements. Grep the journal + git log for prior art first — don't re-litigate a settled question.
+2. **Open — land intent on `main`.** Write the entry: goal/hypothesis, requirements, GO/NO-GO criteria (number-gated where possible), plan. Commit via PR to `main` so the effort is visible *before* you build. This is the coordination move.
+3. **Go / no-go.** Probe or price it cheaply before building. Record the verdict honestly.
+4. **Implement & test.**
+5. **Close out — in the implementing PR.** Update the entry with the outcome (shipped / NO-GO + numbers + mechanism) and update any docs the change affects. Landing the work closes the record in the same PR.
+
+A NO-GO closes out the same way: land the negative result with its mechanism and a reopen condition ("revisit if new hardware / data / regime"). Merge negative probes; don't abandon them.
+
+## Ground every claim in code
+
+The journal's authority is that it traces to source: real commit SHAs, file paths, spec/note files, measured numbers — never invented figures. When you update or reconstruct an entry, re-verify against current code; **stale claims are the main failure mode.** If a detail isn't in the source, say so or omit it.
+
+## Honest-ledger voice
+
+Factual, not diaristic or triumphant. NO-GOs and falsifications are first-class, with their mechanism. Flag what you couldn't measure. Don't overclaim — the record is trusted only if it's honest about what didn't work and what's uncertain.
+
+## Retrospective mode (bootstrap)
+
+For a repo without a journal: cluster the commit history into thematic **arcs/campaigns**, write one grounded entry per arc from its commit range + design docs + notes (one drafter per arc parallelizes well), and add a series index. Same grounding and voice rules.
+
+## Optional: publish as docs
+
+The journal can feed a doc site in **whatever the repo already uses** (mdBook, another SSG, plain markdown, the repo's existing docs) — don't impose a toolchain. Journals stay source-of-truth; the site consumes them. A concrete worked example (private-by-construction mdBook with a build + link-check gate) and reusable scripts are in `publishing-example.md`.
+
+## Related
+
+Prioritizing and picking *which* effort, and maintaining the consolidated NO-GO ledger / reopen conditions, belong to a backlog/roadmap skill (if present). The journal records a single effort; the backlog orders them.
+
+## Common rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "No journal convention here; I won't invent one for one item." | The journal *is* the convention — establish it once. It compounds; every entry saves the next person from re-deriving. |
+| "A GitHub issue is enough." | Issues aren't versioned with the code, aren't greppable in-repo, aren't code-grounded, and the next agent won't find them. The record belongs in the tree. |
+| "I'll keep scratch notes in my head." | Then the reasoning is lost at handoff. The journal is where the reasoning lives. |
+| "It's a dead end — nothing to record." | The dead-end is the highest-value entry. Record the mechanism and the reopen condition. |
+| "I'll write it up after it ships." | Land the record in the same PR. "After" = never, or an unverified reconstruction. |
+| "Close enough on the numbers." | Ground every figure in a source or omit it. Invented numbers destroy the record's authority. |
+
+## Red flags — stop
+
+- About to implement without landing intent for coordination.
+- Recording an outcome you didn't verify against code.
+- Dropping a negative result instead of landing it.
+- Reaching for a GitHub issue as the *only* record of a non-trivial effort.

--- a/.claude/skills/engineering-journal/publishing-example.md
+++ b/.claude/skills/engineering-journal/publishing-example.md
@@ -1,0 +1,115 @@
+# Publishing a journal as docs — worked example
+
+Optional. The journal stands on its own as in-repo markdown; this is one proven
+way to render it (plus curated content) as a browsable site. Use whatever the
+repo already uses — this example is mdBook, but the *pattern* is what matters,
+not the tool.
+
+## The pattern
+
+1. **Journals stay source-of-truth** in `docs/journal/`. The site *consumes*
+   them — never hand-edit rendered copies.
+2. A **sync step** copies the journals into the site's source dir at build time
+   (so their cross-links resolve) rather than duplicating them in git.
+3. **Build + gate**: render the site, then run a link check (and, if you use
+   diagrams, confirm they mounted). A broken internal link fails the build.
+4. **Ship privately by default** for a private repo (see the privacy note) —
+   build in CI and upload the site as a downloadable artifact, no public URL.
+
+## Privacy gotcha (private repos)
+
+GitHub Pages has no access control on personal accounts: a Pages site from a
+personal private repo is either unavailable (Free) or fully public (Pro).
+Access-controlled Pages needs Enterprise Cloud + an org. So for a private repo,
+default to **build-in-CI + upload-artifact** (downloadable only by repo
+members); leave a one-job path to public Pages for if/when the content goes
+public.
+
+## `scripts/build-docs-site.sh` (sync + build + link-check)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+journal_src="$root/docs/journal"
+history_dst="$root/docs-site/src/history"   # gitignore this dir's synced copies
+
+mkdir -p "$history_dst"
+rm -f "$history_dst"/*.md
+cp "$journal_src"/*.md "$history_dst/"       # README/index handled separately if needed
+
+mdbook build "$root/docs-site"
+python3 "$root/scripts/check-docs-links.py" "$root/docs-site/src"
+echo "Built docs site -> $root/docs-site/book"
+```
+
+Gitignore the synced copies (`/src/history/*.md`) and the build output
+(`/book`) in the site dir, so there is a single source of truth.
+
+## `scripts/check-docs-links.py` (internal link check)
+
+Validates that every inline relative `.md` link resolves. Preferred over a full
+link-checker backend when the source contains prose that a strict checker
+misreads (e.g. bracketed shorthand that isn't a link).
+
+```python
+#!/usr/bin/env python3
+"""Fail if any inline relative Markdown link in <src> points at a missing file."""
+import re, sys, pathlib
+link_re = re.compile(r"\]\(([^)]+)\)")
+src = pathlib.Path(sys.argv[1]).resolve()
+errors, pages = [], sorted(src.rglob("*.md"))
+for md in pages:
+    for m in link_re.finditer(md.read_text(encoding="utf-8")):
+        t = m.group(1).strip()
+        if t.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        path = t.split("#", 1)[0]
+        if path.endswith(".md") and not (md.parent / path).resolve().is_file():
+            errors.append(f"{md.relative_to(src)}: broken link -> {t}")
+if errors:
+    print("Broken internal links:", *("  " + e for e in errors), sep="\n", file=sys.stderr)
+    sys.exit(1)
+print(f"Link check OK ({len(pages)} pages scanned).")
+```
+
+## CI (private artifact) — `.github/workflows/docs.yml`
+
+```yaml
+name: docs-site
+on:
+  push: { branches: [main], paths: ['docs-site/**', 'docs/journal/**', 'scripts/build-docs-site.sh'] }
+  pull_request: { paths: ['docs-site/**', 'docs/journal/**', 'scripts/build-docs-site.sh'] }
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v0.4.52/mdbook-v0.4.52-x86_64-unknown-linux-gnu.tar.gz" | tar -xz -C /usr/local/bin
+      - name: Build
+        run: bash scripts/build-docs-site.sh
+      - name: Upload site (private; repo members only)
+        uses: actions/upload-artifact@v4
+        with: { name: docs-site, path: docs-site/book, if-no-files-found: error }
+# To go public later: add a deploy-pages job gated on main (configure-pages +
+# upload-pages-artifact path: docs-site/book + deploy-pages), enable Pages.
+```
+
+## Diagrams (if used)
+
+Text-based diagrams (e.g. Mermaid via `mdbook-mermaid`, bundled locally so a
+private/offline site still renders) are diffable and reviewable. A syntax error
+renders a *blank* diagram rather than failing the build — so the gate must also
+**audit that diagrams mounted**: grep the built HTML for the render marker
+(`class="mermaid"`) present and the unrendered fence (`language-mermaid`)
+absent.
+
+## Content pages, if you add them
+
+Curated pages (overview, guide, architecture, comparisons) follow the same
+discipline as journal entries: **grounded in code** (verify CLI flags, config
+fields, and numbers against source, not memory), honest (cite figures or omit
+them; don't overclaim), and reviewed against source before landing. One
+drafting subagent per page/section parallelizes well; review each against its
+sources before commit.

--- a/docs/journal/2026-07-06-drive-health-sampler.md
+++ b/docs/journal/2026-07-06-drive-health-sampler.md
@@ -1,0 +1,117 @@
+# Drive health sampler — Phase 1: all-drive temperature
+
+- **Opened:** 2026-07-06
+- **Status:** OPEN — intent landed before build (design approved; not yet implemented)
+- **Arc:** "All-drive health" (NVMe + SATA/SAS), delivered in phases. This entry is Phase 1.
+- **Owner:** Brian Martin
+
+This entry doubles as the design spec for Phase 1 (we are exercising the journal
+as the single decision record rather than keeping a separate spec doc).
+
+## Motivation
+
+Identified operational need: track **NVMe drive temperature**. Broadened during
+scoping to "drive health" across all drive types, since the mechanism generalizes.
+Rezolus is grounded in high-resolution *performance* telemetry, so a slow-moving
+health gauge is a deliberate widening of scope — see "Fit with principles" below
+for why it is legitimate rather than a workaround.
+
+## Arc and phasing
+
+"All-drive health" spans three independent data sources with increasing
+complexity. We deliver walking-skeleton first:
+
+- **Phase 1 (this entry): all-drive temperature via hwmon.** One sampler + device
+  discovery + temperature for NVMe *and* SATA/SAS in a single cut. hwmon exposes
+  temperature uniformly for both (the `nvme` driver and the `drivetemp` module),
+  so temperature — the identified need — is reachable everywhere with plain file
+  reads and no admin ioctls.
+- **Phase 2 (later): NVMe SMART-log health.** Wear (`percentage_used`), available
+  spare, critical-warning bits, media errors, power-on hours — via NVMe Get Log
+  Page 0x02 (admin passthrough ioctl).
+- **Phase 3 (later): ATA/SATA SMART attributes.** Vendor-specific attribute
+  parsing (reallocated sectors, etc.).
+
+Each phase is its own journal entry → PR.
+
+## Goal (Phase 1)
+
+Expose per-drive temperature as a gauge, for every NVMe and SATA/SAS drive the
+kernel surfaces via hwmon, with low, bounded per-refresh cost.
+
+## Requirements
+
+1. New Linux-only userspace gauge sampler `drivehealth` under
+   `src/agent/samplers/drivehealth/`, registered via the `SAMPLERS` `linkme`
+   slice. macOS builds a no-op (pattern of existing Linux-only samplers).
+2. Discover drives **once at startup** by walking `/sys/class/hwmon/*`; keep
+   entries backed by a block drive (NVMe controller or a disk exposing
+   `drivetemp`). Resolve the kernel device name (`nvme0`, `sda`).
+3. Emit one metric:
+   ```
+   drive_temperature{device, type, model, serial}   # degrees Celsius, i64
+   ```
+   - `device` = kernel name (`nvme0`, `sda`).
+   - `type` = `nvme` | `sata`.
+   - `model`, `serial` = read once at discovery. **Serial is potentially
+     sensitive** — included deliberately for stable cross-reboot fleet identity;
+     documented in the metric help so operators know it is emitted.
+   - Composite temperature only (per-sensor `sensor=` label deferred).
+   - hwmon reports millidegrees C; divide by 1000. Unit convention matches the
+     existing `gpu_temperature` gauge (Celsius, i64).
+4. Backed by `GaugeGroup::new(MAX_DRIVES)` (cap 64), `.set(idx, celsius)` per
+   refresh, per-index labels via `insert_metadata(idx, key, value)` — the exact
+   mechanism the GPU sampler uses (`src/agent/samplers/gpu/linux/nvidia/`,
+   `src/agent/metrics/mod.rs`).
+5. Robust to absence: no hwmon / no drives / permission error → sampler starts
+   with zero drives and emits no series, never errors the agent (GPU posture when
+   no device present). A per-refresh read failure skips that drive that tick.
+6. Unit tests for hwmon parsing against fixture sysfs trees.
+
+## Fit with principles (why sysfs here is legitimate)
+
+Principle 15 ("prefer BPF/perf over parsing procfs/sysfs") carves out an explicit
+exception: *"A small set of metrics genuinely have no useful BPF or perf hook —
+some kernel-internal gauges only surface through procfs. Those keep parsing the
+file, but the choice should be deliberate, not the default."* Drive temperature
+originates in the drive controller's health data; there is **no** BPF or perf
+hook for it. Discovery is one-time (explicitly blessed). Per-refresh we read only
+small `tempN_input` files, and temperature changes on the order of seconds — so
+the high-sampling-frequency cost concern the principle targets does not apply.
+The sampler module will carry a comment stating this deliberately.
+
+Prior art that this mirrors: the GPU samplers are already non-BPF gauge samplers
+that read temperature (`gpu_temperature`) via vendor SMI. This is the same shape,
+one category over.
+
+## GO / NO-GO criteria
+
+**GO if all hold on a Linux host with at least one NVMe drive:**
+- `drive_temperature` appears with a plausible value (roughly 20–80 °C) and
+  correct `device`/`type`/`model`/`serial` labels.
+- Per-refresh cost is bounded (no directory walk on the hot path; only the
+  small `tempN_input` reads for discovered drives).
+- Agent starts cleanly on a host with **no** supported drive (zero series, no
+  error), and on macOS (no-op).
+
+**NO-GO / rethink if:**
+- hwmon does not expose the drives in target environments (e.g. `drivetemp` not
+  loaded and no NVMe hwmon) — then temperature needs the NVMe SMART-log ioctl,
+  which would fold Phase 1 into Phase 2. Reopen condition: if hwmon coverage is
+  insufficient, promote the ioctl path earlier.
+
+## Plan
+
+1. Scaffold `drivehealth` sampler (mod.rs + linux/ + stats.rs), macOS no-op.
+2. hwmon discovery + drive-name/model/serial resolution (with fixtures).
+3. `drive_temperature` gauge group; wire refresh.
+4. Unit tests for parsing; register and run on real NVMe hardware for GO check.
+5. Close out this entry with the outcome (GO + observed values, or NO-GO +
+   mechanism) in the implementing PR.
+
+## Open questions / limitations (Phase 1)
+
+- **Hotplug:** drives added after startup are not picked up (startup-only
+  discovery). Acceptable for Phase 1; documented. Revisit if hotplug matters.
+- **hwmon coverage** varies by kernel/driver (`drivetemp` must be loaded for
+  SATA). Measured during GO check; drives the Phase-1-vs-Phase-2 boundary.

--- a/docs/journal/README.md
+++ b/docs/journal/README.md
@@ -1,0 +1,22 @@
+# Engineering Journal
+
+An in-repo, code-grounded record of non-trivial efforts: what we set out to do,
+the GO/NO-GO decision, what happened, and what was learned. Entries live here so
+they are versioned with the code, greppable, and readable by the next engineer
+(or agent) without leaving the tree.
+
+Conventions:
+
+- One markdown file per effort, named `YYYY-MM-DD-slug.md` (open date).
+- Ground every claim in source: real commit SHAs, file paths, measured numbers.
+  Never invent figures. If a detail isn't in the source, say so or omit it.
+- NO-GOs and dead-ends are first-class entries — record the mechanism and the
+  condition under which to reopen.
+- Issues/PRs are the task layer; this journal is the narrative/decision layer.
+  Link them together; don't let a PR be the only record of a non-trivial effort.
+
+## Entries
+
+| Date | Effort | Status |
+|------|--------|--------|
+| 2026-07-06 | [Drive health sampler — Phase 1: all-drive temperature](2026-07-06-drive-health-sampler.md) | Open (intent landed, pre-build) |


### PR DESCRIPTION
## Summary
- Establishes an in-repo **engineering journal** (`docs/journal/`) plus the `engineering-journal` skill defining the convention: a code-grounded, greppable record of non-trivial efforts landed alongside the code.
- Lands the **intent** for a new *drive-health sampler* arc *before* building it — the journal's coordination move.
- **Phase 1** scopes a Linux-only userspace gauge sampler reading per-drive temperature (NVMe + SATA/SAS) from **hwmon sysfs**, modeled on the existing GPU temperature sampler. Records GO/NO-GO criteria and documents the sysfs read as a deliberate principle-15 exception (drive temperature has no BPF/perf hook).

This PR is **docs-only** — no code, no version bump (matching recent `docs(skill):` PRs). Implementation lands on a follow-up branch and closes out the entry.

## Test plan
- [x] Docs-only; nothing to build or test.
- [ ] Reviewers: sanity-check the Phase 1 scope, the `serial` label being emitted by default, and the hwmon-coverage NO-GO/reopen condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)