### PR TITLE
fix(analysis): infer subsystems from metric names; never assert unknowable absences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.10"
+version = "5.17.1-alpha.11"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.10"
+version = "5.17.1-alpha.11"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/agent/samplers/mod.rs
+++ b/src/agent/samplers/mod.rs
@@ -127,4 +127,60 @@ mod attribution_tests {
             );
         }
     }
+
+    /// Drift guard for `crate::analysis::extract::context::METRIC_SAMPLERS`:
+    /// walks the live `metriken` registry and asserts the analysis-side
+    /// resolution (`subsystem_of` with no labels, i.e. its
+    /// METRIC_SAMPLERS-then-prefix tiers) agrees with the agent's own
+    /// module-path attribution (`attribute_sampler`) for every registered
+    /// metric it can unambiguously check.
+    ///
+    /// Platform-gated by compilation: `metriken::metrics()` only contains
+    /// metrics compiled for the current target, so this test only exercises
+    /// whatever samplers that target registers. On macOS that's `cpu_usage`
+    /// and `rezolus_rusage` (`gpu_apple`'s own metrics live in a sibling
+    /// `stats` module under `gpu::macos`, not a descendant of the `apple`
+    /// sampler's module, so `attribute_sampler` itself calls them
+    /// `unattributed` today — a pre-existing quirk unrelated to this guard,
+    /// and covered by the "skip unattributed" rule below). Linux CI is what
+    /// actually exercises the Linux-only samplers (every BPF-backed one,
+    /// drivehealth, the GPU vendor samplers, etc) — this test passing on
+    /// one platform does not certify the table for the others.
+    ///
+    /// Two kinds of metric are skipped rather than asserted on:
+    /// - Metrics the agent itself attributes `unattributed` (no ground
+    ///   truth to check against).
+    /// - Names in `AMBIGUOUS_METRIC_NAMES`: declared identically by more
+    ///   than one sampler, so no flat table entry could be correct for all
+    ///   of them (see that constant's doc in context.rs).
+    ///
+    /// On failure, the assertion message names the correct
+    /// `("metric", "sampler")` line to paste into `METRIC_SAMPLERS`.
+    #[test]
+    fn metric_samplers_match_agent_attribution() {
+        use crate::analysis::extract::context::AMBIGUOUS_METRIC_NAMES;
+        use crate::analysis::extract::subsystem_of;
+
+        let mods = super::sampler_modules();
+        for metric in metriken::metrics().iter() {
+            let name = metric.name();
+            if AMBIGUOUS_METRIC_NAMES.contains(&name) {
+                continue;
+            }
+            let truth = super::attribute_sampler(metric.module(), &mods);
+            if truth == "unattributed" {
+                continue;
+            }
+            let resolved = subsystem_of(name, &[]);
+            assert_eq!(
+                resolved,
+                truth,
+                "metric `{name}` (module `{}`) attributes to sampler `{truth}` via \
+                 attribute_sampler, but analysis-side subsystem_of resolves it to \
+                 `{resolved}`; add (\"{name}\", \"{truth}\") to METRIC_SAMPLERS in \
+                 src/analysis/extract/context.rs",
+                metric.module(),
+            );
+        }
+    }
 }

