### PR TITLE
feat(analysis): extract-features front door, golden tests, cross-record validation (Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ target/release/rezolus mcp query file.parquet "sum(rate(cpu_cycles[1m]))"     # 
 # query prints an acquisition-window uncertainty band [lo, hi] beside rate()/irate() values
 # (scalar ops scale the band, e.g. rate(x)*k; series-op-series and non-rate queries show none)
 target/release/rezolus mcp analyze-correlation file.parquet "metric1" "metric2"
+target/release/rezolus mcp extract-features file.parquet             # structured feature record (JSON)
 ```
 
 ## Architecture
@@ -110,7 +111,7 @@ The binary operates in seven modes via subcommands:
 3. **Recorder** (`src/recorder/`) - Writes metrics to parquet files. Auto-detects Rezolus vs Prometheus sources. Supports `--metadata key=value` and `--format {parquet|raw|rez}`. The `.rez` format (`-o out.rez` or `--format rez`) writes a per-sampler archive (see "`.rez` archive format" below); `--label key=value` tags a `.rez` recording.
 4. **Hindsight** (`src/hindsight/`) - Maintains rolling ring buffer on disk for post-incident snapshots.
 5. **Viewer** (`src/viewer/`) - Web dashboard with PromQL query engine and TSDB (from `metriken-query` crate). Supports parquet files, `.rez` archives (a 2-recording `.rez` renders as an A/B baseline/experiment comparison, >2 shows the first two), live agent connections, and upload-only mode. Generates service KPI dashboards from `ServiceExtension` metadata.
-6. **MCP** (`src/mcp/`) - AI analysis tools (anomaly detection, correlation, PromQL queries). Runs as stdio server or one-shot CLI commands. `query` prints acquisition-window uncertainty bands `[lo, hi]` beside `rate()`/`irate()` values (scalar ops scale the band; series-op-series and non-rate queries show none).
+6. **MCP** (`src/mcp/`) - AI analysis tools (anomaly detection, correlation, PromQL queries, feature extraction). Runs as stdio server or one-shot CLI commands. `query` prints acquisition-window uncertainty bands `[lo, hi]` beside `rate()`/`irate()` values (scalar ops scale the band; series-op-series and non-rate queries show none). `extract-features` emits a deterministic, versioned overview record (JSON) summarizing a recording's Rezolus-native features.
 7. **Parquet** (`src/parquet_tools/`) - File operations: `metadata` (inspect; on a `.rez`, describes the manifest), `annotate` (add service extension KPIs; on a `.rez`, `--queries` embeds them into each recording's manifest), `combine` (merge multi-source files, build an A/B tarball, or assemble single-recording `.rez` into a multi-recording `.rez`), `filter` (drop columns not needed by KPIs; on a `.rez`, `--samplers` drops whole per-sampler tables). All four accept `.rez` inputs.
 
 ### Sampler Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.7"
+version = "5.17.1-alpha.8"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.7"
+version = "5.17.1-alpha.8"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/README.md
+++ b/README.md
@@ -273,6 +273,17 @@ rezolus mcp detect-anomalies rezolus.parquet                 # anomaly detection
 rezolus mcp query rezolus.parquet "sum(rate(cpu_cycles[1m]))"
 ```
 
+`extract-features` distills a whole recording into one deterministic, versioned
+JSON record — the structured input for an AI-assisted bottleneck assessment,
+rather than a series of ad-hoc queries. For every metric it reports summary
+stats, noise classification, anomalies, regime shifts, and acquisition-window
+uncertainty; alongside that it reports top cross-metric correlations, resource
+rankings, and subsystem coverage. Requires a recording of at least 10 seconds:
+
+```bash
+rezolus mcp extract-features rezolus.parquet   # parquet or .rez recordings
+```
+
 ---
 
 ## Use Cases

--- a/docs/external_metrics.md
+++ b/docs/external_metrics.md
@@ -64,6 +64,11 @@ The number of buckets is determined by: `(max_value_power - grouping_power) * 2^
 Example: `grouping_power=3, max_value_power=20` creates a histogram that can
 store values up to ~1 million with 136 buckets.
 
+Both parameters must reach the recorded column metadata: a histogram column
+whose parquet metadata lacks a u8-parseable `grouping_power` or
+`max_value_power` is **silently dropped** by the query engine on read (see
+"Histogram columns" in `docs/parquet_metadata.md`).
+
 ## Session Labels
 
 Both protocols support **session labels** - connection-level labels that are

--- a/docs/parquet_metadata.md
+++ b/docs/parquet_metadata.md
@@ -617,3 +617,17 @@ others:
 
 If you write parquet from another tool that you intend to feed into
 `parquet combine`, match these settings to keep behaviour predictable.
+
+## Histogram columns: required column metadata
+
+A histogram column (`<metric>:buckets`, Arrow type `List<UInt64>`) MUST carry
+`grouping_power` and `max_value_power` in its column-level metadata, both
+parseable as `u8`. If either is missing or unparseable, `metriken-query`'s
+parquet reader **silently drops the entire column** from the schema — no
+error, no warning; the histogram simply never appears to queries.
+
+The rezolus agent's exposition path stamps these automatically. Anything else
+that writes histogram snapshots (external producers, test fixtures built via
+`RezRecorder`/`metriken-exposition` builders) must stamp them itself — the
+snapshot builders do not add them for you. See `histogram_labels()` in
+`src/analysis/extract/golden.rs` for a working example.

--- a/src/analysis/assessment.rs
+++ b/src/analysis/assessment.rs
@@ -9,6 +9,8 @@ pub const ASSESSMENT_SCHEMA_VERSION: u32 = 1;
 
 use serde::{Deserialize, Serialize};
 
+use crate::analysis::record::OverviewRecord;
+
 /// A reference from a `Finding` into an element of the `OverviewRecord` that
 /// supports (or, in `ruled_out`, dismisses) the claim. Exactly one of the index
 /// fields is normally set alongside `metric`; all optional so an evidence item
@@ -34,6 +36,52 @@ pub struct EvidenceRef {
     pub correlation_index: Option<usize>,
     /// One-line rationale tying this record element to the claim.
     pub rationale: String,
+}
+
+impl EvidenceRef {
+    /// True when this evidence points at something checkable in a record.
+    fn has_pointer(&self) -> bool {
+        self.metric.is_some() || self.correlation_index.is_some()
+    }
+
+    /// Resolve this reference against a record, or say precisely what failed.
+    fn resolve_in(&self, record: &OverviewRecord, role: &str) -> Result<(), String> {
+        if (self.anomaly_index.is_some() || self.regime_shift_index.is_some())
+            && self.metric.is_none()
+        {
+            return Err(format!("{role}: evidence has an index but no metric"));
+        }
+        if let Some(name) = &self.metric {
+            let Some(m) = record.metrics.iter().find(|m| &m.name == name) else {
+                return Err(format!("{role}: evidence cites unknown metric {name}"));
+            };
+            if let Some(i) = self.anomaly_index {
+                if i >= m.anomalies.len() {
+                    return Err(format!(
+                        "{role}: anomaly_index {i} out of range for {name} ({} anomalies)",
+                        m.anomalies.len()
+                    ));
+                }
+            }
+            if let Some(i) = self.regime_shift_index {
+                if i >= m.regime_shifts.len() {
+                    return Err(format!(
+                        "{role}: regime_shift_index {i} out of range for {name} ({} shifts)",
+                        m.regime_shifts.len()
+                    ));
+                }
+            }
+        }
+        if let Some(i) = self.correlation_index {
+            if i >= record.correlations.len() {
+                return Err(format!(
+                    "{role}: correlation_index {i} out of range ({} correlations)",
+                    record.correlations.len()
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Categorical confidence. Must track the uncertainty signals: a finding whose
@@ -147,6 +195,52 @@ impl Finding {
         if self.confidence == Confidence::High && self.evidence.is_empty() {
             return Err(format!("{role} is High confidence but cites no evidence"));
         }
+        // A High-confidence claim must cite at least one evidence item with a
+        // resolvable pointer — rationale-only evidence (all pointer fields
+        // None) cannot ground High.
+        if self.confidence == Confidence::High
+            && !self.evidence.iter().any(EvidenceRef::has_pointer)
+        {
+            return Err(format!(
+                "{role} is High confidence but no evidence item has a resolvable pointer"
+            ));
+        }
+        Ok(())
+    }
+
+    /// Cross-record checks: every evidence ref resolves, and a High-confidence
+    /// claim may not rest on a metric whose movement sits inside its
+    /// acquisition-window band.
+    fn validate_against_record(&self, record: &OverviewRecord, role: &str) -> Result<(), String> {
+        for e in &self.evidence {
+            e.resolve_in(record, role)?;
+        }
+        if self.confidence >= Confidence::High {
+            for e in &self.evidence {
+                if let Some(name) = &e.metric {
+                    if let Some(m) = record.metrics.iter().find(|m| &m.name == name) {
+                        if m.uncertainty.as_ref().is_some_and(|u| u.within_band) {
+                            return Err(format!(
+                                "{role}: High confidence cites {name}, whose movement is within its measurement band"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TieredFinding {
+    /// Structural invariants specific to the itemized-finding shape.
+    fn validate_self(&self, role: &str) -> Result<(), String> {
+        self.finding.validate_self(role)?;
+        if let FindingKind::NeedsMetric { missing, .. } = &self.kind {
+            if missing.trim().is_empty() {
+                return Err(format!("{role} is NeedsMetric but `missing` is empty"));
+            }
+        }
         Ok(())
     }
 }
@@ -154,14 +248,31 @@ impl Finding {
 impl Assessment {
     /// Structural validation that needs no `OverviewRecord`. Cross-record checks
     /// (evidence indices resolving, uncertainty forcing confidence down) are
-    /// applied in Phase 3 once extraction exists.
+    /// applied by `validate_against`.
     pub fn validate(&self) -> Result<(), String> {
         self.overall.finding.validate_self("overall finding")?;
         for (i, f) in self.findings.iter().enumerate() {
-            f.finding.validate_self(&format!("findings[{i}]"))?;
+            f.validate_self(&format!("findings[{i}]"))?;
         }
         for (i, f) in self.ruled_out.iter().enumerate() {
             f.validate_self(&format!("ruled_out[{i}]"))?;
+        }
+        Ok(())
+    }
+
+    /// Full validation against the record this assessment claims to describe:
+    /// structural invariants plus evidence resolution and the uncertainty cap.
+    pub fn validate_against(&self, record: &OverviewRecord) -> Result<(), String> {
+        self.validate()?;
+        self.overall
+            .finding
+            .validate_against_record(record, "overall finding")?;
+        for (i, f) in self.findings.iter().enumerate() {
+            f.finding
+                .validate_against_record(record, &format!("findings[{i}]"))?;
+        }
+        for (i, f) in self.ruled_out.iter().enumerate() {
+            f.validate_against_record(record, &format!("ruled_out[{i}]"))?;
         }
         Ok(())
     }
@@ -412,5 +523,218 @@ mod tests {
     fn confidence_is_ordered() {
         assert!(Confidence::Low < Confidence::Medium);
         assert!(Confidence::Medium < Confidence::High);
+    }
+
+    use crate::analysis::record::{
+        AnalysisStatus, AnomalyFeature, Context, CorrelationFeature, Coverage, DetailTier,
+        MetricFeatures, NoiseSummary, OverviewRecord, Rankings, Selection, Stats,
+        UncertaintySummary, RECORD_SCHEMA_VERSION,
+    };
+
+    fn record_with(
+        metrics: Vec<MetricFeatures>,
+        correlations: Vec<CorrelationFeature>,
+    ) -> OverviewRecord {
+        OverviewRecord {
+            schema_version: RECORD_SCHEMA_VERSION,
+            context: Context {
+                source: "rezolus".to_string(),
+                agent_version: None,
+                duration_s: 60.0,
+                sampling_interval_s: 1.0,
+                systeminfo: None,
+                coverage: Coverage {
+                    subsystems_present: vec![],
+                    subsystems_absent: vec![],
+                },
+            },
+            metrics,
+            correlations,
+            rankings: Rankings {
+                cpu: vec![],
+                memory: vec![],
+                io: vec![],
+                network: vec![],
+            },
+            selection: Selection {
+                full_detail_count: 0,
+                summary_count: 0,
+                promotions: vec![],
+                correlation_candidate_set: String::new(),
+                total_pairs_tested: 0,
+            },
+        }
+    }
+
+    fn metric(name: &str, anomaly_count: usize, within_band: Option<bool>) -> MetricFeatures {
+        MetricFeatures {
+            name: name.to_string(),
+            metric_type: "counter".to_string(),
+            labels: std::collections::BTreeMap::new(),
+            tier: DetailTier::Full,
+            status: AnalysisStatus::Analyzed,
+            stats: Stats {
+                min: 0.0,
+                max: 1.0,
+                mean: 0.5,
+                last: 0.5,
+                p50: 0.5,
+                p99: 0.9,
+            },
+            noise: NoiseSummary {
+                noise_type: "WhitePhase".to_string(),
+                optimal_tau_s: None,
+            },
+            anomalies: (0..anomaly_count)
+                .map(|i| AnomalyFeature {
+                    timestamp: i as f64,
+                    index: i,
+                    anomaly_type: "PointOutlier".to_string(),
+                    severity: "High".to_string(),
+                    confidence: 0.9,
+                    magnitude: 3.0,
+                })
+                .collect(),
+            regime_shifts: vec![],
+            uncertainty: within_band.map(|w| UncertaintySummary {
+                band_to_signal_ratio: if w { 2.0 } else { 0.1 },
+                within_band: w,
+            }),
+        }
+    }
+
+    #[test]
+    fn valid_assessment_resolves_against_record() {
+        let record = record_with(vec![metric("cpu_usage", 1, Some(false))], vec![]);
+        let mut a = sample_assessment();
+        // point every evidence ref at the one real metric/anomaly
+        a.overall.finding.evidence = vec![EvidenceRef {
+            metric: Some("cpu_usage".to_string()),
+            anomaly_index: Some(0),
+            regime_shift_index: None,
+            correlation_index: None,
+            rationale: "r".to_string(),
+        }];
+        a.findings[0].finding.evidence = a.overall.finding.evidence.clone();
+        a.ruled_out[0].evidence = a.overall.finding.evidence.clone();
+        assert!(a.validate_against(&record).is_ok());
+    }
+
+    #[test]
+    fn unknown_metric_is_rejected() {
+        let record = record_with(vec![metric("cpu_usage", 1, Some(false))], vec![]);
+        let mut a = sample_assessment();
+        a.overall.finding.evidence[0].metric = Some("nonexistent".to_string());
+        let err = a.validate_against(&record).unwrap_err();
+        assert!(err.contains("nonexistent"), "{err}");
+    }
+
+    #[test]
+    fn out_of_range_anomaly_index_is_rejected() {
+        let record = record_with(vec![metric("cpu_usage", 1, Some(false))], vec![]);
+        let mut a = sample_assessment();
+        a.overall.finding.evidence = vec![EvidenceRef {
+            metric: Some("cpu_usage".to_string()),
+            anomaly_index: Some(5),
+            regime_shift_index: None,
+            correlation_index: None,
+            rationale: "r".to_string(),
+        }];
+        assert!(a.validate_against(&record).is_err());
+    }
+
+    #[test]
+    fn index_without_metric_is_rejected() {
+        let record = record_with(vec![metric("cpu_usage", 1, Some(false))], vec![]);
+        let mut a = sample_assessment();
+        a.overall.finding.evidence[0] = EvidenceRef {
+            metric: None,
+            anomaly_index: Some(0),
+            regime_shift_index: None,
+            correlation_index: None,
+            rationale: "r".to_string(),
+        };
+        assert!(a.validate_against(&record).is_err());
+    }
+
+    #[test]
+    fn correlation_index_resolves_against_record() {
+        let record = record_with(vec![metric("cpu_usage", 1, Some(false))], vec![]);
+        let mut a = sample_assessment();
+        let anchored = EvidenceRef {
+            metric: Some("cpu_usage".to_string()),
+            anomaly_index: Some(0),
+            regime_shift_index: None,
+            correlation_index: None,
+            rationale: "r".to_string(),
+        };
+        a.overall.finding.evidence = vec![anchored.clone()];
+        a.ruled_out[0].evidence = vec![anchored];
+        // findings[0] still cites correlation_index 0; the record has none
+        let err = a.validate_against(&record).unwrap_err();
+        assert!(err.contains("correlation_index"), "{err}");
+    }
+
+    #[test]
+    fn medium_confidence_may_cite_within_band_metric() {
+        let record = record_with(vec![metric("cpu_usage", 1, Some(true))], vec![]);
+        let mut a = sample_assessment();
+        let anchored = EvidenceRef {
+            metric: Some("cpu_usage".to_string()),
+            anomaly_index: Some(0),
+            regime_shift_index: None,
+            correlation_index: None,
+            rationale: "r".to_string(),
+        };
+        a.overall.finding.confidence = Confidence::Medium;
+        a.overall.finding.evidence = vec![anchored.clone()];
+        a.findings[0].finding.confidence = Confidence::Medium;
+        a.findings[0].finding.evidence = vec![anchored.clone()];
+        a.ruled_out[0].confidence = Confidence::Medium;
+        a.ruled_out[0].evidence = vec![anchored];
+        assert!(a.validate_against(&record).is_ok());
+    }
+
+    #[test]
+    fn within_band_metric_caps_confidence() {
+        let record = record_with(vec![metric("cpu_usage", 1, Some(true))], vec![]);
+        let mut a = sample_assessment();
+        a.overall.finding.evidence = vec![EvidenceRef {
+            metric: Some("cpu_usage".to_string()),
+            anomaly_index: Some(0),
+            regime_shift_index: None,
+            correlation_index: None,
+            rationale: "r".to_string(),
+        }];
+        a.findings.clear();
+        a.ruled_out.clear();
+        // overall is High and cites a within-band metric -> rejected
+        let err = a.validate_against(&record).unwrap_err();
+        assert!(err.contains("within"), "{err}");
+    }
+
+    #[test]
+    fn high_confidence_requires_a_resolvable_pointer() {
+        let mut a = sample_assessment();
+        // rationale-only evidence (all pointers None) cannot ground High
+        a.overall.finding.evidence = vec![EvidenceRef {
+            metric: None,
+            anomaly_index: None,
+            regime_shift_index: None,
+            correlation_index: None,
+            rationale: "vibes".to_string(),
+        }];
+        let err = a.validate().unwrap_err();
+        assert!(err.contains("pointer"), "{err}");
+    }
+
+    #[test]
+    fn empty_needs_metric_is_rejected() {
+        let mut a = sample_assessment();
+        if let FindingKind::NeedsMetric { missing, .. } = &mut a.findings[1].kind {
+            *missing = String::new();
+        }
+        let err = a.validate().unwrap_err();
+        assert!(err.contains("missing"), "{err}");
     }
 }

--- a/src/analysis/extract/golden.rs
+++ b/src/analysis/extract/golden.rs
@@ -1,0 +1,540 @@
+//! End-to-end golden-record, determinism, and structural tests over
+//! synthesized `.rez` recordings. The golden's expected document was
+//! captured from a reviewed first run (stats depend on PromQL rate() edge
+//! behavior and cannot be hand-authored); the invariant tests below hold
+//! independently of the capture.
+//!
+//! NOTE: the coverage map pins the full `EXPECTED_SUBSYSTEMS` universe —
+//! adding a sampler to that const will (correctly) break the golden test;
+//! update the expected document's `subsystems_absent` when it does.
+
+use std::collections::{BTreeMap, HashMap};
+use std::time::SystemTime;
+
+use metriken::Window;
+use metriken_exposition::{Counter, Gauge, Snapshot, SnapshotV2};
+
+use crate::recorder::rez::RezRecorder;
+
+const NS: u64 = 1_000_000_000;
+
+fn labels(name: &str, sampler: &str) -> HashMap<String, String> {
+    [
+        ("metric".to_string(), name.to_string()),
+        ("sampler".to_string(), sampler.to_string()),
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// As `labels`, plus the `grouping_power`/`max_value_power` metadata the
+/// reader requires to reconstruct a histogram column (`ColKind::Histogram`
+/// in metriken-query's parquet reader returns `None` — silently dropping
+/// the column — without both keys parseable as `u8`).
+fn histogram_labels(name: &str, sampler: &str) -> HashMap<String, String> {
+    let mut m = labels(name, sampler);
+    m.insert("grouping_power".to_string(), "7".to_string());
+    m.insert("max_value_power".to_string(), "64".to_string());
+    m
+}
+
+fn snap(ts: u64, counters: Vec<Counter>, gauges: Vec<Gauge>) -> Snapshot {
+    snap_with_histograms(ts, counters, gauges, Vec::new())
+}
+
+fn snap_with_histograms(
+    ts: u64,
+    counters: Vec<Counter>,
+    gauges: Vec<Gauge>,
+    histograms: Vec<metriken_exposition::Histogram>,
+) -> Snapshot {
+    Snapshot::V2(SnapshotV2 {
+        systemtime: SystemTime::UNIX_EPOCH + std::time::Duration::from_nanos(ts),
+        duration: std::time::Duration::ZERO,
+        metadata: HashMap::new(),
+        counters,
+        gauges,
+        histograms,
+    })
+}
+
+/// 121 snapshots at exactly 1s cadence (120s duration, interval 1.0):
+/// - `test_requests` (tcp_traffic): linear counter, +100/s -> constant rate
+/// - `test_stepped` (scheduler_runqueue): +10/s until t=60, +1000/s after
+/// - `test_depth` (scheduler_runqueue): constant gauge 5
+fn build_fixture() -> (tempfile::TempDir, std::path::PathBuf) {
+    let mut recorder = RezRecorder::new(
+        [
+            ("source".to_string(), "rezolus".to_string()),
+            ("sampling_interval_ms".to_string(), "1000".to_string()),
+        ]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>(),
+        [("source".to_string(), "rezolus".to_string())]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>(),
+        "rezolus".to_string(),
+    );
+    let mut stepped: u64 = 0;
+    for i in 0..121u64 {
+        let ts = NS * (i + 1);
+        let window = Some(Window::new(ts - 50_000_000, ts));
+        stepped += if i < 60 { 10 } else { 1000 };
+        recorder.ingest(
+            &snap(
+                ts,
+                vec![
+                    Counter::new(
+                        "test_requests".to_string(),
+                        i * 100,
+                        labels("test_requests", "tcp_traffic"),
+                    )
+                    .with_window(window),
+                    Counter::new(
+                        "test_stepped".to_string(),
+                        stepped,
+                        labels("test_stepped", "scheduler_runqueue"),
+                    )
+                    .with_window(window),
+                ],
+                vec![Gauge::new(
+                    "test_depth".to_string(),
+                    5,
+                    labels("test_depth", "scheduler_runqueue"),
+                )
+                .with_window(window)],
+            ),
+            ts,
+        );
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("fixture.rez");
+    recorder.finalize(&path).expect("finalize");
+    (dir, path)
+}
+
+/// As `build_fixture`, but with a fourth metric: a histogram
+/// (`test_latency`, subsystem `blockio_latency`) incrementing a handful of
+/// values per snapshot so its quantile-over-time series varies. Kept
+/// separate from `build_fixture` so the golden/determinism/invariant tests
+/// above are unaffected if this attempt is ever pared back.
+fn build_fixture_with_histogram() -> (tempfile::TempDir, std::path::PathBuf) {
+    let mut recorder = RezRecorder::new(
+        [
+            ("source".to_string(), "rezolus".to_string()),
+            ("sampling_interval_ms".to_string(), "1000".to_string()),
+        ]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>(),
+        [("source".to_string(), "rezolus".to_string())]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>(),
+        "rezolus".to_string(),
+    );
+    for i in 0..121u64 {
+        let ts = NS * (i + 1);
+        let window = Some(Window::new(ts - 50_000_000, ts));
+        let mut h = histogram::Histogram::new(7, 64).expect("histogram");
+        // A few increasing values per snapshot so the quantile series varies
+        // over time rather than sitting flat.
+        for v in [10 + i, 20 + i, 30 + i * 2] {
+            h.increment(v).expect("increment");
+        }
+        recorder.ingest(
+            &snap_with_histograms(
+                ts,
+                vec![],
+                vec![],
+                vec![metriken_exposition::Histogram::new(
+                    "test_latency".to_string(),
+                    h,
+                    histogram_labels("test_latency", "blockio_latency"),
+                )
+                .with_window(window)],
+            ),
+            ts,
+        );
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("fixture_hist.rez");
+    recorder.finalize(&path).expect("finalize");
+    (dir, path)
+}
+
+fn extract_fixture() -> crate::analysis::record::OverviewRecord {
+    let (_dir, path) = build_fixture();
+    let reader = crate::mcp::open_source(&path).expect("open");
+    crate::analysis::extract::extract(reader.as_ref()).expect("extract")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::record::{AnalysisStatus, DetailTier, RECORD_SCHEMA_VERSION};
+
+    #[test]
+    fn extraction_invariants_hold() {
+        let record = extract_fixture();
+        assert_eq!(record.schema_version, RECORD_SCHEMA_VERSION);
+        assert_eq!(record.context.source, "rezolus");
+        assert!((record.context.duration_s - 120.0).abs() < 1.0);
+        assert_eq!(record.context.sampling_interval_s, 1.0);
+        // exhaustive coverage: 2 counters + 1 gauge, sorted by name
+        let names: Vec<&str> = record.metrics.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(names, vec!["test_depth", "test_requests", "test_stepped"]);
+        // sampler labels stamped
+        assert_eq!(
+            record.metrics[0].labels.get("sampler").map(String::as_str),
+            Some("scheduler_runqueue")
+        );
+        // coverage: both fixture samplers present, e.g. blockio_latency absent
+        assert!(record
+            .context
+            .coverage
+            .subsystems_present
+            .contains(&"tcp_traffic".to_string()));
+        assert!(record
+            .context
+            .coverage
+            .subsystems_absent
+            .contains(&"blockio_latency".to_string()));
+        // selection accounting is consistent
+        assert_eq!(
+            record.selection.full_detail_count + record.selection.summary_count,
+            record.metrics.len()
+        );
+    }
+
+    #[test]
+    fn stepped_counter_yields_structural_findings() {
+        let record = extract_fixture();
+        let stepped = record
+            .metrics
+            .iter()
+            .find(|m| m.name == "test_stepped")
+            .expect("stepped metric present");
+        assert_eq!(stepped.status, AnalysisStatus::Analyzed);
+        assert_eq!(stepped.tier, DetailTier::Full);
+        // a 100x rate step must register as at least one regime shift or anomaly;
+        // pin structure, never engine confidences/magnitudes (drift-prone)
+        assert!(
+            !stepped.regime_shifts.is_empty() || !stepped.anomalies.is_empty(),
+            "100x step produced no findings"
+        );
+        if let Some(shift) = stepped.regime_shifts.first() {
+            assert_eq!(shift.direction, "Increase");
+        }
+        // the promotion is audited
+        assert!(record
+            .selection
+            .promotions
+            .iter()
+            .any(|p| p.metric == "test_stepped"));
+    }
+
+    #[test]
+    fn linear_counter_is_constant_rate() {
+        let record = extract_fixture();
+        let linear = record
+            .metrics
+            .iter()
+            .find(|m| m.name == "test_requests")
+            .expect("linear metric present");
+        // steady +100/s -> constant rate series -> findings suppressed
+        assert_eq!(linear.status, AnalysisStatus::Constant);
+        assert!(linear.anomalies.is_empty());
+        assert!(linear.regime_shifts.is_empty());
+    }
+
+    #[test]
+    fn extraction_is_deterministic_across_runs_and_thread_counts() {
+        let (_dir, path) = build_fixture();
+        let reader = crate::mcp::open_source(&path).expect("open");
+        let a = serde_json::to_string(
+            &crate::analysis::extract::extract(reader.as_ref()).expect("run a"),
+        )
+        .expect("ser a");
+        let b = serde_json::to_string(
+            &crate::analysis::extract::extract(reader.as_ref()).expect("run b"),
+        )
+        .expect("ser b");
+        assert_eq!(a, b, "same reader, two runs, byte-identical");
+        // vary rayon parallelism via scoped pools (the global pool is
+        // process-wide; install() scopes the change to this closure)
+        let one = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .expect("pool1")
+            .install(|| {
+                serde_json::to_string(
+                    &crate::analysis::extract::extract(reader.as_ref()).expect("run 1t"),
+                )
+                .expect("ser 1t")
+            });
+        let four = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .expect("pool4")
+            .install(|| {
+                serde_json::to_string(
+                    &crate::analysis::extract::extract(reader.as_ref()).expect("run 4t"),
+                )
+                .expect("ser 4t")
+            });
+        assert_eq!(
+            one, four,
+            "1-thread vs 4-thread extraction must be byte-identical"
+        );
+        assert_eq!(a, one, "scoped-pool run matches global-pool run");
+    }
+
+    #[test]
+    fn histogram_metric_yields_three_quantile_entries() {
+        let (_dir, path) = build_fixture_with_histogram();
+        let reader = crate::mcp::open_source(&path).expect("open");
+        let record = crate::analysis::extract::extract(reader.as_ref()).expect("extract");
+        for suffix in [":p50", ":p90", ":p99"] {
+            let name = format!("test_latency{suffix}");
+            let m = record
+                .metrics
+                .iter()
+                .find(|m| m.name == name)
+                .unwrap_or_else(|| panic!("{name} present"));
+            assert_eq!(m.metric_type, "histogram");
+            assert!(m.stats.min.is_finite());
+            assert!(m.stats.max.is_finite());
+            assert!(m.stats.mean.is_finite());
+            assert!(m.stats.last.is_finite());
+            assert!(m.stats.p50.is_finite());
+            assert!(m.stats.p99.is_finite());
+        }
+    }
+
+    /// Re-run to re-capture the golden document: `cargo test
+    /// analysis::extract::golden::tests::regenerate_golden -- --ignored --nocapture`,
+    /// then review the printed JSON and paste it into `GOLDEN` below.
+    #[test]
+    #[ignore]
+    fn regenerate_golden() {
+        let record = extract_fixture();
+        println!("{}", serde_json::to_string_pretty(&record).unwrap());
+    }
+
+    #[test]
+    fn golden_record_matches_captured_expectation() {
+        // A guard against a syntactically-broken const, independent of the
+        // string comparison below.
+        let _: serde_json::Value = serde_json::from_str(GOLDEN).expect("golden parses");
+        let record = extract_fixture();
+        // Text comparison, not `serde_json::Value` comparison: serde_json's
+        // default (non-`float_roundtrip`) float parser is not guaranteed to
+        // round-trip every decimal back to the exact same f64 bit pattern
+        // (observed here — parsing the captured `band_to_signal_ratio` back
+        // landed 1 ULP off from the freshly-computed value, failing a
+        // `Value`-level `assert_eq!` despite both sides being "the same
+        // number" to any practical precision). Comparing the pretty-printed
+        // text both sides were produced with sidesteps that reparse entirely.
+        let actual = serde_json::to_string_pretty(&record).expect("to_string_pretty");
+        assert_eq!(
+            actual, GOLDEN,
+            "record drifted from the reviewed golden; if the change is intentional \
+             (schema/extractor change), re-capture via regenerate_golden and re-review"
+        );
+    }
+
+    /// Captured via `regenerate_golden` and reviewed. Numeric drift here
+    /// means engine behavior changed — re-review the new capture before
+    /// re-pasting; don't just make the test pass.
+    const GOLDEN: &str = r#"{
+  "schema_version": 2,
+  "context": {
+    "source": "rezolus",
+    "duration_s": 120.0,
+    "sampling_interval_s": 1.0,
+    "coverage": {
+      "subsystems_present": [
+        "scheduler_runqueue",
+        "tcp_traffic"
+      ],
+      "subsystems_absent": [
+        "blockio_latency",
+        "blockio_requests",
+        "cpu_bandwidth",
+        "cpu_branch",
+        "cpu_cores",
+        "cpu_dtlb",
+        "cpu_frequency",
+        "cpu_l3",
+        "cpu_migrations",
+        "cpu_perf",
+        "cpu_tlb_flush",
+        "cpu_usage",
+        "drivehealth",
+        "gpu_amd_pmu",
+        "gpu_amd_smi",
+        "gpu_apple",
+        "gpu_nvidia",
+        "memory_meminfo",
+        "memory_vmstat",
+        "network_ethtool",
+        "network_interfaces",
+        "network_traffic",
+        "rezolus_rusage",
+        "syscall_counts",
+        "syscall_latency",
+        "tcp_connect_latency",
+        "tcp_packet_latency",
+        "tcp_receive",
+        "tcp_retransmit"
+      ]
+    }
+  },
+  "metrics": [
+    {
+      "name": "test_depth",
+      "metric_type": "gauge",
+      "labels": {
+        "sampler": "scheduler_runqueue"
+      },
+      "tier": "Summary",
+      "status": "Constant",
+      "stats": {
+        "min": 5.0,
+        "max": 5.0,
+        "mean": 5.0,
+        "last": 5.0,
+        "p50": 5.0,
+        "p99": 5.0
+      },
+      "noise": {
+        "noise_type": "Unknown"
+      }
+    },
+    {
+      "name": "test_requests",
+      "metric_type": "counter",
+      "labels": {
+        "sampler": "tcp_traffic"
+      },
+      "tier": "Summary",
+      "status": "Constant",
+      "stats": {
+        "min": 100.0,
+        "max": 100.0,
+        "mean": 100.0,
+        "last": 100.0,
+        "p50": 100.0,
+        "p99": 100.0
+      },
+      "noise": {
+        "noise_type": "Unknown"
+      }
+    },
+    {
+      "name": "test_stepped",
+      "metric_type": "counter",
+      "labels": {
+        "sampler": "scheduler_runqueue"
+      },
+      "tier": "Full",
+      "status": "Analyzed",
+      "stats": {
+        "min": 10.0,
+        "max": 1000.0,
+        "mean": 513.25,
+        "last": 1000.0,
+        "p50": 1000.0,
+        "p99": 1000.0
+      },
+      "noise": {
+        "noise_type": "FlickerPhase"
+      },
+      "anomalies": [
+        {
+          "timestamp": 47.0,
+          "index": 45,
+          "anomaly_type": "TrendChange",
+          "severity": "High",
+          "confidence": 0.95,
+          "magnitude": 0.882026377777086
+        },
+        {
+          "timestamp": 51.0,
+          "index": 49,
+          "anomaly_type": "TrendChange",
+          "severity": "Low",
+          "confidence": 0.7,
+          "magnitude": 0.882026377777086
+        },
+        {
+          "timestamp": 61.0,
+          "index": 59,
+          "anomaly_type": "TrendChange",
+          "severity": "High",
+          "confidence": 0.95,
+          "magnitude": 0.05188390457512271
+        },
+        {
+          "timestamp": 77.0,
+          "index": 75,
+          "anomaly_type": "TrendChange",
+          "severity": "High",
+          "confidence": 0.95,
+          "magnitude": 0.6744907594765952
+        },
+        {
+          "timestamp": 82.0,
+          "index": 80,
+          "anomaly_type": "TrendChange",
+          "severity": "Low",
+          "confidence": 0.7,
+          "magnitude": 0.6744907594765952
+        }
+      ],
+      "regime_shifts": [
+        {
+          "index": 45,
+          "direction": "Increase",
+          "before_mean": 10.0,
+          "after_mean": 538.0,
+          "mean_change_pct": 5280.0,
+          "confidence": 0.875662013130736,
+          "allan_significance": 16.159207901379325
+        },
+        {
+          "index": 75,
+          "direction": "Increase",
+          "before_mean": 538.0,
+          "after_mean": 1000.0,
+          "mean_change_pct": 85.87360594795538,
+          "confidence": 0.8537042614893939,
+          "allan_significance": 14.139306913706909
+        }
+      ],
+      "uncertainty": {
+        "band_to_signal_ratio": 0.051973367762841484,
+        "within_band": false
+      }
+    }
+  ],
+  "correlations": [],
+  "rankings": {
+    "cpu": [],
+    "memory": [],
+    "io": [],
+    "network": []
+  },
+  "selection": {
+    "full_detail_count": 1,
+    "summary_count": 2,
+    "promotions": [
+      {
+        "metric": "test_stepped",
+        "reason": "anomalous"
+      }
+    ],
+    "correlation_candidate_set": "all pairs among salient metrics (anomalous or regime-shifted) and top-consumer base metrics, excluding same-base-metric pairs, capped at 12 by salience",
+    "total_pairs_tested": 0
+  }
+}"#;
+}

