### PR TITLE
release: prepare v5.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## [Unreleased]
 
+## [5.17.0] - 2026-07-16
+
+### Added
+
+- Viewer: server-side display decimation with a min/max envelope and zoom
+  drill-down. Charts on long recordings render fast from a median + min/max
+  envelope so short-lived spikes survive decimation, and zooming refetches
+  the window at finer resolution. Applies to both the server and WASM
+  (browser) viewers. (#1006)
+
+### Changed
+
+- Recorder: parquet files are written with smaller row groups (1800 rows)
+  so the viewer can drill into zoomed windows faster. (#1003)
+
+### Fixed
+
+- Viewer: the WASM viewer package builds again — wasm-pack was invoked with
+  a conflicting `--profile` flag. The size optimizations are now applied via
+  environment overrides scoped to the WASM build. (#1007)
+- Viewer: embedded JS assets are now revalidated with ETags, so browsers no
+  longer serve a stale mix of modules after upgrading Rezolus. Client-only
+  routes also no longer trigger a spurious section reload and console error.
+  (#1010)
+
 ## [5.16.2] - 2026-07-09
 
 ### Fixed
@@ -933,7 +958,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.16.2...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.17.0...HEAD
+[5.17.0]: https://github.com/iopsystems/rezolus/compare/v5.16.2...v5.17.0
 [5.16.2]: https://github.com/iopsystems/rezolus/compare/v5.16.1...v5.16.2
 [5.16.1]: https://github.com/iopsystems/rezolus/compare/v5.16.0...v5.16.1
 [5.16.0]: https://github.com/iopsystems/rezolus/compare/v5.15.0...v5.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.16.3-alpha.1"
+version = "5.17.0"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.16.3-alpha.1"
+version = "5.17.0"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Release v5.17.0

This PR prepares the release of v5.17.0.

### Changes
- Version bump in Cargo.toml
- Changelog update

### After Merge
The release workflows will automatically:
1. Create git tag `v5.17.0` and bump to next dev version
2. Build and publish packages (deb, rpm, Homebrew)
3. Create GitHub release with all artifacts
4. Publish to crates.io

---
See CHANGELOG.md for details.