### PR TITLE
feat(viewer): terminal UI mode (rezolus view --tui)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ target/release/rezolus record --metadata source=llm-perf http://host:9090/metric
 target/release/rezolus view output.parquet [experiment.parquet] [--listen ADDR]
 target/release/rezolus view http://localhost:4241 [--listen ADDR]   # live agent connection
 target/release/rezolus view [--listen ADDR]                         # upload-only mode (no file)
+target/release/rezolus view --tui output.parquet                    # terminal UI (parquet or live agent; not upload-only)
+target/release/rezolus view --tui http://localhost:4241             # terminal UI, live agent
 
 # Hindsight - rolling ring buffer for incident analysis
 target/release/rezolus hindsight config/hindsight.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.0"
+version = "5.17.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7"
 dependencies = [
  "cfg-if",
- "itertools",
+ "itertools 0.12.1",
  "libc",
  "serde",
  "serde_json",
@@ -575,6 +575,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +706,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -828,6 +857,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,8 +934,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -899,12 +963,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1181,7 +1269,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1569,6 +1657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1683,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1630,6 +1740,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1885,6 +2004,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2579,7 +2704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
 dependencies = [
  "chrono",
- "itertools",
+ "itertools 0.12.1",
  "once_cell",
  "regex",
 ]
@@ -2627,6 +2752,27 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "rayon"
@@ -2783,6 +2929,7 @@ dependencies = [
  "plain",
  "plist",
  "prometheus-parse",
+ "ratatui",
  "rayon",
  "regex",
  "report-save",
@@ -2875,6 +3022,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno 0.3.14",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2882,7 +3042,7 @@ dependencies = [
  "bitflags",
  "errno 0.3.14",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3146,6 +3306,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3240,6 +3421,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -3346,7 +3549,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3745,10 +3948,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"
@@ -4235,7 +4461,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ parquet = { version = "58.2.0", default-features = false, features = [
 ] }
 prometheus-parse = "0.2.5"
 plain = "0.2.3"
+ratatui = "0.29"
 rayon = "1.12"
 regex = "1"
 reqwest = { version = "0.13.3", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.0"
+version = "5.17.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/README.md
+++ b/README.md
@@ -217,7 +217,24 @@ rezolus view http://localhost:4241
 rezolus view
 ```
 
-The same dashboard is also available as a browser-only static site under
+Prefer the terminal? Pass `--tui` to render in the terminal instead of the
+browser — a curated live overview plus a drill-down browser of the same
+sections. It works with a parquet file or a live agent URL (not upload-only
+mode), and serves no HTTP, so `--listen` and the `--proxy-*` flags don't apply.
+A/B compare remains browser-only.
+
+```bash
+# explore a recording in the terminal
+rezolus view --tui rezolus.parquet
+# stream a live agent in the terminal UI
+rezolus view --tui http://localhost:4241
+```
+
+Keys: `Tab`/`o` toggle overview ↔ browser, `j`/`k` move/scroll, `Enter`/`l`
+open, `Esc`/`h` back, `[` / `]` change the time window, `r` refresh, `?` help,
+`q` quit.
+
+The same web dashboard is also available as a browser-only static site under
 [`site/viewer/`](site/viewer/), powered by the
 [`crates/viewer`](crates/viewer) WASM module. It runs the PromQL query engine
 client-side, so parquet files never leave the browser.

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -42,6 +42,7 @@ mod metadata;
 mod report_save;
 mod routes;
 mod state;
+mod tui;
 
 use capture_registry::CaptureId;
 use state::AppState;
@@ -199,6 +200,12 @@ pub fn command() -> Command {
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(
+            clap::Arg::new("TUI")
+                .long("tui")
+                .help("Render a terminal UI instead of the web dashboard (live agent or parquet file; not upload-only)")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
             clap::Arg::new("CACHE_SIZE_MB")
                 .long("cache-size-mb")
                 .value_name("MB")
@@ -225,6 +232,7 @@ pub struct Config {
     proxy_allow: proxy_allow::Allowlist,
     /// Buffer pool budget in bytes. Defaults to `DEFAULT_CACHE_SIZE_BYTES`.
     cache_size_bytes: usize,
+    pub tui: bool,
 }
 
 /// Split a positional input into an optional alias and the remaining
@@ -314,6 +322,7 @@ impl TryFrom<ArgMatches> for Config {
             templates_dir: args.get_one::<PathBuf>("templates").cloned(),
             proxy_allow,
             cache_size_bytes,
+            tui: args.get_flag("TUI"),
         })
     }
 }
@@ -370,6 +379,16 @@ pub fn run(config: Config) {
         warn!(
             "--experiment ignored outside of file mode (v1 compare requires a baseline parquet file)"
         );
+    }
+
+    if config.tui {
+        if matches!(config.source, Source::Empty) {
+            eprintln!("--tui needs a data source: a live agent URL or a parquet file (upload-only is not supported)");
+            std::process::exit(1);
+        }
+        let live = matches!(config.source, Source::Live(_));
+        tui::run_tui(state, live, &rt);
+        return;
     }
 
     let listener = std::net::TcpListener::bind(config.listen).expect("failed to listen");

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -339,7 +339,13 @@ pub fn run(config: Config) {
         .build()
         .expect("failed to launch async runtime");
 
-    ctrlc::set_handler(move || std::process::exit(2)).expect("failed to set ctrl-c handler");
+    // The TUI installs its own SIGINT handler (one that restores the
+    // terminal first); a bare process::exit here would bypass that and
+    // leave the terminal in raw mode. In raw mode a keyboard Ctrl-C is
+    // delivered as a normal key event and handled as a graceful quit.
+    if !config.tui {
+        ctrlc::set_handler(move || std::process::exit(2)).expect("failed to set ctrl-c handler");
+    }
 
     let registry = load_template_registry(config.templates_dir.as_deref());
 

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -232,7 +232,8 @@ pub struct Config {
     proxy_allow: proxy_allow::Allowlist,
     /// Buffer pool budget in bytes. Defaults to `DEFAULT_CACHE_SIZE_BYTES`.
     cache_size_bytes: usize,
-    pub tui: bool,
+    /// Render a terminal UI instead of the web dashboard.
+    tui: bool,
 }
 
 /// Split a positional input into an optional alias and the remaining

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -102,9 +102,22 @@ pub fn command() -> Command {
              The --templates/--category flags (service-extension dashboards) and the --proxy-*\n\
              flags (in-browser 'load from URL' fetching) are advanced; the input forms above\n\
              need none of them.\n\n\
+             TERMINAL UI:\n    \
+             Pass --tui to render in the terminal instead of a web browser: a live overview\n    \
+             plus a drill-down browser of the same dashboard sections (CPU, network,\n    \
+             scheduler, ...). It needs a parquet file or a live agent URL as input; upload-only\n    \
+             (no input) is not supported and errors. It shows a SINGLE capture — A/B compare\n    \
+             and the --category bridge view are browser-only, so a second positional file or\n    \
+             --category is ignored (with a warning). No browser window is opened, no HTTP is\n    \
+             served, and --listen/--proxy-* are ignored. Keys: Tab/o overview<->browser, j/k\n    \
+             move, Enter/l open, Esc/h back, [ / ] time window, r refresh, ? help, q quit.\n\n\
              EXAMPLES:\n    \
              # Open a single recording\n    \
              rezolus view rezolus.parquet\n\n    \
+             # Explore a recording in the terminal (no browser)\n    \
+             rezolus view --tui rezolus.parquet\n\n    \
+             # Stream a live agent in the terminal UI\n    \
+             rezolus view --tui http://localhost:4241\n\n    \
              # A/B compare two recordings with display labels\n    \
              rezolus view redis=baseline.parquet valkey=experiment.parquet\n\n    \
              # Stream live from a remote agent on a fixed address\n    \
@@ -202,7 +215,17 @@ pub fn command() -> Command {
         .arg(
             clap::Arg::new("TUI")
                 .long("tui")
-                .help("Render a terminal UI instead of the web dashboard (live agent or parquet file; not upload-only)")
+                .help(
+                    "Show a terminal UI instead of a web browser dashboard. Needs an input: \
+                     a parquet file or a live agent URL. Upload-only mode (no input) is \
+                     browser-only, so `rezolus view --tui` with no input is an error. Shows a \
+                     single capture: A/B compare and the --category bridge view are \
+                     browser-only, so a second positional file or --category is ignored (with \
+                     a warning). No browser window is opened and no HTTP is served, so \
+                     --listen and the --proxy-* flags are ignored. Keys: Tab/o \
+                     overview<->browser, j/k move, Enter/l open, Esc/h back, [ / ] time \
+                     window, r refresh, ? help, q quit.",
+                )
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(
@@ -392,6 +415,15 @@ pub fn run(config: Config) {
         if matches!(config.source, Source::Empty) {
             eprintln!("--tui needs a data source: a live agent URL or a parquet file (upload-only is not supported)");
             std::process::exit(1);
+        }
+        // The TUI shows a single capture. A/B compare and the category
+        // bridge view are browser-only, so a second capture / --category
+        // is ignored rather than silently changing what's displayed.
+        if config.experiment_path.is_some() {
+            warn!("second capture ignored in --tui mode (A/B compare is browser-only); showing the first input only");
+        }
+        if config.category_name.is_some() {
+            warn!("--category ignored in --tui mode (the category bridge view is browser-only)");
         }
         let live = matches!(config.source, Source::Live(_));
         tui::run_tui(state, live, &rt);

--- a/src/viewer/tui/app.rs
+++ b/src/viewer/tui/app.rs
@@ -167,6 +167,45 @@ impl App {
             s.groups = Some(groups);
         }
     }
+
+    /// Reconcile the nav list against a freshly-derived one (live mode).
+    /// Adds sections that newly appeared, drops ones that disappeared, and
+    /// preserves already-loaded group bodies and the current selection by
+    /// route (so live nav churn never loses loaded data or misplaces the
+    /// cursor). A no-op when the route sets already match.
+    pub fn reconcile_sections(&mut self, latest: Vec<NavSection>) {
+        let same = latest.len() == self.sections.len()
+            && latest
+                .iter()
+                .zip(self.sections.iter())
+                .all(|(a, b)| a.route == b.route);
+        if same {
+            return;
+        }
+        let selected_route = self
+            .sections
+            .get(self.selected_section)
+            .map(|s| s.route.clone());
+        let mut existing: std::collections::HashMap<String, Option<Vec<super::model::NavGroup>>> =
+            std::mem::take(&mut self.sections)
+                .into_iter()
+                .map(|s| (s.route, s.groups))
+                .collect();
+        self.sections = latest
+            .into_iter()
+            .map(|mut s| {
+                if let Some(groups) = existing.remove(&s.route) {
+                    s.groups = groups;
+                }
+                s
+            })
+            .collect();
+        // Keep the cursor on the same section if it still exists, else clamp.
+        self.selected_section = selected_route
+            .and_then(|r| self.sections.iter().position(|s| s.route == r))
+            .unwrap_or(0)
+            .min(self.sections.len().saturating_sub(1));
+    }
 }
 
 /// Logical key, decoded from crossterm events by the loop.
@@ -256,6 +295,38 @@ mod tests {
     fn set_section_groups_stores_body() {
         let mut app = App::new(sections());
         app.set_section_groups(0, vec![NavGroup { name: "g".into(), plots: vec![] }]);
+        assert!(app.sections[0].groups.is_some());
+    }
+
+    #[test]
+    fn reconcile_preserves_loaded_groups_and_selection_by_route() {
+        let mut app = App::new(sections()); // [CPU /cpu, Net /network]
+        app.set_section_groups(1, vec![NavGroup { name: "g".into(), plots: vec![] }]);
+        app.selected_section = 1; // on /network
+
+        // A new section appears before the others; /cpu disappears.
+        let latest = vec![
+            NavSection { name: "GPU".into(), route: "/gpu".into(), groups: None },
+            NavSection { name: "Net".into(), route: "/network".into(), groups: None },
+        ];
+        app.reconcile_sections(latest);
+
+        assert_eq!(app.sections.len(), 2);
+        assert_eq!(app.sections[0].route, "/gpu");
+        // Selection follows /network to its new index.
+        assert_eq!(app.selected_section, 1);
+        assert_eq!(app.sections[1].route, "/network");
+        // Its already-loaded body was carried over, not dropped.
+        assert!(app.sections[1].groups.is_some());
+    }
+
+    #[test]
+    fn reconcile_is_noop_when_routes_match() {
+        let mut app = App::new(sections());
+        app.set_section_groups(0, vec![NavGroup { name: "g".into(), plots: vec![] }]);
+        // Same routes in the same order (bodies None) — must not wipe the
+        // already-loaded group on /cpu.
+        app.reconcile_sections(sections());
         assert!(app.sections[0].groups.is_some());
     }
 }

--- a/src/viewer/tui/app.rs
+++ b/src/viewer/tui/app.rs
@@ -1,0 +1,261 @@
+//! TUI application state machine: current screen, selection, focus, and
+//! keyboard handling. Pure — no ratatui, no I/O — so it is unit-testable.
+
+use super::model::NavSection;
+use super::window::TimeWindow;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Screen {
+    Overview,
+    Browser,
+}
+
+/// Which browser pane has focus (matters only when narrow / single-pane).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BrowserFocus {
+    Nav,
+    Charts,
+}
+
+/// An action the render/event loop must carry out after handling a key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Action {
+    None,
+    Quit,
+    Redraw,
+    /// The selected section changed; loop should ensure its body is loaded.
+    LoadSection(usize),
+    ToggleHelp,
+}
+
+pub struct App {
+    pub screen: Screen,
+    pub sections: Vec<NavSection>,
+    pub selected_section: usize,
+    pub selected_group: usize,
+    pub focus: BrowserFocus,
+    pub window: TimeWindow,
+    pub show_help: bool,
+    /// Vertical scroll offset (in rows) of the charts pane.
+    pub chart_scroll: u16,
+}
+
+impl App {
+    pub fn new(sections: Vec<NavSection>) -> Self {
+        Self {
+            screen: Screen::Overview,
+            sections,
+            selected_section: 0,
+            selected_group: 0,
+            focus: BrowserFocus::Nav,
+            window: TimeWindow::Last5m,
+            show_help: false,
+            chart_scroll: 0,
+        }
+    }
+
+    pub fn current_section(&self) -> Option<&NavSection> {
+        self.sections.get(self.selected_section)
+    }
+
+    fn section_count(&self) -> usize {
+        self.sections.len()
+    }
+
+    fn group_count(&self) -> usize {
+        self.current_section()
+            .and_then(|s| s.groups.as_ref())
+            .map(|g| g.len())
+            .unwrap_or(0)
+    }
+
+    /// Handle a single logical key. Returns the action for the loop.
+    pub fn on_key(&mut self, key: Key) -> Action {
+        if self.show_help {
+            // Any key closes help.
+            self.show_help = false;
+            return Action::Redraw;
+        }
+        match key {
+            Key::Quit => Action::Quit,
+            Key::Help => {
+                self.show_help = true;
+                Action::Redraw
+            }
+            Key::ToggleScreen => {
+                self.screen = match self.screen {
+                    Screen::Overview => Screen::Browser,
+                    Screen::Browser => Screen::Overview,
+                };
+                if self.screen == Screen::Browser {
+                    Action::LoadSection(self.selected_section)
+                } else {
+                    Action::Redraw
+                }
+            }
+            Key::GrowWindow => {
+                self.window = self.window.grow();
+                Action::Redraw
+            }
+            Key::ShrinkWindow => {
+                self.window = self.window.shrink();
+                Action::Redraw
+            }
+            Key::Down => self.move_down(),
+            Key::Up => self.move_up(),
+            Key::Descend => self.descend(),
+            Key::Ascend => self.ascend(),
+            Key::Refresh => Action::LoadSection(self.selected_section),
+        }
+    }
+
+    fn move_down(&mut self) -> Action {
+        match self.screen {
+            Screen::Browser if self.focus == BrowserFocus::Nav => {
+                if self.section_count() > 0 {
+                    self.selected_section =
+                        (self.selected_section + 1).min(self.section_count() - 1);
+                    self.selected_group = 0;
+                    self.chart_scroll = 0;
+                    return Action::LoadSection(self.selected_section);
+                }
+                Action::None
+            }
+            Screen::Browser => {
+                self.chart_scroll = self.chart_scroll.saturating_add(1);
+                Action::Redraw
+            }
+            Screen::Overview => Action::None,
+        }
+    }
+
+    fn move_up(&mut self) -> Action {
+        match self.screen {
+            Screen::Browser if self.focus == BrowserFocus::Nav => {
+                self.selected_section = self.selected_section.saturating_sub(1);
+                self.selected_group = 0;
+                self.chart_scroll = 0;
+                Action::LoadSection(self.selected_section)
+            }
+            Screen::Browser => {
+                self.chart_scroll = self.chart_scroll.saturating_sub(1);
+                Action::Redraw
+            }
+            Screen::Overview => Action::None,
+        }
+    }
+
+    fn descend(&mut self) -> Action {
+        if self.screen == Screen::Browser && self.focus == BrowserFocus::Nav {
+            self.focus = BrowserFocus::Charts;
+            return Action::Redraw;
+        }
+        Action::None
+    }
+
+    fn ascend(&mut self) -> Action {
+        if self.screen == Screen::Browser && self.focus == BrowserFocus::Charts {
+            self.focus = BrowserFocus::Nav;
+            return Action::Redraw;
+        }
+        Action::None
+    }
+
+    /// Called by the loop after it has parsed a section's groups.
+    pub fn set_section_groups(&mut self, idx: usize, groups: Vec<super::model::NavGroup>) {
+        if let Some(s) = self.sections.get_mut(idx) {
+            s.groups = Some(groups);
+        }
+    }
+}
+
+/// Logical key, decoded from crossterm events by the loop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Key {
+    Quit,
+    Help,
+    ToggleScreen,
+    GrowWindow,
+    ShrinkWindow,
+    Up,
+    Down,
+    Descend,
+    Ascend,
+    Refresh,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::model::{NavGroup, NavSection};
+
+    fn sections() -> Vec<NavSection> {
+        vec![
+            NavSection { name: "CPU".into(), route: "/cpu".into(), groups: None },
+            NavSection { name: "Net".into(), route: "/network".into(), groups: None },
+        ]
+    }
+
+    #[test]
+    fn toggle_screen_enters_browser_and_requests_load() {
+        let mut app = App::new(sections());
+        assert_eq!(app.screen, Screen::Overview);
+        let a = app.on_key(Key::ToggleScreen);
+        assert_eq!(app.screen, Screen::Browser);
+        assert_eq!(a, Action::LoadSection(0));
+    }
+
+    #[test]
+    fn nav_down_clamps_and_requests_load() {
+        let mut app = App::new(sections());
+        app.on_key(Key::ToggleScreen); // -> Browser
+        let a = app.on_key(Key::Down);
+        assert_eq!(app.selected_section, 1);
+        assert_eq!(a, Action::LoadSection(1));
+        // clamps at end
+        app.on_key(Key::Down);
+        assert_eq!(app.selected_section, 1);
+    }
+
+    #[test]
+    fn descend_moves_focus_to_charts_then_scrolls() {
+        let mut app = App::new(sections());
+        app.on_key(Key::ToggleScreen);
+        app.on_key(Key::Descend);
+        assert_eq!(app.focus, BrowserFocus::Charts);
+        app.on_key(Key::Down);
+        assert_eq!(app.chart_scroll, 1);
+    }
+
+    #[test]
+    fn window_keys_cycle() {
+        let mut app = App::new(sections());
+        assert_eq!(app.window, TimeWindow::Last5m);
+        app.on_key(Key::ShrinkWindow);
+        assert_eq!(app.window, TimeWindow::Last1m);
+        app.on_key(Key::GrowWindow);
+        assert_eq!(app.window, TimeWindow::Last5m);
+    }
+
+    #[test]
+    fn help_toggles_and_any_key_closes() {
+        let mut app = App::new(sections());
+        app.on_key(Key::Help);
+        assert!(app.show_help);
+        app.on_key(Key::Down);
+        assert!(!app.show_help);
+    }
+
+    #[test]
+    fn quit_key_returns_quit() {
+        let mut app = App::new(sections());
+        assert_eq!(app.on_key(Key::Quit), Action::Quit);
+    }
+
+    #[test]
+    fn set_section_groups_stores_body() {
+        let mut app = App::new(sections());
+        app.set_section_groups(0, vec![NavGroup { name: "g".into(), plots: vec![] }]);
+        assert!(app.sections[0].groups.is_some());
+    }
+}

--- a/src/viewer/tui/app.rs
+++ b/src/viewer/tui/app.rs
@@ -25,14 +25,12 @@ pub enum Action {
     Redraw,
     /// The selected section changed; loop should ensure its body is loaded.
     LoadSection(usize),
-    ToggleHelp,
 }
 
 pub struct App {
     pub screen: Screen,
     pub sections: Vec<NavSection>,
     pub selected_section: usize,
-    pub selected_group: usize,
     pub focus: BrowserFocus,
     pub window: TimeWindow,
     pub show_help: bool,
@@ -46,7 +44,6 @@ impl App {
             screen: Screen::Overview,
             sections,
             selected_section: 0,
-            selected_group: 0,
             focus: BrowserFocus::Nav,
             window: TimeWindow::Last5m,
             show_help: false,
@@ -60,13 +57,6 @@ impl App {
 
     fn section_count(&self) -> usize {
         self.sections.len()
-    }
-
-    fn group_count(&self) -> usize {
-        self.current_section()
-            .and_then(|s| s.groups.as_ref())
-            .map(|g| g.len())
-            .unwrap_or(0)
     }
 
     /// Handle a single logical key. Returns the action for the loop.
@@ -115,7 +105,6 @@ impl App {
                 if self.section_count() > 0 {
                     self.selected_section =
                         (self.selected_section + 1).min(self.section_count() - 1);
-                    self.selected_group = 0;
                     self.chart_scroll = 0;
                     return Action::LoadSection(self.selected_section);
                 }
@@ -133,7 +122,6 @@ impl App {
         match self.screen {
             Screen::Browser if self.focus == BrowserFocus::Nav => {
                 self.selected_section = self.selected_section.saturating_sub(1);
-                self.selected_group = 0;
                 self.chart_scroll = 0;
                 Action::LoadSection(self.selected_section)
             }
@@ -225,13 +213,21 @@ pub enum Key {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model::{NavGroup, NavSection};
+    use super::*;
 
     fn sections() -> Vec<NavSection> {
         vec![
-            NavSection { name: "CPU".into(), route: "/cpu".into(), groups: None },
-            NavSection { name: "Net".into(), route: "/network".into(), groups: None },
+            NavSection {
+                name: "CPU".into(),
+                route: "/cpu".into(),
+                groups: None,
+            },
+            NavSection {
+                name: "Net".into(),
+                route: "/network".into(),
+                groups: None,
+            },
         ]
     }
 
@@ -294,20 +290,40 @@ mod tests {
     #[test]
     fn set_section_groups_stores_body() {
         let mut app = App::new(sections());
-        app.set_section_groups(0, vec![NavGroup { name: "g".into(), plots: vec![] }]);
+        app.set_section_groups(
+            0,
+            vec![NavGroup {
+                name: "g".into(),
+                plots: vec![],
+            }],
+        );
         assert!(app.sections[0].groups.is_some());
     }
 
     #[test]
     fn reconcile_preserves_loaded_groups_and_selection_by_route() {
         let mut app = App::new(sections()); // [CPU /cpu, Net /network]
-        app.set_section_groups(1, vec![NavGroup { name: "g".into(), plots: vec![] }]);
+        app.set_section_groups(
+            1,
+            vec![NavGroup {
+                name: "g".into(),
+                plots: vec![],
+            }],
+        );
         app.selected_section = 1; // on /network
 
         // A new section appears before the others; /cpu disappears.
         let latest = vec![
-            NavSection { name: "GPU".into(), route: "/gpu".into(), groups: None },
-            NavSection { name: "Net".into(), route: "/network".into(), groups: None },
+            NavSection {
+                name: "GPU".into(),
+                route: "/gpu".into(),
+                groups: None,
+            },
+            NavSection {
+                name: "Net".into(),
+                route: "/network".into(),
+                groups: None,
+            },
         ];
         app.reconcile_sections(latest);
 
@@ -323,7 +339,13 @@ mod tests {
     #[test]
     fn reconcile_is_noop_when_routes_match() {
         let mut app = App::new(sections());
-        app.set_section_groups(0, vec![NavGroup { name: "g".into(), plots: vec![] }]);
+        app.set_section_groups(
+            0,
+            vec![NavGroup {
+                name: "g".into(),
+                plots: vec![],
+            }],
+        );
         // Same routes in the same order (bodies None) — must not wipe the
         // already-loaded group on /cpu.
         app.reconcile_sections(sections());

--- a/src/viewer/tui/layout.rs
+++ b/src/viewer/tui/layout.rs
@@ -1,0 +1,105 @@
+//! Pure responsive layout math. No ratatui types so it is trivially
+//! unit-testable; render code consumes these decisions.
+
+/// Minimum terminal size below which we show a "too small" message.
+pub const MIN_WIDTH: u16 = 30;
+pub const MIN_HEIGHT: u16 = 10;
+
+/// Per-tile minimum cell size on the overview grid.
+pub const TILE_MIN_W: u16 = 24;
+pub const TILE_MIN_H: u16 = 6;
+
+/// Overview grid decision: how many columns, and how many tiles fit.
+#[derive(Debug, PartialEq, Eq)]
+pub struct GridPlan {
+    pub cols: u16,
+    pub rows: u16,
+    pub visible: usize,
+}
+
+/// Compute the overview grid for `n` priority-ordered tiles in a `w`x`h`
+/// area. Drops lowest-priority tiles that do not fit vertically.
+pub fn overview_grid(w: u16, h: u16, n: usize) -> GridPlan {
+    if n == 0 {
+        return GridPlan { cols: 0, rows: 0, visible: 0 };
+    }
+    let cols = (w / TILE_MIN_W).max(1);
+    let max_rows = (h / TILE_MIN_H).max(1);
+    let capacity = (cols as usize) * (max_rows as usize);
+    let visible = n.min(capacity);
+    let rows = ((visible as u16) + cols - 1) / cols;
+    GridPlan { cols, rows, visible }
+}
+
+/// Whether the section browser can show both panes side-by-side, and the
+/// nav pane width if so.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BrowserSplit {
+    /// Side-by-side; value is nav pane width in columns.
+    Dual(u16),
+    /// Too narrow: single pane (caller toggles which).
+    Single,
+}
+
+pub const NAV_MIN_W: u16 = 20;
+pub const CHART_MIN_W: u16 = 30;
+
+/// Decide the browser split for a given width.
+pub fn browser_split(w: u16) -> BrowserSplit {
+    if w >= NAV_MIN_W + CHART_MIN_W {
+        // Nav gets ~30%, clamped to a sane band.
+        let nav = ((w as u32 * 30 / 100) as u16).clamp(NAV_MIN_W, 40);
+        BrowserSplit::Dual(nav)
+    } else {
+        BrowserSplit::Single
+    }
+}
+
+/// True when the terminal is too small to render anything useful.
+pub fn too_small(w: u16, h: u16) -> bool {
+    w < MIN_WIDTH || h < MIN_HEIGHT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grid_drops_tiles_that_dont_fit() {
+        // 50 wide => 2 cols; 12 high => 2 rows => capacity 4. 6 tiles => 4 visible.
+        let p = overview_grid(50, 12, 6);
+        assert_eq!(p.cols, 2);
+        assert_eq!(p.visible, 4);
+        assert_eq!(p.rows, 2);
+    }
+
+    #[test]
+    fn grid_fits_all_when_room() {
+        let p = overview_grid(120, 30, 6);
+        assert_eq!(p.visible, 6);
+        assert!(p.cols >= 4);
+    }
+
+    #[test]
+    fn grid_single_column_when_narrow() {
+        let p = overview_grid(24, 30, 6);
+        assert_eq!(p.cols, 1);
+    }
+
+    #[test]
+    fn browser_dual_when_wide() {
+        assert!(matches!(browser_split(120), BrowserSplit::Dual(_)));
+    }
+
+    #[test]
+    fn browser_single_when_narrow() {
+        assert_eq!(browser_split(40), BrowserSplit::Single);
+    }
+
+    #[test]
+    fn too_small_below_minimums() {
+        assert!(too_small(20, 20));
+        assert!(too_small(80, 8));
+        assert!(!too_small(80, 24));
+    }
+}

--- a/src/viewer/tui/layout.rs
+++ b/src/viewer/tui/layout.rs
@@ -21,14 +21,22 @@ pub struct GridPlan {
 /// area. Drops lowest-priority tiles that do not fit vertically.
 pub fn overview_grid(w: u16, h: u16, n: usize) -> GridPlan {
     if n == 0 {
-        return GridPlan { cols: 0, rows: 0, visible: 0 };
+        return GridPlan {
+            cols: 0,
+            rows: 0,
+            visible: 0,
+        };
     }
     let cols = (w / TILE_MIN_W).max(1);
     let max_rows = (h / TILE_MIN_H).max(1);
     let capacity = (cols as usize) * (max_rows as usize);
     let visible = n.min(capacity);
-    let rows = ((visible as u16) + cols - 1) / cols;
-    GridPlan { cols, rows, visible }
+    let rows = (visible as u16).div_ceil(cols);
+    GridPlan {
+        cols,
+        rows,
+        visible,
+    }
 }
 
 /// Whether the section browser can show both panes side-by-side, and the

--- a/src/viewer/tui/layout.rs
+++ b/src/viewer/tui/layout.rs
@@ -5,37 +5,61 @@
 pub const MIN_WIDTH: u16 = 30;
 pub const MIN_HEIGHT: u16 = 10;
 
-/// Per-tile minimum cell size on the overview grid.
-pub const TILE_MIN_W: u16 = 24;
-pub const TILE_MIN_H: u16 = 6;
+/// Per-tile minimum height on the overview grid, below which a tile is too
+/// cramped to read.
+pub const TILE_MIN_H: u16 = 7;
 
-/// Overview grid decision: how many columns, and how many tiles fit.
+/// Preferred tile width. We fit as many preferred-width tiles across as the
+/// terminal allows, rather than as *many* tiles as possible — otherwise a
+/// wide terminal packs the tiles into narrow full-height strips. This also
+/// keeps every tile comfortably above the readable minimum width.
+pub const TILE_PREF_W: u16 = 48;
+
+/// Cap on tile height. Charts read best wider-than-tall, so we never stretch
+/// a tile past this even on a tall terminal; rows pack from the top and the
+/// leftover height is left blank rather than inflating tiles into vertical
+/// strips.
+pub const TILE_MAX_H: u16 = 14;
+
+/// Overview grid decision: column/row counts, how many tiles are shown, and
+/// the fixed per-row (tile) height in cells.
 #[derive(Debug, PartialEq, Eq)]
 pub struct GridPlan {
     pub cols: u16,
     pub rows: u16,
     pub visible: usize,
+    /// Fixed height of each tile row, in cells (already capped for aspect).
+    pub row_height: u16,
 }
 
 /// Compute the overview grid for `n` priority-ordered tiles in a `w`x`h`
-/// area. Drops lowest-priority tiles that do not fit vertically.
+/// area. Chooses a column count that keeps tiles readably wide, caps tile
+/// height so they stay landscape, and drops lowest-priority tiles that do
+/// not fit vertically.
 pub fn overview_grid(w: u16, h: u16, n: usize) -> GridPlan {
     if n == 0 {
         return GridPlan {
             cols: 0,
             rows: 0,
             visible: 0,
+            row_height: 0,
         };
     }
-    let cols = (w / TILE_MIN_W).max(1);
-    let max_rows = (h / TILE_MIN_H).max(1);
-    let capacity = (cols as usize) * (max_rows as usize);
-    let visible = n.min(capacity);
-    let rows = (visible as u16).div_ceil(cols);
+    // Columns: as many preferred-width tiles as fit, clamped to [1, n].
+    let cols = (w / TILE_PREF_W).clamp(1, n as u16);
+    let rows_needed = (n as u16).div_ceil(cols);
+    // Fixed tile height, capped so tiles stay landscape rather than filling
+    // a tall terminal; never below the readable minimum.
+    let row_height = (h / rows_needed).clamp(TILE_MIN_H, TILE_MAX_H);
+    // How many of those rows actually fit in the available height.
+    let rows_fit = (h / row_height).max(1);
+    let rows = rows_needed.min(rows_fit);
+    let visible = n.min((cols as usize) * (rows as usize));
     GridPlan {
         cols,
         rows,
         visible,
+        row_height,
     }
 }
 
@@ -73,24 +97,43 @@ mod tests {
     use super::*;
 
     #[test]
-    fn grid_drops_tiles_that_dont_fit() {
-        // 50 wide => 2 cols; 12 high => 2 rows => capacity 4. 6 tiles => 4 visible.
-        let p = overview_grid(50, 12, 6);
-        assert_eq!(p.cols, 2);
-        assert_eq!(p.visible, 4);
-        assert_eq!(p.rows, 2);
+    fn grid_columns_scale_with_width_not_maximized() {
+        // Preferred width 48: ~one column per 48 cells, so tiles stay wide
+        // instead of being packed into as many narrow strips as fit.
+        assert_eq!(overview_grid(60, 40, 6).cols, 1);
+        assert_eq!(overview_grid(120, 40, 6).cols, 2);
+        assert_eq!(overview_grid(200, 40, 6).cols, 4);
+        // Never more columns than tiles.
+        assert!(overview_grid(1000, 40, 6).cols <= 6);
+    }
+
+    #[test]
+    fn grid_row_height_is_capped_landscape() {
+        // A tall terminal must not stretch tiles into vertical strips.
+        let p = overview_grid(120, 100, 6);
+        assert!(p.row_height <= TILE_MAX_H, "row_height {}", p.row_height);
+        assert!(p.row_height >= TILE_MIN_H);
     }
 
     #[test]
     fn grid_fits_all_when_room() {
-        let p = overview_grid(120, 30, 6);
+        let p = overview_grid(200, 40, 6);
         assert_eq!(p.visible, 6);
-        assert!(p.cols >= 4);
+    }
+
+    #[test]
+    fn grid_drops_tiles_when_too_short() {
+        // 60 wide => 1 col; a short terminal can only show a couple of the
+        // stacked tiles, so the rest are dropped rather than crushed.
+        let p = overview_grid(60, 16, 6);
+        assert_eq!(p.cols, 1);
+        assert!(p.visible < 6);
+        assert_eq!(p.visible, (p.cols * p.rows) as usize);
     }
 
     #[test]
     fn grid_single_column_when_narrow() {
-        let p = overview_grid(24, 30, 6);
+        let p = overview_grid(40, 30, 6);
         assert_eq!(p.cols, 1);
     }
 

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -6,6 +6,7 @@ mod app;
 mod layout;
 mod model;
 mod query;
+mod render;
 mod window;
 
 /// Entry point for the TUI. Replaces the axum server when `--tui` is set.

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -138,6 +138,11 @@ fn load_section_charts(state: &AppState, app: &App) -> Vec<(String, ChartData)> 
 }
 
 /// Entry point for the TUI. Replaces the axum server when `--tui` is set.
+///
+/// `_rt` is the process tokio runtime. In live mode the ingest loop it drives
+/// was already spawned by `init_live_mode`; the TUI itself is synchronous and
+/// reads the shared TSDB. The handle is kept in the signature so the runtime
+/// outlives the ingest task and for future async-driven refresh.
 pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
     // Populate the nav (file mode: from the loaded data; live mode: the
     // ingest loop is already running and has produced at least the initial
@@ -175,54 +180,67 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
     // Redraw cadence: 1s, or coarser if the source samples slower.
     let tick = Duration::from_millis(1000);
 
+    // Whether the visible screen needs re-querying + redrawing this
+    // iteration. Live mode is always dirty (new samples arrive each tick);
+    // file mode is dirty only after input/resize (the data never changes),
+    // so an idle file-mode TUI does no work between keystrokes instead of
+    // re-running PromQL for every visible plot every second.
+    let mut dirty = true;
+
     loop {
         // In live mode, refresh the nav so newly-seen sections appear (and
         // vanished ones are pruned), preserving loaded bodies and selection.
         if live {
             metadata::regenerate_dashboards(&state);
             app.reconcile_sections(initial_sections(&state));
+            dirty = true;
         }
 
         let selected = app.selected_section;
         ensure_section_loaded(&state, &mut app, selected);
 
-        // Gather per-screen render inputs.
-        let section_charts = if app.screen == Screen::Browser {
-            load_section_charts(&state, &app)
-        } else {
-            Vec::new()
-        };
-        let overview_data: Vec<ChartData> = if app.screen == Screen::Overview {
-            let data = state.baseline_data();
-            overview_tiles
-                .iter()
-                .map(|t| load_chart(data.as_ref(), &t.def, app.window))
-                .collect()
-        } else {
-            Vec::new()
-        };
+        if dirty {
+            // Gather per-screen render inputs.
+            let section_charts = if app.screen == Screen::Browser {
+                load_section_charts(&state, &app)
+            } else {
+                Vec::new()
+            };
+            let overview_data: Vec<ChartData> = if app.screen == Screen::Overview {
+                let data = state.baseline_data();
+                overview_tiles
+                    .iter()
+                    .map(|t| load_chart(data.as_ref(), &t.def, app.window))
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
-        let draw_res = guard.term.draw(|f| {
-            match app.screen {
-                Screen::Overview => {
-                    render::overview::draw_overview(f, &overview_tiles, &overview_data)
+            let draw_res = guard.term.draw(|f| {
+                match app.screen {
+                    Screen::Overview => {
+                        render::overview::draw_overview(f, &overview_tiles, &overview_data)
+                    }
+                    Screen::Browser => render::browser::draw_browser(f, &app, &section_charts),
                 }
-                Screen::Browser => render::browser::draw_browser(f, &app, &section_charts),
+                if app.show_help {
+                    render::help::draw_help(f);
+                }
+            });
+            if draw_res.is_err() {
+                break;
             }
-            if app.show_help {
-                render::help::draw_help(f);
-            }
-        });
-        if draw_res.is_err() {
-            break;
+            dirty = false;
         }
 
-        // Input with a timeout so live mode keeps ticking.
+        // Input with a timeout so live mode keeps ticking. Any key or resize
+        // marks the screen dirty so the next iteration re-queries and redraws.
         let poll = event::poll(tick).unwrap_or(false);
         if poll {
             match event::read() {
                 Ok(Event::Key(k)) if k.kind == event::KeyEventKind::Press => {
                     if let Some(key) = decode_key(k) {
+                        dirty = true;
                         match app.on_key(key) {
                             Action::Quit => break,
                             Action::LoadSection(idx) => {
@@ -232,12 +250,61 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
                         }
                     }
                 }
-                Ok(Event::Resize(_, _)) => { /* loop redraws */ }
+                Ok(Event::Resize(_, _)) => dirty = true,
                 _ => {}
             }
         }
-        // In file mode with no pending input, we still loop and redraw;
-        // that is cheap and keeps resize handling simple.
     }
     drop(guard);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn ctrl_c_maps_to_quit_before_bare_c() {
+        let ctrl_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(decode_key(ctrl_c), Some(Key::Quit));
+        // A bare 'c' is not a mapped key.
+        assert_eq!(decode_key(press(KeyCode::Char('c'))), None);
+    }
+
+    #[test]
+    fn keybindings_decode_as_documented() {
+        assert_eq!(decode_key(press(KeyCode::Char('q'))), Some(Key::Quit));
+        assert_eq!(decode_key(press(KeyCode::Char('?'))), Some(Key::Help));
+        assert_eq!(decode_key(press(KeyCode::Tab)), Some(Key::ToggleScreen));
+        assert_eq!(
+            decode_key(press(KeyCode::Char('o'))),
+            Some(Key::ToggleScreen)
+        );
+        assert_eq!(decode_key(press(KeyCode::Char(']'))), Some(Key::GrowWindow));
+        assert_eq!(
+            decode_key(press(KeyCode::Char('['))),
+            Some(Key::ShrinkWindow)
+        );
+        assert_eq!(decode_key(press(KeyCode::Down)), Some(Key::Down));
+        assert_eq!(decode_key(press(KeyCode::Char('j'))), Some(Key::Down));
+        assert_eq!(decode_key(press(KeyCode::Up)), Some(Key::Up));
+        assert_eq!(decode_key(press(KeyCode::Char('k'))), Some(Key::Up));
+        assert_eq!(decode_key(press(KeyCode::Enter)), Some(Key::Descend));
+        assert_eq!(decode_key(press(KeyCode::Right)), Some(Key::Descend));
+        assert_eq!(decode_key(press(KeyCode::Char('l'))), Some(Key::Descend));
+        assert_eq!(decode_key(press(KeyCode::Esc)), Some(Key::Ascend));
+        assert_eq!(decode_key(press(KeyCode::Left)), Some(Key::Ascend));
+        assert_eq!(decode_key(press(KeyCode::Char('h'))), Some(Key::Ascend));
+        assert_eq!(decode_key(press(KeyCode::Char('r'))), Some(Key::Refresh));
+    }
+
+    #[test]
+    fn unmapped_key_is_ignored() {
+        assert_eq!(decode_key(press(KeyCode::Char('z'))), None);
+        assert_eq!(decode_key(press(KeyCode::F(5))), None);
+    }
 }

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -2,6 +2,7 @@
 
 use super::state::AppState;
 
+mod app;
 mod layout;
 mod model;
 mod query;

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -214,6 +214,16 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
             } else {
                 Vec::new()
             };
+            // Clamp the charts-pane scroll to a valid range for the current
+            // terminal size so scrolling back up from the bottom responds
+            // immediately (the charts pane spans the full height, minus its
+            // top/bottom border).
+            if app.screen == Screen::Browser {
+                let h = guard.term.size().map(|s| s.height).unwrap_or(24);
+                let visible = render::browser::visible_charts(h.saturating_sub(2));
+                let max_start = section_charts.len().saturating_sub(visible) as u16;
+                app.chart_scroll = app.chart_scroll.min(max_start);
+            }
             let overview_data: Vec<ChartData> = if app.screen == Screen::Overview {
                 let data = state.baseline_data();
                 overview_tiles

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -228,7 +228,7 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
                             Action::LoadSection(idx) => {
                                 ensure_section_loaded(&state, &mut app, idx);
                             }
-                            Action::None | Action::Redraw | Action::ToggleHelp => {}
+                            Action::None | Action::Redraw => {}
                         }
                     }
                 }

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -5,6 +5,7 @@ mod layout;
 mod model;
 mod query;
 mod render;
+mod units;
 mod window;
 
 use std::io::{self, Stdout};
@@ -114,8 +115,11 @@ fn ensure_section_loaded(state: &AppState, app: &mut App, idx: usize) {
     }
 }
 
+/// A resolved plot ready to render: title, unit system, and loaded data.
+type LoadedPlot = (String, Option<String>, ChartData);
+
 /// Load chart data for every plot in the selected section.
-fn load_section_charts(state: &AppState, app: &App) -> Vec<(String, ChartData)> {
+fn load_section_charts(state: &AppState, app: &App) -> Vec<LoadedPlot> {
     let data = state.baseline_data();
     let Some(section) = app.current_section() else {
         return Vec::new();
@@ -131,7 +135,11 @@ fn load_section_charts(state: &AppState, app: &App) -> Vec<(String, ChartData)> 
             } else {
                 p.title.clone()
             };
-            out.push((title, load_chart(data.as_ref(), p, app.window)));
+            out.push((
+                title,
+                p.unit_system.clone(),
+                load_chart(data.as_ref(), p, app.window),
+            ));
         }
     }
     out

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -2,6 +2,7 @@
 
 use super::state::AppState;
 
+mod layout;
 mod model;
 mod query;
 mod window;

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -21,6 +21,18 @@ use app::{Action, App, Key, Screen};
 use model::{parse_section_groups, NavSection};
 use query::{load_chart, ChartData};
 
+/// Best-effort return of the terminal to a sane state: leave raw mode,
+/// leave the alternate screen, show the cursor. Idempotent, so the RAII
+/// guard's `Drop`, the panic hook, and the SIGINT handler can all call it.
+fn restore_terminal() {
+    let _ = terminal::disable_raw_mode();
+    let _ = execute!(
+        io::stdout(),
+        terminal::LeaveAlternateScreen,
+        ratatui::crossterm::cursor::Show
+    );
+}
+
 /// RAII guard: enters the alternate screen + raw mode on construction and
 /// restores the terminal on drop (including on panic/unwind).
 struct TerminalGuard {
@@ -39,9 +51,7 @@ impl TerminalGuard {
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
-        let _ = terminal::disable_raw_mode();
-        let _ = execute!(self.term.backend_mut(), terminal::LeaveAlternateScreen);
-        let _ = self.term.show_cursor();
+        restore_terminal();
     }
 }
 
@@ -137,6 +147,23 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
     let mut app = App::new(initial_sections(&state));
     let overview_tiles = render::overview::tiles();
 
+    // A panic inside the draw loop, or an external SIGINT (`kill -INT`, a
+    // supervisor) delivered while the terminal is in raw mode, would
+    // otherwise leave the terminal unusable — neither runs `TerminalGuard`'s
+    // `Drop`. Restore the terminal in both paths. (A keyboard Ctrl-C in raw
+    // mode arrives as a key event and quits gracefully via the guard; the
+    // process-wide exit-on-SIGINT handler is intentionally not installed for
+    // `--tui`, see `run()`.)
+    let default_panic = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        default_panic(info);
+    }));
+    let _ = ctrlc::set_handler(|| {
+        restore_terminal();
+        std::process::exit(130);
+    });
+
     let mut guard = match TerminalGuard::new() {
         Ok(g) => g,
         Err(e) => {
@@ -149,19 +176,11 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
     let tick = Duration::from_millis(1000);
 
     loop {
-        // In live mode, refresh the nav so newly-seen sections appear.
+        // In live mode, refresh the nav so newly-seen sections appear (and
+        // vanished ones are pruned), preserving loaded bodies and selection.
         if live {
             metadata::regenerate_dashboards(&state);
-            // Reconcile: if new sections appeared, extend the nav list.
-            let latest = initial_sections(&state);
-            if latest.len() != app.sections.len() {
-                // Preserve loaded bodies by name where possible.
-                for s in latest {
-                    if !app.sections.iter().any(|e| e.route == s.route) {
-                        app.sections.push(s);
-                    }
-                }
-            }
+            app.reconcile_sections(initial_sections(&state));
         }
 
         let selected = app.selected_section;

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -1,0 +1,8 @@
+//! Terminal UI frontend for `rezolus view --tui`.
+
+use super::state::AppState;
+
+/// Entry point for the TUI. Replaces the axum server when `--tui` is set.
+pub fn run_tui(_state: AppState, _live: bool, _rt: &tokio::runtime::Runtime) {
+    eprintln!("TUI not yet implemented");
+}

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -3,6 +3,7 @@
 use super::state::AppState;
 
 mod model;
+mod query;
 mod window;
 
 /// Entry point for the TUI. Replaces the axum server when `--tui` is set.

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -2,6 +2,8 @@
 
 use super::state::AppState;
 
+mod window;
+
 /// Entry point for the TUI. Replaces the axum server when `--tui` is set.
 pub fn run_tui(_state: AppState, _live: bool, _rt: &tokio::runtime::Runtime) {
     eprintln!("TUI not yet implemented");

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -2,6 +2,7 @@
 
 use super::state::AppState;
 
+mod model;
 mod window;
 
 /// Entry point for the TUI. Replaces the axum server when `--tui` is set.

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -1,7 +1,5 @@
 //! Terminal UI frontend for `rezolus view --tui`.
 
-use super::state::AppState;
-
 mod app;
 mod layout;
 mod model;
@@ -9,7 +7,218 @@ mod query;
 mod render;
 mod window;
 
+use std::io::{self, Stdout};
+use std::time::Duration;
+
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::crossterm::{execute, terminal};
+use ratatui::Terminal;
+
+use super::metadata;
+use super::state::AppState;
+use app::{Action, App, Key, Screen};
+use model::{parse_section_groups, NavSection};
+use query::{load_chart, ChartData};
+
+/// RAII guard: enters the alternate screen + raw mode on construction and
+/// restores the terminal on drop (including on panic/unwind).
+struct TerminalGuard {
+    term: Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl TerminalGuard {
+    fn new() -> io::Result<Self> {
+        terminal::enable_raw_mode()?;
+        let mut out = io::stdout();
+        execute!(out, terminal::EnterAlternateScreen)?;
+        let term = Terminal::new(CrosstermBackend::new(out))?;
+        Ok(Self { term })
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+        let _ = execute!(self.term.backend_mut(), terminal::LeaveAlternateScreen);
+        let _ = self.term.show_cursor();
+    }
+}
+
+/// Decode a crossterm key event into our logical `Key`. Returns `None`
+/// for keys we ignore.
+fn decode_key(k: KeyEvent) -> Option<Key> {
+    if k.modifiers.contains(KeyModifiers::CONTROL) && k.code == KeyCode::Char('c') {
+        return Some(Key::Quit);
+    }
+    match k.code {
+        KeyCode::Char('q') => Some(Key::Quit),
+        KeyCode::Char('?') => Some(Key::Help),
+        KeyCode::Tab | KeyCode::Char('o') => Some(Key::ToggleScreen),
+        KeyCode::Char(']') => Some(Key::GrowWindow),
+        KeyCode::Char('[') => Some(Key::ShrinkWindow),
+        KeyCode::Down | KeyCode::Char('j') => Some(Key::Down),
+        KeyCode::Up | KeyCode::Char('k') => Some(Key::Up),
+        KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => Some(Key::Descend),
+        KeyCode::Esc | KeyCode::Left | KeyCode::Char('h') => Some(Key::Ascend),
+        KeyCode::Char('r') => Some(Key::Refresh),
+        _ => None,
+    }
+}
+
+/// Build the initial nav section list from the AppState.
+fn initial_sections(state: &AppState) -> Vec<NavSection> {
+    state
+        .sections
+        .read()
+        .sections()
+        .iter()
+        .map(|s| NavSection {
+            name: s.name.clone(),
+            route: s.route.clone(),
+            groups: None,
+        })
+        .collect()
+}
+
+/// Ensure section `idx`'s groups are loaded into the App.
+fn ensure_section_loaded(state: &AppState, app: &mut App, idx: usize) {
+    if app
+        .sections
+        .get(idx)
+        .map(|s| s.groups.is_some())
+        .unwrap_or(true)
+    {
+        return;
+    }
+    let route = app.sections[idx].route.clone();
+    let data = state.baseline_data();
+    let groups = {
+        let mut store = state.sections.write();
+        store
+            .get_or_generate(&route, data.as_ref())
+            .map(parse_section_groups)
+    };
+    if let Some(groups) = groups {
+        app.set_section_groups(idx, groups);
+    }
+}
+
+/// Load chart data for every plot in the selected section.
+fn load_section_charts(state: &AppState, app: &App) -> Vec<(String, ChartData)> {
+    let data = state.baseline_data();
+    let Some(section) = app.current_section() else {
+        return Vec::new();
+    };
+    let Some(groups) = section.groups.as_ref() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for g in groups {
+        for p in &g.plots {
+            let title = if p.title.is_empty() {
+                g.name.clone()
+            } else {
+                p.title.clone()
+            };
+            out.push((title, load_chart(data.as_ref(), p, app.window)));
+        }
+    }
+    out
+}
+
 /// Entry point for the TUI. Replaces the axum server when `--tui` is set.
-pub fn run_tui(_state: AppState, _live: bool, _rt: &tokio::runtime::Runtime) {
-    eprintln!("TUI not yet implemented");
+pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
+    // Populate the nav (file mode: from the loaded data; live mode: the
+    // ingest loop is already running and has produced at least the initial
+    // context, but regenerate to pick up all metrics seen so far).
+    metadata::regenerate_dashboards(&state);
+
+    let mut app = App::new(initial_sections(&state));
+    let overview_tiles = render::overview::tiles();
+
+    let mut guard = match TerminalGuard::new() {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("failed to initialize terminal: {e}");
+            return;
+        }
+    };
+
+    // Redraw cadence: 1s, or coarser if the source samples slower.
+    let tick = Duration::from_millis(1000);
+
+    loop {
+        // In live mode, refresh the nav so newly-seen sections appear.
+        if live {
+            metadata::regenerate_dashboards(&state);
+            // Reconcile: if new sections appeared, extend the nav list.
+            let latest = initial_sections(&state);
+            if latest.len() != app.sections.len() {
+                // Preserve loaded bodies by name where possible.
+                for s in latest {
+                    if !app.sections.iter().any(|e| e.route == s.route) {
+                        app.sections.push(s);
+                    }
+                }
+            }
+        }
+
+        let selected = app.selected_section;
+        ensure_section_loaded(&state, &mut app, selected);
+
+        // Gather per-screen render inputs.
+        let section_charts = if app.screen == Screen::Browser {
+            load_section_charts(&state, &app)
+        } else {
+            Vec::new()
+        };
+        let overview_data: Vec<ChartData> = if app.screen == Screen::Overview {
+            let data = state.baseline_data();
+            overview_tiles
+                .iter()
+                .map(|t| load_chart(data.as_ref(), &t.def, app.window))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let draw_res = guard.term.draw(|f| {
+            match app.screen {
+                Screen::Overview => {
+                    render::overview::draw_overview(f, &overview_tiles, &overview_data)
+                }
+                Screen::Browser => render::browser::draw_browser(f, &app, &section_charts),
+            }
+            if app.show_help {
+                render::help::draw_help(f);
+            }
+        });
+        if draw_res.is_err() {
+            break;
+        }
+
+        // Input with a timeout so live mode keeps ticking.
+        let poll = event::poll(tick).unwrap_or(false);
+        if poll {
+            match event::read() {
+                Ok(Event::Key(k)) if k.kind == event::KeyEventKind::Press => {
+                    if let Some(key) = decode_key(k) {
+                        match app.on_key(key) {
+                            Action::Quit => break,
+                            Action::LoadSection(idx) => {
+                                ensure_section_loaded(&state, &mut app, idx);
+                            }
+                            Action::None | Action::Redraw | Action::ToggleHelp => {}
+                        }
+                    }
+                }
+                Ok(Event::Resize(_, _)) => { /* loop redraws */ }
+                _ => {}
+            }
+        }
+        // In file mode with no pending input, we still loop and redraw;
+        // that is cheap and keeps resize handling simple.
+    }
+    drop(guard);
 }

--- a/src/viewer/tui/model.rs
+++ b/src/viewer/tui/model.rs
@@ -1,0 +1,182 @@
+//! Navigation model: the section list plus per-section plot definitions,
+//! parsed from the same JSON the web frontend consumes.
+
+/// What kind of chart a plot resolves to in the TUI.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlotKind {
+    /// Gauge / delta_counter: query the base expression directly.
+    Line,
+    /// Histogram percentile scatter: wrap in `histogram_quantiles`.
+    Percentiles,
+    /// Bucket / quantile heatmap: not rendered in v1.
+    HeatmapUnsupported,
+}
+
+/// One plot's render definition, extracted from a section View's JSON.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PlotDef {
+    pub title: String,
+    pub base_query: String,
+    pub kind: PlotKind,
+    pub percentiles: Vec<f64>,
+    pub unit_system: Option<String>,
+}
+
+/// A named group of plots within a section.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavGroup {
+    pub name: String,
+    pub plots: Vec<PlotDef>,
+}
+
+/// A top-level section (nav entry) and, once loaded, its groups.
+#[derive(Clone, Debug, PartialEq)]
+pub struct NavSection {
+    pub name: String,
+    pub route: String,
+    /// `None` until the section body has been fetched/parsed.
+    pub groups: Option<Vec<NavGroup>>,
+}
+
+/// Default percentiles, matching `charts/metric_types.js::DEFAULT_PERCENTILES`.
+pub const DEFAULT_PERCENTILES: [f64; 5] = [0.5, 0.9, 0.99, 0.999, 0.9999];
+
+/// Parse a single plot object from a section View's JSON.
+/// Returns `None` if it has no query (nothing to render).
+pub fn parse_plot(plot: &serde_json::Value) -> Option<PlotDef> {
+    let base_query = plot.get("promql_query")?.as_str()?.to_string();
+    let opts = plot.get("opts");
+    let title = opts
+        .and_then(|o| o.get("title"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("")
+        .to_string();
+    let type_ = opts
+        .and_then(|o| o.get("type"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("gauge");
+    let subtype = opts
+        .and_then(|o| o.get("subtype"))
+        .and_then(|s| s.as_str());
+    let unit_system = opts
+        .and_then(|o| o.get("format"))
+        .and_then(|f| f.get("unit_system"))
+        .and_then(|u| u.as_str())
+        .map(|s| s.to_string());
+
+    let kind = match type_ {
+        "histogram" => match subtype {
+            Some("buckets") | Some("quantile_heatmap") => PlotKind::HeatmapUnsupported,
+            _ => PlotKind::Percentiles,
+        },
+        _ => PlotKind::Line,
+    };
+
+    let percentiles = opts
+        .and_then(|o| o.get("percentiles"))
+        .and_then(|p| p.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_f64()).collect::<Vec<_>>())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_PERCENTILES.to_vec());
+
+    Some(PlotDef {
+        title,
+        base_query,
+        kind,
+        percentiles,
+        unit_system,
+    })
+}
+
+/// Parse the groups+plots out of a section View JSON (as produced by
+/// `LazySectionStore::get_or_generate`).
+pub fn parse_section_groups(view: &serde_json::Value) -> Vec<NavGroup> {
+    let mut out = Vec::new();
+    let Some(groups) = view.get("groups").and_then(|g| g.as_array()) else {
+        return out;
+    };
+    for group in groups {
+        let name = group
+            .get("name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("")
+            .to_string();
+        let mut plots = Vec::new();
+        if let Some(subgroups) = group.get("subgroups").and_then(|s| s.as_array()) {
+            for sg in subgroups {
+                if let Some(ps) = sg.get("plots").and_then(|p| p.as_array()) {
+                    for p in ps {
+                        if let Some(def) = parse_plot(p) {
+                            plots.push(def);
+                        }
+                    }
+                }
+            }
+        }
+        out.push(NavGroup { name, plots });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn gauge_plot_is_line_with_verbatim_query() {
+        let p = json!({
+            "promql_query": "cpu_usage",
+            "opts": { "title": "CPU", "type": "gauge",
+                      "format": { "unit_system": "percentage" } }
+        });
+        let def = parse_plot(&p).unwrap();
+        assert_eq!(def.kind, PlotKind::Line);
+        assert_eq!(def.base_query, "cpu_usage");
+        assert_eq!(def.title, "CPU");
+        assert_eq!(def.unit_system.as_deref(), Some("percentage"));
+    }
+
+    #[test]
+    fn histogram_percentiles_uses_defaults_when_absent() {
+        let p = json!({
+            "promql_query": "scheduler_runqueue_latency",
+            "opts": { "title": "Runq", "type": "histogram" }
+        });
+        let def = parse_plot(&p).unwrap();
+        assert_eq!(def.kind, PlotKind::Percentiles);
+        assert_eq!(def.percentiles, DEFAULT_PERCENTILES.to_vec());
+    }
+
+    #[test]
+    fn histogram_buckets_is_unsupported() {
+        let p = json!({
+            "promql_query": "x",
+            "opts": { "type": "histogram", "subtype": "buckets" }
+        });
+        assert_eq!(parse_plot(&p).unwrap().kind, PlotKind::HeatmapUnsupported);
+    }
+
+    #[test]
+    fn plot_without_query_is_skipped() {
+        let p = json!({ "opts": { "type": "gauge" } });
+        assert!(parse_plot(&p).is_none());
+    }
+
+    #[test]
+    fn parse_groups_flattens_subgroups() {
+        let view = json!({
+            "groups": [
+                { "name": "G1", "subgroups": [
+                    { "plots": [ { "promql_query": "a", "opts": { "type": "gauge" } } ] },
+                    { "plots": [ { "promql_query": "b", "opts": { "type": "gauge" } } ] }
+                ] }
+            ]
+        });
+        let groups = parse_section_groups(&view);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].name, "G1");
+        assert_eq!(groups[0].plots.len(), 2);
+        assert_eq!(groups[0].plots[0].base_query, "a");
+    }
+}

--- a/src/viewer/tui/model.rs
+++ b/src/viewer/tui/model.rs
@@ -55,9 +55,7 @@ pub fn parse_plot(plot: &serde_json::Value) -> Option<PlotDef> {
         .and_then(|o| o.get("type"))
         .and_then(|t| t.as_str())
         .unwrap_or("gauge");
-    let subtype = opts
-        .and_then(|o| o.get("subtype"))
-        .and_then(|s| s.as_str());
+    let subtype = opts.and_then(|o| o.get("subtype")).and_then(|s| s.as_str());
     let unit_system = opts
         .and_then(|o| o.get("format"))
         .and_then(|f| f.get("unit_system"))

--- a/src/viewer/tui/query.rs
+++ b/src/viewer/tui/query.rs
@@ -56,11 +56,7 @@ pub fn percentile_label(q: f64) -> String {
 }
 
 /// Load a plot's chart data for the given window against `data`.
-pub fn load_chart(
-    data: &dyn MetricsSource,
-    def: &PlotDef,
-    window: TimeWindow,
-) -> ChartData {
+pub fn load_chart(data: &dyn MetricsSource, def: &PlotDef, window: TimeWindow) -> ChartData {
     if def.kind == PlotKind::HeatmapUnsupported {
         return ChartData::Unsupported;
     }
@@ -111,8 +107,8 @@ fn series_label(metric: &std::collections::HashMap<String, String>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::model::PlotKind;
+    use super::*;
 
     fn def(kind: PlotKind, pcts: Vec<f64>) -> PlotDef {
         PlotDef {

--- a/src/viewer/tui/query.rs
+++ b/src/viewer/tui/query.rs
@@ -1,0 +1,149 @@
+//! Bridges `PlotDef`s to `MetricsSource::query_range` and shapes results
+//! into chart-ready series.
+
+use metriken_query::{MetricsSource, QueryResult};
+
+use super::model::{PlotDef, PlotKind};
+use super::window::TimeWindow;
+
+/// One line to draw: a label plus (timestamp_s, value) points.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Series {
+    pub label: String,
+    pub points: Vec<(f64, f64)>,
+}
+
+/// Result of loading a plot for the current window.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ChartData {
+    Lines(Vec<Series>),
+    /// A heatmap-only plot we do not render in v1.
+    Unsupported,
+    /// The query failed; message is shown inline.
+    Error(String),
+    /// No data in range.
+    Empty,
+}
+
+/// Build the PromQL expression for a plot, applying the histogram
+/// percentile wrapping rule (mirrors `metric_types.js::buildHistogramQuery`).
+pub fn build_query(def: &PlotDef) -> Option<String> {
+    match def.kind {
+        PlotKind::Line => Some(def.base_query.clone()),
+        PlotKind::Percentiles => {
+            let qs = def
+                .percentiles
+                .iter()
+                .map(|p| format!("{p}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Some(format!("histogram_quantiles([{qs}], {})", def.base_query))
+        }
+        PlotKind::HeatmapUnsupported => None,
+    }
+}
+
+/// Turn a percentile quantile (e.g. 0.999) into a short label ("p99.9").
+pub fn percentile_label(q: f64) -> String {
+    let pct = q * 100.0;
+    if (pct - pct.round()).abs() < 1e-9 {
+        format!("p{}", pct.round() as i64)
+    } else {
+        // Trim trailing zeros: 99.9, 99.99
+        let s = format!("{pct}");
+        format!("p{s}")
+    }
+}
+
+/// Load a plot's chart data for the given window against `data`.
+pub fn load_chart(
+    data: &dyn MetricsSource,
+    def: &PlotDef,
+    window: TimeWindow,
+) -> ChartData {
+    if def.kind == PlotKind::HeatmapUnsupported {
+        return ChartData::Unsupported;
+    }
+    let Some(query) = build_query(def) else {
+        return ChartData::Unsupported;
+    };
+    let Some((start, end, step)) = window.resolve(data.time_range(), data.interval()) else {
+        return ChartData::Empty;
+    };
+    match data.query_range(&query, start, end, step) {
+        Ok(QueryResult::Matrix { result }) => {
+            let series: Vec<Series> = result
+                .into_iter()
+                .map(|s| Series {
+                    label: series_label(&s.metric),
+                    points: s.values,
+                })
+                .filter(|s| !s.points.is_empty())
+                .collect();
+            if series.is_empty() {
+                ChartData::Empty
+            } else {
+                ChartData::Lines(series)
+            }
+        }
+        Ok(_) => ChartData::Empty,
+        Err(e) => ChartData::Error(e.to_string()),
+    }
+}
+
+/// Choose a display label for a matrix series from its metric labels.
+/// Prefers a `percentile`/`quantile` label, then any distinguishing label,
+/// else empty.
+fn series_label(metric: &std::collections::HashMap<String, String>) -> String {
+    if let Some(q) = metric.get("percentile").or_else(|| metric.get("quantile")) {
+        if let Ok(v) = q.parse::<f64>() {
+            return percentile_label(if v > 1.0 { v / 100.0 } else { v });
+        }
+        return q.clone();
+    }
+    // Fall back to a single non-name label value if present.
+    metric
+        .iter()
+        .find(|(k, _)| k.as_str() != "__name__")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::model::PlotKind;
+
+    fn def(kind: PlotKind, pcts: Vec<f64>) -> PlotDef {
+        PlotDef {
+            title: "t".into(),
+            base_query: "m".into(),
+            kind,
+            percentiles: pcts,
+            unit_system: None,
+        }
+    }
+
+    #[test]
+    fn line_query_is_verbatim() {
+        assert_eq!(build_query(&def(PlotKind::Line, vec![])).unwrap(), "m");
+    }
+
+    #[test]
+    fn percentile_query_wraps_histogram_quantiles() {
+        let q = build_query(&def(PlotKind::Percentiles, vec![0.5, 0.99])).unwrap();
+        assert_eq!(q, "histogram_quantiles([0.5, 0.99], m)");
+    }
+
+    #[test]
+    fn heatmap_has_no_query() {
+        assert!(build_query(&def(PlotKind::HeatmapUnsupported, vec![])).is_none());
+    }
+
+    #[test]
+    fn percentile_labels_format() {
+        assert_eq!(percentile_label(0.5), "p50");
+        assert_eq!(percentile_label(0.99), "p99");
+        assert_eq!(percentile_label(0.999), "p99.9");
+    }
+}

--- a/src/viewer/tui/query.rs
+++ b/src/viewer/tui/query.rs
@@ -105,6 +105,59 @@ fn series_label(metric: &std::collections::HashMap<String, String>) -> String {
         .unwrap_or_default()
 }
 
+/// Downsample a time-ordered `(timestamp, value)` series to roughly `target`
+/// buckets, keeping each bucket's **min and max** so short-lived spikes
+/// survive — a post-eval min/max reducer (PromQL step decimation can't do
+/// this: histograms ignore step, and averaging hides spikes). Each bucket
+/// emits its extremes ordered by timestamp so a line renderer sweeps the
+/// bucket's full vertical range. Input is assumed ascending by timestamp
+/// (as `query_range` returns it); returned unchanged when already sparse
+/// enough (≤ ~2 points per target column).
+pub fn min_max_decimate(points: &[(f64, f64)], target: usize) -> Vec<(f64, f64)> {
+    let target = target.max(1);
+    if points.len() <= target.saturating_mul(2) {
+        return points.to_vec();
+    }
+    let x0 = points.first().map(|p| p.0).unwrap_or(0.0);
+    let x1 = points.last().map(|p| p.0).unwrap_or(x0);
+    let span = (x1 - x0).max(f64::EPSILON);
+
+    let mut out: Vec<(f64, f64)> = Vec::with_capacity(target * 2);
+    // Extremes of the bucket currently being accumulated: (bucket index,
+    // lowest-value point so far, highest-value point so far).
+    type Bucket = (usize, (f64, f64), (f64, f64));
+    let mut cur: Option<Bucket> = None;
+
+    let flush = |out: &mut Vec<(f64, f64)>, lo: (f64, f64), hi: (f64, f64)| {
+        // Emit in timestamp order so the swept segment reads naturally.
+        let (a, b) = if lo.0 <= hi.0 { (lo, hi) } else { (hi, lo) };
+        out.push(a);
+        if b != a {
+            out.push(b);
+        }
+    };
+
+    for &(x, y) in points {
+        let bucket = ((((x - x0) / span) * target as f64) as usize).min(target - 1);
+        match cur {
+            Some((b, lo, hi)) if b == bucket => {
+                let lo = if y < lo.1 { (x, y) } else { lo };
+                let hi = if y > hi.1 { (x, y) } else { hi };
+                cur = Some((b, lo, hi));
+            }
+            Some((_, lo, hi)) => {
+                flush(&mut out, lo, hi);
+                cur = Some((bucket, (x, y), (x, y)));
+            }
+            None => cur = Some((bucket, (x, y), (x, y))),
+        }
+    }
+    if let Some((_, lo, hi)) = cur {
+        flush(&mut out, lo, hi);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::model::PlotKind;
@@ -141,5 +194,45 @@ mod tests {
         assert_eq!(percentile_label(0.5), "p50");
         assert_eq!(percentile_label(0.99), "p99");
         assert_eq!(percentile_label(0.999), "p99.9");
+    }
+
+    #[test]
+    fn decimate_returns_input_when_already_sparse() {
+        let pts = vec![(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)];
+        assert_eq!(min_max_decimate(&pts, 10), pts);
+    }
+
+    #[test]
+    fn decimate_bounds_output_size() {
+        // 1000 points into ~10 buckets -> at most 2 points per bucket.
+        let pts: Vec<(f64, f64)> = (0..1000).map(|i| (i as f64, (i % 7) as f64)).collect();
+        let out = min_max_decimate(&pts, 10);
+        assert!(out.len() < pts.len());
+        assert!(out.len() <= 10 * 2, "len {}", out.len());
+    }
+
+    #[test]
+    fn decimate_preserves_a_spike() {
+        // A flat baseline with one tall spike buried in the middle. The
+        // spike's value must survive downsampling (this is the whole point).
+        let mut pts: Vec<(f64, f64)> = (0..1000).map(|i| (i as f64, 1.0)).collect();
+        pts[500].1 = 999.0;
+        let out = min_max_decimate(&pts, 8);
+        let max_y = out.iter().map(|p| p.1).fold(f64::MIN, f64::max);
+        assert_eq!(max_y, 999.0, "spike lost: {out:?}");
+        // The baseline min is also preserved.
+        let min_y = out.iter().map(|p| p.1).fold(f64::MAX, f64::min);
+        assert_eq!(min_y, 1.0);
+    }
+
+    #[test]
+    fn decimate_output_is_time_ordered_across_buckets() {
+        let pts: Vec<(f64, f64)> = (0..1000).map(|i| (i as f64, (i as f64).sin())).collect();
+        let out = min_max_decimate(&pts, 20);
+        // Bucket boundaries are ascending, so consecutive bucket pairs never
+        // step backwards by more than one bucket's width (~50 here).
+        for w in out.windows(2) {
+            assert!(w[1].0 >= w[0].0 - 60.0, "big backstep: {:?}", w);
+        }
     }
 }

--- a/src/viewer/tui/render/browser.rs
+++ b/src/viewer/tui/render/browser.rs
@@ -51,21 +51,23 @@ fn draw_nav(f: &mut Frame, area: Rect, app: &App) {
     let mut state = ListState::default();
     state.select(Some(app.selected_section));
     let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(if focused { "Sections*" } else { "Sections" }),
-        )
+        .block(Block::default().borders(Borders::ALL).title(if focused {
+            "Sections*"
+        } else {
+            "Sections"
+        }))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
     f.render_stateful_widget(list, area, &mut state);
 }
 
 fn draw_charts(f: &mut Frame, area: Rect, app: &App, plots: &[(String, ChartData)]) {
-    // Inner area inside a titled border.
-    let title = app
+    // Inner area inside a titled border; the title also shows the active
+    // time window so the effect of the [ / ] keys is visible.
+    let section = app
         .current_section()
         .map(|s| s.name.clone())
         .unwrap_or_default();
+    let title = format!("{section}  ({})", app.window.label());
     let block = Block::default().borders(Borders::ALL).title(title);
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -101,7 +103,10 @@ mod tests {
         let mut app = App::new(vec![NavSection {
             name: "CPU".into(),
             route: "/cpu".into(),
-            groups: Some(vec![NavGroup { name: "Usage".into(), plots: vec![] }]),
+            groups: Some(vec![NavGroup {
+                name: "Usage".into(),
+                plots: vec![],
+            }]),
         }]);
         app.on_key(Key::ToggleScreen);
         app

--- a/src/viewer/tui/render/browser.rs
+++ b/src/viewer/tui/render/browser.rs
@@ -11,9 +11,12 @@ use crate::viewer::tui::app::{App, BrowserFocus};
 use crate::viewer::tui::layout::{browser_split, too_small, BrowserSplit};
 use crate::viewer::tui::query::ChartData;
 
+/// A resolved plot to render: title, unit system, and loaded data.
+pub type LoadedPlot = (String, Option<String>, ChartData);
+
 /// Render the section browser. `plots` are the currently selected section's
-/// resolved plots (title + loaded data), already produced by the loop.
-pub fn draw_browser(f: &mut Frame, app: &App, plots: &[(String, ChartData)]) {
+/// resolved plots (title + unit + loaded data), already produced by the loop.
+pub fn draw_browser(f: &mut Frame, app: &App, plots: &[LoadedPlot]) {
     let area = f.area();
     if too_small(area.width, area.height) {
         f.render_widget(
@@ -60,7 +63,7 @@ fn draw_nav(f: &mut Frame, area: Rect, app: &App) {
     f.render_stateful_widget(list, area, &mut state);
 }
 
-fn draw_charts(f: &mut Frame, area: Rect, app: &App, plots: &[(String, ChartData)]) {
+fn draw_charts(f: &mut Frame, area: Rect, app: &App, plots: &[LoadedPlot]) {
     // Inner area inside a titled border; the title also shows the active
     // time window so the effect of the [ / ] keys is visible.
     let section = app
@@ -85,8 +88,8 @@ fn draw_charts(f: &mut Frame, area: Rect, app: &App, plots: &[(String, ChartData
         .direction(Direction::Vertical)
         .constraints(constraints)
         .split(inner);
-    for (slot, (title, data)) in rows.iter().zip(plots.iter().skip(start)) {
-        draw_chart(f, *slot, title, data);
+    for (slot, (title, unit, data)) in rows.iter().zip(plots.iter().skip(start)) {
+        draw_chart(f, *slot, title, unit.as_deref(), data);
     }
 }
 
@@ -112,9 +115,10 @@ mod tests {
         app
     }
 
-    fn plots() -> Vec<(String, ChartData)> {
+    fn plots() -> Vec<LoadedPlot> {
         vec![(
             "Usage".into(),
+            Some("percentage".into()),
             ChartData::Lines(vec![Series {
                 label: "p50".into(),
                 points: vec![(0.0, 1.0), (1.0, 2.0)],

--- a/src/viewer/tui/render/browser.rs
+++ b/src/viewer/tui/render/browser.rs
@@ -3,13 +3,23 @@
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::widgets::{
+    Block, Borders, List, ListItem, ListState, Scrollbar, ScrollbarOrientation, ScrollbarState,
+};
 use ratatui::Frame;
 
 use super::chart::draw_chart;
 use crate::viewer::tui::app::{App, BrowserFocus};
 use crate::viewer::tui::layout::{browser_split, too_small, BrowserSplit};
 use crate::viewer::tui::query::ChartData;
+
+/// Fixed height (in cells) of each stacked chart in the browser's charts pane.
+pub const CHART_H: u16 = 10;
+
+/// How many charts fit in a charts pane of the given inner height.
+pub fn visible_charts(inner_height: u16) -> usize {
+    (inner_height / CHART_H).max(1) as usize
+}
 
 /// A resolved plot to render: title, unit system, and loaded data.
 pub type LoadedPlot = (String, Option<String>, ChartData);
@@ -79,17 +89,39 @@ fn draw_charts(f: &mut Frame, area: Rect, app: &App, plots: &[LoadedPlot]) {
         return;
     }
 
-    // Stack plots vertically at a fixed per-chart height; apply scroll.
-    const CHART_H: u16 = 10;
-    let visible = (inner.height / CHART_H).max(1) as usize;
-    let start = (app.chart_scroll as usize).min(plots.len().saturating_sub(1));
+    let visible = visible_charts(inner.height);
+    // Clamp so the last page fills the pane (and the scrollbar thumb reaches
+    // the bottom) instead of scrolling a single chart into an empty pane.
+    let max_start = plots.len().saturating_sub(visible);
+    let start = (app.chart_scroll as usize).min(max_start);
+    let overflow = plots.len() > visible;
+
+    // Reserve the rightmost column for a scrollbar when there's overflow, so
+    // it's obvious more charts exist above/below the visible ones.
+    let charts_area = if overflow {
+        Rect {
+            width: inner.width.saturating_sub(1),
+            ..inner
+        }
+    } else {
+        inner
+    };
+
     let constraints: Vec<Constraint> = vec![Constraint::Length(CHART_H); visible];
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints(constraints)
-        .split(inner);
+        .split(charts_area);
     for (slot, (title, unit, data)) in rows.iter().zip(plots.iter().skip(start)) {
         draw_chart(f, *slot, title, unit.as_deref(), data);
+    }
+
+    if overflow {
+        let mut sb_state = ScrollbarState::new(plots.len())
+            .viewport_content_length(visible)
+            .position(start);
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
+        f.render_stateful_widget(scrollbar, inner, &mut sb_state);
     }
 }
 
@@ -157,5 +189,58 @@ mod tests {
         let buf = term.backend().buffer().clone();
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(text.contains("CPU"));
+    }
+
+    fn many_plots(n: usize) -> Vec<LoadedPlot> {
+        (0..n)
+            .map(|i| {
+                (
+                    format!("plot{i}"),
+                    None,
+                    ChartData::Lines(vec![Series {
+                        label: "x".into(),
+                        points: vec![(0.0, 1.0), (1.0, 2.0)],
+                    }]),
+                )
+            })
+            .collect()
+    }
+
+    fn buffer_text(w: u16, h: u16, plots: &[LoadedPlot], scroll: u16) -> String {
+        let mut app = app_with_section();
+        app.focus = BrowserFocus::Charts;
+        app.chart_scroll = scroll;
+        let backend = TestBackend::new(w, h);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| draw_browser(f, &app, plots)).unwrap();
+        term.backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn scrollbar_appears_only_when_charts_overflow() {
+        // At 60x24 the charts pane fits ~2 charts; 10 plots overflow.
+        let over = buffer_text(60, 24, &many_plots(10), 0);
+        assert!(
+            over.chars().any(|c| matches!(c, '█' | '▲' | '▼' | '│')),
+            "expected a scrollbar glyph when overflowing"
+        );
+        // A single plot fits, so no scrollbar chrome is drawn.
+        let fits = buffer_text(60, 24, &many_plots(1), 0);
+        assert!(!fits.chars().any(|c| matches!(c, '█' | '▲' | '▼')));
+    }
+
+    #[test]
+    fn scroll_is_clamped_so_last_page_fills() {
+        // Scroll far past the end; render must still fill the pane from the
+        // last page (start clamped), never panic or blank out.
+        let text = buffer_text(60, 24, &many_plots(10), 999);
+        // The last plots must be visible (not scrolled into the void).
+        assert!(text.contains("plot9"));
     }
 }

--- a/src/viewer/tui/render/browser.rs
+++ b/src/viewer/tui/render/browser.rs
@@ -1,0 +1,152 @@
+//! The section browser screen: a nav list of sections on the left and a
+//! stacked-charts pane on the right (or single-pane on narrow terminals).
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::Frame;
+
+use super::chart::draw_chart;
+use crate::viewer::tui::app::{App, BrowserFocus};
+use crate::viewer::tui::layout::{browser_split, too_small, BrowserSplit};
+use crate::viewer::tui::query::ChartData;
+
+/// Render the section browser. `plots` are the currently selected section's
+/// resolved plots (title + loaded data), already produced by the loop.
+pub fn draw_browser(f: &mut Frame, app: &App, plots: &[(String, ChartData)]) {
+    let area = f.area();
+    if too_small(area.width, area.height) {
+        f.render_widget(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("terminal too small — resize"),
+            area,
+        );
+        return;
+    }
+
+    match browser_split(area.width) {
+        BrowserSplit::Dual(nav_w) => {
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Length(nav_w), Constraint::Min(0)])
+                .split(area);
+            draw_nav(f, cols[0], app);
+            draw_charts(f, cols[1], app, plots);
+        }
+        BrowserSplit::Single => match app.focus {
+            BrowserFocus::Nav => draw_nav(f, area, app),
+            BrowserFocus::Charts => draw_charts(f, area, app, plots),
+        },
+    }
+}
+
+fn draw_nav(f: &mut Frame, area: Rect, app: &App) {
+    let items: Vec<ListItem> = app
+        .sections
+        .iter()
+        .map(|s| ListItem::new(s.name.clone()))
+        .collect();
+    let focused = app.focus == BrowserFocus::Nav;
+    let mut state = ListState::default();
+    state.select(Some(app.selected_section));
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(if focused { "Sections*" } else { "Sections" }),
+        )
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    f.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_charts(f: &mut Frame, area: Rect, app: &App, plots: &[(String, ChartData)]) {
+    // Inner area inside a titled border.
+    let title = app
+        .current_section()
+        .map(|s| s.name.clone())
+        .unwrap_or_default();
+    let block = Block::default().borders(Borders::ALL).title(title);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if plots.is_empty() {
+        return;
+    }
+
+    // Stack plots vertically at a fixed per-chart height; apply scroll.
+    const CHART_H: u16 = 10;
+    let visible = (inner.height / CHART_H).max(1) as usize;
+    let start = (app.chart_scroll as usize).min(plots.len().saturating_sub(1));
+    let constraints: Vec<Constraint> = vec![Constraint::Length(CHART_H); visible];
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(inner);
+    for (slot, (title, data)) in rows.iter().zip(plots.iter().skip(start)) {
+        draw_chart(f, *slot, title, data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::viewer::tui::app::{App, Key};
+    use crate::viewer::tui::model::{NavGroup, NavSection};
+    use crate::viewer::tui::query::{ChartData, Series};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn app_with_section() -> App {
+        let mut app = App::new(vec![NavSection {
+            name: "CPU".into(),
+            route: "/cpu".into(),
+            groups: Some(vec![NavGroup { name: "Usage".into(), plots: vec![] }]),
+        }]);
+        app.on_key(Key::ToggleScreen);
+        app
+    }
+
+    fn plots() -> Vec<(String, ChartData)> {
+        vec![(
+            "Usage".into(),
+            ChartData::Lines(vec![Series {
+                label: "p50".into(),
+                points: vec![(0.0, 1.0), (1.0, 2.0)],
+            }]),
+        )]
+    }
+
+    fn render_at(w: u16, h: u16) {
+        let app = app_with_section();
+        let backend = TestBackend::new(w, h);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| draw_browser(f, &app, &plots())).unwrap();
+    }
+
+    #[test]
+    fn renders_dual_pane_wide() {
+        render_at(120, 40);
+    }
+
+    #[test]
+    fn renders_single_pane_narrow() {
+        render_at(40, 15);
+    }
+
+    #[test]
+    fn renders_too_small() {
+        render_at(20, 8);
+    }
+
+    #[test]
+    fn nav_shows_selected_section_name() {
+        let app = app_with_section();
+        let backend = TestBackend::new(120, 40);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| draw_browser(f, &app, &plots())).unwrap();
+        let buf = term.backend().buffer().clone();
+        let text: String = buf.content().iter().map(|c| c.symbol()).collect();
+        assert!(text.contains("CPU"));
+    }
+}

--- a/src/viewer/tui/render/chart.rs
+++ b/src/viewer/tui/render/chart.rs
@@ -20,7 +20,9 @@ const PALETTE: [Color; 6] = [
 /// Render a single plot into `area`. Handles the Lines / Empty / Error /
 /// Unsupported states.
 pub fn draw_chart(f: &mut Frame, area: Rect, title: &str, data: &ChartData) {
-    let block = Block::default().borders(Borders::ALL).title(title.to_string());
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title.to_string());
     match data {
         ChartData::Lines(series) => draw_lines(f, area, block, series),
         ChartData::Empty => {
@@ -90,12 +92,10 @@ fn draw_lines(f: &mut Frame, area: Rect, block: Block, series: &[Series]) {
     let chart = Chart::new(datasets)
         .block(block)
         .x_axis(Axis::default().bounds(xb))
-        .y_axis(
-            Axis::default().bounds(yb).labels(vec![
-                Span::raw(format!("{:.3}", yb[0])),
-                Span::raw(format!("{:.3}", yb[1])),
-            ]),
-        );
+        .y_axis(Axis::default().bounds(yb).labels(vec![
+            Span::raw(format!("{:.3}", yb[0])),
+            Span::raw(format!("{:.3}", yb[1])),
+        ]));
     f.render_widget(chart, area);
 }
 

--- a/src/viewer/tui/render/chart.rs
+++ b/src/viewer/tui/render/chart.rs
@@ -1,0 +1,134 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::symbols;
+use ratatui::text::Span;
+use ratatui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType};
+use ratatui::Frame;
+
+use crate::viewer::tui::query::{ChartData, Series};
+
+/// Palette for series lines, cycled by index.
+const PALETTE: [Color; 6] = [
+    Color::Cyan,
+    Color::Yellow,
+    Color::Green,
+    Color::Magenta,
+    Color::Red,
+    Color::Blue,
+];
+
+/// Render a single plot into `area`. Handles the Lines / Empty / Error /
+/// Unsupported states.
+pub fn draw_chart(f: &mut Frame, area: Rect, title: &str, data: &ChartData) {
+    let block = Block::default().borders(Borders::ALL).title(title.to_string());
+    match data {
+        ChartData::Lines(series) => draw_lines(f, area, block, series),
+        ChartData::Empty => {
+            f.render_widget(block.title(format!("{title} — no data")), area);
+        }
+        ChartData::Unsupported => {
+            f.render_widget(
+                block.title(format!("{title} — heatmap (not shown in TUI)")),
+                area,
+            );
+        }
+        ChartData::Error(msg) => {
+            f.render_widget(block.title(format!("{title} — query failed: {msg}")), area);
+        }
+    }
+}
+
+fn bounds(series: &[Series]) -> ([f64; 2], [f64; 2]) {
+    let mut xmin = f64::INFINITY;
+    let mut xmax = f64::NEG_INFINITY;
+    let mut ymin = f64::INFINITY;
+    let mut ymax = f64::NEG_INFINITY;
+    for s in series {
+        for &(x, y) in &s.points {
+            xmin = xmin.min(x);
+            xmax = xmax.max(x);
+            ymin = ymin.min(y);
+            ymax = ymax.max(y);
+        }
+    }
+    if !xmin.is_finite() {
+        xmin = 0.0;
+        xmax = 1.0;
+    }
+    if !ymin.is_finite() {
+        ymin = 0.0;
+        ymax = 1.0;
+    }
+    if (ymax - ymin).abs() < f64::EPSILON {
+        ymax = ymin + 1.0;
+    }
+    ([xmin, xmax], [ymin, ymax])
+}
+
+fn draw_lines(f: &mut Frame, area: Rect, block: Block, series: &[Series]) {
+    let (xb, yb) = bounds(series);
+    let datasets: Vec<Dataset> = series
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            Dataset::default()
+                .name(s.label.clone())
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(PALETTE[i % PALETTE.len()]))
+                .data(&s.points)
+        })
+        .collect();
+
+    let chart = Chart::new(datasets)
+        .block(block)
+        .x_axis(Axis::default().bounds(xb))
+        .y_axis(
+            Axis::default().bounds(yb).labels(vec![
+                Span::raw(format!("{:.3}", yb[0])),
+                Span::raw(format!("{:.3}", yb[1])),
+            ]),
+        );
+    f.render_widget(chart, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn render(data: &ChartData, w: u16, h: u16) {
+        let backend = TestBackend::new(w, h);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            draw_chart(f, f.area(), "Test", data);
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn renders_lines_without_panic() {
+        let data = ChartData::Lines(vec![Series {
+            label: "p50".into(),
+            points: vec![(0.0, 1.0), (1.0, 2.0), (2.0, 1.5)],
+        }]);
+        render(&data, 60, 20);
+    }
+
+    #[test]
+    fn renders_empty_and_error_and_unsupported() {
+        render(&ChartData::Empty, 60, 20);
+        render(&ChartData::Error("boom".into()), 60, 20);
+        render(&ChartData::Unsupported, 60, 20);
+    }
+
+    #[test]
+    fn renders_tiny_area_without_panic() {
+        let data = ChartData::Lines(vec![Series {
+            label: "x".into(),
+            points: vec![(0.0, 0.0)],
+        }]);
+        render(&data, 12, 5);
+    }
+}

--- a/src/viewer/tui/render/chart.rs
+++ b/src/viewer/tui/render/chart.rs
@@ -5,7 +5,7 @@ use ratatui::text::Span;
 use ratatui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType};
 use ratatui::Frame;
 
-use crate::viewer::tui::query::{ChartData, Series};
+use crate::viewer::tui::query::{min_max_decimate, ChartData, Series};
 use crate::viewer::tui::units::format_value;
 
 /// Series palette, cycled by index. Explicit high-luminance RGB (not the
@@ -81,6 +81,15 @@ fn bounds(series: &[Series]) -> ([f64; 2], [f64; 2]) {
 
 fn draw_lines(f: &mut Frame, area: Rect, block: Block, unit: Option<&str>, series: &[Series]) {
     let (xb, yb) = bounds(series);
+    // Downsample each series to about one bucket per horizontal cell (braille
+    // gives ~2 sub-columns/cell), keeping per-bucket min/max so spikes survive
+    // and ratatui iterates O(width) points per frame instead of the full,
+    // possibly thousands-long, series. `reduced` outlives the `Chart` below.
+    let target = (area.width as usize).saturating_mul(2).max(1);
+    let reduced: Vec<Vec<(f64, f64)>> = series
+        .iter()
+        .map(|s| min_max_decimate(&s.points, target))
+        .collect();
     let datasets: Vec<Dataset> = series
         .iter()
         .enumerate()
@@ -90,7 +99,7 @@ fn draw_lines(f: &mut Frame, area: Rect, block: Block, unit: Option<&str>, serie
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(PALETTE[i % PALETTE.len()]))
-                .data(&s.points)
+                .data(&reduced[i])
         })
         .collect();
 
@@ -177,5 +186,19 @@ mod tests {
             text.chars().any(|c| ('\u{2801}'..='\u{28FF}').contains(&c)),
             "expected a braille plot glyph, buffer was: {text:?}"
         );
+    }
+
+    #[test]
+    fn long_series_renders_via_decimation_without_panic() {
+        // Exercise the min/max decimation path in draw_lines with far more
+        // points than horizontal cells, including a buried spike.
+        let mut points: Vec<(f64, f64)> = (0..5000).map(|i| (i as f64, 1.0)).collect();
+        points[2500].1 = 900.0;
+        let data = ChartData::Lines(vec![Series {
+            label: "p999".into(),
+            points,
+        }]);
+        let text = render_text(&data, 60, 18);
+        assert!(text.chars().any(|c| ('\u{2801}'..='\u{28FF}').contains(&c)));
     }
 }

--- a/src/viewer/tui/render/chart.rs
+++ b/src/viewer/tui/render/chart.rs
@@ -62,6 +62,13 @@ fn bounds(series: &[Series]) -> ([f64; 2], [f64; 2]) {
     if (ymax - ymin).abs() < f64::EPSILON {
         ymax = ymin + 1.0;
     }
+    // A zero-width x range makes ratatui's Canvas drop every point (it
+    // divides by the x span), so a single-point series — or the first
+    // live poll where all points share one timestamp — would render
+    // blank. Widen it the same way we widen a flat y range.
+    if (xmax - xmin).abs() < f64::EPSILON {
+        xmax = xmin + 1.0;
+    }
     ([xmin, xmax], [ymin, ymax])
 }
 
@@ -107,6 +114,23 @@ mod tests {
         .unwrap();
     }
 
+    /// Render and return the flattened buffer text, so tests can assert
+    /// that something was actually painted (not just "did not panic").
+    fn render_text(data: &ChartData, w: u16, h: u16) -> String {
+        let backend = TestBackend::new(w, h);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            draw_chart(f, f.area(), "Test", data);
+        })
+        .unwrap();
+        term.backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
     #[test]
     fn renders_lines_without_panic() {
         let data = ChartData::Lines(vec![Series {
@@ -130,5 +154,23 @@ mod tests {
             points: vec![(0.0, 0.0)],
         }]);
         render(&data, 12, 5);
+    }
+
+    #[test]
+    fn single_point_series_paints_a_glyph() {
+        // A degenerate x range (one point, or all points at one timestamp)
+        // must still draw the point — regression guard for the missing
+        // x-bounds widening in `bounds()`.
+        let data = ChartData::Lines(vec![Series {
+            label: "p50".into(),
+            points: vec![(5.0, 5.0)],
+        }]);
+        let text = render_text(&data, 40, 15);
+        // Braille plot glyphs live in the U+2800 block; at least one must
+        // be present in the rendered buffer.
+        assert!(
+            text.chars().any(|c| ('\u{2801}'..='\u{28FF}').contains(&c)),
+            "expected a braille plot glyph, buffer was: {text:?}"
+        );
     }
 }

--- a/src/viewer/tui/render/chart.rs
+++ b/src/viewer/tui/render/chart.rs
@@ -7,14 +7,17 @@ use ratatui::Frame;
 
 use crate::viewer::tui::query::{ChartData, Series};
 
-/// Palette for series lines, cycled by index.
+/// Series palette, cycled by index. Explicit high-luminance RGB (not the
+/// mid-tone ANSI names) so lines pop against a dark terminal background, and
+/// ordered as a cool->hot ramp so percentile series (p50, p90, p99, p999,
+/// p9999 — added in that order) also read semantically: cool = low, hot = high.
 const PALETTE: [Color; 6] = [
-    Color::Cyan,
-    Color::Yellow,
-    Color::Green,
-    Color::Magenta,
-    Color::Red,
-    Color::Blue,
+    Color::Rgb(120, 220, 255), // cyan  (p50)
+    Color::Rgb(120, 240, 150), // green (p90)
+    Color::Rgb(255, 215, 90),  // amber (p99)
+    Color::Rgb(255, 140, 90),  // orange (p999)
+    Color::Rgb(255, 105, 150), // hot pink/red (p9999)
+    Color::Rgb(160, 175, 255), // periwinkle (extra series)
 ];
 
 /// Render a single plot into `area`. Handles the Lines / Empty / Error /

--- a/src/viewer/tui/render/chart.rs
+++ b/src/viewer/tui/render/chart.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::{Axis, Block, Borders, Chart, Dataset, GraphType};
 use ratatui::Frame;
 
 use crate::viewer::tui::query::{ChartData, Series};
+use crate::viewer::tui::units::format_value;
 
 /// Series palette, cycled by index. Explicit high-luminance RGB (not the
 /// mid-tone ANSI names) so lines pop against a dark terminal background, and
@@ -21,13 +22,14 @@ const PALETTE: [Color; 6] = [
 ];
 
 /// Render a single plot into `area`. Handles the Lines / Empty / Error /
-/// Unsupported states.
-pub fn draw_chart(f: &mut Frame, area: Rect, title: &str, data: &ChartData) {
+/// Unsupported states. `unit` is the plot's unit system (e.g. `"percentage"`,
+/// `"time"`, `"bytes"`) used to format the y-axis value labels.
+pub fn draw_chart(f: &mut Frame, area: Rect, title: &str, unit: Option<&str>, data: &ChartData) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(title.to_string());
     match data {
-        ChartData::Lines(series) => draw_lines(f, area, block, series),
+        ChartData::Lines(series) => draw_lines(f, area, block, unit, series),
         ChartData::Empty => {
             f.render_widget(block.title(format!("{title} — no data")), area);
         }
@@ -77,7 +79,7 @@ fn bounds(series: &[Series]) -> ([f64; 2], [f64; 2]) {
     ([xmin, xmax], [ymin, ymax])
 }
 
-fn draw_lines(f: &mut Frame, area: Rect, block: Block, series: &[Series]) {
+fn draw_lines(f: &mut Frame, area: Rect, block: Block, unit: Option<&str>, series: &[Series]) {
     let (xb, yb) = bounds(series);
     let datasets: Vec<Dataset> = series
         .iter()
@@ -96,8 +98,8 @@ fn draw_lines(f: &mut Frame, area: Rect, block: Block, series: &[Series]) {
         .block(block)
         .x_axis(Axis::default().bounds(xb))
         .y_axis(Axis::default().bounds(yb).labels(vec![
-            Span::raw(format!("{:.3}", yb[0])),
-            Span::raw(format!("{:.3}", yb[1])),
+            Span::raw(format_value(unit, yb[0])),
+            Span::raw(format_value(unit, yb[1])),
         ]));
     f.render_widget(chart, area);
 }
@@ -112,7 +114,7 @@ mod tests {
         let backend = TestBackend::new(w, h);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
-            draw_chart(f, f.area(), "Test", data);
+            draw_chart(f, f.area(), "Test", Some("percentage"), data);
         })
         .unwrap();
     }
@@ -123,7 +125,7 @@ mod tests {
         let backend = TestBackend::new(w, h);
         let mut term = Terminal::new(backend).unwrap();
         term.draw(|f| {
-            draw_chart(f, f.area(), "Test", data);
+            draw_chart(f, f.area(), "Test", Some("percentage"), data);
         })
         .unwrap();
         term.backend()

--- a/src/viewer/tui/render/help.rs
+++ b/src/viewer/tui/render/help.rs
@@ -1,0 +1,45 @@
+//! The centered help overlay, toggled with `?`.
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+const HELP: &str = "\
+Tab / o   toggle Overview <-> Browser
+j / k     move selection / scroll
+Enter / l descend (nav -> charts)
+Esc / h   back (charts -> nav)
+[ / ]     shrink / grow time window
+r         refresh
+?         toggle this help
+q         quit";
+
+/// Render a centered help overlay on top of the current screen.
+pub fn draw_help(f: &mut Frame) {
+    let area = centered(50, 12, f.area());
+    f.render_widget(Clear, area);
+    f.render_widget(
+        Paragraph::new(HELP).block(Block::default().borders(Borders::ALL).title("Help")),
+        area,
+    );
+}
+
+fn centered(w: u16, h: u16, area: Rect) -> Rect {
+    let v = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length((area.height.saturating_sub(h)) / 2),
+            Constraint::Length(h),
+            Constraint::Min(0),
+        ])
+        .split(area);
+    let hh = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length((area.width.saturating_sub(w)) / 2),
+            Constraint::Length(w),
+            Constraint::Min(0),
+        ])
+        .split(v[1]);
+    hh[1]
+}

--- a/src/viewer/tui/render/mod.rs
+++ b/src/viewer/tui/render/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod browser;
 pub mod chart;
+pub mod overview;

--- a/src/viewer/tui/render/mod.rs
+++ b/src/viewer/tui/render/mod.rs
@@ -3,4 +3,5 @@
 
 pub mod browser;
 pub mod chart;
+pub mod help;
 pub mod overview;

--- a/src/viewer/tui/render/mod.rs
+++ b/src/viewer/tui/render/mod.rs
@@ -1,0 +1,4 @@
+//! ratatui rendering. Each screen is a free function taking a `Frame`
+//! and the `App`. Kept separate from state so widgets stay dumb.
+
+pub mod chart;

--- a/src/viewer/tui/render/mod.rs
+++ b/src/viewer/tui/render/mod.rs
@@ -1,4 +1,5 @@
 //! ratatui rendering. Each screen is a free function taking a `Frame`
 //! and the `App`. Kept separate from state so widgets stay dumb.
 
+pub mod browser;
 pub mod chart;

--- a/src/viewer/tui/render/overview.rs
+++ b/src/viewer/tui/render/overview.rs
@@ -38,16 +38,26 @@ fn pct(query: &str) -> PlotDef {
 
 /// The v1 curated tile set, in priority order (lowest priority dropped
 /// first when the terminal is small). Queries mirror the web overview
-/// section; adjust once the prototype is tuned against real data
-/// (see Task 11 — these `base_query` strings are placeholders).
+/// section (`crates/dashboard/src/dashboard/overview.rs`) and the memory
+/// section so they resolve against the real metric catalog.
 pub fn tiles() -> Vec<Tile> {
     vec![
-        Tile { title: "CPU Utilization", def: line("cpu_usage_pct", Some("percentage")) },
+        // CPU busy fraction: ns of CPU consumed per second / cores / 1e9.
+        Tile {
+            title: "CPU Utilization",
+            def: line("sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000", Some("percentage")),
+        },
         Tile { title: "Runqueue Latency", def: pct("scheduler_runqueue_latency") },
-        Tile { title: "Syscall Rate", def: line("syscall_rate", Some("rate")) },
-        Tile { title: "Network Throughput", def: line("network_throughput_bytes", Some("bitrate")) },
+        Tile { title: "Syscall Rate", def: line("sum(irate(syscall[5m]))", Some("rate")) },
+        Tile {
+            title: "Network Throughput",
+            def: line("sum(irate(network_bytes[5m])) * 8", Some("bitrate")),
+        },
         Tile { title: "Block IO Latency", def: pct("blockio_latency") },
-        Tile { title: "Memory Used", def: line("memory_used_bytes", Some("bytes")) },
+        Tile {
+            title: "Memory Used",
+            def: line("memory_total - memory_available", Some("bytes")),
+        },
     ]
 }
 

--- a/src/viewer/tui/render/overview.rs
+++ b/src/viewer/tui/render/overview.rs
@@ -45,15 +45,27 @@ pub fn tiles() -> Vec<Tile> {
         // CPU busy fraction: ns of CPU consumed per second / cores / 1e9.
         Tile {
             title: "CPU Utilization",
-            def: line("sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000", Some("percentage")),
+            def: line(
+                "sum(irate(cpu_usage[5m])) / cpu_cores / 1000000000",
+                Some("percentage"),
+            ),
         },
-        Tile { title: "Runqueue Latency", def: pct("scheduler_runqueue_latency") },
-        Tile { title: "Syscall Rate", def: line("sum(irate(syscall[5m]))", Some("rate")) },
+        Tile {
+            title: "Runqueue Latency",
+            def: pct("scheduler_runqueue_latency"),
+        },
+        Tile {
+            title: "Syscall Rate",
+            def: line("sum(irate(syscall[5m]))", Some("rate")),
+        },
         Tile {
             title: "Network Throughput",
             def: line("sum(irate(network_bytes[5m])) * 8", Some("bitrate")),
         },
-        Tile { title: "Block IO Latency", def: pct("blockio_latency") },
+        Tile {
+            title: "Block IO Latency",
+            def: pct("blockio_latency"),
+        },
         Tile {
             title: "Memory Used",
             def: line("memory_total - memory_available", Some("bytes")),
@@ -93,7 +105,10 @@ pub fn draw_overview(f: &mut Frame, tiles: &[Tile], data: &[ChartData]) {
 
     let row_areas = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(vec![Constraint::Ratio(1, plan.rows.max(1) as u32); plan.rows as usize])
+        .constraints(vec![
+            Constraint::Ratio(1, plan.rows.max(1) as u32);
+            plan.rows as usize
+        ])
         .split(area);
 
     for r in 0..plan.rows {
@@ -102,7 +117,10 @@ pub fn draw_overview(f: &mut Frame, tiles: &[Tile], data: &[ChartData]) {
         };
         let cells = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints(vec![Constraint::Ratio(1, plan.cols.max(1) as u32); plan.cols as usize])
+            .constraints(vec![
+                Constraint::Ratio(1, plan.cols.max(1) as u32);
+                plan.cols as usize
+            ])
             .split(*row_area);
         for c in 0..plan.cols {
             let idx = (r * plan.cols + c) as usize;

--- a/src/viewer/tui/render/overview.rs
+++ b/src/viewer/tui/render/overview.rs
@@ -103,12 +103,14 @@ pub fn draw_overview(f: &mut Frame, tiles: &[Tile], data: &[ChartData]) {
         return;
     }
 
+    // Fixed-height rows packed from the top; a trailing flexible spacer
+    // absorbs leftover height so tiles stay landscape instead of stretching.
+    let mut row_constraints: Vec<Constraint> =
+        vec![Constraint::Length(plan.row_height); plan.rows as usize];
+    row_constraints.push(Constraint::Min(0));
     let row_areas = Layout::default()
         .direction(Direction::Vertical)
-        .constraints(vec![
-            Constraint::Ratio(1, plan.rows.max(1) as u32);
-            plan.rows as usize
-        ])
+        .constraints(row_constraints)
         .split(area);
 
     for r in 0..plan.rows {

--- a/src/viewer/tui/render/overview.rs
+++ b/src/viewer/tui/render/overview.rs
@@ -138,7 +138,7 @@ pub fn draw_overview(f: &mut Frame, tiles: &[Tile], data: &[ChartData]) {
 }
 
 fn draw_tile(f: &mut Frame, area: Rect, tile: &Tile, data: &ChartData) {
-    draw_chart(f, area, tile.title, data);
+    draw_chart(f, area, tile.title, tile.def.unit_system.as_deref(), data);
 }
 
 #[cfg(test)]

--- a/src/viewer/tui/render/overview.rs
+++ b/src/viewer/tui/render/overview.rs
@@ -1,0 +1,148 @@
+//! The curated overview screen: a fixed, priority-ordered set of metric
+//! tiles laid out in a responsive grid (see `layout::overview_grid`).
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::widgets::{Block, Borders};
+use ratatui::Frame;
+
+use super::chart::draw_chart;
+use crate::viewer::tui::layout::{overview_grid, too_small};
+use crate::viewer::tui::model::{PlotDef, PlotKind, DEFAULT_PERCENTILES};
+use crate::viewer::tui::query::ChartData;
+
+/// A curated overview tile: a display title and the query that feeds it.
+pub struct Tile {
+    pub title: &'static str,
+    pub def: PlotDef,
+}
+
+fn line(query: &str, unit: Option<&str>) -> PlotDef {
+    PlotDef {
+        title: String::new(),
+        base_query: query.to_string(),
+        kind: PlotKind::Line,
+        percentiles: vec![],
+        unit_system: unit.map(|s| s.to_string()),
+    }
+}
+
+fn pct(query: &str) -> PlotDef {
+    PlotDef {
+        title: String::new(),
+        base_query: query.to_string(),
+        kind: PlotKind::Percentiles,
+        percentiles: DEFAULT_PERCENTILES.to_vec(),
+        unit_system: Some("time".into()),
+    }
+}
+
+/// The v1 curated tile set, in priority order (lowest priority dropped
+/// first when the terminal is small). Queries mirror the web overview
+/// section; adjust once the prototype is tuned against real data
+/// (see Task 11 — these `base_query` strings are placeholders).
+pub fn tiles() -> Vec<Tile> {
+    vec![
+        Tile { title: "CPU Utilization", def: line("cpu_usage_pct", Some("percentage")) },
+        Tile { title: "Runqueue Latency", def: pct("scheduler_runqueue_latency") },
+        Tile { title: "Syscall Rate", def: line("syscall_rate", Some("rate")) },
+        Tile { title: "Network Throughput", def: line("network_throughput_bytes", Some("bitrate")) },
+        Tile { title: "Block IO Latency", def: pct("blockio_latency") },
+        Tile { title: "Memory Used", def: line("memory_used_bytes", Some("bytes")) },
+    ]
+}
+
+/// Render the overview grid. `data` is the loaded chart data for each tile,
+/// in the same order as `tiles()`. `data` must have at least as many
+/// entries as `tiles` (the caller loads one `ChartData` per tile); any
+/// tile beyond `data.len()` is simply not visited since `plan.visible`
+/// never exceeds `tiles.len()` and callers are expected to size `data`
+/// to match `tiles`.
+pub fn draw_overview(f: &mut Frame, tiles: &[Tile], data: &[ChartData]) {
+    let area = f.area();
+    if too_small(area.width, area.height) {
+        f.render_widget(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("terminal too small — resize or press Tab"),
+            area,
+        );
+        return;
+    }
+
+    let plan = overview_grid(area.width, area.height, tiles.len());
+    if plan.visible == 0 {
+        return;
+    }
+
+    // Bound visible by both tiles.len() and data.len() so a caller that
+    // passes mismatched slices cannot trigger an out-of-bounds index below.
+    let visible = plan.visible.min(tiles.len()).min(data.len());
+    if visible == 0 {
+        return;
+    }
+
+    let row_areas = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(vec![Constraint::Ratio(1, plan.rows.max(1) as u32); plan.rows as usize])
+        .split(area);
+
+    for r in 0..plan.rows {
+        let Some(row_area) = row_areas.get(r as usize) else {
+            break;
+        };
+        let cells = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Ratio(1, plan.cols.max(1) as u32); plan.cols as usize])
+            .split(*row_area);
+        for c in 0..plan.cols {
+            let idx = (r * plan.cols + c) as usize;
+            if idx >= visible {
+                break;
+            }
+            let Some(cell_area) = cells.get(c as usize) else {
+                break;
+            };
+            draw_tile(f, *cell_area, &tiles[idx], &data[idx]);
+        }
+    }
+}
+
+fn draw_tile(f: &mut Frame, area: Rect, tile: &Tile, data: &ChartData) {
+    draw_chart(f, area, tile.title, data);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn render_at(w: u16, h: u16) {
+        let tiles = tiles();
+        let data: Vec<ChartData> = tiles.iter().map(|_| ChartData::Empty).collect();
+        assert_eq!(data.len(), tiles.len());
+        let backend = TestBackend::new(w, h);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| draw_overview(f, &tiles, &data)).unwrap();
+    }
+
+    #[test]
+    fn renders_full_grid() {
+        render_at(120, 40);
+    }
+
+    #[test]
+    fn renders_reduced_grid_small() {
+        render_at(50, 14);
+    }
+
+    #[test]
+    fn renders_too_small() {
+        render_at(20, 8);
+    }
+
+    #[test]
+    fn tile_count_is_stable() {
+        assert_eq!(tiles().len(), 6);
+    }
+}

--- a/src/viewer/tui/units.rs
+++ b/src/viewer/tui/units.rs
@@ -1,0 +1,163 @@
+//! Value formatting for TUI chart axes. Mirrors the web viewer's
+//! `assets/lib/charts/util/units.js` so the terminal shows the same scaled
+//! units (e.g. `100.5%`, `503.32ms`, `9.29GB`, `10.34Gbps`, `47.9K/s`).
+//!
+//! Each entry is `(threshold, suffix, divisor, multiplier)`: pick the
+//! largest scale whose `threshold` the absolute value reaches, then render
+//! `value * multiplier / divisor` with the suffix.
+
+type Scale = (f64, &'static str, f64, f64);
+
+// Time, base nanoseconds.
+static TIME: &[Scale] = &[
+    (0.0, "ns", 1.0, 1.0),
+    (1e3, "μs", 1e3, 1.0),
+    (1e6, "ms", 1e6, 1.0),
+    (1e9, "s", 1e9, 1.0),
+];
+
+// Data size, base bytes (binary scaling, matching the web viewer).
+static BYTES: &[Scale] = &[
+    (0.0, "B", 1.0, 1.0),
+    (1024.0, "KB", 1024.0, 1.0),
+    (1_048_576.0, "MB", 1_048_576.0, 1.0),
+    (1_073_741_824.0, "GB", 1_073_741_824.0, 1.0),
+    (1_099_511_627_776.0, "TB", 1_099_511_627_776.0, 1.0),
+];
+
+// Network bit rate, base bits/sec.
+static BITRATE: &[Scale] = &[
+    (0.0, "bps", 1.0, 1.0),
+    (1e3, "Kbps", 1e3, 1.0),
+    (1e6, "Mbps", 1e6, 1.0),
+    (1e9, "Gbps", 1e9, 1.0),
+    (1e12, "Tbps", 1e12, 1.0),
+];
+
+// Data rate, base bytes/sec.
+static DATARATE: &[Scale] = &[
+    (0.0, "B/s", 1.0, 1.0),
+    (1e3, "KB/s", 1e3, 1.0),
+    (1e6, "MB/s", 1e6, 1.0),
+    (1e9, "GB/s", 1e9, 1.0),
+    (1e12, "TB/s", 1e12, 1.0),
+];
+
+// Percentage: value is a fraction, scaled by 100.
+static PERCENTAGE: &[Scale] = &[(0.0, "%", 1.0, 100.0)];
+
+// Frequency, base Hz.
+static FREQUENCY: &[Scale] = &[
+    (0.0, "Hz", 1.0, 1.0),
+    (1e3, "KHz", 1e3, 1.0),
+    (1e6, "MHz", 1e6, 1.0),
+    (1e9, "GHz", 1e9, 1.0),
+];
+
+// Bare count with K/M/B suffixes.
+static COUNT: &[Scale] = &[
+    (0.0, "", 1.0, 1.0),
+    (1e3, "K", 1e3, 1.0),
+    (1e6, "M", 1e6, 1.0),
+    (1e9, "B", 1e9, 1.0),
+];
+
+// Rate (count per second) with /s, K/s, M/s, B/s suffixes.
+static RATE: &[Scale] = &[
+    (0.0, "/s", 1.0, 1.0),
+    (1e3, "K/s", 1e3, 1.0),
+    (1e6, "M/s", 1e6, 1.0),
+    (1e9, "B/s", 1e9, 1.0),
+];
+
+fn scales(unit_system: &str) -> Option<&'static [Scale]> {
+    match unit_system {
+        "time" => Some(TIME),
+        "bytes" => Some(BYTES),
+        "bitrate" => Some(BITRATE),
+        "datarate" => Some(DATARATE),
+        "percentage" => Some(PERCENTAGE),
+        "frequency" => Some(FREQUENCY),
+        "count" => Some(COUNT),
+        "rate" => Some(RATE),
+        _ => None,
+    }
+}
+
+/// Format `value` (in the unit system's base unit) with auto-scaling and a
+/// suffix. An unknown or absent unit system falls back to a plain, trimmed
+/// number. Two decimals, trailing zeros removed (`100.50%` -> `100.5%`,
+/// `9.00` -> `9`).
+pub fn format_value(unit_system: Option<&str>, value: f64) -> String {
+    if !value.is_finite() {
+        return "—".to_string();
+    }
+    let Some(sys) = unit_system.and_then(scales) else {
+        return trim(&format!("{value:.2}")).to_string();
+    };
+    let av = value.abs();
+    let &(_, suffix, divisor, multiplier) = sys
+        .iter()
+        .rev()
+        .find(|&&(th, ..)| av >= th)
+        .unwrap_or(&sys[0]);
+    let scaled = value * multiplier / divisor;
+    format!("{}{}", trim(&format!("{scaled:.2}")), suffix)
+}
+
+/// Trim trailing fractional zeros (and a bare trailing dot) from a decimal
+/// string. Leaves integer strings untouched.
+fn trim(s: &str) -> &str {
+    if s.contains('.') {
+        s.trim_end_matches('0').trim_end_matches('.')
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentage_scales_by_100() {
+        assert_eq!(format_value(Some("percentage"), 1.005), "100.5%");
+        assert_eq!(format_value(Some("percentage"), 0.152), "15.2%");
+        assert_eq!(format_value(Some("percentage"), 0.0), "0%");
+    }
+
+    #[test]
+    fn time_scales_from_nanoseconds() {
+        // 1.535 is 1.5349…9 in f64, so `{:.2}` yields 1.53 — matching the
+        // web viewer's toFixed(2) on the same value.
+        assert_eq!(format_value(Some("time"), 1535.0), "1.53μs");
+        assert_eq!(format_value(Some("time"), 503_316_479.0), "503.32ms");
+        assert_eq!(format_value(Some("time"), 2_000_000_000.0), "2s");
+        assert_eq!(format_value(Some("time"), 42.0), "42ns");
+    }
+
+    #[test]
+    fn bytes_use_binary_scaling() {
+        assert_eq!(format_value(Some("bytes"), 9_980_456_960.0), "9.3GB");
+        assert_eq!(format_value(Some("bytes"), 1024.0), "1KB");
+    }
+
+    #[test]
+    fn bitrate_uses_si_scaling() {
+        assert_eq!(format_value(Some("bitrate"), 10_338_674_776.0), "10.34Gbps");
+    }
+
+    #[test]
+    fn rate_and_count_suffixes() {
+        assert_eq!(format_value(Some("rate"), 47902.0), "47.9K/s");
+        assert_eq!(format_value(Some("rate"), 500.0), "500/s");
+        assert_eq!(format_value(Some("count"), 1_500_000.0), "1.5M");
+    }
+
+    #[test]
+    fn unknown_or_missing_unit_is_plain_trimmed() {
+        assert_eq!(format_value(None, 42.5), "42.5");
+        assert_eq!(format_value(None, 9.0), "9");
+        assert_eq!(format_value(Some("bogus"), 123.456), "123.46");
+    }
+}

--- a/src/viewer/tui/window.rs
+++ b/src/viewer/tui/window.rs
@@ -1,0 +1,100 @@
+//! Time window selection for TUI charts.
+
+/// A selectable look-back window. `All` uses the full data extent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TimeWindow {
+    Last1m,
+    Last5m,
+    Last15m,
+    All,
+}
+
+impl TimeWindow {
+    /// Ordered cycle used by the `[` / `]` keys.
+    pub const ORDER: [TimeWindow; 4] = [
+        TimeWindow::Last1m,
+        TimeWindow::Last5m,
+        TimeWindow::Last15m,
+        TimeWindow::All,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            TimeWindow::Last1m => "1m",
+            TimeWindow::Last5m => "5m",
+            TimeWindow::Last15m => "15m",
+            TimeWindow::All => "all",
+        }
+    }
+
+    fn span_secs(self) -> Option<f64> {
+        match self {
+            TimeWindow::Last1m => Some(60.0),
+            TimeWindow::Last5m => Some(300.0),
+            TimeWindow::Last15m => Some(900.0),
+            TimeWindow::All => None,
+        }
+    }
+
+    /// Grow (`]`) toward `All`; saturates at the ends.
+    pub fn grow(self) -> TimeWindow {
+        let i = Self::ORDER.iter().position(|w| *w == self).unwrap_or(0);
+        Self::ORDER[(i + 1).min(Self::ORDER.len() - 1)]
+    }
+
+    /// Shrink (`[`) toward `Last1m`; saturates at the ends.
+    pub fn shrink(self) -> TimeWindow {
+        let i = Self::ORDER.iter().position(|w| *w == self).unwrap_or(0);
+        Self::ORDER[i.saturating_sub(1)]
+    }
+
+    /// Resolve to `(start_s, end_s, step_s)` given the source's full extent
+    /// and native interval. `end` is always the extent's max. `start` is
+    /// clamped to the extent min. Returns `None` if the extent is empty.
+    pub fn resolve(self, extent: Option<(f64, f64)>, interval_s: f64) -> Option<(f64, f64, f64)> {
+        let (min, max) = extent?;
+        let step = if interval_s > 0.0 { interval_s } else { 1.0 };
+        let start = match self.span_secs() {
+            Some(span) => (max - span).max(min),
+            None => min,
+        };
+        Some((start, max, step))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grow_and_shrink_saturate() {
+        assert_eq!(TimeWindow::Last1m.shrink(), TimeWindow::Last1m);
+        assert_eq!(TimeWindow::All.grow(), TimeWindow::All);
+        assert_eq!(TimeWindow::Last1m.grow(), TimeWindow::Last5m);
+        assert_eq!(TimeWindow::Last5m.shrink(), TimeWindow::Last1m);
+    }
+
+    #[test]
+    fn resolve_clamps_start_to_extent() {
+        // extent only 30s wide, but window is 60s: start clamps to min.
+        let r = TimeWindow::Last1m.resolve(Some((100.0, 130.0)), 1.0).unwrap();
+        assert_eq!(r, (100.0, 130.0, 1.0));
+    }
+
+    #[test]
+    fn resolve_all_spans_full_extent() {
+        let r = TimeWindow::All.resolve(Some((100.0, 1000.0)), 2.0).unwrap();
+        assert_eq!(r, (100.0, 1000.0, 2.0));
+    }
+
+    #[test]
+    fn resolve_windowed_uses_span_from_end() {
+        let r = TimeWindow::Last5m.resolve(Some((0.0, 1000.0)), 1.0).unwrap();
+        assert_eq!(r, (700.0, 1000.0, 1.0));
+    }
+
+    #[test]
+    fn resolve_empty_extent_is_none() {
+        assert_eq!(TimeWindow::All.resolve(None, 1.0), None);
+    }
+}

--- a/src/viewer/tui/window.rs
+++ b/src/viewer/tui/window.rs
@@ -77,7 +77,9 @@ mod tests {
     #[test]
     fn resolve_clamps_start_to_extent() {
         // extent only 30s wide, but window is 60s: start clamps to min.
-        let r = TimeWindow::Last1m.resolve(Some((100.0, 130.0)), 1.0).unwrap();
+        let r = TimeWindow::Last1m
+            .resolve(Some((100.0, 130.0)), 1.0)
+            .unwrap();
         assert_eq!(r, (100.0, 130.0, 1.0));
     }
 
@@ -89,7 +91,9 @@ mod tests {
 
     #[test]
     fn resolve_windowed_uses_span_from_end() {
-        let r = TimeWindow::Last5m.resolve(Some((0.0, 1000.0)), 1.0).unwrap();
+        let r = TimeWindow::Last5m
+            .resolve(Some((0.0, 1000.0)), 1.0)
+            .unwrap();
         assert_eq!(r, (700.0, 1000.0, 1.0));
     }
 


### PR DESCRIPTION
## Summary
- Adds a terminal UI to the viewer via `rezolus view --tui`, a third frontend over the existing viewer core (TSDB + dashboard section tree) — no new dashboard APIs, no HTTP. Built with `ratatui`.
- **Hybrid layout:** a curated live **overview** plus a drill-down **section browser** that mirrors the web viewer's Section→Group→Plot tree. Histograms render as p50/p90/p99/p999 lines via `histogram_quantiles`; heatmap-subtype plots show an "unsupported" placeholder (v1).
- Works with a parquet file **or** a live agent URL (upload-only is browser-only and errors). A/B compare and `--category` are browser-only; a second capture is ignored with a warning. No HTTP is served, so `--listen`/`--proxy-*` don't apply.
- Responsive to terminal size; terminal restored on quit, panic, and external SIGINT.
- Keys: `Tab`/`o` overview↔browser, `j`/`k` move/scroll, `Enter`/`l` open, `Esc`/`h` back, `[`/`]` time window, `r` refresh, `?` help, `q` quit.

## Readability / polish (this branch)
- **Landscape overview tiles** — the grid picks columns for a readable tile width and caps tile height so tiles don't stretch into vertical strips.
- **High-contrast cool→hot palette** — explicit high-luminance RGB (not mid-tone ANSI); percentile series ramp cool=low → hot=high.
- **Unit-aware axis labels** — mirrors the web viewer's `units.js` (CPU `100.5%` not `1.005`, latency `503.32ms` not raw ns, memory `9.3GB` not raw bytes).
- **Min/max decimation** — `query::min_max_decimate` keeps per-bucket min/max so p999 spikes survive downsampling on long captures (the post-eval reducer the existing decimation note calls for; PromQL step can't — histograms ignore it). Also bounds points ratatui iterates per frame.
- **Scrollbar affordance** — a vertical scrollbar appears when a section has more charts than fit; scroll clamped to the last full page.

## Implementation notes
- Pure logic (nav-model parsing, query bridge, time window, responsive layout, app state machine, key decode, unit formatting, decimation) is ratatui-free and unit-tested; `render/*` are dumb over inputs; the event loop is the only place doing I/O + locks.
- File mode is idle-efficient: it only re-queries/redraws on input or resize; live mode refreshes each tick and reconciles nav churn preserving loaded bodies + selection by route.
- Remaining backlog (non-blocking): status/legend strip, zoom/pan.

## Test plan
- [x] `cargo test` — 271 pass (TUI unit + `TestBackend` render smoke at multiple sizes; unit-format, decimation spike-survival, and scrollbar/overflow tests)
- [x] `cargo clippy` clean; `cargo fmt`
- [x] `tests/viewer_smoke.sh` — web viewer path unaffected (exit 0)
- [x] `--tui` help verified with blind agent simulations + fresh-eyes critic (parquet, live-agent, and A/B tasks all resolve correctly)
- [x] Headless: `--tui` with no source errors; with a parquet, loads data + builds the app then fails gracefully at terminal init (no TTY), zero panics
- [x] Interactive file-mode acceptance in a real terminal (overview + browser, layout/contrast/units, scrolling)
- [ ] **Live mode (reviewer, Linux):** `rezolus view --tui http://localhost:4241` — tiles update; disconnect agent → UI keeps last data without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)