### PR TITLE
fix(cpu): conserve CPU time of exited tasks (#1037)

### DIFF
--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -29,6 +29,7 @@
 // the offsets to use in the `counters` group
 #define USER_OFFSET 0
 #define SYSTEM_OFFSET 1
+#define EXITED_OFFSET 2
 
 // the offsets to use in the `softirqs` group
 #define HI 0
@@ -191,6 +192,15 @@ struct {
     __uint(max_entries, MAX_CGROUPS);
 } cgroup_system SEC(".maps");
 
+// per-cgroup CPU time belonging to tasks that have since exited
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, MAX_CGROUPS);
+} cgroup_exited SEC(".maps");
+
 /**
  * handle_new_task - Check if task is new/reused and send info to userspace
  * @task: The task_struct to check
@@ -326,6 +336,7 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, struct task_struct* task, u32 index
         u64 zero = 0;
         bpf_map_update_elem(&cgroup_user, &cgroup_id, &zero, BPF_ANY);
         bpf_map_update_elem(&cgroup_system, &cgroup_id, &zero, BPF_ANY);
+        bpf_map_update_elem(&cgroup_exited, &cgroup_id, &zero, BPF_ANY);
     }
 
     if (delta_utime > 0) {
@@ -346,6 +357,31 @@ static __always_inline int account__sched_process_exit(u64* ctx) {
     u32 pid = BPF_CORE_READ(task, pid);
     if (pid == 0 || pid >= MAX_PID)
         return 0;
+
+    // Fold this task's total into the exited-task aggregates before dropping it.
+    // The per-task counter and its metadata are released together below, so
+    // without this the time is simply gone: the cgroup and host totals still
+    // include it, but no per-task series accounts for it, and a consumer cannot
+    // tell how much of the task view is missing. These aggregates let the books
+    // be reconciled -- sum(live tasks) + exited ~= cgroup total -- at O(1) cost
+    // and with no additional cardinality.
+    u64* usage = bpf_map_lookup_elem(&task_cpu_usage, &pid);
+    if (usage && *usage) {
+        u32 cpu = bpf_get_smp_processor_id();
+
+        if (cpu < MAX_CPUS) {
+            array_add(&cpu_usage, CPU_USAGE_GROUP_WIDTH * cpu + EXITED_OFFSET, *usage);
+        }
+
+        struct task_group* tg = BPF_CORE_READ(task, sched_task_group);
+        if (tg) {
+            int cgroup_id = BPF_CORE_READ(tg, css.id);
+
+            if (cgroup_id > 0 && cgroup_id < MAX_CGROUPS) {
+                array_add(&cgroup_exited, cgroup_id, *usage);
+            }
+        }
+    }
 
     // Zero the exported counter FIRST to prevent exporting values without metadata
     u64 zero = 0;

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -37,7 +37,11 @@ impl_cgroup_info!(bpf::types::cgroup_info);
 unsafe impl plain::Plain for bpf::types::task_info {}
 unsafe impl plain::Plain for bpf::types::task_exit {}
 
-static CGROUP_METRICS: &[&dyn GroupMetadata] = &[&CGROUP_CPU_USAGE_USER, &CGROUP_CPU_USAGE_SYSTEM];
+static CGROUP_METRICS: &[&dyn GroupMetadata] = &[
+    &CGROUP_CPU_USAGE_USER,
+    &CGROUP_CPU_USAGE_SYSTEM,
+    &CGROUP_CPU_USAGE_EXITED,
+];
 static TASK_METRICS: &[&dyn GroupMetadata] = &[&TASK_CPU_USAGE];
 
 fn handle_cgroup_info(data: &[u8]) -> i32 {
@@ -118,7 +122,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let cpu_usage = vec![&CPU_USAGE_USER, &CPU_USAGE_SYSTEM];
+    // order must match the offsets in mod.bpf.c
+    let cpu_usage = vec![&CPU_USAGE_USER, &CPU_USAGE_SYSTEM, &CPU_USAGE_EXITED];
 
     let softirq = vec![
         &SOFTIRQ_HI,
@@ -160,6 +165,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .cpu_counters("softirq_time", softirq_time)
     .packed_counters("cgroup_user", &CGROUP_CPU_USAGE_USER)
     .packed_counters("cgroup_system", &CGROUP_CPU_USAGE_SYSTEM)
+    .packed_counters("cgroup_exited", &CGROUP_CPU_USAGE_EXITED)
     .sparse_packed_counters("task_cpu_usage", &TASK_CPU_USAGE)
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .ringbuf_handler("task_info", handle_task_info)
@@ -191,6 +197,7 @@ impl SkelExt for ModSkel<'_> {
             "cgroup_info" => &self.maps.cgroup_info,
             "cgroup_user" => &self.maps.cgroup_user,
             "cgroup_system" => &self.maps.cgroup_system,
+            "cgroup_exited" => &self.maps.cgroup_exited,
             "cpu_usage" => &self.maps.cpu_usage,
             "softirq" => &self.maps.softirq,
             "softirq_time" => &self.maps.softirq_time,

--- a/src/agent/samplers/cpu/linux/usage/stats.rs
+++ b/src/agent/samplers/cpu/linux/usage/stats.rs
@@ -38,6 +38,16 @@ pub static CPU_USAGE_USER: WindowedCounterGroup = WindowedCounterGroup::new(MAX_
 )]
 pub static CPU_USAGE_SYSTEM: WindowedCounterGroup = WindowedCounterGroup::new(MAX_CPUS);
 
+// Deliberately a distinct metric name rather than another `cpu_usage` state:
+// this time is a *subset* of user+system, not a disjoint category, so exposing
+// it as a third state would double-count any sum across states.
+#[metric(
+    name = "cpu_usage_exited_tasks",
+    description = "The amount of CPU time that was consumed by tasks which have since exited, and so is no longer attributable to any live per-task series",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static CPU_USAGE_EXITED: WindowedCounterGroup = WindowedCounterGroup::new(MAX_CPUS);
+
 /*
  * per-cgroup metrics
  */
