### PR TITLE
fix(viewer): ETag-revalidate JS assets; skip section reload on client-only routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.16.3-alpha.0"
+version = "5.16.3-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.16.3-alpha.0"
+version = "5.16.3-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -91,24 +91,22 @@ Source: [display-mode decimation](journal/2026-07-13-viewer-display-decimation.m
   gap-shading **divergence band** between the two medians. Browser-verified in
   file compare mode across gauges, counters, and percentiles (2026-07-15); the
   validation pass fixed four overlay/color/grid-alignment bugs — see the journal.
-- **Cache headers on the viewer's JS assets** — Open. `lib/*.js` ships with no
-  `Cache-Control`/`ETag`, so a soft refresh after a rebuild loads a stale/mixed
-  ES-module set (surfaced as a spurious "no data" this session). Add `no-cache`/
-  ETags so dev refreshes are reliable.
-- **`reloadCurrentSection` client-only-route guard** — Open. It server-loads
-  `/data/<route>.json` even for client-only `source/` routes, 404-ing and logging
-  on every selection change. Skip the reload for client-only routes.
-- **Live mock-agent + synthetic-live** — Open. Live mode connects to an agent
-  msgpack endpoint, not a parquet; a mock server replaying synthetic snapshots is
-  needed to test the live display path. Pairs with a decision on the default live
-  window (bounded rolling vs full history) and in-memory TSDB retention.
+- **Cache headers on the viewer's JS assets** — Done. `routes.rs` `lib`/`index` now
+  send an ETag (byte hash) + `Cache-Control: no-cache` and honor `If-None-Match`
+  with a `304`, so refreshes revalidate and never load a stale/mixed module set.
+- **`reloadCurrentSection` client-only-route guard** — Done. Skips the server
+  section reload for client-only `source/` routes (`app.js`), killing the
+  per-selection 404 + console error.
+- **Live mock-agent + synthetic-live** — Open (manual eyeball of live mode done
+  2026-07-15). Automating it still needs a mock server replaying synthetic msgpack
+  snapshots. Pairs with a decision on the default live window (bounded rolling vs
+  full history) and in-memory TSDB retention.
 - **Automated browser testing** — Idea. Drive the viewer headless (Chrome CDP) and
   assert rendered chart options; the synthetic generator + scriptable viewer make
   it tractable. A WASM-runtime parity test (server vs WASM display bytes for a
   fixture) is the specific gap the `viewer-parity` skill calls for.