--- a/src/analysis/extract/mod.rs
+++ b/src/analysis/extract/mod.rs
@@ -8,6 +8,10 @@
 //! C(12,2) pairs, re-querying each candidate per pairing — a per-candidate
 //! series cache is a Phase 3 item.
 //!
+//! v2 schema adds `MetricFeatures.status` (distinguishing query failures from
+//! genuinely idle zeros) and per-entry `sampler` labels (subsystem attribution).
+//! Labels now carry the sampler; names remain the unique identity.
+//!
 //! Known v1 limitations: `.rez` recordings carry no `version` metadata
 //! (`agent_version: None`); a multi-recording `.rez` opened via the MCP
 //! pool path exposes only its first recording's metadata.
@@ -49,6 +53,7 @@ pub(crate) struct MetricAnalysis {
     pub metric_type: String,
     pub query: String,
     pub subsystem: String,
+    pub status: crate::analysis::record::AnalysisStatus,
     pub stats: crate::analysis::record::Stats,
     pub noise: crate::analysis::record::NoiseSummary,
     pub anomalies: Vec<crate::analysis::record::AnomalyFeature>,
@@ -102,8 +107,9 @@ pub(crate) fn assemble(
         metrics.push(MetricFeatures {
             name: a.name,
             metric_type: a.metric_type,
-            labels: BTreeMap::new(),
+            labels: BTreeMap::from([("sampler".to_string(), a.subsystem.clone())]),
             tier,
+            status: a.status,
             stats: a.stats,
             noise: a.noise,
             anomalies: if tier == DetailTier::Full {
@@ -236,6 +242,7 @@ fn analyze_entry(
         metric_type: metric_type.to_string(),
         query: query.clone(),
         subsystem,
+        status: crate::analysis::record::AnalysisStatus::NoData,
         stats: features::compute_stats(&[]),
         noise: crate::analysis::record::NoiseSummary {
             noise_type: "Unknown".to_string(),
@@ -248,10 +255,19 @@ fn analyze_entry(
     let Ok(result) = detect_anomalies(data, &query) else {
         return analysis;
     };
+    // The engine currently errors on empty results itself, so these two
+    // guards are belt-and-suspenders: an empty or all-non-finite series
+    // stays NoData rather than masquerading as a valid Constant entry.
+    if result.values.is_empty() || result.values.iter().all(|v| !v.is_finite()) {
+        return analysis;
+    }
     analysis.stats = features::compute_stats(&result.values);
     analysis.noise = features::noise_summary(&result.allan_analysis);
     let constant = analysis.stats.max == analysis.stats.min;
-    if !constant {
+    if constant {
+        analysis.status = crate::analysis::record::AnalysisStatus::Constant;
+    } else {
+        analysis.status = crate::analysis::record::AnalysisStatus::Analyzed;
         analysis.anomalies = result
             .anomalies
             .iter()
@@ -431,6 +447,7 @@ mod tests {
             metric_type: "counter".to_string(),
             query: format!("sum(rate({name}[1m]))"),
             subsystem: "cpu_usage".to_string(),
+            status: crate::analysis::record::AnalysisStatus::Analyzed,
             stats: Stats {
                 min: 0.0,
                 max: 1.0,
@@ -505,6 +522,14 @@ mod tests {
         assert_eq!(record.selection.promotions[0].metric, "aaa");
         assert_eq!(record.selection.promotions[0].reason, "anomalous");
         assert_eq!(record.schema_version, RECORD_SCHEMA_VERSION);
+        assert_eq!(
+            record.metrics[0].labels.get("sampler").map(String::as_str),
+            Some("cpu_usage")
+        );
+        assert_eq!(
+            record.metrics[0].status,
+            crate::analysis::record::AnalysisStatus::Analyzed
+        );
     }
 
     #[test]

--- a/src/analysis/extract/mod.rs
+++ b/src/analysis/extract/mod.rs
@@ -21,6 +21,9 @@ pub mod correlations;
 pub mod features;
 pub mod rankings;
 
+#[cfg(test)]
+mod golden;
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use metriken_query::{MetricsSource, QueryResult};

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -5,20 +5,23 @@
 //! agent emits over that record (`assessment`). See
 //! `docs/superpowers/specs/2026-07-24-recording-assessment-extraction-design.md`.
 
-// Phases 1-2 ship schemas + extraction with no runtime consumers; the
-// MCP/CLI front door (Phase 3) wires them in. Remove once that lands.
-#![allow(dead_code)]
-
+// Assessment types have no runtime consumer until the Phase-4/5 label pipeline; validation is exercised by tests.
+#[allow(dead_code)]
 pub mod assessment;
 pub mod extract;
 pub mod record;
 
+// External callers (src/mcp) reach these through the fully-qualified
+// `crate::analysis::assessment::*` path, not this top-level re-export, so
+// the alias itself is still unused outside this module.
 #[allow(unused_imports)]
 pub use assessment::{
     Assessment, Confidence, DataQuality, EvidenceRef, Finding, FindingKind, Overall, OverallStatus,
     Priority, TieredFinding, ASSESSMENT_SCHEMA_VERSION,
 };
 
+// Same as above: consumers use `crate::analysis::record::*` directly rather
+// than this re-export.
 #[allow(unused_imports)]
 pub use record::{
     AnalysisStatus, AnomalyFeature, Consumer, Context, CorrelationFeature, Coverage, DetailTier,
@@ -26,6 +29,8 @@ pub use record::{
     Selection, Stats, UncertaintySummary, RECORD_SCHEMA_VERSION,
 };
 
-// No runtime caller until Phase 3 wires the MCP/CLI front door.
+// The front door (src/mcp/mod.rs, src/mcp/server.rs) calls
+// `crate::analysis::extract::extract` directly rather than through this
+// re-export, so the alias itself is still unused.
 #[allow(unused_imports)]
 pub use extract::extract;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -21,9 +21,9 @@ pub use assessment::{
 
 #[allow(unused_imports)]
 pub use record::{
-    AnomalyFeature, Consumer, Context, CorrelationFeature, Coverage, DetailTier, MetricFeatures,
-    NoiseSummary, OverviewRecord, Promotion, Rankings, RegimeShiftFeature, Selection, Stats,
-    UncertaintySummary, RECORD_SCHEMA_VERSION,
+    AnalysisStatus, AnomalyFeature, Consumer, Context, CorrelationFeature, Coverage, DetailTier,
+    MetricFeatures, NoiseSummary, OverviewRecord, Promotion, Rankings, RegimeShiftFeature,
+    Selection, Stats, UncertaintySummary, RECORD_SCHEMA_VERSION,
 };
 
 // No runtime caller until Phase 3 wires the MCP/CLI front door.

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -16,12 +16,18 @@
 //! - **Tier↔content coupling.** A `Summary`-tier metric must carry empty
 //!   `anomalies`/`regime_shifts` and no `uncertainty`; the extractor upholds this and
 //!   validation checks it.
-//! - **Readers are lenient.** Unknown fields are ignored on deserialize (serde
-//!   default) — a deliberate forward-compatibility choice across schema versions.
+//! - **Readers are lenient about unknown fields only.** Unknown fields are
+//!   ignored on deserialize (serde default) — a deliberate forward-compatibility
+//!   choice. The reverse direction is strict: a schema bump that adds required
+//!   fields intentionally breaks deserialization of older records; migration
+//!   (if ever needed) goes through `schema_version`, never through serde
+//!   defaults that would fabricate analysis outcomes.
 
 /// Schema version for `OverviewRecord`. Bump on any change to extraction logic
 /// or record shape so stored examples stay attributable to an extractor version.
-pub const RECORD_SCHEMA_VERSION: u32 = 1;
+/// v2: added `MetricFeatures.status` (analysis outcome) and the `sampler` label
+/// (subsystem attribution) stamped by extraction.
+pub const RECORD_SCHEMA_VERSION: u32 = 2;
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -70,15 +76,31 @@ pub enum DetailTier {
     Full,
 }
 
+/// Outcome of a metric entry's analysis pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnalysisStatus {
+    /// The engine analyzed a varying series; findings (if any) are real.
+    Analyzed,
+    /// The series was exactly constant: stats are valid, but anomaly/regime
+    /// detection is suppressed (MAD/CUSUM misfire on zero variance).
+    Constant,
+    /// The query failed, returned no usable data, or an engine stage errored:
+    /// stats are all zero and carry no signal. Distinguishes "broken/absent"
+    /// from "genuinely idle at zero".
+    NoData,
+}
+
 /// Per-metric features. Exhaustive coverage, tiered detail.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MetricFeatures {
     pub name: String,
     /// "counter" | "gauge" | "histogram".
     pub metric_type: String,
-    /// Label set. `BTreeMap` for deterministic serialization order.
+    /// Label set. Extraction stamps {"sampler": <subsystem>} (v2); BTreeMap for deterministic serialization order.
     pub labels: BTreeMap<String, String>,
     pub tier: DetailTier,
+    /// Outcome of the analysis pass for this entry.
+    pub status: AnalysisStatus,
     pub stats: Stats,
     pub noise: NoiseSummary,
     /// Full tier only; empty (and omitted) for summary-tier metrics.
@@ -249,6 +271,7 @@ mod tests {
                     metric_type: "counter".to_string(),
                     labels: labels.clone(),
                     tier: DetailTier::Full,
+                    status: AnalysisStatus::Analyzed,
                     stats: Stats {
                         min: 0.0,
                         max: 1.0,
@@ -288,6 +311,7 @@ mod tests {
                     metric_type: "counter".to_string(),
                     labels: BTreeMap::new(),
                     tier: DetailTier::Summary,
+                    status: AnalysisStatus::Constant,
                     stats: Stats {
                         min: 0.0,
                         max: 10.0,
@@ -374,10 +398,16 @@ mod tests {
     }
 
     #[test]
+    fn analysis_status_serializes_as_bare_string() {
+        let json = serde_json::to_string(&AnalysisStatus::NoData).unwrap();
+        assert_eq!(json, "\"NoData\"");
+    }
+
+    #[test]
     fn record_wire_shape_is_pinned() {
         let v = serde_json::to_value(sample_record()).unwrap();
         let expected = serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "context": {
                 "source": "rezolus",
                 "agent_version": "1.2.3",
@@ -401,6 +431,7 @@ mod tests {
                         "state": "user"
                     },
                     "tier": "Full",
+                    "status": "Analyzed",
                     "stats": {
                         "min": 0.0,
                         "max": 1.0,
@@ -444,6 +475,7 @@ mod tests {
                     "metric_type": "counter",
                     "labels": {},
                     "tier": "Summary",
+                    "status": "Constant",
                     "stats": {
                         "min": 0.0,
                         "max": 10.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,8 @@ fn main() {
              hindsight  Keep an on-disk ring buffer for after-the-fact incident snapshots.\n    \
              record     Scrape an endpoint to a parquet file (optionally wrapping a command).\n    \
              view       Serve a web dashboard for a recording or a live agent.\n    \
-             mcp        AI analysis tools (PromQL, anomaly detection, correlation) over a file.\n    \
+             mcp        AI analysis tools (PromQL, anomaly detection, correlation, feature\n\
+             \x20              extraction) over a file.\n    \
              parquet    Inspect and transform parquet recordings (metadata/annotate/combine/filter).\n    \
              status     Print a running agent's status/sampler health: `rezolus status <endpoint>`.\n\n\
              The agent is the source everything else reads from; start there, then reach for a\n\

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -87,6 +87,7 @@ pub fn run(config: Config) {
         Mode::DescribeMetrics { file } => run_describe_metrics(file),
         Mode::DetectAnomalies { file, query } => run_detect_anomalies(file, query),
         Mode::Query { file, query } => run_query(file, query),
+        Mode::ExtractFeatures { file } => run_extract_features(file),
     }
 }
 
@@ -400,6 +401,30 @@ fn run_query(file: PathBuf, query: String) {
     }
 }
 
+fn run_extract_features(file: PathBuf) {
+    let reader = match open_source(&file) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Failed to open recording: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    match crate::analysis::extract::extract(reader.as_ref()) {
+        Ok(record) => match serde_json::to_string_pretty(&record) {
+            Ok(json) => println!("{json}"),
+            Err(e) => {
+                eprintln!("Failed to serialize record: {e}");
+                std::process::exit(1);
+            }
+        },
+        Err(e) => {
+            eprintln!("Feature extraction failed: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
 fn format_query_result(result: &QueryResult) -> String {
     use std::fmt::Write;
     let mut output = String::new();
@@ -542,6 +567,10 @@ pub enum Mode {
         file: PathBuf,
         query: String,
     },
+    /// Extract structured features from a recording as JSON
+    ExtractFeatures {
+        file: PathBuf,
+    },
 }
 
 /// MCP server configuration
@@ -610,6 +639,13 @@ impl TryFrom<ArgMatches> for Config {
                     .clone();
                 Mode::Query { file, query }
             }
+            Some(("extract-features", sub_args)) => {
+                let file = sub_args
+                    .get_one::<PathBuf>("FILE")
+                    .ok_or("File argument is required")?
+                    .clone();
+                Mode::ExtractFeatures { file }
+            }
             _ => Mode::Server,
         };
 
@@ -630,7 +666,8 @@ pub fn command() -> Command {
              describe-metrics     List every metric in a recording with its type and labels\n    \
              query                Run a PromQL query against a recording\n    \
              detect-anomalies     Flag anomalies for one metric, or exhaustively across all\n    \
-             analyze-correlation  Correlate two PromQL series over the recording\n\n\
+             analyze-correlation  Correlate two PromQL series over the recording\n    \
+             extract-features     Extract structured features from a recording as JSON\n\n\
              A good workflow is describe-metrics (see what's there) → query / detect-anomalies\n\
              (dig in). Run `rezolus mcp <subcommand> --help` for per-subcommand examples.\n\n\
              EXAMPLES:\n    \
@@ -767,6 +804,25 @@ pub fn command() -> Command {
                         .help("PromQL query (e.g., 'sum(rate(cpu_cycles[1m]))')")
                         .required(true)
                         .index(2),
+                ),
+        )
+        .subcommand(
+            Command::new("extract-features")
+                .about("Extract structured features from a recording as JSON")
+                .long_about(
+                    "Produce a deterministic, versioned overview record of a recording's \
+                     Rezolus-native features (per-metric stats, noise class, anomalies, \
+                     regime shifts, acquisition-window uncertainty, correlations, resource \
+                     rankings, subsystem coverage) as JSON on stdout. The record is the \
+                     input half of a recording assessment. Requires a recording of at \
+                     least 10 seconds.",
+                )
+                .arg(
+                    clap::Arg::new("FILE")
+                        .help("Path to a parquet or .rez recording")
+                        .value_parser(clap::value_parser!(PathBuf))
+                        .required(true)
+                        .index(1),
                 ),
         )
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -43,6 +43,7 @@ enum McpTool {
     DescribeMetrics,
     DetectAnomalies,
     Query,
+    ExtractFeatures,
     Unknown(String),
 }
 
@@ -54,6 +55,7 @@ impl From<&str> for McpTool {
             "describe_metrics" => McpTool::DescribeMetrics,
             "detect_anomalies" => McpTool::DetectAnomalies,
             "query" => McpTool::Query,
+            "extract_features" => McpTool::ExtractFeatures,
             other => McpTool::Unknown(other.to_string()),
         }
     }
@@ -81,7 +83,13 @@ impl Server {
         }
     }
 
-    /// Run the MCP server using stdio
+    /// Run the MCP server using stdio.
+    ///
+    /// Dispatch is strictly serial: one request is read, handled to
+    /// completion, and answered before the next is read. CPU-heavy tools
+    /// (extract_features, exhaustive detect_anomalies, analyze_correlation)
+    /// therefore block only the calling client's next request. If dispatch
+    /// ever becomes concurrent, those handlers must move to spawn_blocking.
     pub async fn run_stdio(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let stdin = io::stdin();
         let mut stdout = io::stdout();
@@ -248,6 +256,20 @@ impl Server {
                                         }
                                     },
                                     "required": ["parquet_file", "query"]
+                                }
+                            },
+                            {
+                                "name": "extract_features",
+                                "description": "Extract a deterministic, versioned overview record of a recording's Rezolus-native features (per-metric stats, noise classification, anomalies, regime shifts, acquisition-window uncertainty, top-N correlations, resource rankings, subsystem coverage) as JSON. The record is the structured input for bottleneck assessment. Requires a recording of at least 10 seconds.",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "parquet_file": {
+                                            "type": "string",
+                                            "description": "Path to the recording (parquet or .rez)"
+                                        }
+                                    },
+                                    "required": ["parquet_file"]
                                 }
                             }
                         ]
@@ -463,6 +485,28 @@ impl Server {
                     }
                 }))),
             },
+            McpTool::ExtractFeatures => match self.execute_extract_features(arguments).await {
+                Ok(result) => Ok(Some(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": result
+                            }
+                        ]
+                    }
+                }))),
+                Err(e) => Ok(Some(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": -32000,
+                        "message": format!("Feature extraction error: {}", e)
+                    }
+                }))),
+            },
             McpTool::Unknown(name) => Ok(Some(json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -617,6 +661,22 @@ impl Server {
 
         Ok(serde_json::to_string_pretty(&result)?)
     }
+
+    /// Extract structured features from a recording and return the overview
+    /// record as JSON
+    async fn execute_extract_features(
+        &self,
+        arguments: &Value,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let parquet_file = arguments
+            .get("parquet_file")
+            .and_then(|f| f.as_str())
+            .ok_or("Missing parquet_file")?;
+
+        let reader = self.get_reader(parquet_file).await?;
+        let record = crate::analysis::extract::extract(reader.as_ref())?;
+        Ok(serde_json::to_string_pretty(&record)?)
+    }
 }
 
 #[cfg(test)]
@@ -627,6 +687,14 @@ mod tests {
     #[test]
     fn test_mcp_tool_from_str_query() {
         assert!(matches!(McpTool::from("query"), McpTool::Query));
+    }
+
+    #[test]
+    fn test_mcp_tool_from_str_extract_features() {
+        assert!(matches!(
+            McpTool::from("extract_features"),
+            McpTool::ExtractFeatures
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds the extraction library's front door: `rezolus mcp extract-features <FILE>` (CLI) and an `extract_features` MCP tool, both emitting the versioned `OverviewRecord` as JSON for parquet or `.rez` recordings. Follows the existing `query` tool pattern at every touch point.
- Bumps the overview record to **schema v2**: every metric entry now carries an `AnalysisStatus` (`Analyzed`/`Constant`/`NoData`, distinguishing query failures from genuinely idle-zero series) and a `{"sampler": <subsystem>}` label for subsystem attribution.
- Adds end-to-end golden-record, determinism (cross-run and cross-thread-count byte-identical), and structural integration tests over synthesized `.rez` fixtures, including histogram coverage.
- Adds cross-record assessment validation (`Assessment::validate_against`): every evidence ref must resolve into the record (unknown metrics and out-of-range indices rejected), a High-confidence finding must cite at least one resolvable pointer, may not rest on a metric whose movement is within its acquisition-window band, and `NeedsMetric.missing` must be non-empty.
- Narrows the module-wide `dead_code` allow in `src/analysis` to just `assessment` (no runtime consumer until the Phase-4/5 label pipeline); documents the new subcommand in CLAUDE.md, README, and the top-level help.

## Behavior notes
- **Schema v2 is a breaking change for consumers of v1 records** — deserialization of the two new required fields is intentionally strict (no serde defaults that would fabricate analysis outcomes). No v1 records or consumers exist yet, so nothing breaks in practice; this is exactly why the bump lands before the front door makes records real.
- New user-facing surface only: the `extract-features` CLI subcommand and the `extract_features` MCP tool. No changes to existing subcommand or tool behavior.
- Documented a previously-undocumented footgun discovered by the fixture work: a histogram parquet column whose metadata lacks u8-parseable `grouping_power`/`max_value_power` is **silently dropped** by the query engine on read — now covered in `docs/parquet_metadata.md` (new "Histogram columns" section) and cross-referenced from `docs/external_metrics.md`.
- The golden test's expected document is a reviewed capture; `regenerate_golden` (`#[ignore]`d) re-captures it in one command when extractor behavior intentionally changes.

## Test plan
- [x] 62 `analysis::` unit tests + the new golden/determinism/structural integration tests over synthesized recordings (full extraction runs in-process, no root/eBPF needed)
- [x] Determinism verified byte-identical across runs and across 1-vs-4-thread rayon pools
- [x] Cold-start usability test: an agent with no codebase knowledge produced a feature record from a real 15s recording using only `--help` and the README (4/5, one README nit fixed)
- [x] Full `cargo test` (384), clippy/fmt clean, every commit in the series builds independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)