### PR TITLE
release: prepare v5.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [5.16.1] - 2026-07-08
+
+### Fixed
+
+- Viewer: chart queries now fetch the whole recording at its native
+  sampling interval instead of a decimated trailing window, so charts
+  render on load and short-lived spikes are no longer averaged away
+  before they reach the display. The native sampling interval is now
+  exposed by the metadata endpoints (server and WASM). (#995)
+
 ## [5.16.0] - 2026-07-07
 
 ### Added
@@ -910,7 +920,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.16.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.16.1...HEAD
+[5.16.1]: https://github.com/iopsystems/rezolus/compare/v5.16.0...v5.16.1
 [5.16.0]: https://github.com/iopsystems/rezolus/compare/v5.15.0...v5.16.0
 [5.15.0]: https://github.com/iopsystems/rezolus/compare/v5.14.0...v5.15.0
 [5.14.0]: https://github.com/iopsystems/rezolus/compare/v5.13.0...v5.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.16.1-alpha.1"
+version = "5.16.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.16.1-alpha.1"
+version = "5.16.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Release v5.16.1

This PR prepares the release of v5.16.1.

### Changes
- Version bump `5.16.1-alpha.1` → `5.16.1` (Cargo.toml + Cargo.lock)
- Changelog update

### Included since v5.16.0
- fix(viewer): query full recording at native step, drop windowed decimation (#995)

### After Merge
The release workflows will automatically:
1. Create git tag `v5.16.1` and bump to the next dev version
2. Build and publish packages (deb, rpm, Homebrew)
3. Create the GitHub release with all artifacts
4. Publish to crates.io

---
See CHANGELOG.md for details.