### PR TITLE
feat(scheduler): count voluntary context switches (#1040)

### DIFF
--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -27,6 +27,7 @@
 #define IVCSW 0
 #define RUNQ_WAIT 1
 #define DISCARDED 2
+#define VCSW 3
 
 // counters (see constants defined at top)
 struct {
@@ -132,6 +133,14 @@ struct {
     __type(key, u32);
     __type(value, u64);
     __uint(max_entries, MAX_CGROUPS);
+} cgroup_vcsw SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, MAX_CGROUPS);
 } cgroup_runq_wait SEC(".maps");
 
 struct {
@@ -214,6 +223,7 @@ static __always_inline int account__sched_switch(u64* ctx) {
                 // New cgroup detected, zero the counters
                 u64 zero = 0;
                 bpf_map_update_elem(&cgroup_ivcsw, &prev_cgroup_id, &zero, BPF_ANY);
+                bpf_map_update_elem(&cgroup_vcsw, &prev_cgroup_id, &zero, BPF_ANY);
                 bpf_map_update_elem(&cgroup_runq_wait, &prev_cgroup_id, &zero, BPF_ANY);
                 bpf_map_update_elem(&cgroup_offcpu, &prev_cgroup_id, &zero, BPF_ANY);
             }
@@ -253,6 +263,20 @@ static __always_inline int account__sched_switch(u64* ctx) {
                 *tsp = 0;
             }
         }
+    } else {
+        // prev left the CPU while not runnable, i.e. it blocked: a voluntary
+        // context switch. This mirrors the kernel's own split, which counts
+        // nvcsw when a task deschedules with a non-zero state and nivcsw when
+        // it is preempted while runnable. Emitting both classes is what lets a
+        // consumer tell a blocking wakeup handoff from a true preemption --
+        // with only one class emitted, "no voluntary switches" and "voluntary
+        // switches not measured" are indistinguishable.
+        idx = COUNTER_GROUP_WIDTH * processor_id + VCSW;
+        array_incr(&counters, idx);
+
+        if (prev_cgroup_id < MAX_CGROUPS) {
+            array_incr(&cgroup_vcsw, prev_cgroup_id);
+        }
     }
 
     // for all tasks: track when it went off-cpu
@@ -278,6 +302,7 @@ static __always_inline int account__sched_switch(u64* ctx) {
                 // New cgroup detected, zero the counters
                 u64 zero = 0;
                 bpf_map_update_elem(&cgroup_ivcsw, &next_cgroup_id, &zero, BPF_ANY);
+                bpf_map_update_elem(&cgroup_vcsw, &next_cgroup_id, &zero, BPF_ANY);
                 bpf_map_update_elem(&cgroup_runq_wait, &next_cgroup_id, &zero, BPF_ANY);
                 bpf_map_update_elem(&cgroup_offcpu, &next_cgroup_id, &zero, BPF_ANY);
             }

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.rs
@@ -8,6 +8,7 @@
 //! * `scheduler/running`
 //! * `scheduler/offcpu`
 //! * `scheduler/context_switch/involuntary`
+//! * `scheduler/context_switch/voluntary`
 
 const NAME: &str = "scheduler_runqueue";
 
@@ -29,6 +30,7 @@ impl_cgroup_info!(bpf::types::cgroup_info);
 
 static CGROUP_METRICS: &[&dyn GroupMetadata] = &[
     &CGROUP_SCHEDULER_IVCSW,
+    &CGROUP_SCHEDULER_VCSW,
     &CGROUP_SCHEDULER_OFFCPU,
     &CGROUP_SCHEDULER_RUNQUEUE_WAIT,
 ];