-- **`crates/viewer/build.sh` wasm-pack flag conflict** — Fix pending in **#1007**
-  (blocks local pkg builds until merged). Passed `--profile wasm-release` while
-  wasm-pack 0.13.1 also adds `--release`; the two are mutually exclusive.
+- **`crates/viewer/build.sh` wasm-pack flag conflict** — Done (PR #1007). Was
+  passing `--profile wasm-release` while wasm-pack 0.13.1 also adds `--release`.
 - **Reopen conditions for the 5 measured NO-GOs** (strided-median read, cumulative
   histogram quantiles, decode worker, aggregation worker, M4) live in the journal
   entry — don't re-litigate without the stated trigger.

--- a/docs/journal/2026-07-13-viewer-display-decimation.md
+++ b/docs/journal/2026-07-13-viewer-display-decimation.md
@@ -107,8 +107,9 @@ feel instant. ~1.75× file-size cost, flagged for the maintainer; merged.
 - `tests/viewer_smoke.sh` green after the `display_wire` refactor.
 - **Browser verification (2026-07-15):** file-based compare mode verified across gauges (all
   six `ab_*` scenarios), counters, and percentiles — see the validation-pass section below.
-  Still not done: **live mode** (needs a mock agent) and a WASM-runtime parity test (needs the
-  pkg build; `crates/viewer/build.sh` wasm-pack flag conflict fixed separately in #1007).
+  **Live mode also eyeballed (2026-07-15) — fine.** Still not done: an *automated* live-path
+  test (needs a mock agent) and a WASM-runtime parity test. (`crates/viewer/build.sh` wasm-pack
+  flag conflict fixed and merged in #1007.)
 
 ## Landed after the initial writeup
 
@@ -169,10 +170,16 @@ viewer's JS assets are now a backlog item.
   chart options; the synthetic data + scriptable viewer make this tractable now. (A throwaway
   raw-socket CDP driver worked for `Runtime.evaluate` but the app holds a persistent connection
   that hangs `--dump-dom`/load-idle waits — a real harness needs to poll, not wait for idle.)
-- **`crates/viewer/build.sh` wasm-pack flag conflict** — blocks local pkg builds (fixed in #1007).
-- **Cache headers on the viewer's JS assets** — `lib/*.js` ships with no `Cache-Control`/`ETag`,
-  so a soft refresh after a rebuild loads a stale/mixed module set (cost a debugging detour this
-  session; surfaced as a spurious "no data"). Add `no-cache`/ETags.
-- **`reloadCurrentSection` client-only-route guard** — it server-loads `/data/<route>.json` even
-  for client-only `source/` routes (metric browser), 404-ing and logging on every selection
-  change. Skip the reload for client-only routes.
+- **Automated live-path test** — a mock agent replaying synthetic msgpack snapshots, to test
+  live mode without a real agent (manual eyeball done 2026-07-15; automation still open).
+
+**Follow-ups landed 2026-07-15** (both traced from this entry's deferred list):
+
+- **Cache headers on the viewer's JS assets** — the embedded-asset handlers (`src/viewer/
+  routes.rs` `lib`/`index`) now send an ETag (a hash of the bytes) + `Cache-Control: no-cache`
+  and honor `If-None-Match` with a `304`, so the browser revalidates every load and can't serve
+  the stale/mixed module set that cost a debugging detour this session (dev-mode `ServeDir`
+  already did this). Verified 200→304→200.
+- **`reloadCurrentSection` client-only-route guard** — it no longer server-loads
+  `/data/<route>.json` for client-only `source/` routes (`src/viewer/assets/lib/app.js`),
+  killing the per-selection 404 + console error; the metric browser fetches its own catalog.

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -63,7 +63,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.15.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -341,6 +341,12 @@ const reloadCurrentSection = async () => {
     if (!currentRoute) return;
     const section = currentRoute.replace(/^\//, '');
     if (!section) return;
+    // Client-only routes (the simple-capture metric browser at /source/<name>)
+    // have no server-generated section payload — loadSection would fetch
+    // /data/source/<name>.json and 404 on every selection change, logging an
+    // error. The metric browser fetches its own catalog, so there's nothing to
+    // reload here.
+    if (section.startsWith('source/')) return;
 
     try {
         delete sectionResponseCache[section];

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -531,6 +531,7 @@ fn asset_response(bytes: &'static [u8], content_type: &'static str, req: &Header
         .into_response()
 }
 
+#[cfg(not(feature = "developer-mode"))]
 async fn index(headers: HeaderMap) -> Response {
     let Some(asset) = ASSETS.get_file("index.html") else {
         tracing::error!("index.html missing from build");

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -17,7 +17,7 @@ use tower_livereload::LiveReloadLayer;
 use tracing::warn;
 
 #[cfg(not(feature = "developer-mode"))]
-use http::Uri;
+use http::{HeaderMap, Uri};
 #[cfg(not(feature = "developer-mode"))]
 use include_dir::{include_dir, Dir};
 
@@ -485,36 +485,77 @@ async fn metadata(
 // ── Static asset serving (release builds) ─────────────────────────────
 
 #[cfg(not(feature = "developer-mode"))]
-async fn index() -> impl IntoResponse {
-    if let Some(asset) = ASSETS.get_file("index.html") {
-        let body = asset.contents_utf8().unwrap();
-        (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "text/html")],
-            body.to_string(),
+/// A stable ETag for an embedded asset: a hash of its bytes (deterministic —
+/// `DefaultHasher::new()` has fixed keys), so it changes exactly when the
+/// content does.
+#[cfg(not(feature = "developer-mode"))]
+fn etag_for(bytes: &[u8]) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    format!("\"{:016x}\"", hasher.finish())
+}
+
+/// Serve an embedded asset with an ETag + `Cache-Control: no-cache`, honoring
+/// `If-None-Match` with a `304` so the browser revalidates on every load and
+/// never serves a stale/mixed ES-module set after a rebuild. The assets
+/// previously shipped with no validators, so a soft refresh could load old
+/// bytes for some modules and new for others.
+#[cfg(not(feature = "developer-mode"))]
+fn asset_response(bytes: &'static [u8], content_type: &'static str, req: &HeaderMap) -> Response {
+    let etag = etag_for(bytes);
+    let matched = req
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v == etag)
+        .unwrap_or(false);
+    if matched {
+        return (
+            StatusCode::NOT_MODIFIED,
+            [
+                (header::ETAG, etag),
+                (header::CACHE_CONTROL, "no-cache".to_string()),
+            ],
         )
-    } else {
+            .into_response();
+    }
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, content_type.to_string()),
+            (header::ETAG, etag),
+            (header::CACHE_CONTROL, "no-cache".to_string()),
+        ],
+        bytes.to_vec(),
+    )
+        .into_response()
+}
+
+async fn index(headers: HeaderMap) -> Response {
+    let Some(asset) = ASSETS.get_file("index.html") else {
         tracing::error!("index.html missing from build");
-        (
+        return (
             StatusCode::NOT_FOUND,
             [(header::CONTENT_TYPE, "text/plain")],
-            "404 Not Found".to_string(),
+            "404 Not Found",
         )
-    }
+            .into_response();
+    };
+    asset_response(asset.contents(), "text/html", &headers)
 }
 
 #[cfg(not(feature = "developer-mode"))]
-async fn lib(uri: Uri) -> impl IntoResponse {
+async fn lib(uri: Uri, headers: HeaderMap) -> Response {
     let path = uri.path();
     let Some(asset) = ASSETS.get_file(format!("lib{path}")) else {
         tracing::error!("path: {path} does not map to a static resource");
         return (
             StatusCode::NOT_FOUND,
             [(header::CONTENT_TYPE, "text/plain")],
-            "404 Not Found".to_string(),
-        );
+            "404 Not Found",
+        )
+            .into_response();
     };
-    let body = asset.contents_utf8().unwrap();
     let content_type = match path.rsplit('.').next() {
         Some("js") => "text/javascript",
         Some("css") => "text/css",
@@ -522,9 +563,5 @@ async fn lib(uri: Uri) -> impl IntoResponse {
         Some("json") => "application/json",
         _ => "text/plain",
     };
-    (
-        StatusCode::OK,
-        [(header::CONTENT_TYPE, content_type)],
-        body.to_string(),
-    )
+    asset_response(asset.contents(), content_type, &headers)
 }


### PR DESCRIPTION
## Summary
Two viewer follow-ups surfaced during the display-decimation validation pass (both traced from that journal entry's deferred list):

- **ETag revalidation for embedded assets** — `routes.rs` `lib`/`index` now send an ETag (a hash of the bytes) + `Cache-Control: no-cache` and honor `If-None-Match` with a `304`. The browser revalidates every load and can never serve a stale/mixed ES-module set after a rebuild — the cause of a spurious "no data" during the validation pass. (developer-mode `ServeDir` already did this.)
- **`reloadCurrentSection` client-only-route guard** — no longer server-loads `/data/<route>.json` for client-only `source/` routes (`app.js`), killing the per-selection 404 + console error. The metric browser fetches its own catalog.

Journal + backlog updated; live mode was also eyeballed (2026-07-15, fine).

## Test plan
- [x] `cargo build -p rezolus`, `cargo fmt --check`, `cargo clippy -p rezolus` clean
- [x] ETag behavior verified end-to-end: first GET returns `ETag` + `Cache-Control: no-cache`; `If-None-Match` with the ETag → `304`; stale ETag → `200`; `index.html` also validated
- [x] `node --test tests/*.mjs` (187 pass)
- [x] `tests/viewer_smoke.sh` (asset serving `/`, `/about`, `/lib/style.css` + API) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)