### PR TITLE
fix(scheduler): exclude idle task from involuntary switches (#1046)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.11"
+version = "5.17.1-alpha.12"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.11"
+version = "5.17.1-alpha.12"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
+++ b/src/agent/samplers/scheduler/linux/runqueue/mod.bpf.c
@@ -238,14 +238,22 @@ static __always_inline int account__sched_switch(u64* ctx) {
     // - update prev->pid enqueued_at with now
     // - calculate how long prev task was running and update hist
     if (get_task_state(prev) == TASK_RUNNING) {
-        idx = COUNTER_GROUP_WIDTH * processor_id + IVCSW;
-        array_incr(&counters, idx);
-
-        if (prev_cgroup_id < MAX_CGROUPS) {
-            array_incr(&cgroup_ivcsw, prev_cgroup_id);
-        }
-
+        // The idle task is always TASK_RUNNING, so a CPU simply waking up to run
+        // something counted as an involuntary context switch -- nothing was
+        // competing for the CPU, and no task was preempted. The inflation is
+        // load-dependent and largest exactly where a high context-switch rate is
+        // most likely to be misread as contention: on a 32-core host it was 65%
+        // of such switches when otherwise idle, and ~30% under load. The idle
+        // task is excluded here for the same reason it is excluded from the
+        // timing paths below.
         if (prev_pid) {
+            idx = COUNTER_GROUP_WIDTH * processor_id + IVCSW;
+            array_incr(&counters, idx);
+
+            if (prev_cgroup_id < MAX_CGROUPS) {
+                array_incr(&cgroup_ivcsw, prev_cgroup_id);
+            }
+
             bpf_map_update_elem(&enqueued_at, &prev_pid, &ts, 0);
 
             tsp = bpf_map_lookup_elem(&running_at, &prev_pid);

--- a/src/agent/samplers/scheduler/linux/runqueue/stats.rs
+++ b/src/agent/samplers/scheduler/linux/runqueue/stats.rs
@@ -49,7 +49,7 @@ pub static SCHEDULER_OFFCPU: RwLockHistogram = RwLockHistogram::new(HISTOGRAM_GR
 
 #[metric(
     name = "scheduler_context_switch",
-    description = "The number of involuntary context switches",
+    description = "The number of involuntary context switches, where a runnable task was preempted. Switches away from the idle task are excluded, since nothing was competing for the CPU",
     metadata = { kind = "involuntary" }
 )]
 pub static SCHEDULER_IVCSW: WindowedCounterGroup = WindowedCounterGroup::new(MAX_CPUS);
@@ -94,7 +94,7 @@ pub static CGROUP_SCHEDULER_OFFCPU: CounterGroup = CounterGroup::new(MAX_CGROUPS
 
 #[metric(
     name = "cgroup_scheduler_context_switch",
-    description = "The number of involuntary context switches on a per-cgroup basis",
+    description = "The number of involuntary context switches on a per-cgroup basis, where a runnable task was preempted. Switches away from the idle task are excluded, since nothing was competing for the CPU",
     metadata = { kind = "involuntary" }
 )]
 pub static CGROUP_SCHEDULER_IVCSW: CounterGroup = CounterGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
## Summary

Fixes #1046.

- The idle task is always `TASK_RUNNING`, so every time a CPU left idle to run a real task, `scheduler_context_switch{kind="involuntary"}` counted it as a preemption — and `cgroup_scheduler_context_switch` charged it to the root cgroup. Nothing was competing for the CPU; the CPU just woke up.
- Moves the `IVCSW` / `cgroup_ivcsw` increments inside the existing `prev_pid` guard, the same way #1045 excludes the idle task from the timing paths. The change is a pure subset of what was counted before, and removes work from the hot path rather than adding it.
- Updates the involuntary descriptions (host + cgroup) to state the exclusion, since the metric's meaning changes.

**This changes the values of a shipped metric on every host** — involuntary counts drop by the idle→task switch rate. The inflation being removed is load-dependent: 65% of reported involuntary switches on an otherwise idle 32-core host, ~30% on the same host under load. Worth a release note.

## Verification

The idle task always takes the `TASK_RUNNING` branch (it is never blocked), so its switches are now counted in *neither* class. That gives a falsifiable prediction: #1040's identity must break by **exactly** the idle-task switch count.

```
ctxt - (voluntary + involuntary) == count(sched_switch where prev_pid == 0)
```

Measured on a 32-core EPYC (bare metal, kernel 6.12) over 120s windows, reconciling rezolus against `/proc/stat ctxt` with an independent `bpftrace` count:

| build | Δctxt | gap = ctxt − (vol+invol) | bpftrace `@idle_prev` | agreement |
|---|---|---|---|---|
| clean main `cd270ded` | 17,619,025 | 4,257 | 1,554,732 | gap ≈ 0 — idle counted, as expected |
| this branch | 6,864,263 | 1,525,654 | 1,527,543 | **−0.12%** |
| this branch | 32,458,279 | 1,433,842 | 1,435,058 | **−0.08%** |

Holds across a 4.7× spread in load, so it is not a load-specific coincidence.

Cross-check on the middle run: reconstructing main's involuntary as `3,656,271 + 1,527,543 = 5,183,814` gives `voluntary + that` = 6,866,152 vs ctxt 6,864,263 → **+0.03%**. The change removes exactly the idle→task switches and nothing else.

On clean main the same harness reproduces #1040's identity to **−0.02%**, so the baseline it is measured against is sound.

Every run carries a self-check — bpftrace's total `sched_switch` count vs the `/proc/stat ctxt` delta, all within 0.29% — so a misaligned measurement window cannot masquerade as a result.

## Test plan

- [x] `cargo build --release` on Linux (kernel 6.12, clang 19)
- [x] `cargo test --bin rezolus` on Linux — 492 passed, 0 failed (the attribution guard and perf_read tests are Linux-gated). No `METRIC_SAMPLERS` entry needed; no new metric names.
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo xtask fmt` — no diff
- [x] Reconciliation against `/proc/stat` + bpftrace, three runs, table above
- [x] Confirmed no consumer depends on the old `vol+invol == ctxt` identity — the dashboards just `sum(irate(scheduler_context_switch[...]))`

## Note

The involuntary description added here is not currently observable via `/metrics/descriptions`, which collapses metrics sharing a name and publishes only the first — filed as #1056. The description is still correct at the definition site and will surface once that is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
