### PR TITLE
feat(analysis): recording-assessment schemas & library skeleton (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.5"
+version = "5.17.1-alpha.6"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.5"
+version = "5.17.1-alpha.6"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/analysis/assessment.rs
+++ b/src/analysis/assessment.rs
@@ -6,3 +6,298 @@
 
 /// Schema version for `Assessment`. Bump on any change to the assessment shape.
 pub const ASSESSMENT_SCHEMA_VERSION: u32 = 1;
+
+use serde::{Deserialize, Serialize};
+
+/// A reference from a `Finding` into an element of the `OverviewRecord` that
+/// supports (or, in `ruled_out`, dismisses) the claim. Exactly one of the index
+/// fields is normally set alongside `metric`; all optional so an evidence item
+/// can point at a metric, an anomaly, a regime shift, or a correlation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EvidenceRef {
+    /// Metric this evidence points at, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metric: Option<String>,
+    /// Index into that metric's `anomalies`, if the evidence is an anomaly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anomaly_index: Option<usize>,
+    /// Index into that metric's `regime_shifts`, if the evidence is a regime shift.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub regime_shift_index: Option<usize>,
+    /// Index into the record's `correlations`, if the evidence is a correlation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_index: Option<usize>,
+    /// One-line rationale tying this record element to the claim.
+    pub rationale: String,
+}
+
+/// Categorical confidence. Must track the uncertainty signals: a finding whose
+/// magnitude sits inside its acquisition-window band cannot be `High`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Confidence {
+    Low,
+    Medium,
+    High,
+}
+
+/// The shared unit of an assessment: one grounded claim. Reused in every bucket.
+///
+/// NOTE: `Finding`'s field names share a JSON namespace with the sibling fields of any struct that `#[serde(flatten)]`s it (`Overall`, `TieredFinding`) — adding a field named `status`, `data_quality`, `priority`, or `kind` here would silently corrupt the wire format.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Finding {
+    /// One-line claim.
+    pub summary: String,
+    pub confidence: Confidence,
+    /// References into the overview record + rationale.
+    pub evidence: Vec<EvidenceRef>,
+    /// Concrete next step. Absent on `ruled_out` items (nothing to do).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recommended_action: Option<String>,
+}
+
+/// Whole-recording judgment. `Inconclusive`/`NoLimitingFactor` live here rather
+/// than as findings because they are judgments about the whole recording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OverallStatus {
+    Actionable,
+    Inconclusive,
+    NoLimitingFactor,
+}
+
+/// Explicit fitness-for-conclusion statement.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DataQuality {
+    /// Subsystems absent from the recording (from the record's coverage map).
+    pub coverage_gaps: Vec<String>,
+    /// True if any finding was limited by acquisition-window uncertainty.
+    pub uncertainty_limited: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// The headline conclusion for the whole recording: a `Finding` plus the
+/// whole-recording status and data-quality statement.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Overall {
+    #[serde(flatten)]
+    pub finding: Finding,
+    pub status: OverallStatus,
+    pub data_quality: DataQuality,
+}
+
+/// Priority tier for an itemized finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Priority {
+    High,
+    Medium,
+    Low,
+}
+
+/// What kind of itemized finding this is. Internally tagged on `type` (nested under the `kind` field, so the wire shape is `"kind": {"type": "Bottleneck", ...}`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum FindingKind {
+    /// A resource/subsystem limiting the workload.
+    Bottleneck {
+        subsystem: String,
+        mechanism: String,
+        direction: String,
+    },
+    /// A data gap that must be filled to conclude. Specific and actionable.
+    NeedsMetric {
+        missing: String,
+        would_resolve: String,
+    },
+}
+
+/// An itemized, prioritized finding: a `Finding` plus its tier and kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TieredFinding {
+    #[serde(flatten)]
+    pub finding: Finding,
+    pub priority: Priority,
+    pub kind: FindingKind,
+}
+
+/// A complete assessment of one recording: `Finding`s in three buckets.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Assessment {
+    /// Schema version for this assessment. Readers are expected to check this; enforcement lands with the Phase 3 front door.
+    pub schema_version: u32,
+    /// Headline conclusion for the whole recording.
+    pub overall: Overall,
+    /// Priority-tiered itemized findings.
+    pub findings: Vec<TieredFinding>,
+    /// Hypotheses actively dismissed; `evidence` is the dismissing signal.
+    pub ruled_out: Vec<Finding>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_assessment() -> Assessment {
+        Assessment {
+            schema_version: ASSESSMENT_SCHEMA_VERSION,
+            overall: Overall {
+                finding: Finding {
+                    summary: "Workload is scheduler-bound".to_string(),
+                    confidence: Confidence::High,
+                    evidence: vec![EvidenceRef {
+                        metric: Some("scheduler_runqueue_latency".to_string()),
+                        anomaly_index: None,
+                        regime_shift_index: Some(0),
+                        correlation_index: None,
+                        rationale: "sustained runqueue-latency regime shift".to_string(),
+                    }],
+                    recommended_action: Some("reduce runnable-task oversubscription".to_string()),
+                },
+                status: OverallStatus::Actionable,
+                data_quality: DataQuality {
+                    coverage_gaps: vec!["blockio".to_string()],
+                    uncertainty_limited: false,
+                    note: None,
+                },
+            },
+            findings: vec![TieredFinding {
+                finding: Finding {
+                    summary: "Runqueue latency p99 elevated".to_string(),
+                    confidence: Confidence::High,
+                    evidence: vec![EvidenceRef {
+                        metric: None,
+                        anomaly_index: None,
+                        regime_shift_index: None,
+                        correlation_index: Some(0),
+                        rationale: "runqueue latency co-moves with cpu saturation".to_string(),
+                    }],
+                    recommended_action: Some("pin latency-sensitive threads".to_string()),
+                },
+                priority: Priority::High,
+                kind: FindingKind::Bottleneck {
+                    subsystem: "scheduler".to_string(),
+                    mechanism: "runqueue_latency".to_string(),
+                    direction: "tasks waiting to run".to_string(),
+                },
+            }],
+            ruled_out: vec![Finding {
+                summary: "Thermal throttling".to_string(),
+                confidence: Confidence::High,
+                evidence: vec![EvidenceRef {
+                    metric: Some("cpu_frequency_ratio".to_string()),
+                    anomaly_index: None,
+                    regime_shift_index: None,
+                    correlation_index: None,
+                    rationale: "frequency ratio stable, no Allan noise transition".to_string(),
+                }],
+                recommended_action: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn assessment_wire_shape_is_pinned() {
+        let v = serde_json::to_value(sample_assessment()).unwrap();
+        let expected = serde_json::json!({
+            "schema_version": 1,
+            "overall": {
+                "summary": "Workload is scheduler-bound",
+                "confidence": "High",
+                "evidence": [
+                    {
+                        "metric": "scheduler_runqueue_latency",
+                        "regime_shift_index": 0,
+                        "rationale": "sustained runqueue-latency regime shift"
+                    }
+                ],
+                "recommended_action": "reduce runnable-task oversubscription",
+                "status": "Actionable",
+                "data_quality": {
+                    "coverage_gaps": ["blockio"],
+                    "uncertainty_limited": false
+                }
+            },
+            "findings": [
+                {
+                    "summary": "Runqueue latency p99 elevated",
+                    "confidence": "High",
+                    "evidence": [
+                        {
+                            "correlation_index": 0,
+                            "rationale": "runqueue latency co-moves with cpu saturation"
+                        }
+                    ],
+                    "recommended_action": "pin latency-sensitive threads",
+                    "priority": "High",
+                    "kind": {
+                        "type": "Bottleneck",
+                        "subsystem": "scheduler",
+                        "mechanism": "runqueue_latency",
+                        "direction": "tasks waiting to run"
+                    }
+                }
+            ],
+            "ruled_out": [
+                {
+                    "summary": "Thermal throttling",
+                    "confidence": "High",
+                    "evidence": [
+                        {
+                            "metric": "cpu_frequency_ratio",
+                            "rationale": "frequency ratio stable, no Allan noise transition"
+                        }
+                    ]
+                }
+            ]
+        });
+        assert_eq!(
+            v,
+            expected,
+            "wire shape mismatch:\nactual:\n{}\n",
+            serde_json::to_string_pretty(&v).unwrap()
+        );
+    }
+
+    #[test]
+    fn assessment_round_trips_through_json() {
+        let a = sample_assessment();
+        let json = serde_json::to_string(&a).unwrap();
+        let back: Assessment = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+
+    #[test]
+    fn tiered_finding_wire_shape_nests_kind() {
+        let a = sample_assessment();
+        let json = serde_json::to_string(&a).unwrap();
+        assert!(json.contains("\"kind\":{\"type\":\"Bottleneck\""));
+        assert!(json.contains("\"subsystem\":\"scheduler\""));
+    }
+
+    #[test]
+    fn needs_metric_kind_round_trips() {
+        let f = TieredFinding {
+            finding: Finding {
+                summary: "Cannot assess block IO".to_string(),
+                confidence: Confidence::Medium,
+                evidence: vec![],
+                recommended_action: Some("enable blockio latency sampler".to_string()),
+            },
+            priority: Priority::High,
+            kind: FindingKind::NeedsMetric {
+                missing: "blockio_latency".to_string(),
+                would_resolve: "whether stalls are storage-bound".to_string(),
+            },
+        };
+        let json = serde_json::to_string(&f).unwrap();
+        let back: TieredFinding = serde_json::from_str(&json).unwrap();
+        assert_eq!(f, back);
+        assert!(json.contains("\"kind\":{\"type\":\"NeedsMetric\""));
+    }
+
+    #[test]
+    fn recommended_action_omitted_when_none() {
+        let ruled = &sample_assessment().ruled_out[0];
+        let json = serde_json::to_string(ruled).unwrap();
+        assert!(!json.contains("recommended_action"));
+    }
+}

--- a/src/analysis/assessment.rs
+++ b/src/analysis/assessment.rs
@@ -13,6 +13,12 @@ use serde::{Deserialize, Serialize};
 /// supports (or, in `ruled_out`, dismisses) the claim. Exactly one of the index
 /// fields is normally set alongside `metric`; all optional so an evidence item
 /// can point at a metric, an anomaly, a regime shift, or a correlation.
+///
+/// OPEN QUESTION (must be settled before Phase 3's index-resolution check):
+/// `metric` is a bare name, but the record keys metric entries by
+/// (name, labels) — a name with multiple series is ambiguous. Resolution
+/// options: an index into the record's `metrics` vec, labels here, or an
+/// extraction guarantee that emitted names are unique.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EvidenceRef {
     /// Metric this evidence points at, if any.
@@ -132,6 +138,36 @@ pub struct Assessment {
     pub ruled_out: Vec<Finding>,
 }
 
+impl Finding {
+    /// Structural invariants a single finding must satisfy, regardless of role.
+    fn validate_self(&self, role: &str) -> Result<(), String> {
+        if self.summary.trim().is_empty() {
+            return Err(format!("{role} has an empty summary"));
+        }
+        // A High-confidence claim must be grounded in evidence.
+        if self.confidence == Confidence::High && self.evidence.is_empty() {
+            return Err(format!("{role} is High confidence but cites no evidence"));
+        }
+        Ok(())
+    }
+}
+
+impl Assessment {
+    /// Structural validation that needs no `OverviewRecord`. Cross-record checks
+    /// (evidence indices resolving, uncertainty forcing confidence down) are
+    /// applied in Phase 3 once extraction exists.
+    pub fn validate(&self) -> Result<(), String> {
+        self.overall.finding.validate_self("overall finding")?;
+        for (i, f) in self.findings.iter().enumerate() {
+            f.finding.validate_self(&format!("findings[{i}]"))?;
+        }
+        for (i, f) in self.ruled_out.iter().enumerate() {
+            f.validate_self(&format!("ruled_out[{i}]"))?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,26 +195,41 @@ mod tests {
                     note: None,
                 },
             },
-            findings: vec![TieredFinding {
-                finding: Finding {
-                    summary: "Runqueue latency p99 elevated".to_string(),
-                    confidence: Confidence::High,
-                    evidence: vec![EvidenceRef {
-                        metric: None,
-                        anomaly_index: None,
-                        regime_shift_index: None,
-                        correlation_index: Some(0),
-                        rationale: "runqueue latency co-moves with cpu saturation".to_string(),
-                    }],
-                    recommended_action: Some("pin latency-sensitive threads".to_string()),
+            findings: vec![
+                TieredFinding {
+                    finding: Finding {
+                        summary: "Runqueue latency p99 elevated".to_string(),
+                        confidence: Confidence::High,
+                        evidence: vec![EvidenceRef {
+                            metric: None,
+                            anomaly_index: None,
+                            regime_shift_index: None,
+                            correlation_index: Some(0),
+                            rationale: "runqueue latency co-moves with cpu saturation".to_string(),
+                        }],
+                        recommended_action: Some("pin latency-sensitive threads".to_string()),
+                    },
+                    priority: Priority::High,
+                    kind: FindingKind::Bottleneck {
+                        subsystem: "scheduler".to_string(),
+                        mechanism: "runqueue_latency".to_string(),
+                        direction: "tasks waiting to run".to_string(),
+                    },
                 },
-                priority: Priority::High,
-                kind: FindingKind::Bottleneck {
-                    subsystem: "scheduler".to_string(),
-                    mechanism: "runqueue_latency".to_string(),
-                    direction: "tasks waiting to run".to_string(),
+                TieredFinding {
+                    finding: Finding {
+                        summary: "Cannot rule out storage stalls".to_string(),
+                        confidence: Confidence::Medium,
+                        evidence: vec![],
+                        recommended_action: Some("enable blockio latency sampler".to_string()),
+                    },
+                    priority: Priority::Medium,
+                    kind: FindingKind::NeedsMetric {
+                        missing: "blockio_latency".to_string(),
+                        would_resolve: "whether stalls are storage-bound".to_string(),
+                    },
                 },
-            }],
+            ],
             ruled_out: vec![Finding {
                 summary: "Thermal throttling".to_string(),
                 confidence: Confidence::High,
@@ -233,6 +284,18 @@ mod tests {
                         "subsystem": "scheduler",
                         "mechanism": "runqueue_latency",
                         "direction": "tasks waiting to run"
+                    }
+                },
+                {
+                    "summary": "Cannot rule out storage stalls",
+                    "confidence": "Medium",
+                    "evidence": [],
+                    "recommended_action": "enable blockio latency sampler",
+                    "priority": "Medium",
+                    "kind": {
+                        "type": "NeedsMetric",
+                        "missing": "blockio_latency",
+                        "would_resolve": "whether stalls are storage-bound"
                     }
                 }
             ],
@@ -299,5 +362,50 @@ mod tests {
         let ruled = &sample_assessment().ruled_out[0];
         let json = serde_json::to_string(ruled).unwrap();
         assert!(!json.contains("recommended_action"));
+    }
+
+    #[test]
+    fn valid_assessment_passes_validation() {
+        assert!(sample_assessment().validate().is_ok());
+    }
+
+    #[test]
+    fn high_confidence_without_evidence_is_rejected() {
+        let mut a = sample_assessment();
+        a.findings[0].finding.evidence.clear();
+        a.findings[0].finding.confidence = Confidence::High;
+        let err = a.validate().unwrap_err();
+        assert!(
+            err.contains("High"),
+            "error should mention the High-confidence rule: {err}"
+        );
+        assert!(
+            err.contains("findings[0]"),
+            "error should name the finding: {err}"
+        );
+    }
+
+    #[test]
+    fn ruled_out_high_without_evidence_is_rejected() {
+        let mut a = sample_assessment();
+        a.ruled_out[0].evidence.clear();
+        let err = a.validate().unwrap_err();
+        assert!(
+            err.contains("ruled_out[0]"),
+            "error should name the ruled_out item: {err}"
+        );
+    }
+
+    #[test]
+    fn whitespace_summary_is_rejected_before_evidence_rule() {
+        let mut a = sample_assessment();
+        // Violate both rules at once: summary check must win.
+        a.overall.finding.summary = "   ".to_string();
+        a.overall.finding.evidence.clear();
+        let err = a.validate().unwrap_err();
+        assert!(
+            err.contains("summary"),
+            "summary rule should fire first: {err}"
+        );
     }
 }

--- a/src/analysis/assessment.rs
+++ b/src/analysis/assessment.rs
@@ -1,0 +1,8 @@
+//! The assessment data model — the structured, actionable conclusion an agent
+//! (or fine-tuned model) emits over an `OverviewRecord`.
+//!
+//! The whole assessment is `Finding`s in three buckets (`overall`, `findings`,
+//! `ruled_out`) — one type, three roles, uniform grounding and validation.
+
+/// Schema version for `Assessment`. Bump on any change to the assessment shape.
+pub const ASSESSMENT_SCHEMA_VERSION: u32 = 1;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -5,5 +5,15 @@
 //! agent emits over that record (`assessment`). See
 //! `docs/superpowers/specs/2026-07-24-recording-assessment-extraction-design.md`.
 
+// Phase 1 ships schemas with no runtime consumers; extraction (Phase 2) and the
+// MCP/CLI front door (Phase 3) wire these in. Remove once Phase 2/3 add runtime consumers.
+#![allow(dead_code)]
+
 pub mod assessment;
 pub mod record;
+
+#[allow(unused_imports)]
+pub use assessment::{
+    Assessment, Confidence, DataQuality, EvidenceRef, Finding, FindingKind, Overall, OverallStatus,
+    Priority, TieredFinding, ASSESSMENT_SCHEMA_VERSION,
+};

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,0 +1,9 @@
+//! Structured feature extraction and assessment for recordings.
+//!
+//! Turns a recording into a deterministic, versioned *overview record* of
+//! Rezolus-native features (`record`), and defines the *assessment* schema an
+//! agent emits over that record (`assessment`). See
+//! `docs/superpowers/specs/2026-07-24-recording-assessment-extraction-design.md`.
+
+pub mod assessment;
+pub mod record;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -17,3 +17,10 @@ pub use assessment::{
     Assessment, Confidence, DataQuality, EvidenceRef, Finding, FindingKind, Overall, OverallStatus,
     Priority, TieredFinding, ASSESSMENT_SCHEMA_VERSION,
 };
+
+#[allow(unused_imports)]
+pub use record::{
+    AnomalyFeature, Consumer, Context, CorrelationFeature, Coverage, DetailTier, MetricFeatures,
+    NoiseSummary, OverviewRecord, Promotion, Rankings, RegimeShiftFeature, Selection, Stats,
+    UncertaintySummary, RECORD_SCHEMA_VERSION,
+};

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -2,7 +2,487 @@
 //! recording's Rezolus-native features. This is the input half of a training
 //! example. Fields are a *curated* subset of the internal analysis structs, not
 //! the heavy raw analyses.
+//!
+//! # Invariants (enforced by Phase 2 extraction and validation, not by these types)
+//!
+//! - **All floats are finite.** serde_json serializes NaN/Infinity as `null`, which
+//!   then fails to deserialize into `f64` — a non-finite value produces a record that
+//!   writes successfully but can never be read back. Extraction must reject or clamp
+//!   non-finite values before a record is persisted.
+//! - **Deterministic ordering is two-layered.** These types guarantee same-value →
+//!   same-bytes (BTreeMap label maps, declaration-order fields). Same-recording →
+//!   same-bytes additionally requires the extractor to order `metrics`, coverage
+//!   lists, `correlations`, and `promotions` deterministically.
+//! - **Tier↔content coupling.** A `Summary`-tier metric must carry empty
+//!   `anomalies`/`regime_shifts` and no `uncertainty`; the extractor upholds this and
+//!   validation checks it.
+//! - **Readers are lenient.** Unknown fields are ignored on deserialize (serde
+//!   default) — a deliberate forward-compatibility choice across schema versions.
 
 /// Schema version for `OverviewRecord`. Bump on any change to extraction logic
 /// or record shape so stored examples stay attributable to an extractor version.
 pub const RECORD_SCHEMA_VERSION: u32 = 1;
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A deterministic, versioned summary of a recording's Rezolus-native features.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OverviewRecord {
+    pub schema_version: u32,
+    pub context: Context,
+    /// Every metric appears (exhaustive coverage); detail scales with salience.
+    pub metrics: Vec<MetricFeatures>,
+    /// Top-N cross-metric relationships from a documented candidate set.
+    pub correlations: Vec<CorrelationFeature>,
+    pub rankings: Rankings,
+    pub selection: Selection,
+}
+
+/// Recording-level facts, including the load-bearing coverage map.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Context {
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_version: Option<String>,
+    pub duration_s: f64,
+    pub sampling_interval_s: f64,
+    /// JSON hardware summary passthrough (from agent `systeminfo` metadata).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub systeminfo: Option<serde_json::Value>,
+    pub coverage: Coverage,
+}
+
+/// Which subsystems are present vs absent — what lets an assessment say
+/// `NeedsMetric` instead of hallucinating around a gap.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Coverage {
+    pub subsystems_present: Vec<String>,
+    pub subsystems_absent: Vec<String>,
+}
+
+/// Detail level of a per-metric entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DetailTier {
+    /// Quiet metric: identity + stats + noise class, no findings.
+    Summary,
+    /// Salient metric: additionally carries anomalies, regime shifts, uncertainty.
+    Full,
+}
+
+/// Per-metric features. Exhaustive coverage, tiered detail.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetricFeatures {
+    pub name: String,
+    /// "counter" | "gauge" | "histogram".
+    pub metric_type: String,
+    /// Label set. `BTreeMap` for deterministic serialization order.
+    pub labels: BTreeMap<String, String>,
+    pub tier: DetailTier,
+    pub stats: Stats,
+    pub noise: NoiseSummary,
+    /// Full tier only; empty (and omitted) for summary-tier metrics.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub anomalies: Vec<AnomalyFeature>,
+    /// Full tier only; empty (and omitted) for summary-tier metrics.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub regime_shifts: Vec<RegimeShiftFeature>,
+    /// Full tier only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uncertainty: Option<UncertaintySummary>,
+}
+
+/// Summary statistics for a metric series.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Stats {
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    pub last: f64,
+    pub p50: f64,
+    pub p99: f64,
+}
+
+/// Curated noise classification: the noise type and the optimal-tau minimum.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NoiseSummary {
+    /// `NoiseType` rendered as a string (e.g. "WhiteFrequency").
+    pub noise_type: String,
+    /// Tau (seconds) of the strongest deviation minimum, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub optimal_tau_s: Option<f64>,
+}
+
+/// A curated anomaly (mapped down from `mcp::anomaly_detection::Anomaly`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AnomalyFeature {
+    pub timestamp: f64,
+    pub index: usize,
+    /// `AnomalyType` rendered as a string.
+    pub anomaly_type: String,
+    /// `AnomalySeverity` rendered as a string.
+    pub severity: String,
+    pub confidence: f64,
+    /// Deviation magnitude of the point (computed; `Anomaly` carries the raw value, not a magnitude).
+    pub magnitude: f64,
+}
+
+/// A curated sustained regime shift (mapped down from `WindowChangePoint`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegimeShiftFeature {
+    pub index: usize,
+    /// "Increase" | "Decrease" — derived from the before/after means (`WindowChangePoint` carries no direction field).
+    pub direction: String,
+    pub before_mean: f64,
+    pub after_mean: f64,
+    /// Percent change of the mean, always positive (75.0 = 75%); the sign lives in
+    /// `direction`. Mapped from `WindowChangePoint`'s absolute fraction ×100.
+    pub mean_change_pct: f64,
+    pub confidence: f64,
+    /// How many times larger than expected variance (from Allan analysis).
+    pub allan_significance: f64,
+}
+
+/// Acquisition-window uncertainty summary: is movement bigger than the error?
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UncertaintySummary {
+    /// Ratio of acquisition-window band width to signal magnitude.
+    pub band_to_signal_ratio: f64,
+    /// True when observed movement sits within the measurement band.
+    pub within_band: bool,
+}
+
+/// A curated cross-metric correlation (mapped from `DiscoveredCorrelation`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CorrelationFeature {
+    pub metric1: String,
+    pub metric2: String,
+    pub max_r: f64,
+    /// Measurement-uncertainty range of `max_r`, when inputs carry bands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r_band: Option<(f64, f64)>,
+    /// Optimal lag in seconds (positive = metric2 lags metric1).
+    pub optimal_lag_s: i64,
+    /// "CrossSubsystem" | "SameSubsystem".
+    pub relationship: String,
+}
+
+/// Top resource consumers per domain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Rankings {
+    pub cpu: Vec<Consumer>,
+    pub memory: Vec<Consumer>,
+    pub io: Vec<Consumer>,
+    pub network: Vec<Consumer>,
+}
+
+/// A ranked resource consumer (mapped from `ResourceConsumer`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Consumer {
+    pub name: String,
+    pub labels: BTreeMap<String, String>,
+    pub avg_usage: f64,
+    pub max_usage: f64,
+    pub percent_of_total: f64,
+}
+
+/// Auditability: how much detail each metric got, and the correlation search space.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Selection {
+    pub full_detail_count: usize,
+    pub summary_count: usize,
+    /// Why each full-tier metric was promoted.
+    pub promotions: Vec<Promotion>,
+    /// Human description of which pairs entered the top-N correlation search.
+    pub correlation_candidate_set: String,
+    pub total_pairs_tested: usize,
+}
+
+/// Why a metric was promoted to full detail.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Promotion {
+    pub metric: String,
+    /// "anomalous" | "regime_shift" | "top_consumer" | "strong_correlation".
+    pub reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn sample_record() -> OverviewRecord {
+        let mut labels = BTreeMap::new();
+        labels.insert("id".to_string(), "0".to_string());
+        labels.insert("state".to_string(), "user".to_string());
+        OverviewRecord {
+            schema_version: RECORD_SCHEMA_VERSION,
+            context: Context {
+                source: "rezolus".to_string(),
+                agent_version: Some("1.2.3".to_string()),
+                duration_s: 120.0,
+                sampling_interval_s: 1.0,
+                systeminfo: Some(serde_json::json!({
+                    "os": "linux",
+                    "cores": 8,
+                })),
+                coverage: Coverage {
+                    subsystems_present: vec!["cpu".to_string(), "scheduler".to_string()],
+                    subsystems_absent: vec!["blockio".to_string()],
+                },
+            },
+            metrics: vec![
+                MetricFeatures {
+                    name: "cpu_usage".to_string(),
+                    metric_type: "counter".to_string(),
+                    labels: labels.clone(),
+                    tier: DetailTier::Full,
+                    stats: Stats {
+                        min: 0.0,
+                        max: 1.0,
+                        mean: 0.5,
+                        last: 0.6,
+                        p50: 0.5,
+                        p99: 0.95,
+                    },
+                    noise: NoiseSummary {
+                        noise_type: "WhiteFrequency".to_string(),
+                        optimal_tau_s: Some(4.0),
+                    },
+                    anomalies: vec![AnomalyFeature {
+                        timestamp: 42.0,
+                        index: 42,
+                        anomaly_type: "LevelShift".to_string(),
+                        severity: "High".to_string(),
+                        confidence: 0.9,
+                        magnitude: 0.3,
+                    }],
+                    regime_shifts: vec![RegimeShiftFeature {
+                        index: 40,
+                        direction: "Increase".to_string(),
+                        before_mean: 0.4,
+                        after_mean: 0.7,
+                        mean_change_pct: 75.0,
+                        confidence: 0.95,
+                        allan_significance: 3.2,
+                    }],
+                    uncertainty: Some(UncertaintySummary {
+                        band_to_signal_ratio: 0.05,
+                        within_band: false,
+                    }),
+                },
+                MetricFeatures {
+                    name: "network_bytes".to_string(),
+                    metric_type: "counter".to_string(),
+                    labels: BTreeMap::new(),
+                    tier: DetailTier::Summary,
+                    stats: Stats {
+                        min: 0.0,
+                        max: 10.0,
+                        mean: 5.0,
+                        last: 5.0,
+                        p50: 5.0,
+                        p99: 9.0,
+                    },
+                    noise: NoiseSummary {
+                        noise_type: "WhitePhase".to_string(),
+                        optimal_tau_s: None,
+                    },
+                    anomalies: vec![],
+                    regime_shifts: vec![],
+                    uncertainty: None,
+                },
+            ],
+            correlations: vec![CorrelationFeature {
+                metric1: "cpu_usage".to_string(),
+                metric2: "scheduler_runqueue_latency".to_string(),
+                max_r: 0.85,
+                r_band: Some((0.80, 0.88)),
+                optimal_lag_s: 2,
+                relationship: "CrossSubsystem".to_string(),
+            }],
+            rankings: Rankings {
+                cpu: vec![Consumer {
+                    name: "cpu0".to_string(),
+                    labels: labels.clone(),
+                    avg_usage: 0.5,
+                    max_usage: 1.0,
+                    percent_of_total: 40.0,
+                }],
+                memory: vec![],
+                io: vec![],
+                network: vec![],
+            },
+            selection: Selection {
+                full_detail_count: 1,
+                summary_count: 1,
+                promotions: vec![Promotion {
+                    metric: "cpu_usage".to_string(),
+                    reason: "anomalous".to_string(),
+                }],
+                correlation_candidate_set: "pairs where at least one side is anomalous".to_string(),
+                total_pairs_tested: 3,
+            },
+        }
+    }
+
+    #[test]
+    fn record_round_trips_through_json() {
+        let r = sample_record();
+        let json = serde_json::to_string(&r).unwrap();
+        let back: OverviewRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, back);
+    }
+
+    #[test]
+    fn serialization_is_deterministic() {
+        // Same record serialized twice is byte-identical, and label maps sort.
+        let r = sample_record();
+        let a = serde_json::to_string(&r).unwrap();
+        let b = serde_json::to_string(&r).unwrap();
+        assert_eq!(a, b);
+        // BTreeMap orders keys: "id" before "state".
+        let idx_id = a.find("\"id\"").unwrap();
+        let idx_state = a.find("\"state\"").unwrap();
+        assert!(
+            idx_id < idx_state,
+            "label keys must serialize in sorted order"
+        );
+    }
+
+    #[test]
+    fn summary_tier_metric_omits_empty_detail() {
+        let r = sample_record();
+        let summary_metric = serde_json::to_string(&r.metrics[1]).unwrap();
+        assert!(!summary_metric.contains("anomalies"));
+        assert!(!summary_metric.contains("regime_shifts"));
+        assert!(!summary_metric.contains("uncertainty"));
+    }
+
+    #[test]
+    fn record_wire_shape_is_pinned() {
+        let v = serde_json::to_value(sample_record()).unwrap();
+        let expected = serde_json::json!({
+            "schema_version": 1,
+            "context": {
+                "source": "rezolus",
+                "agent_version": "1.2.3",
+                "duration_s": 120.0,
+                "sampling_interval_s": 1.0,
+                "systeminfo": {
+                    "cores": 8,
+                    "os": "linux"
+                },
+                "coverage": {
+                    "subsystems_present": ["cpu", "scheduler"],
+                    "subsystems_absent": ["blockio"]
+                }
+            },
+            "metrics": [
+                {
+                    "name": "cpu_usage",
+                    "metric_type": "counter",
+                    "labels": {
+                        "id": "0",
+                        "state": "user"
+                    },
+                    "tier": "Full",
+                    "stats": {
+                        "min": 0.0,
+                        "max": 1.0,
+                        "mean": 0.5,
+                        "last": 0.6,
+                        "p50": 0.5,
+                        "p99": 0.95
+                    },
+                    "noise": {
+                        "noise_type": "WhiteFrequency",
+                        "optimal_tau_s": 4.0
+                    },
+                    "anomalies": [
+                        {
+                            "timestamp": 42.0,
+                            "index": 42,
+                            "anomaly_type": "LevelShift",
+                            "severity": "High",
+                            "confidence": 0.9,
+                            "magnitude": 0.3
+                        }
+                    ],
+                    "regime_shifts": [
+                        {
+                            "index": 40,
+                            "direction": "Increase",
+                            "before_mean": 0.4,
+                            "after_mean": 0.7,
+                            "mean_change_pct": 75.0,
+                            "confidence": 0.95,
+                            "allan_significance": 3.2
+                        }
+                    ],
+                    "uncertainty": {
+                        "band_to_signal_ratio": 0.05,
+                        "within_band": false
+                    }
+                },
+                {
+                    "name": "network_bytes",
+                    "metric_type": "counter",
+                    "labels": {},
+                    "tier": "Summary",
+                    "stats": {
+                        "min": 0.0,
+                        "max": 10.0,
+                        "mean": 5.0,
+                        "last": 5.0,
+                        "p50": 5.0,
+                        "p99": 9.0
+                    },
+                    "noise": {
+                        "noise_type": "WhitePhase"
+                    }
+                }
+            ],
+            "correlations": [
+                {
+                    "metric1": "cpu_usage",
+                    "metric2": "scheduler_runqueue_latency",
+                    "max_r": 0.85,
+                    "r_band": [0.8, 0.88],
+                    "optimal_lag_s": 2,
+                    "relationship": "CrossSubsystem"
+                }
+            ],
+            "rankings": {
+                "cpu": [
+                    {
+                        "name": "cpu0",
+                        "labels": {
+                            "id": "0",
+                            "state": "user"
+                        },
+                        "avg_usage": 0.5,
+                        "max_usage": 1.0,
+                        "percent_of_total": 40.0
+                    }
+                ],
+                "memory": [],
+                "io": [],
+                "network": []
+            },
+            "selection": {
+                "full_detail_count": 1,
+                "summary_count": 1,
+                "promotions": [
+                    {
+                        "metric": "cpu_usage",
+                        "reason": "anomalous"
+                    }
+                ],
+                "correlation_candidate_set": "pairs where at least one side is anomalous",
+                "total_pairs_tested": 3
+            }
+        });
+        assert_eq!(v, expected);
+    }
+}

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -1,0 +1,8 @@
+//! The overview-record data model — a deterministic, versioned summary of a
+//! recording's Rezolus-native features. This is the input half of a training
+//! example. Fields are a *curated* subset of the internal analysis structs, not
+//! the heavy raw analyses.
+
+/// Schema version for `OverviewRecord`. Bump on any change to extraction logic
+/// or record shape so stored examples stay attributable to an extractor version.
+pub const RECORD_SCHEMA_VERSION: u32 = 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 
 /// modules for each mode of operation
 mod agent;
