### PR TITLE
fix(viewer): query full recording at native step, drop windowed decimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.15.1-alpha.5"
+version = "5.15.1-alpha.6"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.15.1-alpha.5"
+version = "5.15.1-alpha.6"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -123,6 +123,11 @@ struct MetadataData {
     min_time: f64,
     #[serde(rename = "maxTime")]
     max_time: f64,
+    // Native sampling interval (seconds). The frontend uses this to pick
+    // the query step; without it, data.js falls back to a 1s step and a
+    // coarse recording is over-queried. Mirror of the server viewer's
+    // /api/v1/metadata `interval` field.
+    interval: f64,
     #[serde(rename = "fileChecksum")]
     file_checksum: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,6 +196,13 @@ impl Viewer {
             data: MetadataData {
                 min_time,
                 max_time,
+                // Normalize a degenerate interval (0, or f64::MAX from an
+                // empty multi-file reader) to 0.0 so the frontend's
+                // `interval || 1` fallback engages. Mirrors routes.rs.
+                interval: {
+                    let i = self.reader.interval();
+                    if i.is_finite() && i > 0.0 { i } else { 0.0 }
+                },
                 file_checksum: String::new(),
                 alias: self.alias.clone(),
             },

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -11,6 +11,35 @@ let _stepOverride = null;
 const setStepOverride = (step) => { _stepOverride = step; };
 const getStepOverride = () => _stepOverride;
 
+// Default { start, end, step } for an overview range query: the WHOLE
+// recording at its NATIVE sampling interval. Decimation for display is
+// echarts' job (`sampling: 'lttb'` on line/scatter, the heatmap
+// resolution stores for heatmaps) — a purely presentational pass that
+// preserves extrema.
+//
+// We deliberately do NOT decimate by widening the PromQL step. `step` is
+// a query-*semantics* parameter, not a decimation knob:
+//   - Histograms ignore `step` outright — output resolution is set by
+//     their `stride` arg — so a coarse step bounds nothing for them.
+//   - Counters honor `step` but need their rate window rewritten to
+//     match (rewriteCounterQuery), and any coarse step averages away the
+//     spikes we care about.
+// Widening step therefore corrupts the queries (mismatched per-type
+// resolution, skipped rewrites) without reliably bounding payload. The
+// real payload bound is server-side min/max decimation applied AFTER
+// evaluation (the reducer / DisplayResult envelope) — tracked separately.
+//
+// `_stepOverride` (the Granularity selector) still wins; it drives the
+// stride/rate rewrites via buildEffectiveQuery so a user-chosen coarse
+// step stays self-consistent.
+export const defaultRangeFor = (meta) => {
+    const start = meta.minTime;
+    const end = meta.maxTime;
+    const interval = (Number.isFinite(meta.interval) && meta.interval > 0) ? meta.interval : 1;
+    const step = _stepOverride || Math.max(1, interval);
+    return { start, end, step };
+};
+
 // Query rewriting for non-default granularity (step override).
 // When the user picks a coarser step (e.g. 15s instead of auto ~1s), raw
 // queries must be adjusted so that values are properly smoothed over the
@@ -333,15 +362,11 @@ const createDataApi = ({
     const executePromQLRangeQuery = async (query, metadata) => {
         const meta = metadata || cachedMetadata || await fetchMetadata();
 
-        const minTime = meta.minTime;
-        const maxTime = meta.maxTime;
-        const duration = maxTime - minTime;
+        // Whole recording at native step; echarts LTTB decimates for
+        // display. See defaultRangeFor for why we don't decimate via step.
+        const { start, end, step } = defaultRangeFor(meta);
 
-        const windowDuration = Math.min(3600, duration);
-        const start = Math.max(minTime, maxTime - windowDuration);
-        const step = _stepOverride || Math.max(1, Math.floor(windowDuration / 500));
-
-        return queryRange(query, start, maxTime, step);
+        return queryRange(query, start, end, step);
     };
 
     // Apply the same per-plot query transforms the baseline path applies.
@@ -558,11 +583,7 @@ const createDataApi = ({
         let r = range;
         if (!r) {
             const meta = cachedMetadata || await fetchMetadata();
-            const duration = meta.maxTime - meta.minTime;
-            const windowDuration = Math.min(3600, duration);
-            const start = Math.max(meta.minTime, meta.maxTime - windowDuration);
-            const step = _stepOverride || Math.max(1, Math.floor(windowDuration / 500));
-            r = { start, end: meta.maxTime, step };
+            r = defaultRangeFor(meta);
         }
         return queryRange(wrappedQuery, r.start, r.end, r.step, captureId);
     };

--- a/src/viewer/assets/lib/embed/demo.html
+++ b/src/viewer/assets/lib/embed/demo.html
@@ -108,9 +108,12 @@
             if (!Number.isFinite(minTime) || !Number.isFinite(maxTime) || maxTime <= minTime) {
                 throw new Error('no recording time range (no parquet loaded?)');
             }
-            const windowDuration = Math.min(3600, maxTime - minTime);
-            const start = Math.max(minTime, maxTime - windowDuration);
-            const step = Math.max(1, Math.floor(windowDuration / 500));
+            // Whole recording at native step; echarts LTTB decimates for
+            // display. We don't decimate via a coarse PromQL step — it's
+            // ignored by histograms and corrupts counter rate semantics.
+            // Mirrors defaultRangeFor in ../data.js.
+            const start = minTime;
+            const step = Math.max(1, meta.interval || 1);
 
             const node = await selectedNode();
             const query = node

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -407,10 +407,20 @@ async fn metadata(
     };
     // time_range is in seconds; metadata endpoint returns seconds too.
     let (min_time, max_time) = data.time_range().unwrap_or((0.0, 0.0));
+    // Normalize a degenerate interval (0 for a metadata-less capture,
+    // f64::MAX for an empty multi-file reader) to 0.0 so the frontend's
+    // `interval || 1` fallback engages instead of producing an absurd step.
+    let interval = data.interval();
+    let interval = if interval.is_finite() && interval > 0.0 {
+        interval
+    } else {
+        0.0
+    };
     let filename = state.captures.filename(capture);
     let mut meta = serde_json::json!({
         "minTime": min_time,
         "maxTime": max_time,
+        "interval": interval,
         "filename": filename,
     });
     if let Some(alias) = state.captures.alias(capture) {

--- a/tests/data_spectrum_capture.test.mjs
+++ b/tests/data_spectrum_capture.test.mjs
@@ -73,8 +73,8 @@ test('fetchQuantileSpectrumForPlot: experiment without range falls back to basel
     assert.ok(r);
     assert.equal(calls.length, 1);
     assert.equal(calls[0].captureId, CAPTURE_EXPERIMENT);
-    // Range should derive from baseline meta: end = maxTime (200),
-    // start = max(minTime, maxTime - 3600) = 100 (since duration < 3600).
+    // Range derives from baseline meta: end = maxTime (200),
+    // start = minTime (100) — full range at native interval.
     assert.equal(calls[0].end, 200);
     assert.equal(calls[0].start, 100);
 });

--- a/tests/live_metadata_refresh.test.mjs
+++ b/tests/live_metadata_refresh.test.mjs
@@ -32,7 +32,7 @@ const matrixOk = {
 const makeApi = (metaSeq, queryRangeCalls) => createDataApi({
     getMetadata: async () => {
         const next = metaSeq.shift() ?? metaSeq[metaSeq.length - 1];
-        return next ?? { status: 'success', data: { minTime: 0, maxTime: 0 } };
+        return next ?? { status: 'success', data: { minTime: 0, maxTime: 0, interval: 1 } };
     },
     queryRange: async (query, start, end, step) => {
         queryRangeCalls.push({ query, start, end, step });
@@ -43,8 +43,8 @@ const makeApi = (metaSeq, queryRangeCalls) => createDataApi({
 
 test('processDashboardData: default behavior caches metadata across calls', async () => {
     const metas = [
-        { status: 'success', data: { minTime: 1000, maxTime: 2000 } },
-        { status: 'success', data: { minTime: 1000, maxTime: 3000 } },
+        { status: 'success', data: { minTime: 1000, maxTime: 2000, interval: 1 } },
+        { status: 'success', data: { minTime: 1000, maxTime: 3000, interval: 1 } },
     ];
     const calls = [];
     const api = makeApi(metas, calls);
@@ -59,8 +59,8 @@ test('processDashboardData: default behavior caches metadata across calls', asyn
 
 test('processDashboardData: { freshMetadata: true } refetches metadata, advances query window', async () => {
     const metas = [
-        { status: 'success', data: { minTime: 1000, maxTime: 2000 } },
-        { status: 'success', data: { minTime: 1000, maxTime: 3000 } },
+        { status: 'success', data: { minTime: 1000, maxTime: 2000, interval: 1 } },
+        { status: 'success', data: { minTime: 1000, maxTime: 3000, interval: 1 } },
     ];
     const calls = [];
     const api = makeApi(metas, calls);

--- a/tests/query_window_cap.test.mjs
+++ b/tests/query_window_cap.test.mjs
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createDataApi, defaultRangeFor } from '../src/viewer/assets/lib/data.js';
+
+// Locks in the overview-query contract: the WHOLE recording at its
+// NATIVE sampling interval. We deliberately do NOT decimate by widening
+// the PromQL step — measured behavior is that histogram queries ignore
+// `step` entirely (their resolution is the `stride` arg) so a coarse
+// step bounds nothing for them, while counters honor `step` but need
+// their rate window rewritten to match. Widening step therefore corrupts
+// queries (mismatched per-type resolution, skipped rewrites) without
+// reliably bounding payload — which showed up as charts not rendering
+// until zoom. Decimation for display is echarts' LTTB (client-side); the
+// real payload bound is a server-side post-evaluation reducer, tracked
+// separately. The Granularity selector (_stepOverride) still wins.
+
+function makeApi(calls, { minTime, maxTime, interval = 1 }) {
+    return createDataApi({
+        getMetadata: async () => ({
+            status: 'success',
+            data: { minTime, maxTime, interval },
+        }),
+        queryRange: async (query, start, end, step, captureId = 'baseline') => {
+            calls.push({ query, start, end, step, captureId });
+            return { status: 'success', data: { resultType: 'matrix', result: [] } };
+        },
+        logHeatmapErrors: false,
+    });
+}
+
+test('executePromQLRangeQuery: full range at native step (1s recording)', async () => {
+    const minTime = 1_700_000_000;
+    const maxTime = minTime + 86_400; // 24h @ 1s
+    const calls = [];
+    const api = makeApi(calls, { minTime, maxTime, interval: 1 });
+
+    await api.executePromQLRangeQuery('cpu_usage');
+
+    assert.equal(calls.length, 1);
+    const { start, end, step } = calls[0];
+    assert.equal(start, minTime, 'full range start = minTime (no trailing-window cap)');
+    assert.equal(end, maxTime);
+    assert.equal(step, 1, 'native step (1s) regardless of recording length — no step decimation');
+});
+
+test('executePromQLRangeQuery: step follows meta.interval (5s sampling)', async () => {
+    const minTime = 1_700_000_000;
+    const maxTime = minTime + 3_600;
+    const calls = [];
+    const api = makeApi(calls, { minTime, maxTime, interval: 5 });
+
+    await api.executePromQLRangeQuery('cpu_usage');
+    assert.equal(calls[0].step, 5, 'step = native interval (5s)');
+});
+
+test('executePromQLRangeQuery: sub-second interval clamps to a 1s step floor', async () => {
+    // metriken itself floors step at interval().max(1.0); mirror that.
+    const minTime = 1_700_000_000;
+    const maxTime = minTime + 600;
+    const calls = [];
+    const api = makeApi(calls, { minTime, maxTime, interval: 0.1 });
+
+    await api.executePromQLRangeQuery('cpu_usage');
+    assert.equal(calls[0].step, 1, 'sub-second interval rounds up to a 1s step');
+});
+
+test('executePromQLRangeQuery: step override (Granularity selector) wins', async () => {
+    const minTime = 1_700_000_000;
+    const maxTime = minTime + 86_400;
+    const calls = [];
+    const api = makeApi(calls, { minTime, maxTime, interval: 1 });
+
+    const { setStepOverride } = await import('../src/viewer/assets/lib/data.js');
+    setStepOverride(60);
+    try {
+        await api.executePromQLRangeQuery('cpu_usage');
+        assert.equal(calls[0].step, 60, 'user step override wins');
+    } finally {
+        setStepOverride(null);
+    }
+});
+
+test('executePromQLRangeQuery: missing interval falls back to a 1s step', async () => {
+    const minTime = 1_700_000_000;
+    const maxTime = minTime + 600;
+    const calls = [];
+    const api = makeApi(calls, { minTime, maxTime, interval: undefined });
+    await api.executePromQLRangeQuery('cpu_usage');
+    assert.equal(calls[0].step, 1, 'falls back to 1s when interval absent');
+});
+
+test('defaultRangeFor: whole span, native step, degenerate interval guarded', () => {
+    const minTime = 1_700_000_000;
+    const r = defaultRangeFor({ minTime, maxTime: minTime + 86_400, interval: 1 });
+    assert.deepEqual(r, { start: minTime, end: minTime + 86_400, step: 1 });
+
+    // A non-finite / non-positive interval falls back to a 1s step.
+    // (The f64::MAX-from-empty-multi-file case is normalized to 0.0
+    // server-side in routes.rs / crates/viewer, so the JS only ever sees
+    // 0 here, which this guard maps to 1.)
+    for (const bad of [0, NaN, undefined, -1]) {
+        const rr = defaultRangeFor({ minTime, maxTime: minTime + 600, interval: bad });
+        assert.equal(rr.step, 1, `interval=${bad} → step 1`);
+    }
+});


### PR DESCRIPTION
## Summary

- The chart-data path capped range queries to the trailing 3600s at ~500 points; that PromQL step made the metriken engine **average each bucket**, smoothing away the spikes the viewer exists to surface. Now queries the **whole recording at its native sampling interval** and lets echarts' LTTB decimate for display (a presentational pass that preserves extrema).
- Plumbs the native sampling `interval` (seconds) through the metadata endpoints — added to the server route **and** the WASM `MetadataData` (the static-site payload was missing it, silently forcing `step=1`). A degenerate interval (`0`, or `f64::MAX` from an empty multi-file reader) is normalized to `0.0` so the frontend fallback engages.
- Shared `defaultRangeFor(meta)` helper de-dupes the range/step logic across both `data.js` call sites and the embed demo.

## Why not decimate via a coarser PromQL step?

Investigated and rejected (an earlier draft tried it and broke rendering — charts didn't paint until zoomed in). Measured against a real parquet:

| query | step=1 | step=18 |
|---|---|---|
| `irate(counter[5m])` | 240 pts | 13 pts |
| `histogram_quantiles([...], h)` | 139 pts | **139 pts (identical)** |

**Histograms ignore `step` entirely** — resolution is set by their `stride` arg — so a coarse step bounds nothing for them, while counters need their rate window rewritten to match. `step` is a query-*semantics* lever, not a decimation knob. The correct payload bound is a **post-evaluation min/max reducer**, tracked separately.

## Known tradeoff

Payload is unbounded on very long recordings until the reducer lands — empirically tolerable for current recordings, and the correct fix is the reducer, not a step cap.

## Test plan

- [x] `node --test tests/*.mjs` — 149/149 (incl. new `query_window_cap.test.mjs` locking in whole-span native-step)
- [x] `tests/viewer_smoke.sh` — all four modes green
- [x] `cargo check -p rezolus` + WASM crate (Homebrew LLVM) clean
- [x] `cargo fmt --check`, `cargo clippy -p rezolus` clean
- [ ] Eyeball a real long recording in the browser (renders on load, spikes visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)