### PR TITLE
fix(scheduler): exclude the idle task from runqueue timing (#1035)

### DIFF
--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -26,6 +26,7 @@
 // counter positions
 #define IVCSW 0
 #define RUNQ_WAIT 1
+#define DISCARDED 2
 
 // counters (see constants defined at top)
 struct {
@@ -175,7 +176,7 @@ static __always_inline int account__sched_switch(u64* ctx) {
     struct task_struct* prev = (struct task_struct*)ctx[1];
     struct task_struct* next = (struct task_struct*)ctx[2];
 
-    u32 pid, idx;
+    u32 idx;
     // prev and next can belong to different cgroups; track each separately so
     // runqueue wait and off-cpu time are never charged to prev's cgroup.
     // MAX_CGROUPS is the "no attribution" sentinel.
@@ -185,6 +186,19 @@ static __always_inline int account__sched_switch(u64* ctx) {
 
     u32 processor_id = bpf_get_smp_processor_id();
     u64 ts = bpf_ktime_get_ns();
+
+    // The idle task (pid 0) is not a runqueue participant: it never waits to be
+    // scheduled, and unlike a real task its slot in the per-pid arrays below is
+    // shared by every CPU. Tracking it fabricates runqueue wait for the root
+    // cgroup, and because `ts` is sampled here but consumed further down, it
+    // lets a remote CPU publish a newer timestamp into slot 0 mid-handler --
+    // making `ts - *tsp` underflow into the top histogram bucket. Measured on a
+    // 32-core host: 65% of the writes below were the idle task, and the top
+    // bucket accrued 59-189 samples/s while the machine was otherwise idle.
+    // `trace_enqueue()` already skips pid 0 on the wakeup path; skipping it here
+    // keeps the switch path consistent with it.
+    u32 prev_pid = BPF_CORE_READ(prev, pid);
+    u32 next_pid = BPF_CORE_READ(next, pid);
 
     // read the prev task cgroup details and push to ringbuf if new cgroup
     void* prev_task_group = BPF_CORE_READ(prev, sched_task_group);
@@ -221,29 +235,34 @@ static __always_inline int account__sched_switch(u64* ctx) {
             array_incr(&cgroup_ivcsw, prev_cgroup_id);
         }
 
-        pid = BPF_CORE_READ(prev, pid);
+        if (prev_pid) {
+            bpf_map_update_elem(&enqueued_at, &prev_pid, &ts, 0);
 
-        bpf_map_update_elem(&enqueued_at, &pid, &ts, 0);
+            tsp = bpf_map_lookup_elem(&running_at, &prev_pid);
+            if (tsp && *tsp) {
+                // A timestamp pair can arrive out of order across CPUs; an
+                // unguarded subtraction would wrap to ~2^64 and land in the top
+                // bucket. Discard instead, and count it so the condition stays
+                // observable rather than silently vanishing.
+                if (ts >= *tsp) {
+                    histogram_incr(&running, HISTOGRAM_POWER, ts - *tsp);
+                } else {
+                    array_incr(&counters, COUNTER_GROUP_WIDTH * processor_id + DISCARDED);
+                }
 
-        tsp = bpf_map_lookup_elem(&running_at, &pid);
-        if (tsp && *tsp) {
-            delta_ns = ts - *tsp;
-
-            histogram_incr(&running, HISTOGRAM_POWER, delta_ns);
-
-            *tsp = 0;
+                *tsp = 0;
+            }
         }
     }
 
     // for all tasks: track when it went off-cpu
-    pid = BPF_CORE_READ(prev, pid);
-
-    bpf_map_update_elem(&offcpu_at, &pid, &ts, 0);
+    if (prev_pid) {
+        bpf_map_update_elem(&offcpu_at, &prev_pid, &ts, 0);
+    }
 
     // next task has moved into running
     // - update next->pid running_at with now
     // - calculate how long next task was enqueued, update hist
-    pid = BPF_CORE_READ(next, pid);
 
     // read the next task cgroup details and push to ringbuf if new cgroup
     void* next_task_group = BPF_CORE_READ(next, sched_task_group);
@@ -265,40 +284,52 @@ static __always_inline int account__sched_switch(u64* ctx) {
         }
     }
 
-    bpf_map_update_elem(&running_at, &pid, &ts, 0);
+    if (next_pid) {
+        bpf_map_update_elem(&running_at, &next_pid, &ts, 0);
 
-    tsp = bpf_map_lookup_elem(&enqueued_at, &pid);
-    if (tsp && *tsp) {
-        delta_ns = ts - *tsp;
-
-        histogram_incr(&runqlat, HISTOGRAM_POWER, delta_ns);
-
-        idx = COUNTER_GROUP_WIDTH * processor_id + RUNQ_WAIT;
-        array_add(&counters, idx, delta_ns);
-
-        if (next_cgroup_id < MAX_CGROUPS) {
-            array_add(&cgroup_runq_wait, next_cgroup_id, delta_ns);
-        }
-
-        *tsp = 0;
-
-        // calculate how long it was off-cpu, not including runqueue wait,
-        // and increment stats
-        tsp = bpf_map_lookup_elem(&offcpu_at, &pid);
+        tsp = bpf_map_lookup_elem(&enqueued_at, &next_pid);
         if (tsp && *tsp) {
-            offcpu_ns = ts - *tsp;
+            if (ts >= *tsp) {
+                delta_ns = ts - *tsp;
 
-            if (offcpu_ns > delta_ns) {
-                offcpu_ns = offcpu_ns - delta_ns;
+                histogram_incr(&runqlat, HISTOGRAM_POWER, delta_ns);
 
-                histogram_incr(&offcpu, HISTOGRAM_POWER, offcpu_ns);
+                idx = COUNTER_GROUP_WIDTH * processor_id + RUNQ_WAIT;
+                array_add(&counters, idx, delta_ns);
 
                 if (next_cgroup_id < MAX_CGROUPS) {
-                    array_add(&cgroup_offcpu, next_cgroup_id, offcpu_ns);
+                    array_add(&cgroup_runq_wait, next_cgroup_id, delta_ns);
                 }
-            }
 
-            *tsp = 0;
+                *tsp = 0;
+
+                // calculate how long it was off-cpu, not including runqueue wait,
+                // and increment stats
+                tsp = bpf_map_lookup_elem(&offcpu_at, &next_pid);
+                if (tsp && *tsp) {
+                    if (ts >= *tsp) {
+                        offcpu_ns = ts - *tsp;
+
+                        if (offcpu_ns > delta_ns) {
+                            offcpu_ns = offcpu_ns - delta_ns;
+
+                            histogram_incr(&offcpu, HISTOGRAM_POWER, offcpu_ns);
+
+                            if (next_cgroup_id < MAX_CGROUPS) {
+                                array_add(&cgroup_offcpu, next_cgroup_id, offcpu_ns);
+                            }
+                        }
+                    } else {
+                        array_incr(&counters, COUNTER_GROUP_WIDTH * processor_id + DISCARDED);
+                    }
+
+                    *tsp = 0;
+                }
+            } else {
+                array_incr(&counters, COUNTER_GROUP_WIDTH * processor_id + DISCARDED);
+
+                *tsp = 0;
+            }
         }
     }
 

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -42,7 +42,11 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let counters = vec![&SCHEDULER_IVCSW, &SCHEDULER_RUNQUEUE_WAIT];
+    let counters = vec![
+        &SCHEDULER_IVCSW,
+        &SCHEDULER_RUNQUEUE_WAIT,
+        &SCHEDULER_DISCARDED,
+    ];
 
     let bpf = BpfBuilder::new(
         &config,

--- a/src/agent/samplers/scheduler/linux/runqueue/stats.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/stats.rs
@@ -61,6 +61,12 @@ pub static SCHEDULER_IVCSW: WindowedCounterGroup = WindowedCounterGroup::new(MAX
 )]
 pub static SCHEDULER_RUNQUEUE_WAIT: WindowedCounterGroup = WindowedCounterGroup::new(MAX_CPUS);
 
+#[metric(
+    name = "scheduler_discarded_samples",
+    description = "The number of scheduler timing samples discarded because the two timestamps arrived out of order across CPUs, which would otherwise underflow into the top histogram bucket"
+)]
+pub static SCHEDULER_DISCARDED: WindowedCounterGroup = WindowedCounterGroup::new(MAX_CPUS);
+
 /*
  * per-cgroup
  */

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -206,6 +206,7 @@ pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
     ("rezolus_memory_page_reclaims", "rezolus_rusage"),
     ("rezolus_memory_usage_resident_set_size", "rezolus_rusage"),
     ("scheduler_context_switch", "scheduler_runqueue"),
+    ("scheduler_discarded_samples", "scheduler_runqueue"),
     ("scheduler_offcpu", "scheduler_runqueue"),
     ("scheduler_running", "scheduler_runqueue"),
     ("softirq", "cpu_usage"),


### PR DESCRIPTION
Fixes #1035.

## Root cause

The runqueue sampler tracked the **idle task (pid 0)** in its per-pid timing arrays.

`get_task_state(swapper)` is always `TASK_RUNNING`, so:

- `mod.bpf.c:226` — every **idle→busy** switch wrote `enqueued_at[0]`.
- `mod.bpf.c:270` — every **busy→idle** switch read it back and charged `ts - *tsp` into `runqlat`, the per-CPU `RUNQ_WAIT` counter, and `cgroup_runq_wait`.

Unlike a real task's slot, **slot 0 is shared by every CPU**. `ts` is sampled at the top of the handler but consumed further down, so a remote CPU can publish a newer timestamp into slot 0 within that window — making `ts - *tsp` underflow to ~2^64 and land in the top histogram bucket.

That also explains the load correlation the issue found puzzling: the rate tracks **idle→busy transition frequency**, so it is *higher* on an idle machine and collapses under saturation (the issue measured 3.4/s idle vs 2.7/s busy). Generic clock skew predicts the opposite, since it would scale with context-switch rate.

`trace_enqueue()` already guarded `if (!pid) return 0;` — inherited from BCC's runqslower. The `sched_switch` path added later did not. That inconsistency is the bug.

## Change

- Skip pid 0 in the three timing paths (`enqueued_at`, `offcpu_at`, `running_at`), restoring consistency with `trace_enqueue()`.
- Guard all three delta computations against out-of-order timestamp pairs instead of letting them wrap.
- Add `scheduler_discarded_samples` (new `DISCARDED` slot in the existing counter group — `COUNTER_GROUP_WIDTH` is 8, so no width change) so a discard is observable rather than silent.
- Hoist the repeated `BPF_CORE_READ(prev/next, pid)` reads (3 → 2).

## Verification

32-core EPYC, bare metal, kernel 6.12. Interleaved A/B, **the serving build asserted via `/metrics/descriptions` before each run** (an earlier attempt was invalidated by a stale agent holding the port — every run had actually measured the same binary).

| build | top bucket/s | max occupied bucket |
|---|---|---|
| stock1 | 72.3 | 495 |
| stock2 | 138.9 | 495 |
| **fixed1** | **0.0** | **192** |
| **fixed2** | **0.0** | **200** |

Both stock runs carry the garbage, both fixed runs are clean, across a ~7x spread in background load. After the fix `scheduler_discarded_samples` stays at 0 on this host — the shared pid-0 slot accounted for *all* out-of-order pairs here, and the guard remains as defense-in-depth for the real-PID races a virtualized host is likelier to hit.

Independent confirmation of the mechanism, via a bpftrace program replicating the handler's logic: **170,700 of 263,939** "preempted while runnable" writes in 10s (**65%**) were the idle task, and 147 deltas underflowed to ~2^64 in that window.

### Overhead (principle 16)

`rezolus_bpf_run_time / run_count` for `scheduler_runqueue`, 8-spinner steady load, 30s windows:

| run | ns/run |
|---|---|
| STOCK-1 | 481.5 |
| STOCK-2 | 519.2 |
| **FIXED-1** | **406.8** |
| **FIXED-2** | **434.8** |

~500 → ~421 ns/run (**~16% cheaper**), both fixed runs below both stock runs. Expected: the pid-0 path did a map update, a lookup and a histogram increment on 65% of switches, and those are now skipped.

## Notes for review

- **The counters escaped visible corruption only by accident.** Adding ~2^64 to a `u64` wraps to *subtracting* the true small delta, so `scheduler_runqueue_wait` silently under-counted rather than exploding. This is why the counters looked sane while the histogram was visibly wrong.
- **Deliberately out of scope:** the same defect means idle→task switches are counted as *involuntary context switches*, inflating `scheduler_context_switch` by ~65% on an idle host. That changes a shipped metric's values on every host, so it is filed separately rather than folded in here.
- **#1038 is not addressed** and is not fixed by this change. Its 137.7 core-second spike did not reproduce on this host, and the quantitative prediction I derived from this root cause failed against measurement — see my comment there.
