### PR TITLE
perf(parquet): smaller row groups (1800) for fast viewer drill-down

### DIFF
--- a/crates/report-save/src/lib.rs
+++ b/crates/report-save/src/lib.rs
@@ -34,9 +34,12 @@ pub const KEY_SELECTION: &str = "selection";
 pub const KEY_DESCRIPTIONS: &str = "descriptions";
 pub const KEY_EVENTS: &str = "events";
 
-/// Matches metriken-exposition's ParquetWriter default; row group sizing
-/// stays consistent with what the recorder produces.
-pub const MAX_ROW_GROUP_SIZE: usize = 50_000;
+/// Row group size for saved reports; stays consistent with what the recorder
+/// produces (`rezolus::parquet_metadata::MAX_ROW_GROUP_SIZE`). Kept smaller
+/// than metriken-exposition's 50k default so the viewer's windowed (zoom)
+/// reads decode far fewer row groups — see that constant for the measured
+/// drill-down/size tradeoff.
+pub const MAX_ROW_GROUP_SIZE: usize = 1800;
 
 // ── Payload types ────────────────────────────────────────────────────
 

--- a/src/hindsight/http.rs
+++ b/src/hindsight/http.rs
@@ -432,7 +432,10 @@ fn convert_to_parquet(
     let output =
         tempfile::tempfile().map_err(|e| format!("failed to create output temp file: {}", e))?;
 
-    let mut converter = MsgpackToParquet::with_options(ParquetOptions::new()).metadata(
+    let mut converter = MsgpackToParquet::with_options(
+        ParquetOptions::new().max_batch_size(crate::parquet_metadata::MAX_ROW_GROUP_SIZE),
+    )
+    .metadata(
         "sampling_interval_ms".to_string(),
         interval.as_millis().to_string(),
     );

--- a/src/hindsight/mod.rs
+++ b/src/hindsight/mod.rs
@@ -421,7 +421,10 @@ fn perform_dump_to_file(
         return DumpToFileResponse::error("failed to rewind packed file".to_string());
     }
 
-    let mut converter = MsgpackToParquet::with_options(ParquetOptions::new()).metadata(
+    let mut converter = MsgpackToParquet::with_options(
+        ParquetOptions::new().max_batch_size(crate::parquet_metadata::MAX_ROW_GROUP_SIZE),
+    )
+    .metadata(
         "sampling_interval_ms".to_string(),
         config.general().interval().as_millis().to_string(),
     );

--- a/src/parquet_metadata.rs
+++ b/src/parquet_metadata.rs
@@ -2,12 +2,19 @@
 
 // ── Parquet writer settings ─────────────────────────────────────────────
 
-/// Maximum number of rows per row group. Matches the value used by
-/// `metriken-exposition`'s `ParquetWriter` (`DEFAULT_MAX_BATCH_SIZE`).
-/// All rezolus tools that write parquet files should use this constant
-/// so that row group sizing is consistent across recordings and combined
-/// files.
-pub const MAX_ROW_GROUP_SIZE: usize = 50_000;
+/// Maximum number of rows per row group. All rezolus tools that write parquet
+/// files should apply this (via `ParquetOptions::max_batch_size`) so row group
+/// sizing is consistent across recordings and combined files.
+///
+/// Deliberately smaller than `metriken-exposition`'s 50k default: the viewer
+/// reads time-windowed slices when you zoom in, and a query only decodes the
+/// row groups that overlap the window. Finer groups make drill-down far
+/// cheaper — measured on a 24h @1s recording, a 5-minute-window histogram
+/// query dropped from ~474 ms (2 giant groups) to ~20 ms at 1800 rows/group,
+/// while full-range scans are unchanged (decode-bound). The cost is worse
+/// compression: ~1.75× file size on that recording (small groups compress
+/// less well). 1800 rows ≈ 30 min at the default 1 s sampling interval.
+pub const MAX_ROW_GROUP_SIZE: usize = 1800;
 
 // ── Top-level parquet footer keys ───────────────────────────────────────
 

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -343,7 +343,10 @@ fn build_parquet_converter(
     ep: &EndpointState,
     prom_converter: &Option<prometheus::PrometheusConverter>,
 ) -> MsgpackToParquet {
-    let mut converter = MsgpackToParquet::with_options(ParquetOptions::new()).metadata(
+    let mut converter = MsgpackToParquet::with_options(
+        ParquetOptions::new().max_batch_size(parquet_metadata::MAX_ROW_GROUP_SIZE),
+    )
+    .metadata(
         "sampling_interval_ms".to_string(),
         config.interval.as_millis().to_string(),
     );

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -598,7 +598,8 @@ fn snapshots_to_parquet(
     let reader = Cursor::new(raw);
     let mut output = Vec::new();
     let mut converter = metriken_exposition::MsgpackToParquet::with_options(
-        metriken_exposition::ParquetOptions::new(),
+        metriken_exposition::ParquetOptions::new()
+            .max_batch_size(crate::parquet_metadata::MAX_ROW_GROUP_SIZE),
     )
     .metadata("sampling_interval_ms".to_string(), "1000".to_string());
 


### PR DESCRIPTION
## Summary

Set `MAX_ROW_GROUP_SIZE` **50,000 → 1,800** and actually apply it (via `ParquetOptions::max_batch_size`) at every rezolus parquet write site — recorder, hindsight, viewer "save", `combine`/`filter`, and `report-save`. It was previously documentation-only, relying on it coincidentally matching metriken-exposition's 50k default.

## Why

The viewer decodes only the row groups that overlap a query's time window (`rg_classify` already skips the rest), so **finer row groups make zoom drill-down far cheaper** — with no query-engine changes.

Measured on a real 24h @1s recording:

| query | 2 giant groups (before) | 1800-row groups (after) |
|---|---|---|
| histogram p50, **5-min window** | ~474 ms | **~20 ms** (~24×) |
| histogram p50, full range | ~2000 ms | ~1900 ms (unchanged) |

Full-range scans are decode-bound and unaffected; this is purely a **windowed/zoom-read** win.

## Tradeoff (please weigh)

- **File size ~1.75×** on that recording — smaller row groups compress less well (zstd). A coarser size (e.g. 3600–4800 rows) trades some drill-down speed for less bloat; 1800 was chosen for the snappiest drill-down.
- **Only affects newly written files** — existing recordings keep their current layout.

## Test plan

- [x] `cargo test -p rezolus -p report-save` — 219 + 15 pass
- [x] `cargo clippy` / `cargo fmt --check` on the changed files — clean
- [ ] Reviewer: confirm the ~1.75× size tradeoff is acceptable as the default (vs a coarser value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)