### PR TITLE
fix(viewer): build wasm pkg with --release + env size opts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,12 +159,10 @@ debug = true
 lto = true
 codegen-units = 1
 
-# Profile used by crates/viewer/build.sh for the wasm build. Smaller and
-# debuginfo-free so the .wasm artifact stays compact when shipped to browsers.
-[profile.wasm-release]
-inherits = "release"
-opt-level = "s"
-debug = false
+# NOTE: the wasm viewer's size-optimized build (opt-level "s", no debuginfo) is
+# applied via CARGO_PROFILE_RELEASE_* env overrides in crates/viewer/build.sh,
+# not a custom [profile.wasm-release] — wasm-pack's --release mode conflicts with
+# cargo's --profile flag.
 
 [package.metadata.deb]
 maintainer = "IOP Systems <team@iop.systems>"

--- a/crates/viewer/build.sh
+++ b/crates/viewer/build.sh
@@ -2,8 +2,14 @@
 # Build the WASM viewer and place the output in site/viewer/pkg/ so it can be
 # loaded by the static site frontend (imports `../pkg/wasm_viewer.js`).
 #
-# Requires `wasm-pack` (>= 0.13 for --profile support) and (on macOS) Homebrew
-# LLVM for compiling zstd to wasm32.
+# Requires `wasm-pack` and (on macOS) Homebrew LLVM for compiling zstd to wasm32.
+#
+# We build with `--release` and size-optimize via the CARGO_PROFILE_RELEASE_*
+# env overrides below rather than a custom `--profile`: wasm-pack's build-mode
+# flag (`--release`) is mutually exclusive with cargo's `--profile`, so passing
+# `--profile wasm-release` made cargo reject the invocation
+# ("--release cannot be used with --profile"). The env overrides apply only to
+# this wasm build and leave the native `[profile.release]` untouched.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,9 +49,13 @@ if command -v brew >/dev/null 2>&1 && LLVM_PREFIX=$(brew --prefix llvm 2>/dev/nu
 fi
 
 cd "$SCRIPT_DIR"
+# opt-level "s" + no debug info == the old [profile.wasm-release]; applied via env
+# so it only affects this release build, not the native binary's release profile.
+export CARGO_PROFILE_RELEASE_OPT_LEVEL="s"
+export CARGO_PROFILE_RELEASE_DEBUG="false"
 wasm-pack build \
     --target web \
     --out-dir "$OUT_DIR" \
     --out-name wasm_viewer \
-    --profile wasm-release \
+    --release \
     "$@"


### PR DESCRIPTION
## Summary
`crates/viewer/build.sh` couldn't build the WASM viewer pkg: it passed `--profile wasm-release` to wasm-pack, but wasm-pack injects its own `--release` build-mode flag, and cargo rejects `--release` + `--profile` together (*"--release cannot be used with --profile"*). wasm-pack 0.13.x has no `--profile` flag.

Fix: build with `--release` and apply the size settings — `opt-level = "s"`, no debuginfo (identical to the old `[profile.wasm-release]`) — via `CARGO_PROFILE_RELEASE_OPT_LEVEL` / `CARGO_PROFILE_RELEASE_DEBUG` env overrides, scoped to this build so the native `[profile.release]` is untouched. Removed the now-unused `[profile.wasm-release]`.

## Test plan
- [x] `./crates/viewer/build.sh` builds + wasm-opts + emits `site/viewer/pkg/` (was failing before)
- [x] `node --test tests/wasm_viewer_simple_capture.test.mjs` — 2/2 pass (were failing with no pkg)
- [x] `.wasm` still size-optimized (opt-level "s" + wasm-opt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)