### PR TITLE
fix(bpf): stop publishing perf counters that never measured anything

### DIFF
--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -32,17 +32,77 @@ pub struct PerfEvent {
 pub struct PerfCounter {
     counter: perf_event::Counter,
     group: &'static CounterGroup,
+    /// `(time_enabled, time_running)` from the previous read, used to notice a
+    /// counter that stops advancing while still enabled.
+    prev: Option<(u64, u64)>,
+    /// Whether we have already reported this counter as not measuring, so the
+    /// condition is announced once rather than on every refresh.
+    reported: bool,
+}
+
+/// What a single perf counter read means.
+///
+/// The counters are opened requesting `TOTAL_TIME_ENABLED` and
+/// `TOTAL_TIME_RUNNING`; this is the rule for turning those into a decision.
+/// Kept as a pure function because the interesting inputs -- a PMU that is
+/// advertised but does not count, an event that dies mid-flight -- cannot be
+/// produced on demand on real hardware, but are trivial to express as values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PerfRead {
+    /// The event was never placed on the PMU since it was enabled. A `pinned`
+    /// event that cannot be scheduled goes to `PERF_EVENT_STATE_ERROR` and
+    /// reads a frozen value forever, so publishing it would present "no free
+    /// PMU counter" as a measurement of zero.
+    NeverRan,
+    /// The event was placed at some point but has stopped advancing while still
+    /// enabled -- it died after having worked. The value is still a true count
+    /// of what was observed, so it is published, but the condition is worth
+    /// surfacing because the series has silently gone flat.
+    Stalled(u64),
+    /// A live measurement.
+    Live(u64),
+}
+
+/// Classify one perf counter read. Pure; see [`PerfRead`].
+///
+/// Note these are *lifetime* totals, not per-interval deltas, and the value is
+/// published as an absolute cumulative counter. That is precisely why no
+/// multiplex scaling is applied here: the correction factor would be the
+/// lifetime ratio `time_enabled / time_running`, so an event that froze would
+/// have a numerator that keeps growing and a denominator that does not, and the
+/// published value would climb forever off a dead counter -- fabricating a
+/// steady rate out of nothing. Scaling is right for a bounded `perf stat`
+/// window; it is wrong for a monotonic published counter.
+pub fn classify_perf_read(
+    count: u64,
+    time_enabled: u64,
+    time_running: u64,
+    prev: Option<(u64, u64)>,
+) -> PerfRead {
+    if time_running == 0 {
+        return PerfRead::NeverRan;
+    }
+
+    if let Some((prev_enabled, prev_running)) = prev {
+        if time_running == prev_running && time_enabled > prev_enabled {
+            return PerfRead::Stalled(count);
+        }
+    }
+
+    PerfRead::Live(count)
 }
 
 pub struct CpuPerfCounters {
     cpu: usize,
+    name: &'static str,
     counters: Vec<PerfCounter>,
 }
 
 impl CpuPerfCounters {
-    pub fn new(cpu: usize) -> Self {
+    pub fn new(cpu: usize, name: &'static str) -> Self {
         Self {
             cpu,
+            name,
             counters: Vec::new(),
         }
     }
@@ -52,33 +112,79 @@ impl CpuPerfCounters {
         counter: perf_event::Counter,
         group: &'static CounterGroup,
     ) -> &mut Self {
-        self.counters.push(PerfCounter { counter, group });
+        self.counters.push(PerfCounter {
+            counter,
+            group,
+            prev: None,
+            reported: false,
+        });
 
         self
     }
 
     pub fn refresh(&mut self) {
         for c in self.counters.iter_mut() {
-            if let Ok(value) = c.counter.read() {
-                let _ = c.group.set(self.cpu, value);
+            // Read the scheduling info the counter was built to report, rather
+            // than discarding it. Without it, a counter that never got a PMU
+            // slot is indistinguishable from one that legitimately measured
+            // zero.
+            let Ok(cat) = c.counter.read_count_and_time() else {
+                continue;
+            };
+
+            let verdict = classify_perf_read(cat.count, cat.time_enabled, cat.time_running, c.prev);
+            c.prev = Some((cat.time_enabled, cat.time_running));
+
+            match verdict {
+                PerfRead::NeverRan => {
+                    if !c.reported {
+                        c.reported = true;
+                        crate::agent::sampler_status::note_perf_unavailable(
+                            self.name,
+                            "hardware counters were never scheduled onto the PMU \
+                             (time_running = 0); no free counter, or no usable PMU",
+                        );
+                    }
+                }
+                PerfRead::Stalled(value) => {
+                    if !c.reported {
+                        c.reported = true;
+                        crate::agent::sampler_status::note_perf_unavailable(
+                            self.name,
+                            "hardware counters stopped advancing while still enabled; \
+                             the counter was descheduled and its series has gone flat",
+                        );
+                    }
+
+                    let _ = c.group.set(self.cpu, value);
+                }
+                PerfRead::Live(value) => {
+                    let _ = c.group.set(self.cpu, value);
+                }
             }
         }
     }
 }
 
 pub struct PerfCounters {
+    name: &'static str,
     inner: HashMap<usize, CpuPerfCounters>,
 }
 
 impl PerfCounters {
-    pub fn new() -> Self {
+    pub fn new(name: &'static str) -> Self {
         Self {
+            name,
             inner: HashMap::new(),
         }
     }
 
     pub fn push(&mut self, cpu: usize, counter: perf_event::Counter, group: &'static CounterGroup) {
-        let counters = self.inner.entry(cpu).or_insert(CpuPerfCounters::new(cpu));
+        let name = self.name;
+        let counters = self
+            .inner
+            .entry(cpu)
+            .or_insert(CpuPerfCounters::new(cpu, name));
         counters.push(counter, group);
     }
 
@@ -521,7 +627,7 @@ where
                 self.perf_events.len()
             );
 
-            let mut perf_counters = PerfCounters::new();
+            let mut perf_counters = PerfCounters::new(self.name);
 
             for (name, event, group) in self.perf_events.into_iter() {
                 let map = skel.map(name);
@@ -849,5 +955,75 @@ where
             );
         }
         self
+    }
+}
+
+#[cfg(test)]
+mod perf_read_tests {
+    use super::{classify_perf_read, PerfRead};
+
+    /// A working counter on a healthy PMU: fully scheduled for the whole
+    /// window. Measured shape on bare metal (Threadripper 1950X): count 3.5e9,
+    /// time_enabled == time_running.
+    #[test]
+    fn fully_scheduled_counter_is_live() {
+        assert_eq!(
+            classify_perf_read(3_500_068_433, 986_862_857, 986_862_857, None),
+            PerfRead::Live(3_500_068_433)
+        );
+    }
+
+    /// A `pinned` event that could not be placed. Measured shape for `cycles`
+    /// on both a KVM guest and bare metal: everything zero. Publishing this
+    /// would present "no free PMU counter" as a real measurement of zero.
+    #[test]
+    fn never_scheduled_counter_is_suppressed() {
+        assert_eq!(classify_perf_read(0, 0, 0, None), PerfRead::NeverRan);
+    }
+
+    /// time_running == 0 means never placed even if the event was enabled for a
+    /// long time and somehow carries a non-zero count.
+    #[test]
+    fn enabled_but_never_running_is_suppressed() {
+        assert_eq!(
+            classify_perf_read(1234, 1_000_000_000, 0, None),
+            PerfRead::NeverRan
+        );
+    }
+
+    /// A counter that worked and then died: time_enabled keeps advancing while
+    /// time_running is frozen. The count is still true, so it is published, but
+    /// the condition is reported.
+    #[test]
+    fn counter_that_stops_advancing_is_stalled() {
+        let prev = Some((1_000_000_000, 1_000_000_000));
+        assert_eq!(
+            classify_perf_read(42, 2_000_000_000, 1_000_000_000, prev),
+            PerfRead::Stalled(42)
+        );
+    }
+
+    /// Both clocks advancing is the normal case and must not be mistaken for a
+    /// stall, including when the count itself does not move (a genuinely idle
+    /// CPU retires nothing but the counter is still measuring).
+    #[test]
+    fn idle_but_scheduled_counter_is_live_not_stalled() {
+        let prev = Some((1_000_000_000, 1_000_000_000));
+        assert_eq!(
+            classify_perf_read(7, 2_000_000_000, 2_000_000_000, prev),
+            PerfRead::Live(7)
+        );
+    }
+
+    /// A guest whose PMU is advertised but does not count reports itself fully
+    /// scheduled while retiring 395 instructions per second. This rule cannot
+    /// detect that -- it is recorded here so the limitation is explicit rather
+    /// than assumed covered. Detecting it needs a busy-time reference (#1036).
+    #[test]
+    fn fake_vpmu_is_not_detected_by_time_alone() {
+        assert_eq!(
+            classify_perf_read(395, 1_027_487_719, 1_027_487_719, None),
+            PerfRead::Live(395)
+        );
     }
 }

