### PR TITLE
release: prepare v5.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+## [5.16.2] - 2026-07-09
+
+### Fixed
+
+- Viewer: non-Rezolus "simple capture" parquets now render correctly in the
+  browser (WASM) viewer. The per-source `source:` section and its metric
+  browser appear instead of empty Rezolus built-in sections. Source
+  classification is now shared between the server and WASM backends, and also
+  applies to captures uploaded to the server. (#997)
+- Viewer: the chart Expand link now works in simple-capture (source) sections.
+  Expanding a metric chart reconstructs it from the metric catalog and opens it
+  in the single-chart view instead of landing on a blank route. (#998)
+
 ## [5.16.1] - 2026-07-08
 
 ### Fixed
@@ -920,7 +933,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.16.1...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.16.2...HEAD
+[5.16.2]: https://github.com/iopsystems/rezolus/compare/v5.16.1...v5.16.2
 [5.16.1]: https://github.com/iopsystems/rezolus/compare/v5.16.0...v5.16.1
 [5.16.0]: https://github.com/iopsystems/rezolus/compare/v5.15.0...v5.16.0
 [5.15.0]: https://github.com/iopsystems/rezolus/compare/v5.14.0...v5.15.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.16.2-alpha.2"
+version = "5.16.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.16.2-alpha.2"
+version = "5.16.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Release v5.16.2

This PR prepares the release of v5.16.2.

### Changes
- Version bump in `Cargo.toml` / `Cargo.lock` (`5.16.2-alpha.2` → `5.16.2`)
- Changelog update

### Included since v5.16.1
- Viewer: non-Rezolus "simple capture" parquets render correctly in the WASM viewer; source classification is shared between the server and WASM backends and applies to server uploads too (#997)
- Viewer: chart Expand works in simple-capture (source) sections (#998)

(#997 also added the internal `viewer-parity` skill, omitted from the user-facing changelog.)

### After Merge
The release workflows will automatically:
1. Create git tag `v5.16.2` and bump to next dev version (`5.16.3-alpha.0`)
2. Build and publish packages (deb, rpm, Homebrew)
3. Create the GitHub release with all artifacts

---
See CHANGELOG.md for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)