--- a/src/agent/samplers/mod.rs
+++ b/src/agent/samplers/mod.rs
@@ -130,48 +130,57 @@ mod attribution_tests {
 
     /// Drift guard for `crate::analysis::extract::context::METRIC_SAMPLERS`:
     /// walks the live `metriken` registry and asserts the analysis-side
-    /// resolution (`subsystem_of` with no labels, i.e. its
-    /// METRIC_SAMPLERS-then-prefix tiers) agrees with the agent's own
-    /// module-path attribution (`attribute_sampler`) for every registered
-    /// metric it can unambiguously check.
+    /// resolution (`subsystem_of` called with `infer = true`, i.e. its
+    /// AMBIGUOUS_METRICS-then-METRIC_SAMPLERS-then-prefix tiers) agrees with
+    /// the agent's own module-path attribution (`attribute_sampler`) for
+    /// every registered metric it is *able* to check. `infer = true` here is
+    /// deliberate and always correct for this test regardless of the
+    /// `source`-gating rule extraction applies at runtime: this guard
+    /// verifies the inference tiers' correctness in isolation, not whether
+    /// a given recording should trust them.
     ///
-    /// Platform-gated by compilation: `metriken::metrics()` only contains
-    /// metrics compiled for the current target, so this test only exercises
-    /// whatever samplers that target registers. On macOS that's `cpu_usage`
-    /// and `rezolus_rusage` (`gpu_apple`'s own metrics live in a sibling
-    /// `stats` module under `gpu::macos`, not a descendant of the `apple`
-    /// sampler's module, so `attribute_sampler` itself calls them
-    /// `unattributed` today — a pre-existing quirk unrelated to this guard,
-    /// and covered by the "skip unattributed" rule below). Linux CI is what
-    /// actually exercises the Linux-only samplers (every BPF-backed one,
-    /// drivehealth, the GPU vendor samplers, etc) — this test passing on
-    /// one platform does not certify the table for the others.
+    /// This test does NOT validate the table in full — two real gaps, stated
+    /// plainly rather than glossed over:
     ///
-    /// Two kinds of metric are skipped rather than asserted on:
-    /// - Metrics the agent itself attributes `unattributed` (no ground
-    ///   truth to check against).
-    /// - Names in `AMBIGUOUS_METRIC_NAMES`: declared identically by more
-    ///   than one sampler, so no flat table entry could be correct for all
-    ///   of them (see that constant's doc in context.rs).
+    /// - It only checks metrics the CURRENT PLATFORM'S build registers.
+    ///   `metriken::metrics()` only contains metrics compiled for the
+    ///   current target, so a macOS run only exercises macOS samplers
+    ///   (`cpu_usage`, `rezolus_rusage`) and macOS's cpu_cores/ambiguous
+    ///   cases; a Linux CI run is what actually exercises the Linux-only
+    ///   samplers (every BPF-backed one, drivehealth, the GPU vendor
+    ///   samplers, etc). Passing on one platform does not certify the table
+    ///   rows that platform never registers.
+    /// - It cannot check metrics the agent's OWN `attribute_sampler` calls
+    ///   `unattributed` — there is no ground truth to compare against. On
+    ///   macOS today this silently excludes `gpu_apple`'s own metrics:
+    ///   `gpu/macos/stats.rs` is a sibling module of `gpu/macos/apple.rs`,
+    ///   not a descendant of the `apple` sampler's registered module, so
+    ///   `attribute_sampler`'s module-prefix rule misses it. That's a
+    ///   pre-existing quirk in `attribute_sampler` itself, unrelated to this
+    ///   guard or to `METRIC_SAMPLERS`/`AMBIGUOUS_METRICS` — not something
+    ///   this commit fixes.
     ///
-    /// On failure, the assertion message names the correct
+    /// What IS tight: every metric the registry has an opinion on (agent
+    /// attributes it to a real sampler, not `unattributed`) and whose name
+    /// isn't in `AMBIGUOUS_METRICS` is unconditionally asserted — no further
+    /// skipping. On failure, the assertion message names the correct
     /// `("metric", "sampler")` line to paste into `METRIC_SAMPLERS`.
     #[test]
     fn metric_samplers_match_agent_attribution() {
-        use crate::analysis::extract::context::AMBIGUOUS_METRIC_NAMES;
+        use crate::analysis::extract::context::AMBIGUOUS_METRICS;
         use crate::analysis::extract::subsystem_of;
 
         let mods = super::sampler_modules();
         for metric in metriken::metrics().iter() {
             let name = metric.name();
-            if AMBIGUOUS_METRIC_NAMES.contains(&name) {
+            if AMBIGUOUS_METRICS.iter().any(|(n, _)| *n == name) {
                 continue;
             }
             let truth = super::attribute_sampler(metric.module(), &mods);
             if truth == "unattributed" {
                 continue;
             }
-            let resolved = subsystem_of(name, &[]);
+            let resolved = subsystem_of(name, &[], true);
             assert_eq!(
                 resolved,
                 truth,

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -1,5 +1,16 @@
 //! Recording-level context: source, version, duration, interval, systeminfo,
 //! and the coverage map (subsystems present vs absent).
+//!
+//! Subsystem attribution (see `extract::subsystem_of`) has two sources: a
+//! `sampler` label stamped by agents >= 5.17.1 (preferred), or — for older
+//! recordings that carry no such label — the longest sampler name in
+//! [`EXPECTED_SUBSYSTEMS`] that is a `_`-boundary prefix of the metric name.
+//! When neither source disambiguates, the metric is `unattributed` and its
+//! *domain* ([`domain_of`]) becomes "uncertain": `build_coverage` excludes
+//! any sampler in an uncertain domain from `subsystems_absent`, since its
+//! true presence/absence can't be known from an unattributed name. It is
+//! also not added to `subsystems_present` — we refuse to claim absence we
+//! can't know, and we don't fabricate presence either.
 
 use std::collections::BTreeSet;
 
@@ -47,16 +58,55 @@ pub(crate) const EXPECTED_SUBSYSTEMS: &[&str] = &[
     "tcp_traffic",
 ];
 
+/// Metric-name domains that diverge from their owning sampler's leading
+/// token — the sampler's metrics don't share its name prefix, so the plain
+/// first-token rule below would compute the wrong domain for them. Applied
+/// uniformly to sampler names too for simplicity; harmless in practice
+/// since no *sampler* name in [`EXPECTED_SUBSYSTEMS`] starts with `drive_`
+/// or `gpmu_` (`domain_of("drivehealth")` still yields `"drivehealth"` —
+/// its first token doesn't match either alias key).
+const DOMAIN_ALIASES: &[(&str, &str)] = &[
+    ("drive", "drivehealth"), // drivehealth sampler emits drive_* metrics
+    ("gpmu", "gpu"),          // gpu_amd_pmu sampler emits gpmu_* metrics
+];
+
+/// Domain of a sampler or metric name: its first `_`-separated token, except
+/// names prefixed `cgroup_` strip that prefix first and take the *next*
+/// token (`cgroup_cpu_usage` -> `cpu`, `cgroup_scheduler_offcpu` ->
+/// `scheduler`, `cgroup_syscall` -> `syscall`), and the result is mapped
+/// through [`DOMAIN_ALIASES`] (`drive_temperature` -> `drive` -> aliased to
+/// `drivehealth`; `gpmu_busy_cycles` -> `gpmu` -> aliased to `gpu`).
+/// Applied to sampler names (`blockio_latency` -> `blockio`, `drivehealth`
+/// -> `drivehealth`, `rezolus_rusage` -> `rezolus`) and to metric names
+/// alike, so `build_coverage`'s pruning and extraction's uncertain-domain
+/// collection agree on the same notion of "domain".
+pub(crate) fn domain_of(name: &str) -> &str {
+    let stripped = name.strip_prefix("cgroup_").unwrap_or(name);
+    let token = stripped.split('_').next().unwrap_or(stripped);
+    DOMAIN_ALIASES
+        .iter()
+        .find(|(from, _)| *from == token)
+        .map_or(token, |(_, to)| *to)
+}
+
 /// present = the distinct `sampler` label values observed in the recording;
 /// callers insert the synthetic `unattributed` for metrics lacking the
 /// label (this function does not add it). absent = the static universe
-/// minus present. Both sorted (BTreeSet iteration order).
-pub(crate) fn build_coverage(present: &BTreeSet<String>) -> Coverage {
+/// minus present, minus any sampler whose domain is in `uncertain_domains`
+/// (a domain with at least one still-`unattributed` metric after
+/// name-prefix inference — its true presence/absence can't be known, so we
+/// exclude it from `subsystems_absent` rather than assert a false absence;
+/// it is *not* added to present either, since we don't fabricate presence
+/// we can't confirm). Both output lists sorted (BTreeSet iteration order).
+pub(crate) fn build_coverage(
+    present: &BTreeSet<String>,
+    uncertain_domains: &BTreeSet<String>,
+) -> Coverage {
     Coverage {
         subsystems_present: present.iter().cloned().collect(),
         subsystems_absent: EXPECTED_SUBSYSTEMS
             .iter()
-            .filter(|&&s| !present.contains(s))
+            .filter(|&&s| !present.contains(s) && !uncertain_domains.contains(domain_of(s)))
             .map(|s| s.to_string())
             .collect(),
     }
@@ -72,6 +122,7 @@ pub(crate) fn build_context(
     sampling_interval_s: f64,
     systeminfo_raw: Option<String>,
     present: &BTreeSet<String>,
+    uncertain_domains: &BTreeSet<String>,
 ) -> Context {
     Context {
         source,
@@ -83,7 +134,7 @@ pub(crate) fn build_context(
         duration_s,
         sampling_interval_s,
         systeminfo: systeminfo_raw.and_then(|raw| serde_json::from_str(&raw).ok()),
-        coverage: build_coverage(present),
+        coverage: build_coverage(present, uncertain_domains),
     }
 }
 
@@ -92,12 +143,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn domain_of_takes_first_token() {
+        // sampler names
+        assert_eq!(domain_of("blockio_latency"), "blockio");
+        assert_eq!(domain_of("drivehealth"), "drivehealth");
+        assert_eq!(domain_of("rezolus_rusage"), "rezolus");
+        assert_eq!(domain_of("cpu_usage"), "cpu");
+        // metric names, including the cgroup-prefix strip
+        assert_eq!(domain_of("cgroup_cpu_usage"), "cpu");
+        assert_eq!(domain_of("cgroup_scheduler_offcpu"), "scheduler");
+        assert_eq!(domain_of("cgroup_syscall"), "syscall");
+    }
+
+    #[test]
+    fn domain_of_aliases_metric_domains_that_diverge_from_their_sampler() {
+        // drivehealth sampler emits drive_* metrics: first-token domain
+        // "drive" must alias to the sampler's domain "drivehealth".
+        assert_eq!(domain_of("drive_temperature"), "drivehealth");
+        // gpu_amd_pmu sampler emits gpmu_* metrics: first-token domain
+        // "gpmu" must alias to the sampler's domain "gpu".
+        assert_eq!(domain_of("gpmu_busy_cycles"), "gpu");
+        // the alias must not clash with the sampler name's own domain.
+        assert_eq!(domain_of("drivehealth"), "drivehealth");
+    }
+
+    #[test]
     fn coverage_diffs_present_against_universe() {
         let mut present = BTreeSet::new();
         present.insert("cpu_usage".to_string());
         present.insert("scheduler_runqueue".to_string());
         present.insert("unattributed".to_string());
-        let c = build_coverage(&present);
+        // empty uncertain_domains preserves old (pre-inference) behavior.
+        let c = build_coverage(&present, &BTreeSet::new());
         assert_eq!(
             c.subsystems_present,
             vec![
@@ -116,6 +193,46 @@ mod tests {
     }
 
     #[test]
+    fn coverage_prunes_uncertain_domains_from_absent_without_adding_to_present() {
+        let present = BTreeSet::new();
+        let mut uncertain = BTreeSet::new();
+        uncertain.insert("scheduler".to_string());
+        uncertain.insert("blockio".to_string());
+        let c = build_coverage(&present, &uncertain);
+        // pruned domains' samplers are excluded from absent...
+        assert!(!c
+            .subsystems_absent
+            .contains(&"scheduler_runqueue".to_string()));
+        assert!(!c.subsystems_absent.contains(&"blockio_latency".to_string()));
+        assert!(!c
+            .subsystems_absent
+            .contains(&"blockio_requests".to_string()));
+        // ...but not fabricated into present either.
+        assert!(c.subsystems_present.is_empty());
+        // unrelated domains are unaffected.
+        assert!(c.subsystems_absent.contains(&"cpu_usage".to_string()));
+    }
+
+    #[test]
+    fn coverage_prunes_drivehealth_and_gpu_via_aliased_metric_domains() {
+        let present = BTreeSet::new();
+        // As extraction would compute it: domain_of("drive_temperature") ==
+        // "drivehealth", domain_of("gpmu_busy_cycles") == "gpu".
+        let mut uncertain = BTreeSet::new();
+        uncertain.insert(domain_of("drive_temperature").to_string());
+        uncertain.insert(domain_of("gpmu_busy_cycles").to_string());
+        let c = build_coverage(&present, &uncertain);
+        assert!(!c.subsystems_absent.contains(&"drivehealth".to_string()));
+        // every gpu_* sampler is pruned, not just the pmu one.
+        assert!(!c.subsystems_absent.contains(&"gpu_amd_pmu".to_string()));
+        assert!(!c.subsystems_absent.contains(&"gpu_amd_smi".to_string()));
+        assert!(!c.subsystems_absent.contains(&"gpu_apple".to_string()));
+        assert!(!c.subsystems_absent.contains(&"gpu_nvidia".to_string()));
+        // unrelated domains still assert absence.
+        assert!(c.subsystems_absent.contains(&"cpu_usage".to_string()));
+    }
+
+    #[test]
     fn context_fields_normalized() {
         let ctx = build_context(
             "rezolus".to_string(),
@@ -123,6 +240,7 @@ mod tests {
             120.0,
             1.0,
             Some(r#"{"os":"linux"}"#.to_string()),
+            &BTreeSet::new(),
             &BTreeSet::new(),
         );
         assert_eq!(ctx.agent_version, None);
@@ -134,6 +252,7 @@ mod tests {
             10.0,
             1.0,
             Some("not json".into()),
+            &BTreeSet::new(),
             &BTreeSet::new(),
         );
         assert_eq!(bad.agent_version.as_deref(), Some("1.2.3"));

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -1,16 +1,21 @@
 //! Recording-level context: source, version, duration, interval, systeminfo,
 //! and the coverage map (subsystems present vs absent).
 //!
-//! Subsystem attribution (see `extract::subsystem_of`) has two sources: a
-//! `sampler` label stamped by agents >= 5.17.1 (preferred), or — for older
-//! recordings that carry no such label — the longest sampler name in
+//! Subsystem attribution (see `extract::subsystem_of`) has three tiers,
+//! tried in order: a `sampler` label stamped by agents >= 5.17.1
+//! (preferred); failing that, an exact lookup in [`METRIC_SAMPLERS`] — a
+//! static table of metric names whose sampler can't be recovered from the
+//! name alone; failing that, the longest sampler name in
 //! [`EXPECTED_SUBSYSTEMS`] that is a `_`-boundary prefix of the metric name.
-//! When neither source disambiguates, the metric is `unattributed` and its
-//! *domain* ([`domain_of`]) becomes "uncertain": `build_coverage` excludes
-//! any sampler in an uncertain domain from `subsystems_absent`, since its
-//! true presence/absence can't be known from an unattributed name. It is
-//! also not added to `subsystems_present` — we refuse to claim absence we
-//! can't know, and we don't fabricate presence either.
+//! When none of the three disambiguates, the metric is `unattributed` and
+//! its *domain* ([`domain_of`]) becomes "uncertain": `build_coverage`
+//! excludes any sampler in an uncertain domain from `subsystems_absent`,
+//! since its true presence/absence can't be known from an unattributed
+//! name. It is also not added to `subsystems_present` — we refuse to claim
+//! absence we can't know, and we don't fabricate presence either. This
+//! pruning is defense-in-depth for foreign sources and future metrics, not
+//! the primary resolution mechanism now that [`METRIC_SAMPLERS`] covers the
+//! known non-prefixing cases.
 
 use std::collections::BTreeSet;
 
@@ -56,6 +61,179 @@ pub(crate) const EXPECTED_SUBSYSTEMS: &[&str] = &[
     "tcp_receive",
     "tcp_retransmit",
     "tcp_traffic",
+];
+
+/// Explicit metric-name -> sampler mapping for metrics whose name cannot be
+/// resolved against [`EXPECTED_SUBSYSTEMS`] by exact match or `_`-boundary
+/// prefix (e.g. `cpu_cycles` has no `cpu_perf`-prefixed spelling, and
+/// `cgroup_cpu_usage` doesn't share `cpu_usage`'s prefix at all — it's
+/// declared inside the `cpu_usage` sampler's own module, there is no
+/// separate cgroup sampler).
+///
+/// Provenance: harvested by reading every sampler's `stats.rs`
+/// (`src/agent/samplers/*/*/*/stats.rs` and `src/agent/samplers/*/stats.rs`,
+/// all platforms) and mapping each `metric(name = "...")` declaration to
+/// the sampler whose `const NAME` governs that module tree, cross-checked
+/// against each sampler's `mod.rs` (`attribute_sampler` in
+/// `src/agent/samplers/mod.rs` attributes by module-path prefix, so e.g.
+/// everything under `samplers/cpu/linux/perf/` belongs to `cpu_perf`,
+/// `samplers/tcp/linux/traffic/` to `tcp_traffic`). Only entries that
+/// *need* it are included — a name that already resolves correctly via
+/// [`EXPECTED_SUBSYSTEMS`] prefix matching (e.g. `cpu_branch_instructions`
+/// -> `cpu_branch`, `tcp_connect_latency` -> `tcp_connect_latency`) is left
+/// out to keep the table minimal. Sorted alphabetically.
+///
+/// Deliberately excludes [`AMBIGUOUS_METRIC_NAMES`] — names declared
+/// identically by more than one sampler, where a flat mapping can't be
+/// correct for all of them.
+///
+/// `metric_samplers_match_agent_attribution` in `src/agent/samplers/mod.rs`
+/// is this table's drift guard: it walks the live `metriken` registry and
+/// asserts this table (plus prefix inference) agrees with the agent's own
+/// module-path attribution for every metric it can unambiguously check,
+/// printing the correct line to paste in here when it doesn't.
+pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
+    ("blockio_bytes", "blockio_requests"),
+    ("blockio_errors", "blockio_requests"),
+    ("blockio_operations", "blockio_requests"),
+    ("blockio_requeues", "blockio_requests"),
+    ("blockio_size", "blockio_requests"),
+    ("cgroup_cpu_bandwidth_period_duration", "cpu_bandwidth"),
+    ("cgroup_cpu_bandwidth_periods", "cpu_bandwidth"),
+    ("cgroup_cpu_bandwidth_quota", "cpu_bandwidth"),
+    ("cgroup_cpu_bandwidth_throttled_periods", "cpu_bandwidth"),
+    ("cgroup_cpu_bandwidth_throttled_time", "cpu_bandwidth"),
+    ("cgroup_cpu_cycles", "cpu_perf"),
+    ("cgroup_cpu_instructions", "cpu_perf"),
+    ("cgroup_cpu_migrations", "cpu_migrations"),
+    ("cgroup_cpu_throttled", "cpu_bandwidth"),
+    ("cgroup_cpu_throttled_time", "cpu_bandwidth"),
+    ("cgroup_cpu_tlb_flush", "cpu_tlb_flush"),
+    ("cgroup_cpu_usage", "cpu_usage"),
+    ("cgroup_scheduler_context_switch", "scheduler_runqueue"),
+    ("cgroup_scheduler_offcpu", "scheduler_runqueue"),
+    ("cgroup_scheduler_runqueue_wait", "scheduler_runqueue"),
+    ("cgroup_syscall", "syscall_counts"),
+    ("cpu_aperf", "cpu_frequency"),
+    ("cpu_cycles", "cpu_perf"),
+    ("cpu_instructions", "cpu_perf"),
+    ("cpu_mperf", "cpu_frequency"),
+    ("cpu_tsc", "cpu_frequency"),
+    ("drive_temperature", "drivehealth"),
+    ("drive_temperature_critical_time", "drivehealth"),
+    ("drive_temperature_warning_time", "drivehealth"),
+    ("drive_thermal_throttle_time", "drivehealth"),
+    ("drive_thermal_throttle_transitions", "drivehealth"),
+    ("gpmu_active_clock", "gpu_amd_pmu"),
+    ("gpmu_busy_cycles", "gpu_amd_pmu"),
+    ("gpmu_clock", "gpu_amd_pmu"),
+    ("gpmu_icache_hits", "gpu_amd_pmu"),
+    ("gpmu_icache_requests", "gpu_amd_pmu"),
+    ("gpmu_l2_hits", "gpu_amd_pmu"),
+    ("gpmu_l2_misses", "gpu_amd_pmu"),
+    ("gpmu_lds_instructions", "gpu_amd_pmu"),
+    ("gpmu_salu_instructions", "gpu_amd_pmu"),
+    ("gpmu_valu_instructions", "gpu_amd_pmu"),
+    ("gpmu_vram_read_requests", "gpu_amd_pmu"),
+    ("gpmu_vram_write_requests", "gpu_amd_pmu"),
+    ("gpmu_wave_cycles", "gpu_amd_pmu"),
+    ("gpmu_waves", "gpu_amd_pmu"),
+    ("gpu_dram_bandwidth_utilization", "gpu_nvidia"),
+    ("gpu_pcie_bandwidth", "gpu_nvidia"),
+    ("gpu_sm_occupancy", "gpu_nvidia"),
+    ("gpu_sm_utilization", "gpu_nvidia"),
+    ("gpu_tensor_utilization", "gpu_nvidia"),
+    ("memory_available", "memory_meminfo"),
+    ("memory_buffers", "memory_meminfo"),
+    ("memory_cached", "memory_meminfo"),
+    ("memory_free", "memory_meminfo"),
+    ("memory_numa_foreign", "memory_vmstat"),
+    ("memory_numa_hit", "memory_vmstat"),
+    ("memory_numa_interleave", "memory_vmstat"),
+    ("memory_numa_local", "memory_vmstat"),
+    ("memory_numa_miss", "memory_vmstat"),
+    ("memory_numa_other", "memory_vmstat"),
+    ("memory_total", "memory_meminfo"),
+    ("network_bytes", "network_traffic"),
+    ("network_drop", "network_interfaces"),
+    (
+        "network_ena_bandwidth_allowance_exceeded",
+        "network_ethtool",
+    ),
+    (
+        "network_ena_conntrack_allowance_exceeded",
+        "network_ethtool",
+    ),
+    (
+        "network_ena_linklocal_allowance_exceeded",
+        "network_ethtool",
+    ),
+    ("network_ena_pps_allowance_exceeded", "network_ethtool"),
+    ("network_packets", "network_traffic"),
+    ("network_transmit_busy", "network_interfaces"),
+    ("network_transmit_complete", "network_interfaces"),
+    ("network_transmit_timeout", "network_interfaces"),
+    ("rezolus_blockio_operations", "rezolus_rusage"),
+    ("rezolus_context_switch", "rezolus_rusage"),
+    ("rezolus_cpu_usage", "rezolus_rusage"),
+    ("rezolus_memory_page_faults", "rezolus_rusage"),
+    ("rezolus_memory_page_reclaims", "rezolus_rusage"),
+    ("rezolus_memory_usage_resident_set_size", "rezolus_rusage"),
+    ("scheduler_context_switch", "scheduler_runqueue"),
+    ("scheduler_offcpu", "scheduler_runqueue"),
+    ("scheduler_running", "scheduler_runqueue"),
+    ("softirq", "cpu_usage"),
+    ("softirq_time", "cpu_usage"),
+    ("syscall", "syscall_counts"),
+    ("task_cpu_usage", "cpu_usage"),
+    ("tcp_bytes", "tcp_traffic"),
+    ("tcp_jitter", "tcp_receive"),
+    ("tcp_packets", "tcp_traffic"),
+    ("tcp_size", "tcp_traffic"),
+    ("tcp_srtt", "tcp_receive"),
+];
+
+/// Metric names declared identically by more than one sampler (verified by
+/// reading every sampler's `stats.rs`): a flat name -> sampler table can
+/// only be correct for one of them, so these are deliberately absent from
+/// [`METRIC_SAMPLERS`] and from `metric_samplers_match_agent_attribution`'s
+/// strict per-metric check. An unlabeled recording carrying one of these
+/// names falls through table lookup and name-prefix inference alike to
+/// `unattributed`, and its domain is pruned from `subsystems_absent` rather
+/// than asserted — the same defense-in-depth path that covers foreign or
+/// future metrics. Freshly recorded data (agents >= 5.17.1) is unaffected:
+/// the `sampler` label resolves these correctly without consulting either
+/// table.
+///
+/// - `cpu_cores`: the Linux `cpu_cores` sampler's own metric, but also
+///   emitted by the macOS `cpu_usage` sampler (macOS folds core-count
+///   reporting into its usage sampler rather than having a standalone
+///   `cpu_cores` one) — same name, different true sampler depending on
+///   platform.
+/// - `gpu_clock`, `gpu_energy_consumption`, `gpu_memory`,
+///   `gpu_memory_utilization`, `gpu_pcie_throughput`, `gpu_power_usage`,
+///   `gpu_temperature`, `gpu_utilization`: shared vocabulary across
+///   `gpu_amd_smi`, `gpu_nvidia`, and (where applicable) `gpu_apple` — each
+///   vendor sampler declares its own metric under the same generic name.
+/// - `rezolus_bpf_run_count`, `rezolus_bpf_run_time`: every eBPF-backed
+///   sampler declares its own pair of these under its own module (self-timing
+///   instrumentation), so the name is common to all ~17 BPF samplers.
+// Consulted only by the (test-only, platform-gated)
+// `metric_samplers_match_agent_attribution` guard in
+// `src/agent/samplers/mod.rs`; a non-test build never references it.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) const AMBIGUOUS_METRIC_NAMES: &[&str] = &[
+    "cpu_cores",
+    "gpu_clock",
+    "gpu_energy_consumption",
+    "gpu_memory",
+    "gpu_memory_utilization",
+    "gpu_pcie_throughput",
+    "gpu_power_usage",
+    "gpu_temperature",
+    "gpu_utilization",
+    "rezolus_bpf_run_count",
+    "rezolus_bpf_run_time",
 ];
 
 /// Metric-name domains that diverge from their owning sampler's leading

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -1,21 +1,43 @@
 //! Recording-level context: source, version, duration, interval, systeminfo,
 //! and the coverage map (subsystems present vs absent).
 //!
-//! Subsystem attribution (see `extract::subsystem_of`) has three tiers,
-//! tried in order: a `sampler` label stamped by agents >= 5.17.1
-//! (preferred); failing that, an exact lookup in [`METRIC_SAMPLERS`] — a
-//! static table of metric names whose sampler can't be recovered from the
-//! name alone; failing that, the longest sampler name in
-//! [`EXPECTED_SUBSYSTEMS`] that is a `_`-boundary prefix of the metric name.
-//! When none of the three disambiguates, the metric is `unattributed` and
-//! its *domain* ([`domain_of`]) becomes "uncertain": `build_coverage`
-//! excludes any sampler in an uncertain domain from `subsystems_absent`,
-//! since its true presence/absence can't be known from an unattributed
-//! name. It is also not added to `subsystems_present` — we refuse to claim
-//! absence we can't know, and we don't fabricate presence either. This
-//! pruning is defense-in-depth for foreign sources and future metrics, not
-//! the primary resolution mechanism now that [`METRIC_SAMPLERS`] covers the
-//! known non-prefixing cases.
+//! Subsystem attribution (see `extract::subsystem_of`) has one prerequisite
+//! and three tiers. The prerequisite: a `sampler` label is always trusted
+//! (agents >= 5.17.1 stamp it), but *inference from the metric name* is
+//! trusted only when the recording's `source` metadata is exactly
+//! `"rezolus"` (`extract()` computes this once as `infer` and threads it
+//! through). A name like `cpu_usage` or `memory_free` proves nothing about
+//! a Prometheus-scraped or otherwise foreign recording — the name is just a
+//! string some other exporter happened to also use — so a missing, empty,
+//! or non-`"rezolus"` source disables inference entirely and every
+//! unlabeled metric is `unattributed`. rezolus-agent recordings (parquet
+//! and `.rez`, every agent version) always carry `source = "rezolus"`.
+//!
+//! When inference is trusted, the three tiers, tried in order, are: the
+//! `sampler` label (still checked first, redundantly with the
+//! prerequisite, since it's authoritative regardless); an exact lookup in
+//! [`METRIC_SAMPLERS`] — a static table of metric names whose sampler can't
+//! be recovered from the name alone; and name-prefix inference — the
+//! longest sampler name in [`EXPECTED_SUBSYSTEMS`] that is a `_`-boundary
+//! prefix of the metric name. Before either of the latter two, a name in
+//! [`AMBIGUOUS_METRICS`] (declared by more than one sampler, so a flat
+//! mapping can't be correct) is forced to `unattributed` rather than
+//! guessing one of its candidates.
+//!
+//! When nothing disambiguates, the metric is `unattributed`, and
+//! `extract()` credits its uncertainty at the tightest granularity it can:
+//! a name in [`AMBIGUOUS_METRICS`] contributes its exact *candidate sampler
+//! set* to `uncertain_samplers`; anything else (inference untrusted, or a
+//! genuinely unknown name) contributes its *domain* ([`domain_of`]) to
+//! `uncertain_domains`. `build_coverage` excludes both — every sampler in
+//! an uncertain domain, and every sampler in `uncertain_samplers` — from
+//! `subsystems_absent`, since their true presence/absence can't be known.
+//! Nothing in either set is added to `subsystems_present` either — we
+//! refuse to claim absence we can't know, and we don't fabricate presence
+//! we can't confirm. This is all defense-in-depth for foreign sources,
+//! ambiguous vocabulary, and future metrics, not the primary resolution
+//! mechanism now that [`METRIC_SAMPLERS`] covers the known non-prefixing
+//! cases on trusted (rezolus-sourced) recordings.
 
 use std::collections::BTreeSet;
 
@@ -83,15 +105,19 @@ pub(crate) const EXPECTED_SUBSYSTEMS: &[&str] = &[
 /// -> `cpu_branch`, `tcp_connect_latency` -> `tcp_connect_latency`) is left
 /// out to keep the table minimal. Sorted alphabetically.
 ///
-/// Deliberately excludes [`AMBIGUOUS_METRIC_NAMES`] — names declared
-/// identically by more than one sampler, where a flat mapping can't be
-/// correct for all of them.
+/// Deliberately excludes [`AMBIGUOUS_METRICS`] — names declared identically
+/// by more than one sampler, where a flat mapping can't be correct for all
+/// of them.
 ///
 /// `metric_samplers_match_agent_attribution` in `src/agent/samplers/mod.rs`
 /// is this table's drift guard: it walks the live `metriken` registry and
 /// asserts this table (plus prefix inference) agrees with the agent's own
-/// module-path attribution for every metric it can unambiguously check,
-/// printing the correct line to paste in here when it doesn't.
+/// module-path attribution, for every registered metric whose name isn't in
+/// [`AMBIGUOUS_METRICS`] and that the agent doesn't itself call
+/// `unattributed`, printing the correct line to paste in here when it
+/// doesn't. See that test's doc comment for what it can't check (metrics
+/// the agent's own `attribute_sampler` calls `unattributed`, and samplers
+/// not registered on whatever platform compiled the test).
 pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
     ("blockio_bytes", "blockio_requests"),
     ("blockio_errors", "blockio_requests"),
@@ -193,47 +219,100 @@ pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
     ("tcp_srtt", "tcp_receive"),
 ];
 
+/// The samplers that self-report `rezolus_bpf_run_count`/
+/// `rezolus_bpf_run_time`: every eBPF-backed sampler declares its own pair
+/// of these two metrics under its own module (self-timing instrumentation
+/// baked into each BPF-backed `stats.rs`), so the name alone can't tell you
+/// which one ran. Harvested by reading every `stats.rs` that declares
+/// `rezolus_bpf_run_count`; matches the "BPF-enabled samplers" list in
+/// `CLAUDE.md` (`blockio/{latency,requests}`,
+/// `cpu/{bandwidth,migrations,perf,tlb_flush,usage}`,
+/// `network/{interfaces,traffic}`, `scheduler/runqueue`,
+/// `syscall/{counts,latency}`,
+/// `tcp/{connect_latency,packet_latency,receive,retransmit,traffic}`) —
+/// cross-checked independently rather than assumed from that doc. Sorted
+/// alphabetically.
+const BPF_SAMPLERS: &[&str] = &[
+    "blockio_latency",
+    "blockio_requests",
+    "cpu_bandwidth",
+    "cpu_migrations",
+    "cpu_perf",
+    "cpu_tlb_flush",
+    "cpu_usage",
+    "network_interfaces",
+    "network_traffic",
+    "scheduler_runqueue",
+    "syscall_counts",
+    "syscall_latency",
+    "tcp_connect_latency",
+    "tcp_packet_latency",
+    "tcp_receive",
+    "tcp_retransmit",
+    "tcp_traffic",
+];
+
 /// Metric names declared identically by more than one sampler (verified by
-/// reading every sampler's `stats.rs`): a flat name -> sampler table can
-/// only be correct for one of them, so these are deliberately absent from
-/// [`METRIC_SAMPLERS`] and from `metric_samplers_match_agent_attribution`'s
-/// strict per-metric check. An unlabeled recording carrying one of these
-/// names falls through table lookup and name-prefix inference alike to
-/// `unattributed`, and its domain is pruned from `subsystems_absent` rather
-/// than asserted — the same defense-in-depth path that covers foreign or
-/// future metrics. Freshly recorded data (agents >= 5.17.1) is unaffected:
-/// the `sampler` label resolves these correctly without consulting either
-/// table.
+/// reading every sampler's `stats.rs`): a flat name -> sampler mapping
+/// can't be correct for all of them, but the name still proves *one of* its
+/// candidate samplers ran. `subsystem_of` resolves these to `unattributed`
+/// (deliberately absent from [`METRIC_SAMPLERS`] and from
+/// `metric_samplers_match_agent_attribution`'s strict per-metric check)
+/// rather than guessing a single one — but `extract()` credits the
+/// **candidate set**, not a whole name-token domain, to
+/// `uncertain_samplers`, so `build_coverage` prunes exactly those samplers
+/// from `subsystems_absent`. This is deliberately tighter than the
+/// `uncertain_domains` fallback: crediting `rezolus_bpf_run_count`'s whole
+/// `"rezolus"` domain, for example, would also prune the unrelated
+/// `rezolus_rusage` sampler on essentially every unlabeled BPF recording —
+/// a real precision loss the candidate-set form avoids.
+///
+/// Only consulted when inference is trusted (`infer`, see the module doc):
+/// on a non-`rezolus` source we don't trust that a name like `gpu_clock`
+/// came from *our* GPU samplers at all, so no candidate set is credited
+/// there either — the metric just falls into `uncertain_domains` like any
+/// other unlabeled name on an untrusted source.
+///
+/// Freshly recorded data (agents >= 5.17.1) is unaffected either way: the
+/// `sampler` label resolves these correctly without consulting this table.
 ///
 /// - `cpu_cores`: the Linux `cpu_cores` sampler's own metric, but also
 ///   emitted by the macOS `cpu_usage` sampler (macOS folds core-count
 ///   reporting into its usage sampler rather than having a standalone
 ///   `cpu_cores` one) — same name, different true sampler depending on
 ///   platform.
-/// - `gpu_clock`, `gpu_energy_consumption`, `gpu_memory`,
-///   `gpu_memory_utilization`, `gpu_pcie_throughput`, `gpu_power_usage`,
-///   `gpu_temperature`, `gpu_utilization`: shared vocabulary across
-///   `gpu_amd_smi`, `gpu_nvidia`, and (where applicable) `gpu_apple` — each
-///   vendor sampler declares its own metric under the same generic name.
-/// - `rezolus_bpf_run_count`, `rezolus_bpf_run_time`: every eBPF-backed
-///   sampler declares its own pair of these under its own module (self-timing
-///   instrumentation), so the name is common to all ~17 BPF samplers.
-// Consulted only by the (test-only, platform-gated)
-// `metric_samplers_match_agent_attribution` guard in
-// `src/agent/samplers/mod.rs`; a non-test build never references it.
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) const AMBIGUOUS_METRIC_NAMES: &[&str] = &[
-    "cpu_cores",
-    "gpu_clock",
-    "gpu_energy_consumption",
-    "gpu_memory",
-    "gpu_memory_utilization",
-    "gpu_pcie_throughput",
-    "gpu_power_usage",
-    "gpu_temperature",
-    "gpu_utilization",
-    "rezolus_bpf_run_count",
-    "rezolus_bpf_run_time",
+/// - `gpu_clock`, `gpu_energy_consumption`, `gpu_power_usage`,
+///   `gpu_utilization`: shared vocabulary across `gpu_amd_smi`,
+///   `gpu_apple`, and `gpu_nvidia`.
+/// - `gpu_memory`, `gpu_memory_utilization`, `gpu_pcie_throughput`,
+///   `gpu_temperature`: shared between `gpu_amd_smi` and `gpu_nvidia` only
+///   (no macOS/`gpu_apple` equivalent — `gpu/macos/stats.rs` declares no
+///   metric under these names).
+/// - `rezolus_bpf_run_count`, `rezolus_bpf_run_time`: see [`BPF_SAMPLERS`].
+///
+/// Sorted alphabetically by name; each candidate list sorted alphabetically
+/// too.
+pub(crate) const AMBIGUOUS_METRICS: &[(&str, &[&str])] = &[
+    ("cpu_cores", &["cpu_cores", "cpu_usage"]),
+    ("gpu_clock", &["gpu_amd_smi", "gpu_apple", "gpu_nvidia"]),
+    (
+        "gpu_energy_consumption",
+        &["gpu_amd_smi", "gpu_apple", "gpu_nvidia"],
+    ),
+    ("gpu_memory", &["gpu_amd_smi", "gpu_nvidia"]),
+    ("gpu_memory_utilization", &["gpu_amd_smi", "gpu_nvidia"]),
+    ("gpu_pcie_throughput", &["gpu_amd_smi", "gpu_nvidia"]),
+    (
+        "gpu_power_usage",
+        &["gpu_amd_smi", "gpu_apple", "gpu_nvidia"],
+    ),
+    ("gpu_temperature", &["gpu_amd_smi", "gpu_nvidia"]),
+    (
+        "gpu_utilization",
+        &["gpu_amd_smi", "gpu_apple", "gpu_nvidia"],
+    ),
+    ("rezolus_bpf_run_count", BPF_SAMPLERS),
+    ("rezolus_bpf_run_time", BPF_SAMPLERS),
 ];
 
 /// Metric-name domains that diverge from their owning sampler's leading
@@ -267,24 +346,41 @@ pub(crate) fn domain_of(name: &str) -> &str {
         .map_or(token, |(_, to)| *to)
 }
 
+/// The two "we don't know" sets `extract()` accumulates while attributing
+/// metric names to subsystems, bundled into one type so `build_context`
+/// doesn't need an unrelated arg-count workaround for what is conceptually
+/// a single uncertainty bundle (see the module doc for what each means).
+pub(crate) struct Uncertainty<'a> {
+    /// Domains ([`domain_of`]) with at least one still-`unattributed`
+    /// metric not covered by a tighter [`AMBIGUOUS_METRICS`] entry.
+    pub domains: &'a BTreeSet<String>,
+    /// Samplers named directly as an [`AMBIGUOUS_METRICS`] candidate for
+    /// some unattributed metric — pruned individually rather than by
+    /// domain.
+    pub samplers: &'a BTreeSet<String>,
+}
+
 /// present = the distinct `sampler` label values observed in the recording;
 /// callers insert the synthetic `unattributed` for metrics lacking the
 /// label (this function does not add it). absent = the static universe
-/// minus present, minus any sampler whose domain is in `uncertain_domains`
-/// (a domain with at least one still-`unattributed` metric after
-/// name-prefix inference — its true presence/absence can't be known, so we
-/// exclude it from `subsystems_absent` rather than assert a false absence;
-/// it is *not* added to present either, since we don't fabricate presence
-/// we can't confirm). Both output lists sorted (BTreeSet iteration order).
-pub(crate) fn build_coverage(
-    present: &BTreeSet<String>,
-    uncertain_domains: &BTreeSet<String>,
-) -> Coverage {
+/// minus present, minus any sampler whose domain is in
+/// `uncertainty.domains` (its true presence/absence can't be known, so we
+/// exclude it from `subsystems_absent` rather than assert a false absence),
+/// minus any sampler named directly in `uncertainty.samplers` (the exact
+/// candidate set of an [`AMBIGUOUS_METRICS`] name seen unlabeled — see that
+/// constant's doc for why this is tighter than domain pruning). Neither set
+/// is added to present either, since we don't fabricate presence we can't
+/// confirm. Both output lists sorted (BTreeSet iteration order).
+pub(crate) fn build_coverage(present: &BTreeSet<String>, uncertainty: &Uncertainty) -> Coverage {
     Coverage {
         subsystems_present: present.iter().cloned().collect(),
         subsystems_absent: EXPECTED_SUBSYSTEMS
             .iter()
-            .filter(|&&s| !present.contains(s) && !uncertain_domains.contains(domain_of(s)))
+            .filter(|&&s| {
+                !present.contains(s)
+                    && !uncertainty.domains.contains(domain_of(s))
+                    && !uncertainty.samplers.contains(s)
+            })
             .map(|s| s.to_string())
             .collect(),
     }
@@ -300,7 +396,7 @@ pub(crate) fn build_context(
     sampling_interval_s: f64,
     systeminfo_raw: Option<String>,
     present: &BTreeSet<String>,
-    uncertain_domains: &BTreeSet<String>,
+    uncertainty: &Uncertainty,
 ) -> Context {
     Context {
         source,
@@ -312,7 +408,7 @@ pub(crate) fn build_context(
         duration_s,
         sampling_interval_s,
         systeminfo: systeminfo_raw.and_then(|raw| serde_json::from_str(&raw).ok()),
-        coverage: build_coverage(present, uncertain_domains),
+        coverage: build_coverage(present, uncertainty),
     }
 }
 
@@ -351,8 +447,14 @@ mod tests {
         present.insert("cpu_usage".to_string());
         present.insert("scheduler_runqueue".to_string());
         present.insert("unattributed".to_string());
-        // empty uncertain_domains preserves old (pre-inference) behavior.
-        let c = build_coverage(&present, &BTreeSet::new());
+        // empty uncertainty sets preserve old (pre-inference) behavior.
+        let c = build_coverage(
+            &present,
+            &Uncertainty {
+                domains: &BTreeSet::new(),
+                samplers: &BTreeSet::new(),
+            },
+        );
         assert_eq!(
             c.subsystems_present,
             vec![
@@ -376,7 +478,13 @@ mod tests {
         let mut uncertain = BTreeSet::new();
         uncertain.insert("scheduler".to_string());
         uncertain.insert("blockio".to_string());
-        let c = build_coverage(&present, &uncertain);
+        let c = build_coverage(
+            &present,
+            &Uncertainty {
+                domains: &uncertain,
+                samplers: &BTreeSet::new(),
+            },
+        );
         // pruned domains' samplers are excluded from absent...
         assert!(!c
             .subsystems_absent
@@ -399,7 +507,13 @@ mod tests {
         let mut uncertain = BTreeSet::new();
         uncertain.insert(domain_of("drive_temperature").to_string());
         uncertain.insert(domain_of("gpmu_busy_cycles").to_string());
-        let c = build_coverage(&present, &uncertain);
+        let c = build_coverage(
+            &present,
+            &Uncertainty {
+                domains: &uncertain,
+                samplers: &BTreeSet::new(),
+            },
+        );
         assert!(!c.subsystems_absent.contains(&"drivehealth".to_string()));
         // every gpu_* sampler is pruned, not just the pmu one.
         assert!(!c.subsystems_absent.contains(&"gpu_amd_pmu".to_string()));
@@ -411,7 +525,64 @@ mod tests {
     }
 
     #[test]
+    fn coverage_prunes_exactly_the_candidate_set_for_an_ambiguous_metric() {
+        // As extraction would compute it for an unlabeled cpu_cores metric
+        // on a trusted (rezolus) source: exactly {cpu_cores, cpu_usage} is
+        // credited, not the whole "cpu" domain.
+        let present = BTreeSet::new();
+        let mut uncertain_samplers = BTreeSet::new();
+        uncertain_samplers.insert("cpu_cores".to_string());
+        uncertain_samplers.insert("cpu_usage".to_string());
+        let c = build_coverage(
+            &present,
+            &Uncertainty {
+                domains: &BTreeSet::new(),
+                samplers: &uncertain_samplers,
+            },
+        );
+        assert!(!c.subsystems_absent.contains(&"cpu_cores".to_string()));
+        assert!(!c.subsystems_absent.contains(&"cpu_usage".to_string()));
+        // every other "cpu" sampler still asserts absence -- the candidate
+        // set is exact, not the whole domain.
+        assert!(c.subsystems_absent.contains(&"cpu_perf".to_string()));
+        assert!(c.subsystems_absent.contains(&"cpu_bandwidth".to_string()));
+        assert!(c.subsystems_present.is_empty());
+    }
+
+    #[test]
+    fn coverage_prunes_bpf_set_without_touching_unrelated_rezolus_rusage() {
+        // rezolus_bpf_run_count's candidate set is BPF_SAMPLERS; it must
+        // NOT prune rezolus_rusage even though domain_of both names is
+        // "rezolus" -- this is exactly the precision loss the candidate-set
+        // form (vs. whole-domain pruning) is meant to avoid.
+        let present = BTreeSet::new();
+        let uncertain_samplers: BTreeSet<String> =
+            BPF_SAMPLERS.iter().map(|s| s.to_string()).collect();
+        let c = build_coverage(
+            &present,
+            &Uncertainty {
+                domains: &BTreeSet::new(),
+                samplers: &uncertain_samplers,
+            },
+        );
+        for sampler in BPF_SAMPLERS {
+            assert!(
+                !c.subsystems_absent.contains(&sampler.to_string()),
+                "{sampler} should be pruned (in the BPF candidate set)"
+            );
+        }
+        assert!(
+            c.subsystems_absent.contains(&"rezolus_rusage".to_string()),
+            "rezolus_rusage must still assert absence -- it is not a BPF sampler"
+        );
+    }
+
+    #[test]
     fn context_fields_normalized() {
+        let empty_uncertainty = Uncertainty {
+            domains: &BTreeSet::new(),
+            samplers: &BTreeSet::new(),
+        };
         let ctx = build_context(
             "rezolus".to_string(),
             String::new(), // .rez recordings have no version metadata
@@ -419,7 +590,7 @@ mod tests {
             1.0,
             Some(r#"{"os":"linux"}"#.to_string()),
             &BTreeSet::new(),
-            &BTreeSet::new(),
+            &empty_uncertainty,
         );
         assert_eq!(ctx.agent_version, None);
         assert_eq!(ctx.duration_s, 120.0);
@@ -431,7 +602,7 @@ mod tests {
             1.0,
             Some("not json".into()),
             &BTreeSet::new(),
-            &BTreeSet::new(),
+            &empty_uncertainty,
         );
         assert_eq!(bad.agent_version.as_deref(), Some("1.2.3"));
         assert_eq!(bad.systeminfo, None);

--- a/src/analysis/extract/mod.rs
+++ b/src/analysis/extract/mod.rs
@@ -197,19 +197,33 @@ pub(crate) fn validate_no_nulls(record: &OverviewRecord) -> Result<(), String> {
     }
 }
 
-/// Derive a metric's subsystem from its label sets (the agent stamps a
-/// `sampler` label on every metric); falls back to `unattributed` when
-/// absent. `extract()` inserts whatever this returns into
-/// `present_subsystems`, fulfilling `build_coverage`'s documented caller
-/// obligation that `unattributed` be added by the caller, not by
-/// `build_coverage` itself.
-fn subsystem_of(label_sets: &[BTreeMap<String, String>]) -> String {
+/// Derive a metric's subsystem, preferring the `sampler` label (stamped by
+/// agents >= 5.17.1) and falling back to name-prefix inference for older
+/// recordings that carry no such label: the longest sampler name in
+/// [`context::EXPECTED_SUBSYSTEMS`] that is a `_`-boundary prefix of the
+/// metric name (an exact match, or `name.starts_with("{sampler}_")`).
+/// Longest match wins so e.g. a name starting with `blockio_latency_`
+/// prefers `blockio_latency` over a shorter unrelated match. Falls back to
+/// `unattributed` when neither source disambiguates (e.g. `cpu_cycles`
+/// could come from `cpu_perf` but no sampler name is a prefix of it).
+/// `extract()` inserts whatever this returns into `present_subsystems`,
+/// fulfilling `build_coverage`'s documented caller obligation that
+/// `unattributed` be added by the caller, not by `build_coverage` itself.
+fn subsystem_of(name: &str, label_sets: &[BTreeMap<String, String>]) -> String {
     for labels in label_sets {
         if let Some(s) = labels.get("sampler") {
             return s.clone();
         }
     }
-    "unattributed".to_string()
+    context::EXPECTED_SUBSYSTEMS
+        .iter()
+        .filter(|s| {
+            name.strip_prefix(**s)
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with('_'))
+        })
+        .max_by_key(|sampler| sampler.len())
+        .map(|sampler| sampler.to_string())
+        .unwrap_or_else(|| "unattributed".to_string())
 }
 
 /// Query templates matching the MCP exhaustive mode.
@@ -326,8 +340,15 @@ pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::
     // --- enumerate entries (exhaustive: every metric appears) ---
     let mut entries: Vec<(String, &'static str, String, String, bool)> = Vec::new();
     let mut present_subsystems = BTreeSet::new();
+    // Domains that still have at least one unattributed metric after
+    // name-prefix inference: their true absence is unknowable, so
+    // build_coverage must exclude them from subsystems_absent.
+    let mut uncertain_domains = BTreeSet::new();
     for name in data.counter_names() {
-        let subsystem = subsystem_of(&data.counter_labels(&name));
+        let subsystem = subsystem_of(&name, &data.counter_labels(&name));
+        if subsystem == "unattributed" {
+            uncertain_domains.insert(context::domain_of(&name).to_string());
+        }
         present_subsystems.insert(subsystem.clone());
         entries.push((
             name.clone(),
@@ -338,12 +359,18 @@ pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::
         ));
     }
     for name in data.gauge_names() {
-        let subsystem = subsystem_of(&data.gauge_labels(&name));
+        let subsystem = subsystem_of(&name, &data.gauge_labels(&name));
+        if subsystem == "unattributed" {
+            uncertain_domains.insert(context::domain_of(&name).to_string());
+        }
         present_subsystems.insert(subsystem.clone());
         entries.push((name.clone(), "gauge", gauge_query(&name), subsystem, false));
     }
     for name in data.histogram_names() {
-        let subsystem = subsystem_of(&data.histogram_labels(&name));
+        let subsystem = subsystem_of(&name, &data.histogram_labels(&name));
+        if subsystem == "unattributed" {
+            uncertain_domains.insert(context::domain_of(&name).to_string());
+        }
         present_subsystems.insert(subsystem.clone());
         // The `m:pNN` entries' stats describe the quantile-over-time series
         // (e.g. `p99` of `blockio_latency:p50` is the p99-across-time of the
@@ -424,6 +451,7 @@ pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::
         data.interval(),
         data.metadata_get("systeminfo"),
         &present_subsystems,
+        &uncertain_domains,
     );
 
     let record = assemble(
@@ -443,6 +471,47 @@ mod tests {
     use super::*;
     use crate::analysis::record::*;
     use std::collections::BTreeSet;
+
+    #[test]
+    fn subsystem_of_prefers_the_sampler_label() {
+        let labels = vec![BTreeMap::from([(
+            "sampler".to_string(),
+            "cpu_usage".to_string(),
+        )])];
+        // Name alone would infer nothing useful; the label wins regardless.
+        assert_eq!(subsystem_of("some_unrelated_name", &labels), "cpu_usage");
+    }
+
+    #[test]
+    fn subsystem_of_infers_from_name_prefix_when_unlabeled() {
+        assert_eq!(
+            subsystem_of("scheduler_runqueue_latency", &[]),
+            "scheduler_runqueue"
+        );
+        assert_eq!(subsystem_of("cpu_usage", &[]), "cpu_usage");
+        assert_eq!(
+            subsystem_of("tcp_connect_latency", &[]),
+            "tcp_connect_latency"
+        );
+    }
+
+    #[test]
+    fn subsystem_of_longest_prefix_wins() {
+        // blockio_latency is a real sampler name; a metric name extending it
+        // with a further `_`-boundary suffix must still resolve to it.
+        assert_eq!(subsystem_of("blockio_latency_p50", &[]), "blockio_latency");
+    }
+
+    #[test]
+    fn subsystem_of_stays_unattributed_when_name_cannot_disambiguate() {
+        // cpu_cycles comes from cpu_perf, but no sampler name is a
+        // `_`-boundary prefix of "cpu_cycles" itself.
+        assert_eq!(subsystem_of("cpu_cycles", &[]), "unattributed");
+        // tcp_bytes comes from tcp_traffic, same story.
+        assert_eq!(subsystem_of("tcp_bytes", &[]), "unattributed");
+        // memory_free could be meminfo or vmstat; ambiguous by name.
+        assert_eq!(subsystem_of("memory_free", &[]), "unattributed");
+    }
 
     fn quiet(name: &str) -> MetricAnalysis {
         MetricAnalysis {

--- a/src/analysis/extract/mod.rs
+++ b/src/analysis/extract/mod.rs
@@ -197,10 +197,24 @@ pub(crate) fn validate_no_nulls(record: &OverviewRecord) -> Result<(), String> {
     }
 }
 
-/// Derive a metric's subsystem via three tiers, tried in order:
+/// Derive a metric's subsystem. The `sampler` label (stamped by agents >=
+/// 5.17.1) is always authoritative when present. Absent a label, *name
+/// inference* — everything below — only runs when `infer` is true, which
+/// callers must compute from the recording's `source` metadata being
+/// exactly `"rezolus"` (see `extract()` and the module doc in
+/// `context.rs`): a metric named `cpu_usage` in a Prometheus-scraped or
+/// otherwise foreign recording proves nothing, since the name is just a
+/// string some unrelated exporter happened to also use. When `infer` is
+/// false and no label matched, the result is unconditionally
+/// `unattributed`.
 ///
-/// 1. The `sampler` label (stamped by agents >= 5.17.1) — authoritative
-///    when present.
+/// When inference is trusted, in order:
+///
+/// 1. [`context::AMBIGUOUS_METRICS`]: a name declared identically by more
+///    than one sampler resolves to `unattributed` rather than guessing one
+///    of its candidates (the name still proves *one of* them ran — see
+///    `extract()`, which credits the candidate set to `uncertain_samplers`
+///    instead of a domain).
 /// 2. An exact lookup in [`context::METRIC_SAMPLERS`] — a static table,
 ///    harvested from the sampler `stats.rs` declarations, covering metric
 ///    names whose sampler can't be recovered from the name alone (e.g.
@@ -211,23 +225,31 @@ pub(crate) fn validate_no_nulls(record: &OverviewRecord) -> Result<(), String> {
 ///    Longest match wins so e.g. a name starting with `blockio_latency_`
 ///    prefers `blockio_latency` over a shorter unrelated match.
 ///
-/// Falls back to `unattributed` when none of the three disambiguates —
-/// either a genuinely foreign/future metric, or one of
-/// [`context::AMBIGUOUS_METRIC_NAMES`] (a name declared identically by more
-/// than one sampler, so no flat table entry could be correct for all of
-/// them). `extract()` inserts whatever this returns into
+/// Falls back to `unattributed` when nothing disambiguates — a genuinely
+/// foreign/future metric name, an ambiguous one, or inference not trusted
+/// at all. `extract()` inserts whatever this returns into
 /// `present_subsystems`, fulfilling `build_coverage`'s documented caller
 /// obligation that `unattributed` be added by the caller, not by
 /// `build_coverage` itself.
 ///
 /// `pub(crate)` so `metric_samplers_match_agent_attribution`
 /// (`src/agent/samplers/mod.rs`) can drive it directly with the real
-/// analysis-side resolution, rather than duplicating tiers 2/3's logic.
-pub(crate) fn subsystem_of(name: &str, label_sets: &[BTreeMap<String, String>]) -> String {
+/// analysis-side resolution, rather than duplicating tiers 1-3's logic.
+pub(crate) fn subsystem_of(
+    name: &str,
+    label_sets: &[BTreeMap<String, String>],
+    infer: bool,
+) -> String {
     for labels in label_sets {
         if let Some(s) = labels.get("sampler") {
             return s.clone();
         }
+    }
+    if !infer {
+        return "unattributed".to_string();
+    }
+    if context::AMBIGUOUS_METRICS.iter().any(|(n, _)| *n == name) {
+        return "unattributed".to_string();
     }
     if let Some((_, sampler)) = context::METRIC_SAMPLERS.iter().find(|(n, _)| *n == name) {
         return sampler.to_string();
@@ -354,17 +376,47 @@ pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::
         );
     }
 
+    // Name inference (METRIC_SAMPLERS/prefix/ambiguity tiers) is trusted
+    // only for genuine rezolus recordings (parquet and .rez, every agent
+    // version) -- a metric coincidentally named e.g. `cpu_usage` in a
+    // Prometheus-scraped or otherwise foreign recording proves nothing. A
+    // missing/empty source is treated as unknown, i.e. conservative (no
+    // inference). See the module doc in context.rs.
+    let source = data.source();
+    let infer = source == "rezolus";
+
     // --- enumerate entries (exhaustive: every metric appears) ---
     let mut entries: Vec<(String, &'static str, String, String, bool)> = Vec::new();
     let mut present_subsystems = BTreeSet::new();
-    // Domains that still have at least one unattributed metric after
-    // name-prefix inference: their true absence is unknowable, so
-    // build_coverage must exclude them from subsystems_absent.
+    // Domains that still have at least one unattributed metric that isn't
+    // covered by a tighter AMBIGUOUS_METRICS candidate set: their true
+    // absence is unknowable, so build_coverage must exclude them from
+    // subsystems_absent.
     let mut uncertain_domains = BTreeSet::new();
+    // Samplers named directly as an AMBIGUOUS_METRICS candidate for some
+    // unattributed metric: pruned from subsystems_absent individually
+    // (tighter than uncertain_domains -- see AMBIGUOUS_METRICS's doc for
+    // why, e.g. rezolus_bpf_run_count must not also prune the unrelated
+    // rezolus_rusage sampler).
+    let mut uncertain_samplers = BTreeSet::new();
+    // Record that `name` resolved to "unattributed": credit its exact
+    // AMBIGUOUS_METRICS candidate set when inference is trusted and the
+    // name is one of them, else fall back to its whole domain.
+    let mut note_unattributed = |name: &str| {
+        if infer {
+            if let Some((_, candidates)) =
+                context::AMBIGUOUS_METRICS.iter().find(|(n, _)| *n == name)
+            {
+                uncertain_samplers.extend(candidates.iter().map(|s| s.to_string()));
+                return;
+            }
+        }
+        uncertain_domains.insert(context::domain_of(name).to_string());
+    };
     for name in data.counter_names() {
-        let subsystem = subsystem_of(&name, &data.counter_labels(&name));
+        let subsystem = subsystem_of(&name, &data.counter_labels(&name), infer);
         if subsystem == "unattributed" {
-            uncertain_domains.insert(context::domain_of(&name).to_string());
+            note_unattributed(&name);
         }
         present_subsystems.insert(subsystem.clone());
         entries.push((
@@ -376,17 +428,17 @@ pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::
         ));
     }
     for name in data.gauge_names() {
-        let subsystem = subsystem_of(&name, &data.gauge_labels(&name));
+        let subsystem = subsystem_of(&name, &data.gauge_labels(&name), infer);
         if subsystem == "unattributed" {
-            uncertain_domains.insert(context::domain_of(&name).to_string());
+            note_unattributed(&name);
         }
         present_subsystems.insert(subsystem.clone());
         entries.push((name.clone(), "gauge", gauge_query(&name), subsystem, false));
     }
     for name in data.histogram_names() {
-        let subsystem = subsystem_of(&name, &data.histogram_labels(&name));
+        let subsystem = subsystem_of(&name, &data.histogram_labels(&name), infer);
         if subsystem == "unattributed" {
-            uncertain_domains.insert(context::domain_of(&name).to_string());
+            note_unattributed(&name);
         }
         present_subsystems.insert(subsystem.clone());
         // The `m:pNN` entries' stats describe the quantile-over-time series
@@ -462,13 +514,16 @@ pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::
     // preferable to silently substituting 1s into a provenance field.
     // (All current MetricsSource impls return finite intervals.)
     let context = context::build_context(
-        data.source(),
+        source,
         data.version(),
         duration_s,
         data.interval(),
         data.metadata_get("systeminfo"),
         &present_subsystems,
-        &uncertain_domains,
+        &context::Uncertainty {
+            domains: &uncertain_domains,
+            samplers: &uncertain_samplers,
+        },
     );
 
     let record = assemble(
@@ -495,19 +550,27 @@ mod tests {
             "sampler".to_string(),
             "cpu_usage".to_string(),
         )])];
-        // Name alone would infer nothing useful; the label wins regardless.
-        assert_eq!(subsystem_of("some_unrelated_name", &labels), "cpu_usage");
+        // Name alone would infer nothing useful; the label wins regardless,
+        // and regardless of `infer` too (a label is always authoritative).
+        assert_eq!(
+            subsystem_of("some_unrelated_name", &labels, true),
+            "cpu_usage"
+        );
+        assert_eq!(
+            subsystem_of("some_unrelated_name", &labels, false),
+            "cpu_usage"
+        );
     }
 
     #[test]
     fn subsystem_of_infers_from_name_prefix_when_unlabeled() {
         assert_eq!(
-            subsystem_of("scheduler_runqueue_latency", &[]),
+            subsystem_of("scheduler_runqueue_latency", &[], true),
             "scheduler_runqueue"
         );
-        assert_eq!(subsystem_of("cpu_usage", &[]), "cpu_usage");
+        assert_eq!(subsystem_of("cpu_usage", &[], true), "cpu_usage");
         assert_eq!(
-            subsystem_of("tcp_connect_latency", &[]),
+            subsystem_of("tcp_connect_latency", &[], true),
             "tcp_connect_latency"
         );
     }
@@ -516,7 +579,10 @@ mod tests {
     fn subsystem_of_longest_prefix_wins() {
         // blockio_latency is a real sampler name; a metric name extending it
         // with a further `_`-boundary suffix must still resolve to it.
-        assert_eq!(subsystem_of("blockio_latency_p50", &[]), "blockio_latency");
+        assert_eq!(
+            subsystem_of("blockio_latency_p50", &[], true),
+            "blockio_latency"
+        );
     }
 
     #[test]
@@ -524,26 +590,42 @@ mod tests {
         // cpu_cycles comes from cpu_perf, but no sampler name is a
         // `_`-boundary prefix of "cpu_cycles" itself — resolved via the
         // METRIC_SAMPLERS table instead of falling to unattributed.
-        assert_eq!(subsystem_of("cpu_cycles", &[]), "cpu_perf");
+        assert_eq!(subsystem_of("cpu_cycles", &[], true), "cpu_perf");
         // tcp_bytes comes from tcp_traffic, same story.
-        assert_eq!(subsystem_of("tcp_bytes", &[]), "tcp_traffic");
+        assert_eq!(subsystem_of("tcp_bytes", &[], true), "tcp_traffic");
         // memory_free is declared in memory/linux/meminfo/stats.rs.
-        assert_eq!(subsystem_of("memory_free", &[]), "memory_meminfo");
+        assert_eq!(subsystem_of("memory_free", &[], true), "memory_meminfo");
         // a cgroup_* metric: declared inside its owning sampler's own
         // module (there is no separate cgroup sampler).
-        assert_eq!(subsystem_of("cgroup_syscall", &[]), "syscall_counts");
+        assert_eq!(subsystem_of("cgroup_syscall", &[], true), "syscall_counts");
     }
 
     #[test]
     fn subsystem_of_stays_unattributed_for_genuinely_ambiguous_or_foreign_names() {
         // gpu_memory is declared identically by both gpu_amd_smi and
         // gpu_nvidia; a flat table can't pick one, so it's excluded from
-        // METRIC_SAMPLERS (see AMBIGUOUS_METRIC_NAMES) and stays
-        // unattributed absent a label.
-        assert_eq!(subsystem_of("gpu_memory", &[]), "unattributed");
+        // METRIC_SAMPLERS (see AMBIGUOUS_METRICS) and stays unattributed
+        // absent a label, even with inference trusted.
+        assert_eq!(subsystem_of("gpu_memory", &[], true), "unattributed");
         // A metric name with no relationship to any known sampler at all
         // (e.g. from a foreign/future source) stays unattributed too.
-        assert_eq!(subsystem_of("totally_unknown_metric", &[]), "unattributed");
+        assert_eq!(
+            subsystem_of("totally_unknown_metric", &[], true),
+            "unattributed"
+        );
+    }
+
+    #[test]
+    fn subsystem_of_cpu_cores_is_ambiguous_not_a_linux_exact_match() {
+        // CRITICAL regression: "cpu_cores" exactly matches the Linux
+        // cpu_cores sampler's own name via tier-3 prefix inference, but the
+        // same name is also emitted by macOS's cpu_usage sampler. Before
+        // AMBIGUOUS_METRICS covered it, an unlabeled macOS recording would
+        // fabricate presence of the Linux-only cpu_cores sampler. It must
+        // resolve to unattributed instead (and extract() credits exactly
+        // {cpu_cores, cpu_usage} to uncertain_samplers -- see context.rs
+        // tests).
+        assert_eq!(subsystem_of("cpu_cores", &[], true), "unattributed");
     }
 
     #[test]
@@ -554,15 +636,46 @@ mod tests {
             "sampler".to_string(),
             "some_override".to_string(),
         )])];
-        assert_eq!(subsystem_of("cpu_cycles", &labeled), "some_override");
+        assert_eq!(subsystem_of("cpu_cycles", &labeled, true), "some_override");
 
         // No label: table lookup wins over prefix inference. "tcp_bytes"
         // would not prefix-match any EXPECTED_SUBSYSTEMS entry, so without
         // the table it would fall to unattributed; the table resolves it.
-        assert_eq!(subsystem_of("tcp_bytes", &[]), "tcp_traffic");
+        assert_eq!(subsystem_of("tcp_bytes", &[], true), "tcp_traffic");
 
         // No label, no table entry: prefix inference is the last resort.
-        assert_eq!(subsystem_of("cpu_usage", &[]), "cpu_usage");
+        assert_eq!(subsystem_of("cpu_usage", &[], true), "cpu_usage");
+    }
+
+    #[test]
+    fn subsystem_of_infer_false_blocks_table_and_prefix_tiers() {
+        // CRITICAL regression: without a `sampler` label, and with
+        // inference untrusted (a non-rezolus source), a metric coincidentally
+        // named `cpu_usage`/`memory_free`/`tcp_bytes` must NOT fabricate
+        // subsystem presence -- neither the METRIC_SAMPLERS table nor
+        // name-prefix inference may run.
+        assert_eq!(subsystem_of("cpu_usage", &[], false), "unattributed");
+        assert_eq!(subsystem_of("memory_free", &[], false), "unattributed");
+        assert_eq!(subsystem_of("tcp_bytes", &[], false), "unattributed");
+        assert_eq!(subsystem_of("cpu_cycles", &[], false), "unattributed");
+
+        // Same names resolve normally when inference IS trusted -- proves
+        // the difference is solely the `infer` flag, not the names.
+        assert_eq!(subsystem_of("cpu_usage", &[], true), "cpu_usage");
+        assert_eq!(subsystem_of("memory_free", &[], true), "memory_meminfo");
+        assert_eq!(subsystem_of("tcp_bytes", &[], true), "tcp_traffic");
+        assert_eq!(subsystem_of("cpu_cycles", &[], true), "cpu_perf");
+    }
+
+    #[test]
+    fn subsystem_of_label_wins_even_when_infer_is_false() {
+        // A `sampler` label is agent-stamped ground truth, independent of
+        // whether the *recording's* source is trusted for name inference.
+        let labels = vec![BTreeMap::from([(
+            "sampler".to_string(),
+            "cpu_usage".to_string(),
+        )])];
+        assert_eq!(subsystem_of("cpu_usage", &labels, false), "cpu_usage");
     }
 
     fn quiet(name: &str) -> MetricAnalysis {

--- a/src/analysis/extract/mod.rs
+++ b/src/analysis/extract/mod.rs
@@ -197,23 +197,40 @@ pub(crate) fn validate_no_nulls(record: &OverviewRecord) -> Result<(), String> {
     }
 }
 
-/// Derive a metric's subsystem, preferring the `sampler` label (stamped by
-/// agents >= 5.17.1) and falling back to name-prefix inference for older
-/// recordings that carry no such label: the longest sampler name in
-/// [`context::EXPECTED_SUBSYSTEMS`] that is a `_`-boundary prefix of the
-/// metric name (an exact match, or `name.starts_with("{sampler}_")`).
-/// Longest match wins so e.g. a name starting with `blockio_latency_`
-/// prefers `blockio_latency` over a shorter unrelated match. Falls back to
-/// `unattributed` when neither source disambiguates (e.g. `cpu_cycles`
-/// could come from `cpu_perf` but no sampler name is a prefix of it).
-/// `extract()` inserts whatever this returns into `present_subsystems`,
-/// fulfilling `build_coverage`'s documented caller obligation that
-/// `unattributed` be added by the caller, not by `build_coverage` itself.
-fn subsystem_of(name: &str, label_sets: &[BTreeMap<String, String>]) -> String {
+/// Derive a metric's subsystem via three tiers, tried in order:
+///
+/// 1. The `sampler` label (stamped by agents >= 5.17.1) — authoritative
+///    when present.
+/// 2. An exact lookup in [`context::METRIC_SAMPLERS`] — a static table,
+///    harvested from the sampler `stats.rs` declarations, covering metric
+///    names whose sampler can't be recovered from the name alone (e.g.
+///    `cpu_cycles`, `tcp_bytes`, `cgroup_cpu_usage`).
+/// 3. Name-prefix inference: the longest sampler name in
+///    [`context::EXPECTED_SUBSYSTEMS`] that is a `_`-boundary prefix of the
+///    metric name (an exact match, or `name.starts_with("{sampler}_")`).
+///    Longest match wins so e.g. a name starting with `blockio_latency_`
+///    prefers `blockio_latency` over a shorter unrelated match.
+///
+/// Falls back to `unattributed` when none of the three disambiguates —
+/// either a genuinely foreign/future metric, or one of
+/// [`context::AMBIGUOUS_METRIC_NAMES`] (a name declared identically by more
+/// than one sampler, so no flat table entry could be correct for all of
+/// them). `extract()` inserts whatever this returns into
+/// `present_subsystems`, fulfilling `build_coverage`'s documented caller
+/// obligation that `unattributed` be added by the caller, not by
+/// `build_coverage` itself.
+///
+/// `pub(crate)` so `metric_samplers_match_agent_attribution`
+/// (`src/agent/samplers/mod.rs`) can drive it directly with the real
+/// analysis-side resolution, rather than duplicating tiers 2/3's logic.
+pub(crate) fn subsystem_of(name: &str, label_sets: &[BTreeMap<String, String>]) -> String {
     for labels in label_sets {
         if let Some(s) = labels.get("sampler") {
             return s.clone();
         }
+    }
+    if let Some((_, sampler)) = context::METRIC_SAMPLERS.iter().find(|(n, _)| *n == name) {
+        return sampler.to_string();
     }
     context::EXPECTED_SUBSYSTEMS
         .iter()
@@ -503,14 +520,49 @@ mod tests {
     }
 
     #[test]
-    fn subsystem_of_stays_unattributed_when_name_cannot_disambiguate() {
+    fn subsystem_of_resolves_non_prefixing_names_via_metric_samplers_table() {
         // cpu_cycles comes from cpu_perf, but no sampler name is a
-        // `_`-boundary prefix of "cpu_cycles" itself.
-        assert_eq!(subsystem_of("cpu_cycles", &[]), "unattributed");
+        // `_`-boundary prefix of "cpu_cycles" itself — resolved via the
+        // METRIC_SAMPLERS table instead of falling to unattributed.
+        assert_eq!(subsystem_of("cpu_cycles", &[]), "cpu_perf");
         // tcp_bytes comes from tcp_traffic, same story.
-        assert_eq!(subsystem_of("tcp_bytes", &[]), "unattributed");
-        // memory_free could be meminfo or vmstat; ambiguous by name.
-        assert_eq!(subsystem_of("memory_free", &[]), "unattributed");
+        assert_eq!(subsystem_of("tcp_bytes", &[]), "tcp_traffic");
+        // memory_free is declared in memory/linux/meminfo/stats.rs.
+        assert_eq!(subsystem_of("memory_free", &[]), "memory_meminfo");
+        // a cgroup_* metric: declared inside its owning sampler's own
+        // module (there is no separate cgroup sampler).
+        assert_eq!(subsystem_of("cgroup_syscall", &[]), "syscall_counts");
+    }
+
+    #[test]
+    fn subsystem_of_stays_unattributed_for_genuinely_ambiguous_or_foreign_names() {
+        // gpu_memory is declared identically by both gpu_amd_smi and
+        // gpu_nvidia; a flat table can't pick one, so it's excluded from
+        // METRIC_SAMPLERS (see AMBIGUOUS_METRIC_NAMES) and stays
+        // unattributed absent a label.
+        assert_eq!(subsystem_of("gpu_memory", &[]), "unattributed");
+        // A metric name with no relationship to any known sampler at all
+        // (e.g. from a foreign/future source) stays unattributed too.
+        assert_eq!(subsystem_of("totally_unknown_metric", &[]), "unattributed");
+    }
+
+    #[test]
+    fn subsystem_of_precedence_label_beats_table_beats_prefix() {
+        // Table would resolve cpu_cycles -> cpu_perf, but an explicit label
+        // wins regardless of what the name implies.
+        let labeled = vec![BTreeMap::from([(
+            "sampler".to_string(),
+            "some_override".to_string(),
+        )])];
+        assert_eq!(subsystem_of("cpu_cycles", &labeled), "some_override");
+
+        // No label: table lookup wins over prefix inference. "tcp_bytes"
+        // would not prefix-match any EXPECTED_SUBSYSTEMS entry, so without
+        // the table it would fall to unattributed; the table resolves it.
+        assert_eq!(subsystem_of("tcp_bytes", &[]), "tcp_traffic");
+
+        // No label, no table entry: prefix inference is the last resort.
+        assert_eq!(subsystem_of("cpu_usage", &[]), "cpu_usage");
     }
 
     fn quiet(name: &str) -> MetricAnalysis {

--- a/src/analysis/ground_truth.rs
+++ b/src/analysis/ground_truth.rs
@@ -41,8 +41,8 @@ pub enum SignalCheck {
     /// carry at least one `RegimeShiftIncreaseInWindow` signal, so this can
     /// never be the sole gate. Revisit when extraction grows windowed stats.
     ElevatedInWindow,
-    /// The metric exists in the record and its sampler label appears in
-    /// coverage.subsystems_present.
+    /// The metric exists in the record and its sampler (labeled or
+    /// name-inferred) appears in coverage.subsystems_present.
     SubsystemPresent,
 }
 

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -61,6 +61,19 @@ pub struct Context {
 
 /// Which subsystems are present vs absent — what lets an assessment say
 /// `NeedsMetric` instead of hallucinating around a gap.
+///
+/// Absence is asserted only for subsystems whose domain (first `_`-token of
+/// the sampler name, e.g. `blockio` for `blockio_latency`) had no
+/// unattributed metrics: extraction attributes each metric to a subsystem
+/// via its `sampler` label when present, or by name-prefix inference when
+/// not, and any domain that still has an unattributed metric after that
+/// inference is excluded from `subsystems_absent` rather than asserted
+/// absent on unreliable information. Recordings from agents older than
+/// 5.17.1 carry no `sampler` labels at all, so every metric falls to name
+/// inference; ambiguous names (e.g. `cpu_cycles`, `tcp_bytes`) stay
+/// unattributed and their domains are pruned — such recordings may
+/// therefore report a shorter `subsystems_absent` list than a labeled one
+/// covering the same subsystems.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Coverage {
     pub subsystems_present: Vec<String>,

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -62,18 +62,35 @@ pub struct Context {
 /// Which subsystems are present vs absent — what lets an assessment say
 /// `NeedsMetric` instead of hallucinating around a gap.
 ///
+/// Extraction attributes each metric to a subsystem in three tiers (see
+/// `extract::subsystem_of`): the `sampler` label when present (agents >=
+/// 5.17.1); failing that, an exact lookup in `extract::context::
+/// METRIC_SAMPLERS` — a static table, harvested from the sampler `stats.rs`
+/// declarations, of metric names whose sampler can't be recovered from the
+/// name alone (e.g. `cpu_cycles` -> `cpu_perf`, `tcp_bytes` ->
+/// `tcp_traffic`, `cgroup_cpu_usage` -> `cpu_usage`); failing that,
+/// name-prefix inference against `EXPECTED_SUBSYSTEMS`. A drift guard test
+/// (`metric_samplers_match_agent_attribution` in
+/// `src/agent/samplers/mod.rs`) checks the table against the agent's own
+/// module-path attribution over the live metric registry, so the table
+/// tracks sampler additions/renames rather than silently going stale.
+///
 /// Absence is asserted only for subsystems whose domain (first `_`-token of
-/// the sampler name, e.g. `blockio` for `blockio_latency`) had no
-/// unattributed metrics: extraction attributes each metric to a subsystem
-/// via its `sampler` label when present, or by name-prefix inference when
-/// not, and any domain that still has an unattributed metric after that
-/// inference is excluded from `subsystems_absent` rather than asserted
-/// absent on unreliable information. Recordings from agents older than
-/// 5.17.1 carry no `sampler` labels at all, so every metric falls to name
-/// inference; ambiguous names (e.g. `cpu_cycles`, `tcp_bytes`) stay
-/// unattributed and their domains are pruned — such recordings may
-/// therefore report a shorter `subsystems_absent` list than a labeled one
-/// covering the same subsystems.
+/// the sampler name, e.g. `blockio` for `blockio_latency`) had no metric
+/// left unattributed after all three tiers: any domain that still has an
+/// unattributed metric is excluded from `subsystems_absent` rather than
+/// asserted absent on unreliable information. This pruning is
+/// defense-in-depth now — it exists for genuinely unknowable cases (foreign
+/// sources, metrics newer than this build's METRIC_SAMPLERS table, or a
+/// handful of names declared identically by more than one sampler, e.g.
+/// `gpu_memory` across `gpu_amd_smi`/`gpu_nvidia` — see
+/// `AMBIGUOUS_METRIC_NAMES`) rather than the primary mechanism it was
+/// before the table existed. Recordings from agents older than 5.17.1 carry
+/// no `sampler` labels at all, so every metric falls to the table/prefix
+/// tiers; only the residual ambiguous or foreign names stay unattributed —
+/// such recordings may therefore still report a shorter `subsystems_absent`
+/// list than a labeled one covering the same subsystems, just a much
+/// shorter gap than under prefix inference alone.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Coverage {
     pub subsystems_present: Vec<String>,

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -62,35 +62,57 @@ pub struct Context {
 /// Which subsystems are present vs absent — what lets an assessment say
 /// `NeedsMetric` instead of hallucinating around a gap.
 ///
-/// Extraction attributes each metric to a subsystem in three tiers (see
-/// `extract::subsystem_of`): the `sampler` label when present (agents >=
-/// 5.17.1); failing that, an exact lookup in `extract::context::
-/// METRIC_SAMPLERS` — a static table, harvested from the sampler `stats.rs`
-/// declarations, of metric names whose sampler can't be recovered from the
-/// name alone (e.g. `cpu_cycles` -> `cpu_perf`, `tcp_bytes` ->
-/// `tcp_traffic`, `cgroup_cpu_usage` -> `cpu_usage`); failing that,
-/// name-prefix inference against `EXPECTED_SUBSYSTEMS`. A drift guard test
+/// Extraction attributes each metric to a subsystem via `extract::
+/// subsystem_of`. A `sampler` label (agents >= 5.17.1) is always
+/// authoritative. Absent a label, *name inference* only runs at all when
+/// the recording's `source` metadata is exactly `"rezolus"` (computed once
+/// per recording as `infer`): a metric named e.g. `cpu_usage` in a
+/// Prometheus-scraped or otherwise foreign recording proves nothing about
+/// which sampler produced it — the name is just a string some unrelated
+/// exporter happened to reuse — so a missing, empty, or non-`"rezolus"`
+/// source disables inference and every unlabeled metric is `unattributed`.
+/// rezolus-agent recordings (parquet and `.rez`, every agent version)
+/// always carry `source = "rezolus"`.
+///
+/// When inference is trusted, in order: a name in `extract::context::
+/// AMBIGUOUS_METRICS` (declared identically by more than one sampler, e.g.
+/// `gpu_memory` across `gpu_amd_smi`/`gpu_nvidia`, or
+/// `rezolus_bpf_run_count`/`_time` across every eBPF-backed sampler) is
+/// deliberately left `unattributed` rather than guessing one of its
+/// candidates; then an exact lookup in `extract::context::METRIC_SAMPLERS`
+/// — a static table, harvested from the sampler `stats.rs` declarations, of
+/// metric names whose sampler can't be recovered from the name alone (e.g.
+/// `cpu_cycles` -> `cpu_perf`, `tcp_bytes` -> `tcp_traffic`,
+/// `cgroup_cpu_usage` -> `cpu_usage`); then name-prefix inference against
+/// `EXPECTED_SUBSYSTEMS`. A drift guard test
 /// (`metric_samplers_match_agent_attribution` in
 /// `src/agent/samplers/mod.rs`) checks the table against the agent's own
-/// module-path attribution over the live metric registry, so the table
-/// tracks sampler additions/renames rather than silently going stale.
+/// module-path attribution over the live metric registry (with documented
+/// limits — see that test's doc comment), so the table tracks sampler
+/// additions/renames rather than silently going stale.
 ///
-/// Absence is asserted only for subsystems whose domain (first `_`-token of
-/// the sampler name, e.g. `blockio` for `blockio_latency`) had no metric
-/// left unattributed after all three tiers: any domain that still has an
-/// unattributed metric is excluded from `subsystems_absent` rather than
-/// asserted absent on unreliable information. This pruning is
-/// defense-in-depth now — it exists for genuinely unknowable cases (foreign
-/// sources, metrics newer than this build's METRIC_SAMPLERS table, or a
-/// handful of names declared identically by more than one sampler, e.g.
-/// `gpu_memory` across `gpu_amd_smi`/`gpu_nvidia` — see
-/// `AMBIGUOUS_METRIC_NAMES`) rather than the primary mechanism it was
-/// before the table existed. Recordings from agents older than 5.17.1 carry
-/// no `sampler` labels at all, so every metric falls to the table/prefix
-/// tiers; only the residual ambiguous or foreign names stay unattributed —
-/// such recordings may therefore still report a shorter `subsystems_absent`
-/// list than a labeled one covering the same subsystems, just a much
-/// shorter gap than under prefix inference alone.
+/// Absence is pruned at two granularities. An `AMBIGUOUS_METRICS` name seen
+/// unattributed prunes exactly its *candidate sampler set* — e.g. an
+/// unlabeled `cpu_cores` prunes only `{cpu_cores, cpu_usage}`, and an
+/// unlabeled `rezolus_bpf_run_count` prunes only the BPF-backed samplers,
+/// deliberately NOT the unrelated `rezolus_rusage` sampler even though both
+/// names share the `"rezolus"` first-token domain. Anything else left
+/// unattributed (inference untrusted, or a genuinely unknown name) prunes
+/// its whole domain (first `_`-token of the sampler name, e.g. `blockio`
+/// for `blockio_latency`) — coarser, but still never asserts a false
+/// absence. Both forms are defense-in-depth now — they exist for genuinely
+/// unknowable cases (foreign sources, metrics newer than this build's
+/// `METRIC_SAMPLERS` table, or ambiguous vocabulary) rather than the
+/// primary mechanism pruning was before the table existed. Recordings from
+/// agents older than 5.17.1 carry no `sampler` labels at all, so on a
+/// trusted (rezolus-sourced) recording every metric falls to the table/
+/// prefix tiers; only the residual ambiguous or foreign names stay
+/// unattributed — such recordings may therefore still report a shorter
+/// `subsystems_absent` list than a labeled one covering the same
+/// subsystems, just a much shorter gap than under prefix inference alone.
+/// A foreign (non-`"rezolus"`) source gets none of this: every unlabeled
+/// metric is `unattributed`, so `subsystems_absent` will typically be
+/// empty or near-empty rather than fabricated.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Coverage {
     pub subsystems_present: Vec<String>,


### PR DESCRIPTION
## Summary
- Recordings from agents older than 5.17.1 carry no `sampler` labels, so extraction filed every metric as `unattributed` and the coverage map listed genuinely-present subsystems (e.g. `scheduler_runqueue`, `cpu_usage`) as absent — false absences that mislead any consumer using coverage to reason about what a recording can show.
- Attribution is now three-tier: the `sampler` label when present (agents ≥ 5.17.1), else an explicit **89-entry metric→sampler table** harvested from the sampler declarations, else longest sampler-name-prefix inference. **Inference is hard-gated to `source == "rezolus"` recordings** — foreign/Prometheus-recorded files get label-only attribution, so coincidental metric names can never fabricate presence.
- **Genuinely ambiguous names carry candidate-sampler sets** (`AMBIGUOUS_METRICS`): a name declared by multiple samplers resolves to `unattributed`, and coverage excludes exactly its candidates from `subsystems_absent` — e.g. `rezolus_bpf_run_count` (declared by all 17 BPF samplers) prunes those 17, not the unrelated `rezolus_rusage`; `cpu_cores` (Linux standalone sampler vs macOS `cpu_usage`) prunes exactly those two.
- Domain-level pruning remains as defense-in-depth for unknown names on rezolus-source recordings. A **drift-guard test** checks resolution against the agent's own module-path attribution over the live metriken registry (Linux CI is the real gate; its two unverifiable categories are documented plainly).

## Adversarial review
Two adversarial subagents attacked the change before this revision; their findings are fixed and re-verified:
- **Fixed (critical): foreign-source fabrication** — inference originally ran regardless of `data.source()`, so a Prometheus-recorded parquet (`rezolus record --metadata source=llm-perf …`, a documented workflow) with a metric coincidentally named `cpu_usage`/`memory_free`/`tcp_bytes` fabricated `subsystems_present`. Now hard-gated; verified across `.rez`, old-agent parquet, source-tagged and auto-detected Prometheus recordings, and bare parquet (empty source → conservative, no inference).
- **Fixed (critical): `cpu_cores` self-collision** — the ambiguity list originally guarded only the table tier; `cpu_cores` exact-matched the Linux sampler name via prefix inference, fabricating a Linux-only sampler's presence on unlabeled macOS recordings and bypassing pruning. Ambiguity is now checked before both inference tiers, with a regression test.
- **Fixed: `rezolus_rusage` over-pruning** — the `rezolus_bpf_*` ambiguity previously pruned the unrelated `rezolus_rusage` from the absent list on essentially every unlabeled BPF recording (shared name token). Candidate-set pruning replaces domain-token pruning for ambiguous names; a test positively asserts `rezolus_rusage` remains assertable-absent.
- **Verified safe:** mixed labeled/unlabeled series ordering (label sets are sorted/deduped — deterministic); custom sampler label values; present/absent/uncertain bookkeeping (no double counting); `domain_of` panic-freedom on degenerate names; registry-vs-recorded metric-name equivalence for the drift guard; `parquet combine` output (its `::`-renaming and array-serialized source key both independently prevent inference — conservative direction, pre-existing).
- **Documented, not fixed here:** the drift guard cannot check table rows for metrics the agent itself attributes `unattributed` (the `gpu_apple` sibling-module quirk, filed as follow-up) or rows absent from the current platform's registry.

## Validation
- Labeled recordings unchanged: the extraction golden test passes unmodified throughout.
- Live before/after on real recordings from a 5.17.0 agent: coverage went from "31 absent, only `unattributed` present" to **25 subsystems correctly attributed**; `cpu_cores` is honestly unattributed (cross-platform ambiguous) with exactly its two candidates pruned; the absent list is exactly the samplers with no metrics in the recording.

## Follow-up filed separately
- `gpu_apple`'s metrics attribute as `unattributed` even on labeled recordings (its `stats` module is a sibling, not descendant, of the module registered for attribution). Agent-side fix; also closes the drift guard's remaining blind spot.

## Test plan
- [x] 96 attribution/coverage-related tests incl. 5 adversarial regression tests (infer-gate blocking, label-beats-gate, cpu_cores ambiguity, exact candidate-set pruning, BPF-set-not-rusage)
- [x] Table + candidate sets independently re-harvested during review from all sampler stats declarations
- [x] Full suite green (413); clippy/fmt clean; golden unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)