### PR TITLE
fix(viewer): missing boxplot.js symlink (deployed viewer down) + CI guard against recurrence

### DIFF
--- a/.claude/scripts/pre-commit-check.sh
+++ b/.claude/scripts/pre-commit-check.sh
@@ -63,35 +63,15 @@ check_clippy() {
 # ── 3. Check symlinks ───────────────────────────────────────────────
 
 check_symlinks() {
-    # Walk every .js and .css file under src/viewer/assets/lib/
-    while IFS= read -r src_file; do
-        rel="${src_file#$SRC/}"          # e.g. "charts/metric_types.js" or "theme.js"
-        base="$(basename "$rel")"
-        dir="$(dirname "$rel")"          # "." for top-level
-
-        # Skip top-level standalone files
-        if [ "$dir" = "." ]; then
-            skip=false
-            for s in $STANDALONE_TOP; do
-                [ "$base" = "$s" ] && skip=true && break
-            done
-            if $skip; then
-                # Special case: data.js -> data_base.js
-                if [ "$base" = "data.js" ]; then
-                    link="$SITE/data_base.js"
-                    if [ ! -L "$link" ]; then
-                        errors+=("missing symlink: site/viewer/lib/data_base.js -> $src_file")
-                    fi
-                fi
-                continue
-            fi
-        fi
-
-        link="$SITE/$rel"
-        if [ ! -L "$link" ]; then
-            errors+=("missing symlink: site/viewer/lib/$rel")
-        fi
-    done < <(find "$SRC" -type f \( -name '*.js' -o -name '*.css' \))
+    # Delegate to the canonical, CI-shared check so the local hook and the
+    # viewer-symlinks CI job can never diverge. That script is resolution-based
+    # ([ -e ], not [ -L ]) so it correctly treats a file covered by a parent
+    # directory symlink (e.g. site/viewer/lib/embed) as present. See the
+    # sync-viewer-symlinks skill.
+    local out
+    if ! out="$("$ROOT/scripts/check-viewer-symlinks.sh" 2>&1)"; then
+        errors+=("$out")
+    fi
 }
 
 # ── 3b. Check template symlinks ────────────────────────────────────

--- a/.claude/skills/sync-viewer-symlinks/SKILL.md
+++ b/.claude/skills/sync-viewer-symlinks/SKILL.md
@@ -19,29 +19,46 @@ and fixes any missing symlinks.
 
 ## Standalone files (never symlinked)
 
-These files in `site/viewer/lib/` are site-specific and must NOT be replaced
-with symlinks:
+Only these two top-level files in `site/viewer/lib/` are site-specific real
+files (site keeps its own copy):
 
-- `data.js` — site-specific wrapper that imports shared logic from `data_base.js`
 - `script.js` — site-specific entry point
-- `dashboards.js` — site-specific dashboard definitions
-- `viewer_api.js` — site-specific API transport layer
+- `viewer_api.js` — site-specific API transport layer (calls the in-browser
+  WASM registry instead of the HTTP backend)
 
-## Special mapping
+Everything else — **including `data.js`** — is a same-name symlink into
+`src/viewer/assets/lib/`. (There is no `data_base.js`; that was an older
+architecture. `dashboards.js` no longer exists.)
 
-- `src/viewer/assets/lib/data.js` is symlinked as `site/viewer/lib/data_base.js`
-  (different name, because site has its own `data.js` wrapper)
+## Coverage can be per-file OR a directory symlink
+
+Most of `site/viewer/lib/` is per-file symlinks, but some subtrees are covered
+by a **directory symlink** — e.g. `site/viewer/lib/embed ->
+../../../src/viewer/assets/lib/embed` — which serves every file underneath it.
+So the invariant is **resolution, not per-file-symlink presence**: every shared
+module must *resolve* at the same relative path under `site/viewer/lib/`.
+
+A tool that looks only for a per-file symlink (or a `find` that doesn't descend
+through a directory symlink) will **false-flag** files under a directory
+symlink. Test with `[ -e "$link" ]` (follows all symlinks), never `[ -L ]`.
+CAUTION: because `site/viewer/lib/embed` is a directory symlink into `src/`,
+writing to `site/viewer/lib/embed/X` writes *through* it into `src/…/embed/X` —
+never `mkdir`/`ln` inside a directory-symlinked path.
+
+## Enforced in CI
+
+`scripts/check-viewer-symlinks.sh` implements this (resolution-based) check and
+runs on every PR via `.github/workflows/viewer-symlinks.yml`. Run it locally
+before pushing a viewer change: `bash scripts/check-viewer-symlinks.sh`.
 
 ## Steps
 
 1. **Scan** `src/viewer/assets/lib/` recursively for all `.js` and `.css` files
 
-2. **For each source file**, determine the expected symlink path in
-   `site/viewer/lib/` using these rules:
-   - Skip files that have standalone site-specific versions:
-     `script.js`, `viewer_api.js` (top-level only)
-   - Map `data.js` (top-level) → `data_base.js` symlink
-   - Everything else → same relative path
+2. **For each source file**, determine the expected path in `site/viewer/lib/`:
+   - Skip the standalone top-level files `script.js`, `viewer_api.js`
+   - Everything else → same relative path, which must **resolve** (`[ -e ]`)
+     via either a per-file symlink or a covering directory symlink
 
 3. **Check** whether the expected symlink exists and points to the correct
    target. Compute the relative path from the symlink location back to the
@@ -66,12 +83,15 @@ A Claude Code hook at `.claude/settings.json` runs
 `.claude/scripts/pre-commit-check.sh` before every `git commit`. It blocks
 the commit if:
 
-- Any expected symlinks are missing in `site/viewer/lib/`
+- Any shared viewer module fails to resolve under `site/viewer/lib/`
 - Dashboard JSON is out of date with Rust definitions (only when
   `src/viewer/dashboard/` or `src/viewer/plot.rs` files are staged)
 
-Both files are git-ignored (`.claude/*` excluding skills). To set up the
-hook on a fresh checkout, create `.claude/settings.json`:
+The hook **wiring** (`.claude/settings.json`) is per-checkout Claude Code
+config, so the hook only fires for local Claude Code users — that is exactly
+why the symlink check is *also* enforced in CI (`viewer-symlinks.yml` →
+`scripts/check-viewer-symlinks.sh`), which is the binding gate for every PR.
+To set up the local hook on a fresh checkout, create `.claude/settings.json`:
 
 ```json
 {

--- a/.claude/skills/viewer-parity/SKILL.md
+++ b/.claude/skills/viewer-parity/SKILL.md
@@ -21,6 +21,13 @@ description: Use when adding or changing what the rezolus viewer exposes — an 
   registry), so it *must* differ — which means a change to the server's
   `viewer_api.js` does **not** propagate to the WASM shell. Editing either →
   mirror the other copy.
+  - **A new shared module under `src/viewer/assets/lib/` needs a resolving
+    entry under `site/viewer/lib/`** (a per-file symlink, or coverage by a
+    parent directory symlink like `site/viewer/lib/embed`) — or the deployed
+    static viewer 404s on the import and **fails to load entirely**. This is
+    now enforced in CI (`viewer-symlinks.yml` → `scripts/check-viewer-symlinks.sh`);
+    run it locally before pushing a viewer change. (A missing `charts/boxplot.js`
+    symlink shipped exactly this outage before the guard existed.)
 
 `crates/viewer` **cannot depend on the `rezolus` binary crate** (separate wasm32
 workspace), so any backend logic both need must live in the shared **`dashboard`**

--- a/.github/workflows/viewer-symlinks.yml
+++ b/.github/workflows/viewer-symlinks.yml
@@ -1,0 +1,27 @@
+name: viewer-symlinks
+
+# The server viewer serves src/viewer/assets/lib/ directly; the static (WASM)
+# viewer loads the SAME modules through site/viewer/lib/ symlinks. A shared
+# module added to src/ without a resolving site/ entry makes the deployed
+# static viewer 404 on the import and fail to load. This job enforces that
+# every shared module resolves under site/viewer/lib/ — the check the local
+# Claude Code pre-commit hook runs, promoted to CI so it binds every PR.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/viewer/assets/lib/**'
+      - 'site/viewer/lib/**'
+      - 'scripts/check-viewer-symlinks.sh'
+      - '.github/workflows/viewer-symlinks.yml'
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    name: site/viewer symlinks resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check every shared viewer module resolves under site/viewer/lib
+        run: bash scripts/check-viewer-symlinks.sh

--- a/scripts/check-viewer-symlinks.sh
+++ b/scripts/check-viewer-symlinks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Guard: every shared module under src/viewer/assets/lib/ must RESOLVE at the
+# same relative path under site/viewer/lib/, or the deployed static (WASM)
+# viewer 404s on the ES-module import and fails to load (see the charts/boxplot.js
+# fix). Coverage may be a per-file symlink OR a parent-directory symlink (e.g.
+# site/viewer/lib/embed -> ../../../src/viewer/assets/lib/embed), so we test
+# resolution (-e), not symlink presence. Only script.js and viewer_api.js are
+# standalone (site keeps its own real copy).
+#
+# Runs in CI so the guard is enforced on every PR — the Claude Code pre-commit
+# hook runs the same check but only fires for local Claude Code users.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$ROOT/src/viewer/assets/lib"; SITE="$ROOT/site/viewer/lib"
+missing=(); n=0
+while IFS= read -r src; do
+    rel="${src#"$SRC"/}"
+    case "$rel" in script.js|viewer_api.js) continue ;; esac
+    n=$((n+1))
+    [ -e "$SITE/$rel" ] || missing+=("$rel")
+done < <(find "$SRC" -type f \( -name '*.js' -o -name '*.css' \))
+if ((${#missing[@]})); then
+    echo "::error::shared viewer modules that do not resolve under site/viewer/lib/ — the deployed static viewer will 404 on these imports and fail to load:"
+    printf '  src/viewer/assets/lib/%s\n' "${missing[@]}"
+    echo "  fix: add the per-file symlink under site/viewer/lib/ (or ensure a parent-dir symlink covers it); the sync-viewer-symlinks skill does this."
+    exit 1
+fi
+echo "OK: $n shared viewer modules all resolve under site/viewer/lib/"

--- a/site/viewer/lib/charts/boxplot.js
+++ b/site/viewer/lib/charts/boxplot.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/charts/boxplot.js


### PR DESCRIPTION
## Symptom

The **deployed static (WASM) viewer doesn't come up at all** — blank page, load-time failure.

## Root cause

`src/viewer/assets/lib/charts/boxplot.js` (from the display-mode/decimation work) is statically imported by `line.js`/`multi.js`/`scatter.js` — core chart renderers loaded at bootstrap — but its `site/viewer/lib/charts/boxplot.js` symlink was never created. The server viewer serves `src/` directly (fine); the static viewer loads `./lib/charts/boxplot.js`, **404s**, the ES-module chain fails, and the app never boots. (`charts/` is a real dir with per-file symlinks, so a new file there needs its own symlink — unlike `embed/`/`lit/`, which are directory symlinks that already cover their files.)

## Fix (commit 1)

Add the one missing per-file symlink `site/viewer/lib/charts/boxplot.js`. One line, no code change.

## Guard against recurrence (commit 2)

The class of bug — a shared `src/viewer/assets/lib` module with no resolving `site/viewer/lib` entry — was only checked by a **local Claude Code pre-commit hook** whose wiring is per-checkout config, so plain-git/CI never ran it and the gap merged. This commit makes it a **binding CI gate**:

- `scripts/check-viewer-symlinks.sh` + `.github/workflows/viewer-symlinks.yml` — fails any PR where a shared viewer module doesn't **resolve** under `site/viewer/lib/`. It's resolution-based (`[ -e ]`), so files covered by a directory symlink (`embed`, `lit`) are correctly treated as present. Verified: it **catches** the boxplot gap (exit 1) and passes on the fixed tree (55 modules).
- The pre-commit hook now calls the same canonical script (hook == CI), fixing its two staleness bugs: a per-file-only `-L` check that false-flagged directory-symlinked files, and a dead `data.js → data_base.js` special case.
- Corrected the `sync-viewer-symlinks` + `viewer-parity` skills: the only standalone files are `script.js` + `viewer_api.js` (`data.js` is a same-name symlink; there is no `data_base.js`; `dashboards.js` is gone); coverage may be a directory symlink; CI is the binding gate.

No embed/lit change needed — they're directory-symlinked and were never missing (a tooling false-positive during triage; corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)