@@ -42,10 +44,12 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
+    // order must match the counter positions in mod.bpf.c
     let counters = vec![
         &SCHEDULER_IVCSW,
         &SCHEDULER_RUNQUEUE_WAIT,
         &SCHEDULER_DISCARDED,
+        &SCHEDULER_VCSW,
     ];
 
     let bpf = BpfBuilder::new(
@@ -64,6 +68,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .packed_counters("cgroup_runq_wait", &CGROUP_SCHEDULER_RUNQUEUE_WAIT)
     .packed_counters("cgroup_offcpu", &CGROUP_SCHEDULER_OFFCPU)
     .packed_counters("cgroup_ivcsw", &CGROUP_SCHEDULER_IVCSW)
+    .packed_counters("cgroup_vcsw", &CGROUP_SCHEDULER_VCSW)
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .disabled_programs(if kernel_has_btf() {
         &[
@@ -100,6 +105,7 @@ impl SkelExt for ModSkel<'_> {
             "cgroup_runq_wait" => &self.maps.cgroup_runq_wait,
             "cgroup_offcpu" => &self.maps.cgroup_offcpu,
             "cgroup_ivcsw" => &self.maps.cgroup_ivcsw,
+            "cgroup_vcsw" => &self.maps.cgroup_vcsw,
             "cgroup_info" => &self.maps.cgroup_info,
             _ => unimplemented!(),
         }

--- a/src/agent/samplers/scheduler/linux/runqueue/stats.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/stats.rs
@@ -55,6 +55,13 @@ pub static SCHEDULER_OFFCPU: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GR
 pub static SCHEDULER_IVCSW: WindowedCounterGroup = WindowedCounterGroup::new(MAX_CPUS);
 
 #[metric(
+    name = "scheduler_context_switch",
+    description = "The number of voluntary context switches, where a task left the CPU because it blocked",
+    metadata = { kind = "voluntary" }
+)]
+pub static SCHEDULER_VCSW: WindowedCounterGroup = WindowedCounterGroup::new(MAX_CPUS);
+
+#[metric(
     name = "scheduler_runqueue_wait",
     description = "Tracks time spent in the runqueue on a per-CPU basis",
     metadata = { unit = "nanoseconds" }
@@ -91,3 +98,10 @@ pub static CGROUP_SCHEDULER_OFFCPU: CounterGroup = CounterGroup::new(MAX_CGROUPS
     metadata = { kind = "involuntary" }
 )]
 pub static CGROUP_SCHEDULER_IVCSW: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_scheduler_context_switch",
+    description = "The number of voluntary context switches on a per-cgroup basis, where a task left the CPU because it blocked",
+    metadata = { kind = "voluntary" }
+)]
+pub static CGROUP_SCHEDULER_VCSW: CounterGroup = CounterGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
Closes #1040.

> **Stacked on #1045.** This branch contains that commit as its base because both edit the same `if (get_task_state(prev) == TASK_RUNNING)` block. Review the second commit, or merge #1045 first and this will reduce to it.

## Change

A voluntary switch is exactly the complement of the branch the handler already takes: `prev` left the CPU while **not** runnable, i.e. it blocked. The tracepoint is already hooked, the task-state read is already done, and the kernel-version portability that makes that read awkward is already handled — only the increment on the else-branch was missing.

This mirrors the kernel's own split (`nvcsw` when a task deschedules with a non-zero state, `nivcsw` when preempted while runnable).

- `VCSW` added to the existing counter group. `COUNTER_GROUP_WIDTH` is 8 and slots 0–2 were in use, so no width change.
- `cgroup_vcsw` map alongside `cgroup_ivcsw`, zeroed in the same two new-cgroup paths.
- `SCHEDULER_VCSW` / `CGROUP_SCHEDULER_VCSW` registered with `metadata = { kind = "voluntary" }`, mirroring the involuntary metrics — same metric name, distinguished by label, as the issue suggested.

## Verification

32-core EPYC, bare metal, kernel 6.12.

Every `sched_switch` lands in exactly one branch, so `voluntary + involuntary` must reconcile with the kernel's own total switch count in `/proc/stat` `ctxt`. That is a falsifiable check on both the classification and the counting:

| workload | ctxt/s (kernel) | vol/s | invol/s | vol% | **sum vs kernel** |
|---|---|---|---|---|---|
| idle | 36,121 | 9,552 | 26,476 | 26.5 | **−0.26%** |
| pipe ping-pong | 546,801 | 272,581 | 274,198 | 49.9 | **−0.00%** |
| oversubscribed spin (64 on 32) | 205,378 | 10,242 | 195,830 | 5.0 | **+0.34%** |

It reconciles in every regime, and it discriminates exactly what the issue needed: blocking wakeup handoffs read as 49.9% voluntary, true preemption as 5.0%.

### Overhead (principle 16)

`rezolus_bpf_run_time / run_count` for `scheduler_runqueue`, 8-spinner steady load, 30s windows:

| build | ns/run |
|---|---|
| base (#1045) | 595.6, 522.1 |
| with VCSW | 548.3, 596.5 |

Fully overlapping ranges — within run-to-run noise, as expected for one `array_incr` on a branch that previously did no counting. Background load varied 125k–412k runs/s across those runs, which is what drives the spread; I'm reporting this as "no measurable regression" rather than claiming a direction.

## Note on the involuntary side

The 49.9/50.1 split on the ping-pong is not what you'd expect from a pure blocking workload — it should be nearly all voluntary. That's #1046: idle→task switches are counted as involuntary because `get_task_state(swapper)` is always `TASK_RUNNING`. So this PR makes the voluntary class correct and available, but the involuntary class stays inflated until #1046 lands. Worth knowing when reading the numbers above.