--- a/src/agent/sampler_status.rs
+++ b/src/agent/sampler_status.rs
@@ -123,6 +123,50 @@ pub fn set_active_if_absent(name: &'static str) {
         });
 }
 
+/// Record that a sampler's hardware perf counters are not measuring.
+///
+/// Unlike a probe attach, this is only discoverable at read time -- a counter
+/// that never got a PMU slot, or that stopped advancing after having worked,
+/// looks identical to a healthy one until its `time_running` is inspected. The
+/// perf read threads call this once per affected counter so the condition
+/// reaches `/samplers` instead of only a log line, letting a consumer tell
+/// *not measured* from a genuine zero.
+///
+/// Idempotent per sampler: repeated calls refresh the reason rather than
+/// accumulating entries.
+///
+/// Called from the BPF builder's perf read threads (Linux-only); on other
+/// platforms it is exercised only by unit tests, so suppress the dead-code lint
+/// there, matching `classify_program`/`rollup_health` above.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn note_perf_unavailable(name: &'static str, reason: &str) {
+    let mut registry = registry().lock().unwrap();
+
+    let entry = registry.entry(name).or_insert_with(|| SamplerStatus {
+        name: name.to_string(),
+        state: SamplerState::Active,
+        health: None,
+        programs: Vec::new(),
+    });
+
+    if let Some(existing) = entry.programs.iter_mut().find(|p| p.name == "pmu") {
+        existing.error = Some(reason.to_string());
+    } else {
+        entry.programs.push(ProgramStatus {
+            name: "pmu".to_string(),
+            attached: false,
+            error: Some(reason.to_string()),
+            intent: None,
+            label: Some("hardware perf counters".to_string()),
+            expected: true,
+            verdict: ProbeVerdict::Unsupported,
+        });
+    }
+
+    let verdicts: Vec<ProbeVerdict> = entry.programs.iter().map(|p| p.verdict).collect();
+    entry.health = Some(rollup_health(true, &verdicts));
+}
+
 /// Snapshot of all sampler statuses, sorted by name (BTreeMap order).
 pub fn snapshot() -> Vec<SamplerStatus> {
     registry().lock().unwrap().values().cloned().collect()


### PR DESCRIPTION
Refs #1036. **Does not close it** — see "What this does not fix".

## Problem

The perf counters are built requesting `TOTAL_TIME_ENABLED | TOTAL_TIME_RUNNING` (`builder.rs`), and then the read path throws both away:

```rust
if let Ok(value) = c.counter.read() {
    let _ = c.group.set(self.cpu, value);
}
```

So a counter that never got a PMU slot is indistinguishable from one that legitimately measured zero, and a counter that died mid-flight is indistinguishable from an idle CPU.

Measured with a probe replicating the exact counter configuration (`one_cpu`, `any_pid`, `exclude_hv(false)`, `exclude_kernel(false)`, `pinned(true)`), on a KVM guest and bare metal of the **same CPU model** (Threadripper 1950X):

```
baremetal  instructions raw=3500068433  enabled=986862857   running=986862857
guest      instructions raw=395         enabled=1027487719  running=1027487719
both       cycles       raw=0           enabled=0           running=0
```

The `cycles` row is what this PR fixes. A `pinned` event that cannot be placed goes to `PERF_EVENT_STATE_ERROR` and reads a frozen value forever — and note it happened **on bare metal too**, not only under virtualization. `perf stat` on that same host independently reports `<not counted> instructions (0.00%)`. This is not exotic: `cpu_perf`, `cpu_branch`, `cpu_l3` and `cpu_dtlb` each open their own pinned events, so on a host with few free general-purpose counters several can land in this state at once.

## Change

Read via `read_count_and_time()` and classify with a pure function:

| condition | meaning | action |
|---|---|---|
| `time_running == 0` | never placed since enable | **don't publish** |
| `time_running` frozen while `time_enabled` advances | died after having worked | publish (the count is true), **report** |
| otherwise | live | publish |

The condition is surfaced on `/samplers` via `note_perf_unavailable()` rather than only as a log line, so a consumer can distinguish *not measured* from a genuine zero.

## Why there is deliberately no multiplex scaling

Scaling by `time_enabled / time_running` is the standard treatment and the crate's own docs suggest it, but it is **wrong here**, and would have introduced a worse bug than the one being fixed.

These are **lifetime totals**, published as **absolute cumulative counters** that consumers difference downstream. So the correction factor is a lifetime ratio. Consider a pinned event that works for an hour and then errors out: `count` and `time_running` freeze while `time_enabled` keeps growing, so `count · enabled/running` **keeps climbing off a dead counter** — manufacturing a steady non-zero rate from nothing. That is the same class of artifact as the fabricated values fixed in #1045.

Scaling is correct for a bounded `perf stat` window; it is not correct for a monotonic published counter.

It is also mostly moot in practice: because the events are `pinned`, the kernel either places them or errors them rather than round-robining. Both hosts showed exactly that binary behaviour — `running == enabled` exactly, or both zero — with no partial multiplexing observed.

## Verification

- **6 unit tests** on the classification rule, using the real measured shapes above. This is the point of extracting it: a fake vPMU and a mid-flight death cannot be produced on demand on real hardware, but are trivial as values.
- **Full suite on Linux: 486 passed, 0 failed.** (These tests do not run on macOS — `builder.rs` is Linux-gated — so a local macOS run reports 0 of them.)
- **Healthy path unaffected on a 32-core EPYC:** `cpu_perf` stays `healthy` with no `pmu` entry, and `cpu_instructions` reads 134.87e9/s under load — physically plausible, versus the 2.6k/s in the issue.

## What this does not fix

The guest above reports `time_running == time_enabled` — fully scheduled — while retiring **395 instructions/s**. **No rule based on timing alone can detect that**, so the headline symptom in #1036 is still unaddressed. `fake_vpmu_is_not_detected_by_time_alone` asserts that limitation explicitly rather than leaving it assumed covered.

Catching it needs a plausibility check against a busy-time reference (e.g. `cpu_usage` for the same CPU). I tried a self-contained startup probe first and it was wrong — a task-scoped counter gets starved by the CPU-wide pinned events rezolus itself opens, so it declared a healthy bare-metal PMU broken. That dead end and the constraints a correct design must satisfy are written up on #1036.