+mod analysis;
 mod exporter;
 mod hindsight;
 mod mcp;


### PR DESCRIPTION
## Summary
- New top-level `src/analysis/` module: pure serde schemas for the recording-assessment effort (no extraction logic or MCP wiring yet — those are Phases 2/3)
- `Assessment`: a unified `Finding` (summary/confidence/evidence/recommended_action) reused across three buckets — `overall` (+ status + data-quality), priority-tiered `findings` (+ nested internally-tagged `FindingKind`: Bottleneck/NeedsMetric), and `ruled_out` — plus structural validation (non-empty summaries; High confidence must cite evidence) with indexed error messages
- `OverviewRecord`: deterministic, versioned, curated summary of a recording's Rezolus-native features (coverage map, tiered per-metric features with noise class/anomalies/regime shifts/acquisition-window uncertainty, correlations, consumer rankings, selection audit trail); `BTreeMap` label maps keep serialization byte-stable
- Both schemas carry version constants and full-document golden wire-shape tests so any drift fails loudly; `record.rs` module docs pin the invariants Phase 2 extraction must enforce (finite floats, ordering determinism, tier↔content coupling)

## Test plan
- [x] `cargo test analysis::` — 13 unit tests: JSON round-trips, golden wire-shape pinning for both schemas, serialization determinism + BTreeMap key ordering, summary-tier field omission, validation rules incl. rule precedence and `ruled_out` branch coverage (mutation-verified in review)
- [x] Full `cargo test` suite green (333 passed)
- [x] `cargo clippy` / `cargo fmt --check` clean; each commit builds independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)