### PR TITLE
fix(viewer): add missing site symlink for charts/boxplot.js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.16.3-alpha.1"
+version = "5.16.3-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.16.3-alpha.1"
+version = "5.16.3-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/viewer/lib/charts/boxplot.js
+++ b/site/viewer/lib/charts/boxplot.js
@@ -1,0 +1,1 @@
+../../../../src/viewer/assets/lib/charts/boxplot.js


### PR DESCRIPTION
## Summary
- The rezolus.com static-site (WASM) viewer demo hung at the "Loading…" splash and rendered no charts.
- Root cause: `charts/boxplot.js` (added to the shared frontend by the display-decimation work in #1006) is statically imported by `line.js`, `multi.js`, and `scatter.js`, but the matching symlink under `site/viewer/lib/charts/` was never created. The site 404'd on it, and a 404 on a statically-imported ES module collapses the whole module graph — so `script.js` never ran and the splash never cleared.
- Fix: add the `site/viewer/lib/charts/boxplot.js` symlink (matching the sibling `charts/` links). This is the same class of failure the `sync-viewer-symlinks` skill guards against.

## Test plan
- [x] Confirmed `boxplot.js` existed in `src/viewer/assets/lib/charts/` but was absent from `site/viewer/lib/charts/`; full scan of `src/viewer/assets/lib/**` found this as the only genuinely missing symlink.
- [x] Reproduced the hang in headless Chrome (`?demo=demo.parquet`): splash stuck at "Loading…", console `404 lib/charts/boxplot.js`, zero canvases.
- [x] After adding the symlink: demo renders 155 chart cards in ~1s, title updates to "Overview (demo.parquet) — Rezolus", no console errors (except a pre-existing, unrelated `favicon.svg` 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)