@@ -55,6 +65,13 @@ pub static CGROUP_CPU_USAGE_USER: CounterGroup = CounterGroup::new(MAX_CGROUPS);
     metadata = { state = "system", unit = "nanoseconds" }
 )]
 pub static CGROUP_CPU_USAGE_SYSTEM: CounterGroup = CounterGroup::new(MAX_CGROUPS);
+
+#[metric(
+    name = "cgroup_cpu_usage_exited_tasks",
+    description = "The amount of CPU time that was consumed by tasks which have since exited, on a per-cgroup basis",
+    metadata = { unit = "nanoseconds" }
+)]
+pub static CGROUP_CPU_USAGE_EXITED: CounterGroup = CounterGroup::new(MAX_CGROUPS);
 
 /*
  * per-task metrics

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -136,6 +136,7 @@ pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
     ("cgroup_cpu_throttled_time", "cpu_bandwidth"),
     ("cgroup_cpu_tlb_flush", "cpu_tlb_flush"),
     ("cgroup_cpu_usage", "cpu_usage"),
+    ("cgroup_cpu_usage_exited_tasks", "cpu_usage"),
     ("cgroup_scheduler_context_switch", "scheduler_runqueue"),
     ("cgroup_scheduler_offcpu", "scheduler_runqueue"),
     ("cgroup_scheduler_runqueue_wait", "scheduler_runqueue"),


### PR DESCRIPTION
Refs #1037.

## What's actually wrong

Per-task attribution is **accurate while a task lives** and loses its **entire total at exit**.

Measured on a 32-core EPYC (bare metal, kernel 6.12) — a `taskset`-pinned single-core burner, rezolus vs the kernel's own `utime+stime`:

```
kernel_ticks=102   rezolus_ns=1028000000
kernel_ticks=990   rezolus_ns=9920000000
kernel_ticks=2948  rezolus_ns=29500000000    <- 29.48s vs 29.500s, ~0.07%
--- killed ---
kernel_ticks=gone  rezolus_ns=absent
```

No drip-loss during the run. The whole total disappears in one step at exit, because `mod.bpf.c:352` zeroes the exported counter in `sched_process_exit` at the same moment `handle_task_exit()` calls `clear_metadata(pid)` — value and labels are released together.

**The mechanism suspected in the issue does not exist.** There is no bounded task table and no slot eviction: `task_cpu_usage` is a full `MAX_PID` array, and `sparse_packed_counters` is a bare alias for `packed_counters` with no cap. The issue's suggested fix ("preserve accumulated time across slot churn") has nothing to attach to.

This explains both original observations exactly: instantaneous samples read a full core because the live counter is correct, while any window mean or rate spanning the exit collapses toward zero; and an 8-thread burner that exits before a scrape lands never appears at all.

## Why it matters more here than for a live exporter

A vanishing series is normal for live per-process metrics. But rezolus recordings are analyzed **after the fact**, so every short-lived task — build jobs, request handlers, anything exiting inside the capture — contributes CPU time that is invisible in the task view while still counted in the cgroup and host totals. The two views silently disagree with no indication which is short.

## Approach

The zeroing is deliberate (the comment at `:350` gives the reason, and it's a real constraint). Rather than change the retention lifecycle — which would keep dead-task cardinality alive for up to a scrape interval, unbounded under fork churn — this **folds the task's total into exited-task aggregates before dropping it**, so the books reconcile:

```
sum(live task_cpu_usage) + cpu_usage_exited_tasks  ~=  cgroup/host total
```

O(1) per exit, no added cardinality.

`cpu_usage_exited_tasks` and `cgroup_cpu_usage_exited_tasks` are deliberately **distinct metric names**, not a third `cpu_usage` state: this time is a *subset* of user+system, not a disjoint category, so exposing it as a state would double-count any sum across states.

## Verification

| | |
|---|---|
| last live per-task value | 20.108 s |
| exited aggregate before kill | 5.995 s |
| exited aggregate after kill | 26.195 s |
| **delta** | **20.200 s** |

The aggregate gains 20.200s where the per-task series loses 20.108s; the 92ms difference is CPU consumed between the final sample and the actual exit. The host baseline also climbs steadily from other short-lived tasks exiting (0.36s → 5.99s over 20s), including a **+4.6 core-second** step that was previously invisible entirely.

Full Linux test suite: 480 passed, 0 failed.

### Overhead (principle 16)

`rezolus_bpf_run_time / run_count` for `cpu_usage`, 8-spinner steady load, 30s windows:

| build | ns/run |
|---|---|
| stock | 193.2, 210.4 |
| with change | 224.8, 255.3 |

A rise of roughly 30–45 ns/run on this measure. Worth review attention, but note what it is measuring: the added work (one map lookup plus up to two `array_add`s) happens **only in `sched_process_exit`**, never in the `cpuacct_account_field` hot path that dominates this sampler's run count. Both programs' runs are pooled into one `run_time`/`run_count` pair, so an exit-path cost is averaged across all runs rather than isolated. The absolute cost stays ~0.4% of one core on a 32-core host.

## Scope note

This satisfies the issue's own fallback ("emit a counter so consumers know attribution is partial") and makes the totals reconcile. It deliberately does **not** restore the ability to *name* a short-lived hog after it exits — that needs deferred metadata release, which is a lifecycle change with real cardinality cost and should be decided separately.
