### PR TITLE
fix(viewer): make chart expansion work in simple-metric (source) mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.16.2-alpha.1"
+version = "5.16.2-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.16.2-alpha.1"
+version = "5.16.2-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/charts/source_metric.js
+++ b/site/viewer/lib/charts/source_metric.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/charts/source_metric.js

--- a/site/viewer/lib/features/source_routes.js
+++ b/site/viewer/lib/features/source_routes.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/features/source_routes.js

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -19,6 +19,7 @@ import { initTheme } from './ui/theme.js';
 import { isHistogramPlot } from './charts/metric_types.js';
 import { renderServiceSection, createServiceRoutes } from './features/service.js';
 import { MetricBrowserView } from './features/metric_browser.js';
+import { createSourceRoutes } from './features/source_routes.js';
 import { createGroupComponent, getCachedSectionMeta, buildClientOnlySectionView } from './viewer_core.js';
 import { renderSectionNotes } from './sections/section_notes.js';
 import {
@@ -915,43 +916,24 @@ const initDashboard = (config = {}) => {
             withSharedSections: withCachedSections,
             getDefaultRoute: () => defaultRoute,
         }),
-        // Foreign-source sections. Unlike built-in/service sections these
-        // carry no server-rendered groups — the MetricBrowser (mounted by
-        // SectionContent's `/source/` branch) fetches its own catalog via
-        // ViewerApi.getMetrics and runs per-metric queries client-side.
-        // So there's nothing to loadSection here; just resolve the
-        // activeSection and hand it to Main.
-        '/source/:sourceName': {
-            onmatch(params, requestedPath) {
-                if (m.route.get() === requestedPath) {
-                    return new Promise(function () {});
-                }
-                if (requestedPath !== m.route.get()) {
-                    chartsState.charts.clear();
-                    window.scrollTo(0, 0);
-                }
-                const sectionRoute = `/source/${params.sourceName}`;
-                return {
-                    view() {
-                        const activeSection = getCachedSections().find(
-                            (s) => s.route === sectionRoute,
-                        ) || { name: `source: ${params.sourceName}`, route: sectionRoute };
-                        // Interval isn't strictly required — Chart tolerates
-                        // its absence (QueryExplorer passes none) and the
-                        // query window is derived from metadata. Borrow it
-                        // from any cached section when present.
-                        const anyCached = Object.values(sectionResponseCache)[0];
-                        return m(Main, {
-                            activeSection,
-                            groups: [],
-                            sections: getCachedSections(),
-                            compareMode,
-                            interval: anyCached?.interval,
-                        });
-                    },
-                };
-            },
-        },
+        // Foreign-source ("simple capture") sections + their expanded single
+        // charts. Unlike built-in/service sections these carry no
+        // server-rendered groups — the MetricBrowser fetches its own catalog
+        // and runs per-metric queries client-side — so the chart route
+        // reconstructs one chart from the catalog. See features/source_routes.js.
+        ...createSourceRoutes({
+            sectionResponseCache,
+            ViewerApi,
+            processDashboardData,
+            applyResultToPlot,
+            SingleChartView,
+            TopNav,
+            topNavAttrs,
+            Main,
+            getSections: getCachedSections,
+            getCompareMode: () => compareMode,
+            chartsState,
+        }),
         '/about': {
             render() {
                 return m('div', { style: 'display:flex;align-items:center;justify-content:center;min-height:100vh;padding:2rem' },

--- a/src/viewer/assets/lib/charts/source_metric.js
+++ b/src/viewer/assets/lib/charts/source_metric.js
@@ -1,0 +1,51 @@
+// Shared plot-spec construction for foreign (non-Rezolus) source metrics.
+//
+// Two consumers must agree byte-for-byte on the spec — the MetricBrowser, which
+// renders a selected metric inline, and the `/source/:sourceName/chart/:chartId`
+// single-chart route, which reconstructs one chart from the URL. The chart id
+// is the shared handle between them: the expand link builds
+// `#/source/<name>/chart/<opts.id>`, and the route resolves `<opts.id>` back to
+// the same metric via `specForChartId`. Keep them in one place so the id and
+// the type→query mapping can't drift.
+
+import { buildDefaultQuery } from './metric_types.js';
+
+/** Deterministic chart id for a source metric — the round-trip handle. */
+export const sourceMetricChartId = (name) => `source-metric-${name}`;
+
+/**
+ * Build a section-style plot spec for a foreign-source metric.
+ *
+ * Histograms carry the RAW metric name as `promql_query` (with
+ * `opts.subtype = 'percentiles'`) because the section pipeline
+ * (buildEffectiveQuery) wraps histograms itself; passing an already-wrapped
+ * `histogram_quantiles(...)` would double-wrap and return no data.
+ * Counters/gauges are not re-wrapped, so they carry their buildDefaultQuery
+ * form (rate(...) / raw).
+ */
+export const specForSourceMetric = (info) => {
+    const opts = {
+        id: sourceMetricChartId(info.name),
+        title: info.name,
+        description: info.description || '',
+        type: info.metric_type,
+    };
+    let promql_query;
+    if (info.metric_type === 'histogram') {
+        opts.subtype = 'percentiles';
+        promql_query = info.name;
+    } else {
+        promql_query = buildDefaultQuery(info);
+    }
+    return { promql_query, opts };
+};
+
+/**
+ * Resolve the plot spec for a chart id against a metric catalog (as returned by
+ * `ViewerApi.getMetrics`). Returns null when no metric matches — an unknown or
+ * stale id, or an empty/absent catalog.
+ */
+export const specForChartId = (chartId, metrics) => {
+    const info = (metrics || []).find((mi) => sourceMetricChartId(mi.name) === chartId);
+    return info ? specForSourceMetric(info) : null;
+};

--- a/src/viewer/assets/lib/features/metric_browser.js
+++ b/src/viewer/assets/lib/features/metric_browser.js
@@ -11,37 +11,13 @@
 // did nothing). The per-metric query is run via `runQuery` (app.js's
 // processDashboardData wrapper) which populates the plot spec in place.
 
-import { buildDefaultQuery } from '../charts/metric_types.js';
+import { specForSourceMetric } from '../charts/source_metric.js';
 import { ViewerApi } from '../viewer_api.js';
 import { DEFAULT_SORT, cycleSortKeys, sortMetrics } from './metric_sort.js';
 
-// Build a section-style plot spec for a metric. Carrying `promql_query`
-// (not just opts) is what lets the section pipeline populate data and the
-// scatter Full/Tail controls fetch their spectra. Histograms need
-// opts.subtype so resolveStyle() picks 'scatter'; gauge and counter infer
-// their style from the result shape.
-const specForMetric = (info) => {
-    const opts = {
-        id: `source-metric-${info.name}`,
-        title: info.name,
-        description: info.description || '',
-        type: info.metric_type,
-    };
-    // The section pipeline (buildEffectiveQuery) wraps histograms itself from
-    // opts.type/subtype, so a histogram's promql_query must be the RAW metric —
-    // passing buildDefaultQuery's already-wrapped histogram_quantiles(...) would
-    // double-wrap it (`histogram_quantiles(..., histogram_quantiles(...))`) and
-    // return no data. Counters/gauges are not re-wrapped by the pipeline, so they
-    // carry their buildDefaultQuery form (rate(...) / raw).
-    let promql_query;
-    if (info.metric_type === 'histogram') {
-        opts.subtype = 'percentiles';
-        promql_query = info.name;
-    } else {
-        promql_query = buildDefaultQuery(info);
-    }
-    return { promql_query, opts };
-};
+// Plot-spec construction lives in charts/source_metric.js so this inline render
+// and the /source/:sourceName/chart/:chartId single-chart route derive the SAME
+// spec (and the same opts.id, which is the chart-URL handle).
 
 // The component must keep a stable vnode identity across redraws or Mithril
 // tears it down and remounts it (losing filter/selection/chartsState and
@@ -92,7 +68,7 @@ export function MetricBrowserView(sourceName) {
                     return;
                 }
 
-                const plot = specForMetric(info);
+                const plot = specForSourceMetric(info);
                 const entry = { plot, status: 'loading' };
                 st.selected.set(info.name, entry);
                 m.redraw();

--- a/src/viewer/assets/lib/features/source_routes.js
+++ b/src/viewer/assets/lib/features/source_routes.js
@@ -1,0 +1,145 @@
+// Route map for foreign (non-Rezolus) "simple capture" source sections.
+// Mirrors features/service.js's createServiceRoutes so app.js can spread it in.
+//
+// Extracted from app.js (rather than inlined) so the single-chart
+// reconstruction — the part that was broken in Bug 1 — is unit-testable with
+// stubbed deps (see tests/source_routes.test.mjs).
+//
+// A source section has NO server-rendered groups: the MetricBrowser fetches its
+// own catalog and runs per-metric queries client-side. So the expanded
+// single-chart route can't resolve a plot from a cached section the way the
+// built-in / service chart routes do — it reconstructs the one chart from the
+// catalog. The chart id encodes the metric (charts/source_metric.js), so
+// specForChartId re-derives the same spec the MetricBrowser rendered.
+
+import { specForChartId } from '../charts/source_metric.js';
+
+export function createSourceRoutes(deps) {
+    const {
+        sectionResponseCache,
+        ViewerApi,
+        processDashboardData,
+        applyResultToPlot,
+        SingleChartView,
+        TopNav,
+        topNavAttrs,
+        Main,
+        getSections,
+        getCompareMode,
+        chartsState,
+    } = deps;
+
+    return {
+        '/source/:sourceName/chart/:chartId': {
+            onmatch(params) {
+                const sourceName = params.sourceName;
+                const chartId = decodeURIComponent(params.chartId);
+                const sectionRoute = `/source/${sourceName}`;
+                // Same one-plot pipeline wrapper the MetricBrowser mount uses,
+                // so the reconstructed plot is populated identically (data +
+                // _resolvedStyle) and renders with a title + working controls.
+                const runQuery = (plot) => processDashboardData(
+                    { groups: [{ name: '', subgroups: [{ name: null, plots: [plot] }] }] },
+                    null,
+                    sectionRoute,
+                );
+
+                // Closure state, mirroring app.js's '/:section/chart/:chartId':
+                // fetch + query asynchronously, redraw when resolved. `ready`
+                // is exposed so tests can await the reconstruction.
+                const st = { plot: null, loading: true, error: null };
+                const ready = ViewerApi.getMetrics(sourceName)
+                    .then(async (resp) => {
+                        const spec = specForChartId(chartId, (resp && resp.metrics) || []);
+                        if (!spec) {
+                            st.error = `Chart "${chartId}" not found`;
+                        } else {
+                            try {
+                                await runQuery(spec);
+                                st.plot = spec;
+                            } catch (e) {
+                                st.error = (e && e.message) || 'Query failed';
+                            }
+                        }
+                        st.loading = false;
+                        m.redraw();
+                    })
+                    .catch((e) => {
+                        st.error = (e && e.message) || 'Failed to load metrics';
+                        st.loading = false;
+                        m.redraw();
+                    });
+
+                return {
+                    ready,
+                    view() {
+                        const activeSection = getSections().find((s) => s.route === sectionRoute)
+                            || { name: `source: ${sourceName}`, route: sectionRoute };
+                        if (st.loading) {
+                            return m('div#splash', m('div.card', [
+                                m('h1', activeSection.name),
+                                m('p.subtitle', 'Loading…'),
+                                m('div.progress-bar',
+                                    m('div.progress-fill.indeterminate'),
+                                ),
+                            ]));
+                        }
+                        // Borrow file-level metadata from any cached section for
+                        // the TopNav chrome; source sections don't populate the
+                        // cache, so this is best-effort.
+                        const anyCached = Object.values(sectionResponseCache)[0] || {};
+                        const data = {
+                            groups: st.plot ? [{ subgroups: [{ plots: [st.plot] }] }] : [],
+                            filename: anyCached.filename,
+                            source: anyCached.source,
+                            version: anyCached.version,
+                            interval: anyCached.interval,
+                            filesize: anyCached.filesize,
+                            num_series: anyCached.num_series,
+                        };
+                        return m('div', [
+                            m(TopNav, topNavAttrs(data, activeSection.route)),
+                            m('main.single-chart-main', [
+                                st.error
+                                    ? m('div.single-chart-view', m('p', st.error))
+                                    : m(SingleChartView, { data, chartId, applyResultToPlot }),
+                            ]),
+                        ]);
+                    },
+                };
+            },
+        },
+
+        '/source/:sourceName': {
+            onmatch(params, requestedPath) {
+                if (m.route.get() === requestedPath) {
+                    return new Promise(function () {});
+                }
+                if (requestedPath !== m.route.get()) {
+                    chartsState.charts.clear();
+                    window.scrollTo(0, 0);
+                }
+                const sectionRoute = `/source/${params.sourceName}`;
+                return {
+                    view() {
+                        const activeSection = getSections().find(
+                            (s) => s.route === sectionRoute,
+                        ) || { name: `source: ${params.sourceName}`, route: sectionRoute };
+                        // Interval isn't strictly required — Chart tolerates
+                        // its absence (QueryExplorer passes none) and the query
+                        // window is derived from metadata. Borrow it from any
+                        // cached section when present.
+                        const anyCached = Object.values(sectionResponseCache)[0];
+                        return m(Main, {
+                            activeSection,
+                            groups: [],
+                            sections: getSections(),
+                            compareMode: getCompareMode(),
+                            interval: anyCached?.interval,
+                        });
+                    },
+                };
+            },
+        },
+    };
+}

--- a/tests/source_metric_chart.test.mjs
+++ b/tests/source_metric_chart.test.mjs
@@ -1,0 +1,66 @@
+// Bug 1: expanding a chart in simple-metric (foreign source) mode was dead —
+// the expand link builds `#/source/<name>/chart/<id>`, a 4-segment route that
+// matched nothing, and even if routed there was no server-rendered section to
+// resolve the plot from. The single-chart route reconstructs the chart from the
+// URL by re-deriving the spec from the metric catalog. That only works if the
+// expand link and the resolver agree on `opts.id` and on how each metric type
+// maps to a query — this pins that shared contract.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    sourceMetricChartId,
+    specForSourceMetric,
+    specForChartId,
+} from '../src/viewer/assets/lib/charts/source_metric.js';
+
+test('chart id convention is source-metric-<name>', () => {
+    assert.equal(sourceMetricChartId('hub_heartbeat'), 'source-metric-hub_heartbeat');
+});
+
+test('counter spec: rate() query, stable id, carried metadata', () => {
+    const spec = specForSourceMetric({
+        name: 'hub_heartbeat',
+        metric_type: 'counter',
+        description: 'beats',
+    });
+    assert.equal(spec.opts.id, 'source-metric-hub_heartbeat');
+    assert.equal(spec.opts.type, 'counter');
+    assert.equal(spec.opts.title, 'hub_heartbeat');
+    assert.equal(spec.opts.description, 'beats');
+    assert.equal(spec.promql_query, 'rate(hub_heartbeat[5m])');
+});
+
+test('gauge spec: raw query, empty description default', () => {
+    const spec = specForSourceMetric({ name: 'queue_depth', metric_type: 'gauge' });
+    assert.equal(spec.promql_query, 'queue_depth');
+    assert.equal(spec.opts.description, '');
+});
+
+test('histogram spec: RAW metric + percentiles subtype (pipeline wraps once)', () => {
+    // Must be the bare name, NOT histogram_quantiles(...) — the section
+    // pipeline wraps histograms itself; a pre-wrapped query double-wraps.
+    const spec = specForSourceMetric({ name: 'latency', metric_type: 'histogram' });
+    assert.equal(spec.promql_query, 'latency');
+    assert.equal(spec.opts.subtype, 'percentiles');
+    assert.equal(spec.opts.type, 'histogram');
+});
+
+test('specForChartId round-trips the expand-link id back to the same spec', () => {
+    const catalog = [
+        { name: 'hub_heartbeat', metric_type: 'counter' },
+        { name: 'queue_depth', metric_type: 'gauge' },
+        { name: 'latency', metric_type: 'histogram' },
+    ];
+    for (const info of catalog) {
+        const built = specForSourceMetric(info);
+        const resolved = specForChartId(built.opts.id, catalog);
+        assert.deepEqual(resolved, built);
+    }
+});
+
+test('specForChartId returns null for unknown or stale ids', () => {
+    const catalog = [{ name: 'hub_heartbeat', metric_type: 'counter' }];
+    assert.equal(specForChartId('source-metric-does_not_exist', catalog), null);
+    assert.equal(specForChartId('source-metric-hub_heartbeat', []), null);
+    assert.equal(specForChartId('source-metric-hub_heartbeat', undefined), null);
+});

--- a/tests/source_routes.test.mjs
+++ b/tests/source_routes.test.mjs
@@ -1,0 +1,136 @@
+// Regression test for Bug 1: expanding a chart in simple-metric (foreign
+// source) mode. The `/source/:sourceName/chart/:chartId` route must reconstruct
+// the single chart from the metric catalog (there is no server-rendered section
+// to resolve it from) and hand a populated plot to SingleChartView. Mirrors
+// tests/service_routes.test.mjs — the route factory is exported so its onmatch
+// is exercisable with stubbed deps.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createSourceRoutes } from '../src/viewer/assets/lib/features/source_routes.js';
+
+// Minimal hyperscript fake that distinguishes an attrs object (plain object,
+// no `tag`) from children (array / string / vnode), so we can walk the tree.
+const setupGlobals = () => {
+    const prevM = globalThis.m;
+    const prevWindow = globalThis.window;
+    globalThis.m = (tag, attrs, ...rest) => {
+        let children;
+        if (Array.isArray(attrs)) {
+            children = attrs; // m(tag, [children])
+            attrs = {};
+        } else if (attrs && typeof attrs === 'object' && !('tag' in attrs)) {
+            children = rest; // m(tag, attrsObject, ...children)
+        } else {
+            children = [attrs, ...rest].filter((x) => x !== undefined); // m(tag, child)
+            attrs = {};
+        }
+        return { tag, attrs, children };
+    };
+    globalThis.m.route = { get: () => '/overview', set: () => {} };
+    globalThis.m.redraw = () => {};
+    globalThis.window = { scrollTo() {} };
+    return () => {
+        globalThis.m = prevM;
+        globalThis.window = prevWindow;
+    };
+};
+
+const findByTag = (vnode, tag) => {
+    if (Array.isArray(vnode)) {
+        for (const v of vnode) {
+            const found = findByTag(v, tag);
+            if (found) return found;
+        }
+        return null;
+    }
+    if (!vnode || typeof vnode !== 'object') return null;
+    if (vnode.tag === tag) return vnode;
+    return findByTag(vnode.children, tag);
+};
+
+const baseDeps = (over = {}) => ({
+    sectionResponseCache: {},
+    ViewerApi: {
+        getMetrics: async () => ({
+            metrics: [
+                { name: 'hub_heartbeat', metric_type: 'counter' },
+                { name: 'queue_depth', metric_type: 'gauge' },
+            ],
+        }),
+    },
+    // Mimic processDashboardData: populate the plot in place and resolve.
+    processDashboardData: async (payload) => {
+        const plot = payload.groups[0].subgroups[0].plots[0];
+        plot.data = [[[0, 1]]];
+        return payload;
+    },
+    applyResultToPlot: () => {},
+    SingleChartView: 'SingleChartView',
+    TopNav: 'TopNav',
+    topNavAttrs: (data, route) => ({ data, route }),
+    Main: 'Main',
+    getSections: () => [{ name: 'source: hub', route: '/source/hub' }],
+    getCompareMode: () => false,
+    chartsState: { charts: new Map() },
+    ...over,
+});
+
+test('source chart route reconstructs the chart from the catalog', async () => {
+    const restore = setupGlobals();
+    try {
+        const routes = createSourceRoutes(baseDeps());
+        const comp = routes['/source/:sourceName/chart/:chartId'].onmatch({
+            sourceName: 'hub',
+            chartId: 'source-metric-hub_heartbeat',
+        });
+        await comp.ready; // await the async reconstruction
+
+        const v = comp.view();
+        const scv = findByTag(v, 'SingleChartView');
+        assert.ok(scv, 'expected SingleChartView to render once reconstructed');
+        assert.equal(scv.attrs.chartId, 'source-metric-hub_heartbeat');
+
+        const plots = scv.attrs.data.groups[0].subgroups[0].plots;
+        assert.equal(plots[0].opts.id, 'source-metric-hub_heartbeat');
+        assert.equal(plots[0].promql_query, 'rate(hub_heartbeat[5m])');
+        assert.ok(plots[0].data, 'plot should be populated by the query');
+    } finally {
+        restore();
+    }
+});
+
+test('source chart route reports not-found for an unknown chart id', async () => {
+    const restore = setupGlobals();
+    try {
+        const routes = createSourceRoutes(baseDeps());
+        const comp = routes['/source/:sourceName/chart/:chartId'].onmatch({
+            sourceName: 'hub',
+            chartId: 'source-metric-does_not_exist',
+        });
+        await comp.ready;
+
+        const v = comp.view();
+        assert.equal(findByTag(v, 'SingleChartView'), null, 'no chart for a stale id');
+        // TopNav still renders so the user can navigate away.
+        assert.ok(findByTag(v, 'TopNav'), 'expected TopNav in the error view');
+    } finally {
+        restore();
+    }
+});
+
+test('source section route hands an empty group list to Main', async () => {
+    const restore = setupGlobals();
+    try {
+        const routes = createSourceRoutes(baseDeps());
+        const result = routes['/source/:sourceName'].onmatch(
+            { sourceName: 'hub' },
+            '/source/hub',
+        );
+        const v = result.view();
+        assert.equal(v.tag, 'Main');
+        assert.equal(v.attrs.activeSection.route, '/source/hub');
+        assert.deepEqual(v.attrs.groups, []);
+    } finally {
+        restore();
+    }
+});


### PR DESCRIPTION
## Bug

Clicking a chart's **Expand** link in a foreign-source ("simple capture") section did nothing. The expand link builds `#/source/<name>/chart/<id>` — a 4-segment path that matched **no** route. And even if it had, the existing `/:section/chart/:chartId` handler resolves the plot from a cached server-rendered section, which source sections never have (the MetricBrowser fetches its own catalog and runs queries client-side).

## Fix

Add a `/source/:sourceName/chart/:chartId` route that **reconstructs** the single chart from the metric catalog. The chart id encodes the metric name, so the route re-derives the same plot spec the MetricBrowser rendered, runs its query through the same one-plot pipeline, and hands the populated plot to `SingleChartView`.

- **`charts/source_metric.js`** (new) owns spec construction — `sourceMetricChartId` / `specForSourceMetric` / `specForChartId`. The MetricBrowser (which builds the expand-link id) and the route (which resolves it) now share **one** implementation, so the id and the type→query mapping can't drift. `metric_browser.js` imports it instead of its private copy.
- **`features/source_routes.js`** (new) — `createSourceRoutes`, mirroring `features/service.js`, so the reconstruction is unit-testable; `app.js` spreads it in (both source routes moved out of the inline route map).
- New **`site/viewer/lib/` symlinks** for both shared modules so the static WASM viewer serves them too. These are tracked, per-file symlinks — a new shared frontend module needs its own, or the deployed WASM viewer 404s on the import. (Exactly the hazard the `viewer-parity` skill flags.)

This is a shared-frontend change, so it lands for **both** the server and WASM viewers at once — no Rust change.

## Tests

- `tests/source_metric_chart.test.mjs` — the spec/id round-trip contract: the expand-link id resolves back to the same spec; counter→`rate`, gauge→raw, histogram→raw+`percentiles`; null for stale ids.
- `tests/source_routes.test.mjs` — the route reconstructs the chart from a stubbed catalog and renders `SingleChartView` with the populated plot; the not-found path; the source section hands empty groups to `Main`.

Verification: `node --test tests/*.mjs` 160 green · `node --check` on all changed JS · server build · dev-mode smoke (source section present, both new JS assets serve HTTP 200, `/api/v1/metrics` returns the catalog the route reconstructs from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)