### PR TITLE
fix(install): detect arch for apt repo instead of hardcoding amd64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.1"
+version = "5.17.1-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.1"
+version = "5.17.1-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,8 +45,9 @@ specific instructions:
 source /etc/os-release
 DISTRO=$(echo "$ID" | tr '[:upper:]' '[:lower:]')
 CODENAME="$VERSION_CODENAME"
+ARCH="$(dpkg --print-architecture)"   # amd64 or arm64
 curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rezolus-archive-keyring.gpg
-echo "deb [arch=amd64] https://us-apt.pkg.dev/projects/rezolus ${DISTRO}-${CODENAME} main" | sudo tee /etc/apt/sources.list.d/rezolus.list
+echo "deb [arch=${ARCH}] https://us-apt.pkg.dev/projects/rezolus ${DISTRO}-${CODENAME} main" | sudo tee /etc/apt/sources.list.d/rezolus.list
 sudo apt update && sudo apt install rezolus
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,22 @@ echo "Detected distribution: $DISTRO"
 # Determine package manager and repo name
 if command -v apt &> /dev/null; then
     PACKAGE_MANAGER="apt"
+
+    # Determine the Debian architecture apt should pull. The Rezolus repo
+    # publishes amd64 and arm64 packages; pinning the wrong arch makes apt
+    # try to install e.g. rezolus:amd64 on an arm64 host, which then fails
+    # with unsatisfiable dependencies.
+    DEB_ARCH="$(dpkg --print-architecture)"
+    case "$DEB_ARCH" in
+        amd64|arm64)
+            ;;
+        *)
+            echo "Error: Unsupported architecture for APT packages: $DEB_ARCH" >&2
+            echo "Prebuilt packages are available for amd64 and arm64 only" >&2
+            exit 1
+            ;;
+    esac
+
     case "$DISTRO" in
         debian)
             case "$CODENAME" in
@@ -129,7 +145,16 @@ if command -v apt &> /dev/null; then
             ;;
         ubuntu)
             case "$CODENAME" in
-                focal|jammy|noble)
+                focal)
+                    # Ubuntu focal (20.04) is amd64-only in our build matrix.
+                    if [[ "$DEB_ARCH" != "amd64" ]]; then
+                        echo "Error: Ubuntu focal (20.04) packages are only available for amd64 (got $DEB_ARCH)" >&2
+                        echo "arm64 packages are available for jammy (22.04) and noble (24.04)" >&2
+                        exit 1
+                    fi
+                    REPO_NAME="ubuntu-${CODENAME}"
+                    ;;
+                jammy|noble)
                     REPO_NAME="ubuntu-${CODENAME}"
                     ;;
                 *)
@@ -258,7 +283,7 @@ case "$PACKAGE_MANAGER" in
         fi
 
         echo "Adding Rezolus APT repository..."
-        echo "deb [arch=amd64] https://us-apt.pkg.dev/projects/rezolus ${REPO_NAME} main" | tee /etc/apt/sources.list.d/rezolus.list > /dev/null
+        echo "deb [arch=${DEB_ARCH}] https://us-apt.pkg.dev/projects/rezolus ${REPO_NAME} main" | tee /etc/apt/sources.list.d/rezolus.list > /dev/null
 
         echo "Updating package list..."
         apt update

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -63,7 +63,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.16.2</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">


### PR DESCRIPTION
## Summary
- The installer (`install.sh`) and manual docs (`docs/installation.md`) hardcoded `deb [arch=amd64] …` in the apt source, so on arm64 hosts apt resolved `rezolus:amd64` and failed with unsatisfiable deps (`libc6`, `libelf1t64`, …) — even though arm64 packages are published for the same repos. Reported on an NVIDIA Jetson Thor AGX (Ubuntu noble / aarch64).
- Derive the arch from `dpkg --print-architecture` in both the installer and the documented manual steps.
- Reject unsupported arches early, and guard Ubuntu focal (amd64-only in our build matrix) against arm64 with a clear error.

## Test plan
- [x] `bash -n install.sh` passes
- [ ] `curl -fsSL https://install.rezolus.com | bash` on an arm64 host (Jetson Thor / Graviton) installs the arm64 package
- [ ] amd64 install path unchanged (still writes `arch=amd64`)
- [ ] focal/arm64 exits with the guard message

🤖 Generated with [Claude Code](https://claude.com/claude-code)