### PR TITLE
feat(parquet): add `convert` for raw msgpack recordings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,12 @@ target/release/rezolus parquet metadata -i file.parquet --json      # JSON outpu
 target/release/rezolus parquet metadata -i file.parquet --field source
 target/release/rezolus parquet annotate file.parquet                # add service extension KPIs
 target/release/rezolus parquet annotate file.parquet --queries ext.json
+target/release/rezolus parquet convert rezolus.raw.zst               # raw msgpack -> parquet (writes rezolus.parquet)
+target/release/rezolus parquet convert rezolus.raw -o out.parquet --interval 250ms
+target/release/rezolus parquet convert rezolus.raw --systeminfo sysinfo.json --descriptions help.json
+# convert auto-detects zstd by magic bytes; interval is inferred from snapshot
+# timestamps unless --interval is given; -m/--metadata key=value tags the file;
+# --force overwrites an existing output. Raw input only (not .rez, not parquet).
 target/release/rezolus parquet combine a.parquet b.parquet -o combined.parquet       # row-merge multi-source
 target/release/rezolus parquet combine a.parquet b.parquet --ab baseline=redis experiment=valkey -o out.parquet.ab.tar  # A/B tarball (values are source names)
 target/release/rezolus parquet filter file.parquet -o slim.parquet   # drop columns not needed by KPIs
@@ -112,7 +118,7 @@ The binary operates in seven modes via subcommands:
 4. **Hindsight** (`src/hindsight/`) - Maintains rolling ring buffer on disk for post-incident snapshots.
 5. **Viewer** (`src/viewer/`) - Web dashboard with PromQL query engine and TSDB (from `metriken-query` crate). Supports parquet files, `.rez` archives (a 2-recording `.rez` renders as an A/B baseline/experiment comparison, >2 shows the first two), live agent connections, and upload-only mode. Generates service KPI dashboards from `ServiceExtension` metadata.
 6. **MCP** (`src/mcp/`) - AI analysis tools (anomaly detection, correlation, PromQL queries, feature extraction). Runs as stdio server or one-shot CLI commands. `query` prints acquisition-window uncertainty bands `[lo, hi]` beside `rate()`/`irate()` values (scalar ops scale the band; series-op-series and non-rate queries show none). `extract-features` emits a deterministic, versioned overview record (JSON) summarizing a recording's Rezolus-native features.
-7. **Parquet** (`src/parquet_tools/`) - File operations: `metadata` (inspect; on a `.rez`, describes the manifest), `annotate` (add service extension KPIs; on a `.rez`, `--queries` embeds them into each recording's manifest), `combine` (merge multi-source files, build an A/B tarball, or assemble single-recording `.rez` into a multi-recording `.rez`), `filter` (drop columns not needed by KPIs; on a `.rez`, `--samplers` drops whole per-sampler tables). All four accept `.rez` inputs.
+7. **Parquet** (`src/parquet_tools/`) - File operations: `metadata` (inspect; on a `.rez`, describes the manifest), `annotate` (add service extension KPIs; on a `.rez`, `--queries` embeds them into each recording's manifest), `combine` (merge multi-source files, build an A/B tarball, or assemble single-recording `.rez` into a multi-recording `.rez`), `filter` (drop columns not needed by KPIs; on a `.rez`, `--samplers` drops whole per-sampler tables), `convert` (raw msgpack recording, plain or zstd, into parquet — the offline complement to `record -f raw`). Those four accept `.rez` inputs; `convert` takes raw input only and emits parquet only.
 
 ### Sampler Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.12"
+version = "5.17.1-alpha.13"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "walkdir",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ syscall-numbers = "4.0.3"
 sysconf = "0.3.4"
 tempfile = "3.27.0"
 thiserror.workspace = true
+# Direct dep for `parquet convert`'s zstd-compressed raw input. Already in the
+# graph via parquet's `zstd` feature, so this costs no extra build time.
+zstd = "0.13.3"
 tokio = { version = "1.52.2", features = [
     "fs",
     "io-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.12"
+version = "5.17.1-alpha.13"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/README.md
+++ b/README.md
@@ -295,13 +295,15 @@ rezolus parquet convert rezolus.raw.zst              # writes rezolus.parquet
 rezolus parquet filter rezolus.parquet -o slim.parquet
 ```
 
-`convert` infers the sampling interval from the snapshot timestamps; pass
-`--interval` to override it. A raw recording carries no `systeminfo` or metric
-descriptions — the recorder fetches those from the agent's HTTP endpoints while
-recording — so supply them with `--systeminfo` / `--descriptions` if you saved
-them, or attach them afterwards with `parquet annotate`. A `.rez` archive cannot
-be produced from a raw recording: it needs the per-sampler cadence and
-acquisition windows that a raw snapshot stream never carried.
+`convert` infers the sampling interval from the median gap between snapshot
+timestamps; pass `--interval` to override it. A raw recording carries no
+`systeminfo` or metric descriptions — the recorder fetches those from the
+agent's `/systeminfo` and `/metrics/descriptions` endpoints while recording — so
+supply them with `--systeminfo` / `--descriptions` if you saved them. Afterwards
+`parquet annotate --systeminfo` can still add the hardware summary, but there is
+no annotate route for descriptions. A `.rez` archive cannot be produced from a
+raw recording: it needs the per-sampler cadence and acquisition windows that a
+raw snapshot stream never carried.
 
 ### MCP Server
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ File operations for parquet recordings:
 - **Combine** — merge a Rezolus parquet with service-level parquet files,
   joining on timestamps to produce a unified multi-source recording, or package
   two captures as an A/B tarball for the viewer's compare mode.
+- **Convert** — turn a raw msgpack recording (from `record -f raw`) into
+  parquet. The input may be plain or zstd-compressed; which one it is is
+  detected from the file's contents, not its name.
 - **Filter** — drop metric columns not referenced by a file's service extension
   KPIs, shrinking the recording.
 
@@ -288,8 +291,17 @@ File operations for parquet recordings:
 rezolus parquet metadata -i rezolus.parquet
 rezolus parquet annotate rezolus.parquet --queries ext.json
 rezolus parquet combine rezolus.parquet service.parquet -o combined.parquet
+rezolus parquet convert rezolus.raw.zst              # writes rezolus.parquet
 rezolus parquet filter rezolus.parquet -o slim.parquet
 ```
+
+`convert` infers the sampling interval from the snapshot timestamps; pass
+`--interval` to override it. A raw recording carries no `systeminfo` or metric
+descriptions — the recorder fetches those from the agent's HTTP endpoints while
+recording — so supply them with `--systeminfo` / `--descriptions` if you saved
+them, or attach them afterwards with `parquet annotate`. A `.rez` archive cannot
+be produced from a raw recording: it needs the per-sampler cadence and
+acquisition windows that a raw snapshot stream never carried.
 
 ### MCP Server
 
@@ -411,6 +423,7 @@ target/release/rezolus view http://localhost:4241
 # parquet file operations
 target/release/rezolus parquet metadata -i rezolus.parquet
 target/release/rezolus parquet combine rezolus.parquet service.parquet -o combined.parquet
+target/release/rezolus parquet convert rezolus.raw.zst
 ```
 
 To rebuild the browser-only static viewer (`site/viewer/`) that ships the PromQL

--- a/README.md
+++ b/README.md
@@ -296,7 +296,9 @@ rezolus parquet filter rezolus.parquet -o slim.parquet
 ```
 
 `convert` infers the sampling interval from the median gap between snapshot
-timestamps; pass `--interval` to override it. A raw recording carries no
+timestamps; pass `--interval` to override it. It warns on stderr (without
+failing) when the sampled gaps have no dominant cadence, or when they are closer
+together than the whole milliseconds `sampling_interval_ms` can hold. A raw recording carries no
 `systeminfo` or metric descriptions — the recorder fetches those from the
 agent's `/systeminfo` and `/metrics/descriptions` endpoints while recording — so
 supply them with `--systeminfo` / `--descriptions` if you saved them. Afterwards

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -179,11 +179,18 @@ Source: [simple-capture viewer](journal/2026-07-03-simple-capture-viewer.md).
 
 Source: [per-source descriptions](journal/2026-07-04-per-source-descriptions.md).
 
-- **Backfill descriptions on a parquet lacking `# HELP`** — Open (optional). A
+- **Backfill descriptions on a parquet lacking `# HELP`** — Open. A
   Prometheus capture whose exporter emits no `# HELP` has blank descriptions
   (nothing to harvest at record time). A `parquet annotate --descriptions name=text`
   path could backfill the footer `descriptions` key after the fact. *Reopen:* if
   blank-description foreign captures become a recurring annoyance.
+  **Second motivation (2026-08-13):** `parquet convert` gave raw recordings the
+  same gap, and harder — `annotate` already takes `--systeminfo`, so a converted
+  file can get its hardware summary back, but descriptions have no annotate route
+  at all. The only recovery is a full `--force` reconvert of the original raw
+  input, which is a poor trade for one footer key. Making `annotate` accept
+  `--descriptions` (file or `name=text`) closes both cases at once; scoped as its
+  own PR, deliberately kept out of the `convert` change.
 - Per-source-not-per-node descriptions, and "descriptions only exist if the origin
   supplied them," are **by design** — not backlog.
 

--- a/docs/parquet-convert-design.md
+++ b/docs/parquet-convert-design.md
@@ -1,6 +1,10 @@
 # `rezolus parquet convert` — raw recordings to parquet
 
-Status: **Design approved 2026-08-13. Not yet implemented.**
+Status: **Implemented 2026-08-13** in `src/parquet_tools/convert.rs` (38 unit
+tests). Two things changed during implementation, both noted inline below:
+`--metadata` rejects a malformed argument instead of dropping it the way
+`record` does, and the output's permissions are reset after the staged temp
+file is persisted.
 
 ## The problem
 
@@ -74,6 +78,12 @@ saved alongside it.
 --metadata`. `source=rezolus` is stamped unless `--metadata source=…` overrides
 it.
 
+*Divergence from `record` (implementation):* `record` parses these with
+`filter_map` and silently drops an argument it cannot split on `=`. `convert`
+rejects it instead. Quietly producing a recording that is missing the label you
+asked for is worse than refusing to start, and unlike a live recording there is
+nothing lost by exiting — the input is still there to retry against.
+
 ## Structure
 
 New module `src/parquet_tools/convert.rs`, registered in `mod.rs` the way the
@@ -146,7 +156,16 @@ the other `parquet` subcommands:
   object of string→string)
 - decompression or write failure, including ENOSPC on the temp file
 
-A partial output file is never left behind on failure.
+A partial output file is never left behind on failure: the parquet is written to
+a temp file in the output directory and renamed into place only on success.
+
+*Found in verification (implementation):* staging through `NamedTempFile` also
+carried its 0600 mode onto the output, so a converted recording was private
+where a recorded one is group-readable. The mode is now reset after `persist` to
+whatever plain file creation yields under the current umask, taken from a
+reference file created in the same directory (the process umask cannot be read
+without temporarily setting it). Covered by
+`output_permissions_match_a_normally_created_file`.
 
 ## Testing
 

--- a/docs/parquet-convert-design.md
+++ b/docs/parquet-convert-design.md
@@ -185,6 +185,59 @@ building `Snapshot::V2(SnapshotV2{…})` values and tempfiles:
 - malformed inputs: truncated mid-stream, and a parquet file as input — both
   exit non-zero with the specific message
 
+## Increment: warning on an implausible inferred interval
+
+Inference always produces a number, and until now it produced it silently. Two
+cases make that number a poor description of the recording, and both are
+invisible in the output file:
+
+**The clamped case.** A median below 1ms cannot be represented by
+`sampling_interval_ms` and is clamped up to 1ms, so every rate computed against
+the file understates the real cadence.
+
+**The irregular case.** When the sampled gaps do not cluster around any single
+value — a recording stitched from two sources, or one full of restart gaps —
+the median is arithmetic rather than meaningful, and no single stamped interval
+describes the file.
+
+`infer_interval` returns `Option<Inferred>`, pairing the interval with an
+optional `IntervalConcern` (`Clamped` or `Irregular`). `Converted` carries the
+concern out to `run`, which prints one `warning:` line to stderr. The conversion
+still succeeds and exits 0: the stamped value is the best available reading, not
+a failure. An explicit `--interval` never warns — the operator asserted it, and
+`interval_millis` already refuses the value it could not represent.
+
+### The irregularity rule
+
+Count the sampled deltas within ±25% of the median; warn when fewer than 60%
+qualify.
+
+Those constants have one job: **not firing on the case the median exists to
+absorb.** `infer_interval` uses a median precisely so a single stalled sample
+does not move the answer, so a rule that then warns about that stall would
+contradict the design it is reporting on. One stall in ten deltas leaves 90%
+inside the band — silent. A recording stitched from a 1s half and a 250ms half
+leaves about 50% — warned. The rule fires when there is no dominant cadence at
+all, which is exactly when any single stamped value misleads.
+
+### Remedies differ, so the two warnings read differently
+
+The irregular warning names `--interval` as the fix. The clamped warning must
+not: `interval_millis` rejects an explicit sub-millisecond value too, so there
+is no value the operator could pass. It states the format limit instead —
+`sampling_interval_ms` holds whole milliseconds, and this recording is faster
+than that. Offering a remedy that the next command refuses would be worse than
+offering none.
+
+### Scope of the verdict
+
+Inference reads only the first `INTERVAL_SAMPLE_SNAPSHOTS` snapshots, so the
+concern describes the sample the interval was drawn from, not the whole file. A
+recording that turns gappy later will not warn. This is deliberate rather than a
+gap to close: the warning is evidence about exactly the data the stamped value
+came from, and widening it to the whole file would mean a full read to produce
+a number that is already only a header-derived estimate.
+
 ## Verification findings (implementation)
 
 The `document-feature` loop (5 blind user-simulations + a fresh-eyes critic per

--- a/docs/parquet-convert-design.md
+++ b/docs/parquet-convert-design.md
@@ -185,6 +185,37 @@ building `Snapshot::V2(SnapshotV2{…})` values and tempfiles:
 - malformed inputs: truncated mid-stream, and a parquet file as input — both
   exit non-zero with the specific message
 
+## Verification findings (implementation)
+
+The `document-feature` loop (5 blind user-simulations + a fresh-eyes critic per
+round, 3 rounds) passed 5/5 blind sims in every round. Two of its findings were
+not documentation problems:
+
+**`-i` collided across sibling subcommands.** `rezolus parquet metadata -i FILE`
+means the *input file*; `convert -i 250ms` meant the *interval*. An agent
+generalizing from one to the other got `expected number at 0` from the duration
+parser, with the required positional also missing. Fixed in the CLI, not the
+prose: `--interval` has no short alias, so `-i` now fails with `unexpected
+argument '-i' found`.
+
+**A sub-millisecond `--interval` stamped zero.** `sampling_interval_ms` holds
+whole milliseconds and `Duration::as_millis` truncates, so `--interval 500us`
+wrote `sampling_interval_ms=0` — a divide-by-nothing for every rate computed
+against the file. The inference path had a `.max(1)` floor; the explicit path
+never did. Now a single `interval_millis` rounds to the nearest millisecond and
+rejects anything below 1ms outright, since rounding 500us up to 1ms would
+understate every rate by half with nothing in the file to say so. Covered by
+`sub_millisecond_interval_is_rejected` and
+`sub_millisecond_precision_rounds_to_the_nearest_millisecond`.
+
+## Deferred
+
+`parquet annotate --descriptions` — a converted recording can get its
+`systeminfo` back via `annotate --systeminfo`, but descriptions have no annotate
+route, so the only recovery is a `--force` reconvert of the original raw input.
+Deliberately out of scope here; tracked in `docs/backlog.md` under
+"Parquet / recorder" alongside the pre-existing Prometheus-`# HELP` case.
+
 ## Documentation
 
 Run the `document-feature` skill after implementation: it writes the `--help`

--- a/docs/parquet-convert-design.md
+++ b/docs/parquet-convert-design.md
@@ -1,0 +1,182 @@
+# `rezolus parquet convert` — raw recordings to parquet
+
+Status: **Design approved 2026-08-13. Not yet implemented.**
+
+## The problem
+
+`rezolus record -f raw` writes concatenated msgpack snapshots. Raw is the right
+choice for a long unattended capture: it costs the recorder nothing at write
+time, and finalization is a byte copy rather than a schema-building conversion
+that scales with run length. Agrippa's `launch_workboat.py` records this way for
+exactly that reason — a multi-hour boat run must not risk losing the recording to
+a SIGKILL during a slow parquet finalize.
+
+The cost is that nothing can read the result. Raw→parquet conversion only exists
+inside `record` and `hindsight` at finalize time, as an internal step. Once a
+raw file is on disk — and in practice zstd-compressed by whatever ships it off
+the boat — the viewer, the MCP tools and `parquet metadata` all reject it. The
+only recovery today is a hand-written program against
+`metriken_exposition::MsgpackToParquet`.
+
+This adds the offline complement to `record -f raw`.
+
+## Non-goals
+
+**No `.rez` output.** A `.rez` archive holds one table per sampler at that
+sampler's own cadence, and every observation carries acquisition-window columns
+(`<m>:window_begin` / `<m>:window_width`) that the query engine consumes to put
+uncertainty bounds on `rate()`. A raw stream is whole-agent snapshots on a
+single recorder clock; the per-sampler cadence and the windows were never in it.
+Synthesizing them would fabricate uncertainty bounds that look measured. If a
+recording needs to be a `.rez`, it has to be recorded as one (`-f rez`).
+
+**No change to `record`.** `record -f raw` stays exactly as it is. This is a
+separate offline command, not a flag on the recorder.
+
+**No streaming conversion.** See "Why compressed input needs a temp file".
+
+## CLI surface
+
+```
+rezolus parquet convert <FILE> [-o OUTPUT] [--interval DUR]
+                               [--systeminfo FILE] [--descriptions FILE]
+                               [--metadata KEY=VALUE]... [--force]
+```
+
+`<FILE>` is a raw recording, plain or zstd-compressed.
+
+**Compression is detected by magic bytes, not by extension.** A recording that
+arrives as `rezolus.raw.zst`, one that is zstd-compressed but named `.raw`, and
+a plain `.raw` all work. Extension-based detection would fail on exactly the
+files that get moved and renamed between machines, which is every file this
+command exists to handle.
+
+**`-o` defaults to the input path** with `.zst` and `.raw` stripped and
+`.parquet` appended: `rezolus.raw.zst` → `rezolus.parquet`. An existing output
+is refused without `--force`, matching `combine` and `filter`.
+
+**`--interval` overrides the stamped `sampling_interval_ms`.** The default is
+*inferred* from the snapshot timestamps, not hardcoded to the recorder's 1s
+default. A recording made at `--interval 250ms` would otherwise be silently
+stamped 1s, and every rate in the viewer would be wrong by 4× with nothing on
+screen to say so. The value used, and whether it was inferred or explicit, is
+logged.
+
+**`--systeminfo FILE` and `--descriptions FILE`** read JSON from a file, or from
+stdin with `-`, mirroring `annotate --systeminfo`. Both are validated as JSON
+before anything is written; `--descriptions` must additionally be an object of
+string→string. These two keys cannot be recovered from a raw file — the recorder
+fetches them from the agent's HTTP endpoints at record time — so the only way to
+get them into a converted recording is for the operator to supply what they
+saved alongside it.
+
+**`--metadata KEY=VALUE`** is repeatable with the same semantics as `record
+--metadata`. `source=rezolus` is stamped unless `--metadata source=…` overrides
+it.
+
+## Structure
+
+New module `src/parquet_tools/convert.rs`, registered in `mod.rs` the way the
+other five subcommands are: a `mod convert;` declaration, a `.subcommand(...)`
+block carrying `long_about` examples, a dispatch arm in the `args.subcommand()`
+match, and a line in the parent `long_about`'s `SUBCOMMANDS:` list.
+
+Four internal units, each testable without the others:
+
+### `sniff(path) -> InputKind`
+
+Reads the first bytes of the file and classifies: zstd (`28 B5 2F FD`), parquet
+(`PAR1`), tar (`ustar` at offset 257), else raw msgpack. Pure classification.
+
+Detecting parquet and tar matters for the error message, not for conversion —
+someone will pass a `.parquet` or a `.rez` to this command, and "input is
+already a parquet file" beats a msgpack parse error forty megabytes in.
+
+### `materialize(path, kind, out_dir) -> impl Read + Seek`
+
+A plain file passes through. A zstd file is decoded through `zstd::Decoder` into
+a `tempfile::NamedTempFile` created in the **output's** directory, then reopened.
+
+*Why compressed input needs a temp file:*
+`MsgpackToParquet::convert_file_handle` takes `Read + Seek` and makes two passes
+— one to build the schema across every snapshot, one to write rows — rewinding
+between them. A zstd stream decoder is not seekable, so the decompressed bytes
+have to exist somewhere. The temp file goes in the output directory rather than
+`/tmp` because the expansion is large (13× on the observed sample: 16 MiB → 220
+MiB) and `/tmp` is frequently a small tmpfs; putting it next to the output means
+if there's room for the result there's room for the intermediate. `NamedTempFile`
+cleans up on drop and on crash.
+
+Adds `zstd = "0.13"` as a direct dependency. It is already in the build graph via
+`parquet`'s `zstd` feature, so this costs no additional compile time.
+
+### `infer_interval(reader) -> Option<Duration>`
+
+Deserializes up to 11 snapshots, takes the **median** of consecutive
+`Snapshot::systemtime()` deltas, rounds to the nearest millisecond, and rewinds.
+Median rather than mean so that one stalled sample — a scheduling hiccup, a slow
+agent scrape — doesn't drag the inferred interval off the real cadence.
+
+Returns `None` for a file with fewer than two snapshots; the caller falls back to
+1s and logs that it did.
+
+### `build_converter(...)`
+
+Assembles the `MsgpackToParquet` with `MAX_ROW_GROUP_SIZE` from
+`parquet_metadata.rs` and the same file-level metadata keys
+`recorder::build_parquet_converter` writes: `sampling_interval_ms`, `source`,
+user `--metadata`, `systeminfo`, `descriptions`.
+
+Deliberately *not* shared with the recorder's function. That one is wired to
+`RecordingConfig` and `EndpointState`; reaching it from here would mean
+constructing a fake endpoint state, which couples the offline path to the
+recording path's types for no benefit. The metadata key list is short and both
+sides are covered by tests that assert the exact keys.
+
+## Error handling
+
+Every failure exits non-zero with an `error: …` line on stderr, consistent with
+the other `parquet` subcommands:
+
+- input is parquet or tar → say which, and that conversion is not needed
+- input is not a recognized recording → say so before the long read
+- truncated or malformed snapshot mid-stream → report the byte offset
+- output exists without `--force`
+- `--systeminfo` / `--descriptions` not valid JSON (or descriptions not an
+  object of string→string)
+- decompression or write failure, including ENOSPC on the temp file
+
+A partial output file is never left behind on failure.
+
+## Testing
+
+Unit tests in the module, following the `annotate.rs` / `filter.rs` pattern of
+building `Snapshot::V2(SnapshotV2{…})` values and tempfiles:
+
+- `sniff` on all four magics, plus a zstd file with no `.zst` extension and a
+  `.zst`-named plain file — extension must not decide the outcome
+- output-path derivation: `x.raw.zst`, `x.raw`, extensionless, explicit `-o`
+  wins, existing output refused without `--force`
+- `infer_interval` at 1s and 250ms, `None` for a single snapshot, and a stream
+  with one jittered gap to pin the median-not-mean behavior
+- end-to-end: synthesize a raw stream with `to_msgpack`, convert both the plain
+  and zstd'd forms, read the footer back, assert `sampling_interval_ms`,
+  `source`, `systeminfo`, `descriptions`, and row count. This is the test that
+  would have caught the seekability problem.
+- malformed inputs: truncated mid-stream, and a parquet file as input — both
+  exit non-zero with the specific message
+
+## Documentation
+
+Run the `document-feature` skill after implementation: it writes the `--help`
+and README text and dispatches a fresh subagent that has never seen the code to
+prove the help is usable on its own.
+
+## Prior art
+
+The one-off that motivated this converted a 20m 24s agrippa recording
+(`rezolus.raw.zst`, 16 MiB → 220 MiB → 8.7 MiB parquet, 1189 columns × 1225
+rows) in 7.6 seconds, using `MsgpackToParquet` with `sampling_interval_ms` and
+`source` stamped by hand. The output reads correctly in `parquet metadata` and
+answers `mcp query 'sum(rate(cpu_usage[1m]))'`. This design is that program plus
+input detection, interval inference, metadata flags, and error handling.

--- a/src/parquet_tools/convert.rs
+++ b/src/parquet_tools/convert.rs
@@ -1,0 +1,1039 @@
+//! `rezolus parquet convert` — turn a raw msgpack recording into parquet.
+//!
+//! `rezolus record -f raw` writes concatenated msgpack snapshots: cheap to
+//! write and cheap to finalize, which is what a long unattended capture needs.
+//! Nothing downstream reads that format, though, so this is the offline
+//! complement — the conversion `record` would have done at finalize time, run
+//! after the fact against a file that has since been moved and compressed.
+//!
+//! See `docs/parquet-convert-design.md`.
+
+use metriken_exposition::{MsgpackToParquet, ParquetOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// What a candidate input file actually is, decided by magic bytes rather than
+/// by extension: these recordings get renamed and re-compressed on their way
+/// off the machine that produced them, so the name is not evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputKind {
+    /// Concatenated msgpack snapshots — what this command converts.
+    RawMsgpack,
+    /// zstd-compressed; decompress before converting.
+    Zstd,
+    /// Already parquet.
+    Parquet,
+    /// A tar archive, most likely a `.rez`.
+    Tar,
+}
+
+/// Classify `path` by its leading bytes.
+fn sniff(path: &Path) -> io::Result<InputKind> {
+    use std::io::Read;
+
+    // 512 is one tar header block, which is the furthest any magic we check
+    // for reaches (`ustar` at offset 257).
+    let mut head = [0u8; 512];
+    let mut f = std::fs::File::open(path)?;
+    let mut filled = 0;
+    while filled < head.len() {
+        match f.read(&mut head[filled..])? {
+            0 => break,
+            n => filled += n,
+        }
+    }
+    let head = &head[..filled];
+
+    Ok(if head.starts_with(&[0x28, 0xb5, 0x2f, 0xfd]) {
+        InputKind::Zstd
+    } else if head.starts_with(b"PAR1") {
+        InputKind::Parquet
+    } else if head.len() >= 262 && &head[257..262] == b"ustar" {
+        InputKind::Tar
+    } else {
+        InputKind::RawMsgpack
+    })
+}
+
+/// Where the parquet lands when `-o` was not given: the input path with a
+/// trailing `.zst` and then a trailing `.raw` removed, and `.parquet` appended.
+/// `rezolus.raw.zst` becomes `rezolus.parquet`.
+fn default_output_path(input: &Path) -> PathBuf {
+    let mut stem = input.to_path_buf();
+    for ext in ["zst", "raw"] {
+        if stem
+            .extension()
+            .is_some_and(|e| e.eq_ignore_ascii_case(ext))
+        {
+            stem = stem.with_extension("");
+        }
+    }
+
+    let mut name = stem.into_os_string();
+    name.push(".parquet");
+    PathBuf::from(name)
+}
+
+/// How many snapshots to read when inferring the interval. Ten deltas is
+/// plenty to find the cadence and costs a few hundred microseconds even on a
+/// multi-gigabyte recording.
+const INTERVAL_SAMPLE_SNAPSHOTS: usize = 11;
+
+/// Infer the recording's sampling interval from the first snapshots'
+/// timestamps, rewinding the reader afterwards.
+///
+/// The recorder stamps `sampling_interval_ms` from its own `--interval`, which
+/// a raw file does not carry. Defaulting to the recorder's 1s default would
+/// silently mislabel a recording made at any other cadence, and every rate in
+/// the viewer would be wrong by that ratio with nothing on screen to say so.
+///
+/// Uses the median delta, not the mean, so one stalled sample — a scheduling
+/// hiccup, a slow scrape — does not drag the answer off the real cadence.
+/// Returns `None` when there are fewer than two snapshots to compare.
+fn infer_interval(reader: &mut (impl io::Read + io::Seek)) -> Option<Duration> {
+    use metriken_exposition::Snapshot;
+
+    let mut times = Vec::with_capacity(INTERVAL_SAMPLE_SNAPSHOTS);
+    {
+        let mut buffered = io::BufReader::new(&mut *reader);
+        while times.len() < INTERVAL_SAMPLE_SNAPSHOTS {
+            // Any error ends the sample: end of stream on a short recording,
+            // or malformed bytes that the conversion pass will report properly.
+            let Ok(snapshot) = rmp_serde::from_read::<_, Snapshot>(&mut buffered) else {
+                break;
+            };
+            times.push(snapshot.systemtime());
+        }
+    }
+    let _ = reader.rewind();
+
+    let mut deltas: Vec<Duration> = times
+        .windows(2)
+        .filter_map(|w| w[1].duration_since(w[0]).ok())
+        .collect();
+    if deltas.is_empty() {
+        return None;
+    }
+
+    deltas.sort_unstable();
+    let median = deltas[deltas.len() / 2];
+
+    // Round to the nearest millisecond, since that is the resolution
+    // `sampling_interval_ms` records. Never round down to zero: a degenerate
+    // interval would make every rate in the viewer divide by nothing.
+    let ms = (median.as_nanos() as f64 / 1e6).round() as u64;
+    Some(Duration::from_millis(ms.max(1)))
+}
+
+/// Everything the conversion needs beyond the two paths.
+#[derive(Debug, Default)]
+pub(crate) struct ConvertOptions {
+    /// Explicit `--interval`; `None` means infer from the snapshots.
+    pub interval: Option<Duration>,
+    /// Validated JSON for the `systeminfo` footer key.
+    pub systeminfo: Option<String>,
+    /// Validated JSON for the `descriptions` footer key.
+    pub descriptions: Option<String>,
+    /// Repeatable `--metadata key=value`, in the order given.
+    pub metadata: Vec<(String, String)>,
+    /// Overwrite an existing output.
+    pub force: bool,
+}
+
+/// What a successful conversion did, for the summary line.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Converted {
+    pub rows: i64,
+    pub interval: Duration,
+    /// False when `--interval` supplied the value.
+    pub interval_inferred: bool,
+}
+
+#[derive(Debug)]
+pub(crate) enum ConvertError {
+    /// The input is already parquet — there is nothing to convert.
+    InputIsParquet,
+    /// The input is a tar archive, most likely a `.rez`.
+    InputIsTar,
+    /// The output exists and `--force` was not given.
+    OutputExists(PathBuf),
+    Io(io::Error),
+    /// The msgpack stream could not be read, or parquet could not be written.
+    Stream(String),
+    /// A `--systeminfo` / `--descriptions` argument was not the JSON it must be.
+    InvalidJson {
+        what: &'static str,
+        detail: String,
+    },
+    /// A `--metadata` argument was not `key=value`.
+    BadMetadata(String),
+}
+
+impl std::fmt::Display for ConvertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InputIsParquet => write!(
+                f,
+                "input is already a parquet file; no conversion is needed"
+            ),
+            Self::InputIsTar => write!(
+                f,
+                "input is a tar archive (a .rez?), not a raw recording; \
+                 a .rez cannot be converted to parquet"
+            ),
+            Self::OutputExists(p) => {
+                write!(f, "output {} already exists (use --force)", p.display())
+            }
+            Self::Io(e) => write!(f, "{e}"),
+            Self::Stream(e) => write!(f, "{e}"),
+            Self::InvalidJson { what, detail } => write!(f, "{what} is not valid: {detail}"),
+            Self::BadMetadata(arg) => {
+                write!(f, "--metadata must be key=value, got {arg:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConvertError {}
+
+impl From<io::Error> for ConvertError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Split one `--metadata key=value` argument.
+///
+/// Unlike `record`, which silently drops an argument it cannot split, a
+/// malformed one is an error here: quietly producing a recording that is
+/// missing the label you asked for is worse than refusing to start.
+fn parse_metadata(arg: &str) -> Result<(String, String), ConvertError> {
+    match arg.split_once('=') {
+        Some((key, value)) if !key.is_empty() => Ok((key.to_string(), value.to_string())),
+        _ => Err(ConvertError::BadMetadata(arg.to_string())),
+    }
+}
+
+/// What a JSON argument has to look like to be accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JsonShape {
+    /// Any JSON value (`systeminfo` is an opaque blob to us).
+    Any,
+    /// An object whose values are all strings (`descriptions` is metric → help).
+    StringMap,
+}
+
+/// Read and validate a JSON argument, from a file or from stdin when `source`
+/// is `-`, mirroring how `annotate --systeminfo` takes its input.
+///
+/// Validation happens before the conversion starts: a typo in a descriptions
+/// file should cost a second, not a full re-read of a multi-gigabyte recording.
+fn load_json(source: &Path, shape: JsonShape, what: &'static str) -> Result<String, ConvertError> {
+    let text = if source.as_os_str() == "-" {
+        let mut buf = String::new();
+        io::Read::read_to_string(&mut io::stdin(), &mut buf)?;
+        buf
+    } else {
+        std::fs::read_to_string(source)?
+    };
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| ConvertError::InvalidJson {
+            what,
+            detail: e.to_string(),
+        })?;
+
+    if shape == JsonShape::StringMap
+        && !parsed
+            .as_object()
+            .is_some_and(|map| map.values().all(serde_json::Value::is_string))
+    {
+        return Err(ConvertError::InvalidJson {
+            what,
+            detail: "expected a JSON object mapping metric names to help strings".to_string(),
+        });
+    }
+
+    // Verbatim, not re-serialized: what the agent captured is what the footer
+    // should carry.
+    Ok(text)
+}
+
+/// The interval stamped when a recording is too short to infer one from.
+/// Matches `record`'s own `--interval` default.
+const FALLBACK_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// Assemble the converter with the file-level metadata keys
+/// `recorder::build_parquet_converter` writes, so a converted recording is
+/// indistinguishable from one `record -f parquet` produced.
+///
+/// `source` is stamped before the user's `--metadata`, which lets
+/// `--metadata source=…` override it — the same precedence `record` gives.
+fn build_converter(interval: Duration, opts: &ConvertOptions) -> MsgpackToParquet {
+    let mut converter = MsgpackToParquet::with_options(
+        ParquetOptions::new().max_batch_size(crate::parquet_metadata::MAX_ROW_GROUP_SIZE),
+    )
+    .metadata(
+        "sampling_interval_ms".to_string(),
+        interval.as_millis().to_string(),
+    )
+    .metadata("source".to_string(), "rezolus".to_string());
+
+    for (key, value) in &opts.metadata {
+        converter = converter.metadata(key.clone(), value.clone());
+    }
+    if let Some(json) = &opts.systeminfo {
+        converter = converter.metadata("systeminfo".to_string(), json.clone());
+    }
+    if let Some(json) = &opts.descriptions {
+        converter = converter.metadata("descriptions".to_string(), json.clone());
+    }
+
+    converter
+}
+
+/// Decompress a zstd input into a temp file beside the output and hand back an
+/// open handle on it.
+///
+/// The bytes have to land on disk because `convert_file_handle` needs `Seek`:
+/// it makes one pass to build the schema across every snapshot and a second to
+/// write rows. A zstd stream decoder cannot rewind.
+///
+/// The temp file goes next to the output rather than in `/tmp` because the
+/// expansion is large — 13x on a sample recording — and `/tmp` is often a small
+/// tmpfs. If there is room for the result there is room for the intermediate.
+fn decompress_beside_output(
+    input: &Path,
+    out_dir: &Path,
+) -> io::Result<(tempfile::NamedTempFile, std::fs::File)> {
+    use io::Seek;
+
+    let tmp = tempfile::NamedTempFile::new_in(out_dir)?;
+    let mut sink = tmp.as_file().try_clone()?;
+    let mut decoder = zstd::Decoder::new(std::fs::File::open(input)?)?;
+    io::copy(&mut decoder, &mut sink)?;
+    io::Write::flush(&mut sink)?;
+
+    let mut handle = tmp.reopen()?;
+    handle.rewind()?;
+    Ok((tmp, handle))
+}
+
+/// Relax the staged file's 0600 to whatever plain file creation yields here.
+///
+/// The conversion stages through a `NamedTempFile`, which is deliberately
+/// private, and `persist` keeps that mode. `record` writes its parquet with
+/// `File::create`, so a converted recording would otherwise be unreadable by
+/// the group that a recorded one is readable by — surprising, and only
+/// discovered by whoever cannot open the file.
+///
+/// The mode is taken from a reference file created in the same directory
+/// rather than by reading the process umask, which cannot be queried without
+/// temporarily setting it.
+#[cfg(unix)]
+fn apply_default_permissions(target: &Path, dir: &Path) -> io::Result<()> {
+    let reference = dir.join(format!(".rezolus-convert-{}.perm", std::process::id()));
+    let mode = {
+        let _f = std::fs::File::create(&reference)?;
+        std::fs::metadata(&reference)?.permissions()
+    };
+    let _ = std::fs::remove_file(&reference);
+
+    std::fs::set_permissions(target, mode)
+}
+
+#[cfg(not(unix))]
+fn apply_default_permissions(_target: &Path, _dir: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+/// Convert a raw recording at `input` into a parquet file at `output`.
+fn convert_file(
+    input: &Path,
+    output: &Path,
+    opts: &ConvertOptions,
+) -> Result<Converted, ConvertError> {
+    use io::Seek;
+
+    if output.exists() && !opts.force {
+        return Err(ConvertError::OutputExists(output.to_path_buf()));
+    }
+
+    match sniff(input)? {
+        InputKind::Parquet => Err(ConvertError::InputIsParquet),
+        InputKind::Tar => Err(ConvertError::InputIsTar),
+        kind => {
+            let out_dir = output
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .unwrap_or(Path::new("."));
+
+            // Held for the duration: dropping it removes the decompressed
+            // intermediate, including on the error paths below.
+            let _scratch;
+            let mut source = if kind == InputKind::Zstd {
+                let (tmp, handle) = decompress_beside_output(input, out_dir)?;
+                _scratch = Some(tmp);
+                handle
+            } else {
+                _scratch = None;
+                std::fs::File::open(input)?
+            };
+
+            let (interval, interval_inferred) = match opts.interval {
+                Some(explicit) => (explicit, false),
+                None => (
+                    infer_interval(&mut source).unwrap_or(FALLBACK_INTERVAL),
+                    true,
+                ),
+            };
+            // `infer_interval` rewinds too, but the conversion is wrong in a
+            // way nothing downstream can see if the handle is mid-stream, so
+            // the failure is checked here rather than assumed away.
+            source.rewind()?;
+
+            // Write through a temp file so a failure part-way leaves no
+            // half-written parquet for the next command to pick up.
+            let staged = tempfile::NamedTempFile::new_in(out_dir)?;
+            let rows = build_converter(interval, opts)
+                .convert_file_handle(source, staged.as_file().try_clone()?)
+                .map_err(|e| ConvertError::Stream(e.to_string()))?;
+            staged
+                .persist(output)
+                .map_err(|e| ConvertError::Io(e.error))?;
+            apply_default_permissions(output, out_dir)?;
+
+            Ok(Converted {
+                rows,
+                interval,
+                interval_inferred,
+            })
+        }
+    }
+}
+
+/// Gather the options from parsed arguments, validating everything that can be
+/// validated before the conversion starts reading.
+fn options_from_args(args: &clap::ArgMatches) -> Result<ConvertOptions, ConvertError> {
+    let metadata = args
+        .get_many::<String>("metadata")
+        .unwrap_or_default()
+        .map(|s| parse_metadata(s))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let systeminfo = args
+        .get_one::<PathBuf>("systeminfo")
+        .map(|p| load_json(p, JsonShape::Any, "systeminfo"))
+        .transpose()?;
+
+    let descriptions = args
+        .get_one::<PathBuf>("descriptions")
+        .map(|p| load_json(p, JsonShape::StringMap, "descriptions"))
+        .transpose()?;
+
+    Ok(ConvertOptions {
+        interval: args.get_one::<humantime::Duration>("interval").map(|d| **d),
+        systeminfo,
+        descriptions,
+        metadata,
+        force: args.get_flag("force"),
+    })
+}
+
+pub(crate) fn run(args: &clap::ArgMatches) {
+    let input = args.get_one::<PathBuf>("FILE").expect("FILE is required");
+    let output = args
+        .get_one::<PathBuf>("output")
+        .cloned()
+        .unwrap_or_else(|| default_output_path(input));
+
+    let result = options_from_args(args).and_then(|opts| {
+        let done = convert_file(input, &output, &opts)?;
+        Ok((done, opts))
+    });
+
+    match result {
+        Ok((done, opts)) => {
+            let how = if done.interval_inferred {
+                "inferred"
+            } else {
+                "given"
+            };
+            println!(
+                "Wrote {} ({} rows, {:?} interval, {how})",
+                output.display(),
+                done.rows,
+                done.interval,
+            );
+            // Say what is missing rather than letting it be discovered in the
+            // viewer as absent help text and a blank hardware summary.
+            let missing: Vec<&str> = [
+                opts.systeminfo.is_none().then_some("systeminfo"),
+                opts.descriptions.is_none().then_some("descriptions"),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            if !missing.is_empty() {
+                println!(
+                    "Note: no {} in the output — a raw recording does not carry {}. \
+                     Supply them with --systeminfo/--descriptions, or add them later \
+                     with `rezolus parquet annotate`.",
+                    missing.join(" or "),
+                    if missing.len() == 1 { "it" } else { "them" },
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Seek, Write};
+
+    /// Write `bytes` to a temp file and classify it.
+    fn sniff_bytes(bytes: &[u8]) -> InputKind {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(bytes).unwrap();
+        f.flush().unwrap();
+        sniff(f.path()).unwrap()
+    }
+
+    /// A minimal well-formed raw stream: one msgpack snapshot.
+    fn raw_bytes() -> Vec<u8> {
+        // The first byte of a V2 snapshot is a msgpack fixarray header.
+        vec![0x96, 0x92, 0xce, 0x6a, 0x7e, 0x0c, 0xc8]
+    }
+
+    #[test]
+    fn sniff_detects_zstd() {
+        assert_eq!(
+            sniff_bytes(&[0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x01]),
+            InputKind::Zstd
+        );
+    }
+
+    #[test]
+    fn sniff_detects_parquet() {
+        assert_eq!(sniff_bytes(b"PAR1\x15\x04"), InputKind::Parquet);
+    }
+
+    #[test]
+    fn sniff_detects_tar() {
+        // `ustar` lives at offset 257 in a tar header block.
+        let mut bytes = vec![0u8; 512];
+        bytes[..8].copy_from_slice(b"manifest");
+        bytes[257..262].copy_from_slice(b"ustar");
+        assert_eq!(sniff_bytes(&bytes), InputKind::Tar);
+    }
+
+    #[test]
+    fn sniff_detects_raw_msgpack() {
+        assert_eq!(sniff_bytes(&raw_bytes()), InputKind::RawMsgpack);
+    }
+
+    #[test]
+    fn sniff_ignores_the_extension() {
+        // A zstd file that was renamed to look plain, and a plain file that was
+        // renamed to look compressed. Both are shaped like the real mistakes
+        // that happen when recordings are copied between machines.
+        let dir = tempfile::tempdir().unwrap();
+
+        let lying_plain = dir.path().join("rezolus.raw");
+        std::fs::write(&lying_plain, [0x28, 0xb5, 0x2f, 0xfd, 0x00]).unwrap();
+        assert_eq!(sniff(&lying_plain).unwrap(), InputKind::Zstd);
+
+        let lying_zst = dir.path().join("rezolus.raw.zst");
+        std::fs::write(&lying_zst, raw_bytes()).unwrap();
+        assert_eq!(sniff(&lying_zst).unwrap(), InputKind::RawMsgpack);
+    }
+
+    #[test]
+    fn default_output_strips_zst_and_raw() {
+        assert_eq!(
+            default_output_path(Path::new("/logs/run7/rezolus.raw.zst")),
+            PathBuf::from("/logs/run7/rezolus.parquet")
+        );
+    }
+
+    #[test]
+    fn default_output_strips_raw_alone() {
+        assert_eq!(
+            default_output_path(Path::new("rezolus.raw")),
+            PathBuf::from("rezolus.parquet")
+        );
+    }
+
+    #[test]
+    fn default_output_appends_to_an_extensionless_name() {
+        assert_eq!(
+            default_output_path(Path::new("capture")),
+            PathBuf::from("capture.parquet")
+        );
+    }
+
+    #[test]
+    fn default_output_keeps_an_unrecognized_extension() {
+        // Only `.zst` and `.raw` are stripped. Anything else is kept, so the
+        // output can never collide with the input we are still reading.
+        assert_eq!(
+            default_output_path(Path::new("capture.msgpack")),
+            PathBuf::from("capture.msgpack.parquet")
+        );
+    }
+
+    /// A raw stream: one msgpack snapshot per timestamp (nanoseconds), each
+    /// carrying a single counter so the stream is shaped like a real one.
+    fn raw_stream(timestamps_ns: &[u64]) -> Vec<u8> {
+        use metriken_exposition::{Counter, Snapshot, SnapshotV2};
+        use std::collections::HashMap;
+        use std::time::SystemTime;
+
+        let mut out = Vec::new();
+        for (i, ts) in timestamps_ns.iter().enumerate() {
+            let snap = Snapshot::V2(SnapshotV2 {
+                systemtime: SystemTime::UNIX_EPOCH + Duration::from_nanos(*ts),
+                duration: Duration::ZERO,
+                metadata: HashMap::new(),
+                counters: vec![Counter::new(
+                    "cpu_cycles".to_string(),
+                    i as u64,
+                    [("metric".to_string(), "cpu_cycles".to_string())]
+                        .into_iter()
+                        .collect(),
+                )],
+                gauges: Vec::new(),
+                histograms: Vec::new(),
+            });
+            out.extend_from_slice(&Snapshot::to_msgpack(&snap).unwrap());
+        }
+        out
+    }
+
+    /// Timestamps `count` apart by `step_ns`, starting at an arbitrary epoch.
+    fn cadence(count: usize, step_ns: u64) -> Vec<u64> {
+        (0..count as u64)
+            .map(|i| 1_786_645_704_000_000_000 + i * step_ns)
+            .collect()
+    }
+
+    #[test]
+    fn infer_interval_finds_one_second() {
+        let mut r = Cursor::new(raw_stream(&cadence(5, 1_000_000_000)));
+        assert_eq!(infer_interval(&mut r), Some(Duration::from_millis(1000)));
+    }
+
+    #[test]
+    fn infer_interval_finds_a_sub_second_cadence() {
+        let mut r = Cursor::new(raw_stream(&cadence(5, 250_000_000)));
+        assert_eq!(infer_interval(&mut r), Some(Duration::from_millis(250)));
+    }
+
+    #[test]
+    fn infer_interval_ignores_a_stalled_sample() {
+        // Deltas of 1s, 1s, 3s, 1s. The mean would say 1.5s; the median says
+        // 1s, which is the cadence the recorder was actually asked for.
+        let base = 1_786_645_704_000_000_000u64;
+        let ts = [
+            base,
+            base + 1_000_000_000,
+            base + 2_000_000_000,
+            base + 5_000_000_000,
+            base + 6_000_000_000,
+        ];
+        let mut r = Cursor::new(raw_stream(&ts));
+        assert_eq!(infer_interval(&mut r), Some(Duration::from_millis(1000)));
+    }
+
+    #[test]
+    fn infer_interval_returns_none_for_a_single_snapshot() {
+        let mut r = Cursor::new(raw_stream(&cadence(1, 1_000_000_000)));
+        assert_eq!(infer_interval(&mut r), None);
+    }
+
+    #[test]
+    fn infer_interval_rewinds_for_the_conversion_pass() {
+        // The converter reads the same handle afterwards and needs every
+        // snapshot, including the ones inference consumed.
+        let bytes = raw_stream(&cadence(3, 1_000_000_000));
+        let mut r = Cursor::new(bytes.clone());
+        infer_interval(&mut r);
+        assert_eq!(r.stream_position().unwrap(), 0);
+    }
+
+    /// File-level metadata of a parquet file, as a lookup.
+    fn footer(path: &Path) -> std::collections::HashMap<String, String> {
+        crate::parquet_tools::read_file_metadata(path)
+            .unwrap()
+            .into_iter()
+            .filter_map(|kv| kv.value.map(|v| (kv.key, v)))
+            .collect()
+    }
+
+    /// Write `bytes` into `dir` as `name`.
+    fn write_input(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    #[test]
+    fn converts_a_plain_raw_recording() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(
+            dir.path(),
+            "rezolus.raw",
+            &raw_stream(&cadence(3, 1_000_000_000)),
+        );
+        let output = dir.path().join("out.parquet");
+
+        let done = convert_file(&input, &output, &ConvertOptions::default()).unwrap();
+
+        assert_eq!(done.rows, 3);
+        assert_eq!(done.interval, Duration::from_millis(1000));
+        assert!(done.interval_inferred);
+
+        let meta = footer(&output);
+        assert_eq!(
+            meta.get("sampling_interval_ms").map(String::as_str),
+            Some("1000")
+        );
+        assert_eq!(meta.get("source").map(String::as_str), Some("rezolus"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn output_permissions_match_a_normally_created_file() {
+        // The conversion stages through a temp file, which is 0600. A recording
+        // that lands unreadable by the group that has to analyze it is a
+        // regression against `record`, which creates its output normally.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(2, 1_000_000_000)));
+        let output = dir.path().join("out.parquet");
+
+        convert_file(&input, &output, &ConvertOptions::default()).unwrap();
+
+        let reference = dir.path().join("reference");
+        std::fs::File::create(&reference).unwrap();
+        let want = std::fs::metadata(&reference).unwrap().permissions().mode() & 0o777;
+        let got = std::fs::metadata(&output).unwrap().permissions().mode() & 0o777;
+
+        assert_eq!(got, want, "expected {want:o}, got {got:o}");
+    }
+
+    #[test]
+    fn converts_a_zstd_compressed_recording() {
+        let dir = tempfile::tempdir().unwrap();
+        let raw = raw_stream(&cadence(4, 1_000_000_000));
+        let input = write_input(
+            dir.path(),
+            "rezolus.raw.zst",
+            &zstd::encode_all(Cursor::new(&raw), 3).unwrap(),
+        );
+        let output = dir.path().join("out.parquet");
+
+        let done = convert_file(&input, &output, &ConvertOptions::default()).unwrap();
+
+        assert_eq!(done.rows, 4);
+        assert_eq!(
+            footer(&output).get("source").map(String::as_str),
+            Some("rezolus")
+        );
+    }
+
+    #[test]
+    fn stamps_systeminfo_descriptions_and_user_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(2, 1_000_000_000)));
+        let output = dir.path().join("out.parquet");
+
+        let opts = ConvertOptions {
+            systeminfo: Some(r#"{"os":"linux"}"#.to_string()),
+            descriptions: Some(r#"{"cpu_cycles":"CPU cycles"}"#.to_string()),
+            metadata: vec![("run".to_string(), "boat-7".to_string())],
+            ..Default::default()
+        };
+        convert_file(&input, &output, &opts).unwrap();
+
+        let meta = footer(&output);
+        assert_eq!(
+            meta.get("systeminfo").map(String::as_str),
+            Some(r#"{"os":"linux"}"#)
+        );
+        assert_eq!(
+            meta.get("descriptions").map(String::as_str),
+            Some(r#"{"cpu_cycles":"CPU cycles"}"#)
+        );
+        assert_eq!(meta.get("run").map(String::as_str), Some("boat-7"));
+    }
+
+    #[test]
+    fn user_metadata_can_override_the_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(2, 1_000_000_000)));
+        let output = dir.path().join("out.parquet");
+
+        let opts = ConvertOptions {
+            metadata: vec![("source".to_string(), "llm-perf".to_string())],
+            ..Default::default()
+        };
+        convert_file(&input, &output, &opts).unwrap();
+
+        let meta = footer(&output);
+        assert_eq!(meta.get("source").map(String::as_str), Some("llm-perf"));
+    }
+
+    #[test]
+    fn explicit_interval_overrides_inference() {
+        let dir = tempfile::tempdir().unwrap();
+        // Snapshots are 1s apart, but the operator says the recording is 5s.
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(3, 1_000_000_000)));
+        let output = dir.path().join("out.parquet");
+
+        let opts = ConvertOptions {
+            interval: Some(Duration::from_millis(5000)),
+            ..Default::default()
+        };
+        let done = convert_file(&input, &output, &opts).unwrap();
+
+        assert_eq!(done.interval, Duration::from_millis(5000));
+        assert!(!done.interval_inferred);
+        assert_eq!(
+            footer(&output)
+                .get("sampling_interval_ms")
+                .map(String::as_str),
+            Some("5000")
+        );
+    }
+
+    #[test]
+    fn single_snapshot_recording_falls_back_to_one_second() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(1, 1_000_000_000)));
+        let output = dir.path().join("out.parquet");
+
+        let done = convert_file(&input, &output, &ConvertOptions::default()).unwrap();
+
+        assert_eq!(done.interval, Duration::from_millis(1000));
+        assert!(done.interval_inferred);
+    }
+
+    #[test]
+    fn refuses_to_overwrite_an_existing_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(2, 1_000_000_000)));
+        let output = write_input(dir.path(), "out.parquet", b"precious");
+
+        let err = convert_file(&input, &output, &ConvertOptions::default()).unwrap_err();
+
+        assert!(matches!(err, ConvertError::OutputExists(_)), "got {err:?}");
+        assert_eq!(std::fs::read(&output).unwrap(), b"precious");
+    }
+
+    #[test]
+    fn force_overwrites_an_existing_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(2, 1_000_000_000)));
+        let output = write_input(dir.path(), "out.parquet", b"stale");
+
+        let opts = ConvertOptions {
+            force: true,
+            ..Default::default()
+        };
+        convert_file(&input, &output, &opts).unwrap();
+
+        assert_eq!(
+            footer(&output).get("source").map(String::as_str),
+            Some("rezolus")
+        );
+    }
+
+    #[test]
+    fn rejects_a_parquet_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "already.parquet", b"PAR1\x00\x00");
+        let err = convert_file(
+            &input,
+            &dir.path().join("out.parquet"),
+            &ConvertOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConvertError::InputIsParquet), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_a_rez_archive_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut tar = vec![0u8; 512];
+        tar[..8].copy_from_slice(b"manifest");
+        tar[257..262].copy_from_slice(b"ustar");
+        let input = write_input(dir.path(), "capture.rez", &tar);
+
+        let err = convert_file(
+            &input,
+            &dir.path().join("out.parquet"),
+            &ConvertOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConvertError::InputIsTar), "got {err:?}");
+    }
+
+    #[test]
+    fn a_truncated_stream_leaves_no_output_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut bytes = raw_stream(&cadence(3, 1_000_000_000));
+        bytes.truncate(bytes.len() - 5);
+        let input = write_input(dir.path(), "cut.raw", &bytes);
+        let output = dir.path().join("out.parquet");
+
+        let err = convert_file(&input, &output, &ConvertOptions::default()).unwrap_err();
+
+        assert!(matches!(err, ConvertError::Stream(_)), "got {err:?}");
+        assert!(
+            !output.exists(),
+            "a failed conversion must not leave a partial parquet behind"
+        );
+    }
+
+    #[test]
+    fn parse_metadata_splits_key_and_value() {
+        assert_eq!(
+            parse_metadata("run=boat-7").unwrap(),
+            ("run".to_string(), "boat-7".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_metadata_splits_on_the_first_equals_only() {
+        // Values legitimately contain '=' — a base64 tag, a query string.
+        assert_eq!(
+            parse_metadata("tag=a=b=c").unwrap(),
+            ("tag".to_string(), "a=b=c".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_metadata_allows_an_empty_value() {
+        assert_eq!(
+            parse_metadata("note=").unwrap(),
+            ("note".to_string(), String::new())
+        );
+    }
+
+    #[test]
+    fn parse_metadata_rejects_a_missing_equals() {
+        let err = parse_metadata("source rezolus").unwrap_err();
+        assert!(matches!(err, ConvertError::BadMetadata(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn parse_metadata_rejects_an_empty_key() {
+        let err = parse_metadata("=value").unwrap_err();
+        assert!(matches!(err, ConvertError::BadMetadata(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn load_json_returns_the_file_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_input(dir.path(), "sysinfo.json", br#"{"os":"linux","cpus":8}"#);
+
+        let got = load_json(&p, JsonShape::Any, "systeminfo").unwrap();
+
+        // Verbatim, not re-serialized: the agent's blob goes into the footer
+        // exactly as it was captured.
+        assert_eq!(got, r#"{"os":"linux","cpus":8}"#);
+    }
+
+    #[test]
+    fn load_json_rejects_malformed_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_input(dir.path(), "sysinfo.json", b"{not json");
+
+        let err = load_json(&p, JsonShape::Any, "systeminfo").unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                ConvertError::InvalidJson {
+                    what: "systeminfo",
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_json_accepts_a_descriptions_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_input(dir.path(), "d.json", br#"{"cpu_cycles":"CPU cycles"}"#);
+        assert!(load_json(&p, JsonShape::StringMap, "descriptions").is_ok());
+    }
+
+    #[test]
+    fn load_json_rejects_descriptions_that_are_not_a_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_input(dir.path(), "d.json", br#"["cpu_cycles"]"#);
+
+        let err = load_json(&p, JsonShape::StringMap, "descriptions").unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                ConvertError::InvalidJson {
+                    what: "descriptions",
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_json_rejects_descriptions_with_non_string_values() {
+        // Valid JSON, wrong shape: the viewer reads these as help text and
+        // would get a number.
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_input(dir.path(), "d.json", br#"{"cpu_cycles":42}"#);
+
+        let err = load_json(&p, JsonShape::StringMap, "descriptions").unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                ConvertError::InvalidJson {
+                    what: "descriptions",
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_json_reports_a_missing_file() {
+        let err = load_json(
+            Path::new("/nonexistent/x.json"),
+            JsonShape::Any,
+            "systeminfo",
+        )
+        .unwrap_err();
+        assert!(matches!(err, ConvertError::Io(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn sniff_reports_a_short_file_as_raw() {
+        // Too short to match any magic. It will fail later as a malformed
+        // snapshot, with a message about the stream rather than about the file
+        // type — sniff's job is only to route.
+        assert_eq!(sniff_bytes(&[0x96]), InputKind::RawMsgpack);
+    }
+}

--- a/src/parquet_tools/convert.rs
+++ b/src/parquet_tools/convert.rs
@@ -168,6 +168,9 @@ pub(crate) enum ConvertError {
     },
     /// A `--metadata` argument was not `key=value`.
     BadMetadata(String),
+    /// An explicit `--interval` below the millisecond resolution the
+    /// `sampling_interval_ms` footer key can represent.
+    IntervalTooSmall(Duration),
 }
 
 impl std::fmt::Display for ConvertError {
@@ -191,6 +194,11 @@ impl std::fmt::Display for ConvertError {
             Self::BadMetadata(arg) => {
                 write!(f, "--metadata must be key=value, got {arg:?}")
             }
+            Self::IntervalTooSmall(d) => write!(
+                f,
+                "--interval {d:?} is below 1ms; sampling_interval_ms records whole \
+                 milliseconds and a sub-millisecond value would be stamped as 0"
+            ),
         }
     }
 }
@@ -270,14 +278,28 @@ const FALLBACK_INTERVAL: Duration = Duration::from_millis(1000);
 ///
 /// `source` is stamped before the user's `--metadata`, which lets
 /// `--metadata source=…` override it — the same precedence `record` gives.
-fn build_converter(interval: Duration, opts: &ConvertOptions) -> MsgpackToParquet {
+/// The value stamped into `sampling_interval_ms`, rounded to the nearest whole
+/// millisecond.
+///
+/// `Duration::as_millis` truncates, which turns 1.5ms into 1ms and — the case
+/// that matters — any sub-millisecond interval into 0. A stamped 0 is worse
+/// than a wrong interval: it is a divide-by-nothing for every rate computed
+/// against the file, so it is refused rather than written.
+fn interval_millis(interval: Duration) -> Result<u64, ConvertError> {
+    // Below 1ms there is no honest answer: rounding 500us up to 1ms would
+    // understate every rate by half, with nothing in the file to say so.
+    if interval < Duration::from_millis(1) {
+        return Err(ConvertError::IntervalTooSmall(interval));
+    }
+
+    Ok((interval.as_nanos() as f64 / 1e6).round() as u64)
+}
+
+fn build_converter(interval_ms: u64, opts: &ConvertOptions) -> MsgpackToParquet {
     let mut converter = MsgpackToParquet::with_options(
         ParquetOptions::new().max_batch_size(crate::parquet_metadata::MAX_ROW_GROUP_SIZE),
     )
-    .metadata(
-        "sampling_interval_ms".to_string(),
-        interval.as_millis().to_string(),
-    )
+    .metadata("sampling_interval_ms".to_string(), interval_ms.to_string())
     .metadata("source".to_string(), "rezolus".to_string());
 
     for (key, value) in &opts.metadata {
@@ -360,6 +382,12 @@ fn convert_file(
         return Err(ConvertError::OutputExists(output.to_path_buf()));
     }
 
+    // Validated before any reading or writing: an unusable --interval should
+    // cost nothing, not a full decompress-and-convert pass.
+    if let Some(explicit) = opts.interval {
+        interval_millis(explicit)?;
+    }
+
     match sniff(input)? {
         InputKind::Parquet => Err(ConvertError::InputIsParquet),
         InputKind::Tar => Err(ConvertError::InputIsTar),
@@ -396,7 +424,7 @@ fn convert_file(
             // Write through a temp file so a failure part-way leaves no
             // half-written parquet for the next command to pick up.
             let staged = tempfile::NamedTempFile::new_in(out_dir)?;
-            let rows = build_converter(interval, opts)
+            let rows = build_converter(interval_millis(interval)?, opts)
                 .convert_file_handle(source, staged.as_file().try_clone()?)
                 .map_err(|e| ConvertError::Stream(e.to_string()))?;
             staged
@@ -811,6 +839,49 @@ mod tests {
                 .get("sampling_interval_ms")
                 .map(String::as_str),
             Some("5000")
+        );
+    }
+
+    #[test]
+    fn sub_millisecond_interval_is_rejected() {
+        // `sampling_interval_ms` holds whole milliseconds, so 500us would be
+        // stamped as 0 and every rate computed against this file would be
+        // divided by a zero interval. Refuse rather than write that.
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(2, 500_000)));
+        let output = dir.path().join("out.parquet");
+
+        let opts = ConvertOptions {
+            interval: Some(Duration::from_micros(500)),
+            ..Default::default()
+        };
+        let err = convert_file(&input, &output, &opts).unwrap_err();
+
+        assert!(
+            matches!(err, ConvertError::IntervalTooSmall(_)),
+            "got {err:?}"
+        );
+        assert!(!output.exists(), "nothing should be written");
+    }
+
+    #[test]
+    fn sub_millisecond_precision_rounds_to_the_nearest_millisecond() {
+        // 1.5ms is representable-ish; truncation would call it 1ms.
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(2, 1_500_000)));
+        let output = dir.path().join("out.parquet");
+
+        let opts = ConvertOptions {
+            interval: Some(Duration::from_micros(1500)),
+            ..Default::default()
+        };
+        convert_file(&input, &output, &opts).unwrap();
+
+        assert_eq!(
+            footer(&output)
+                .get("sampling_interval_ms")
+                .map(String::as_str),
+            Some("2")
         );
     }
 

--- a/src/parquet_tools/convert.rs
+++ b/src/parquet_tools/convert.rs
@@ -80,6 +80,41 @@ fn default_output_path(input: &Path) -> PathBuf {
 /// multi-gigabyte recording.
 const INTERVAL_SAMPLE_SNAPSHOTS: usize = 11;
 
+/// An inferred interval, plus anything about the sample that makes it a poor
+/// description of the recording.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Inferred {
+    pub interval: Duration,
+    pub concern: Option<IntervalConcern>,
+}
+
+/// Why a stamped interval should not be trusted at face value. Both cases are
+/// invisible in the output file, which is why they are reported at conversion.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum IntervalConcern {
+    /// The median was below 1ms and the stamped value was clamped up to it, so
+    /// every rate against this file understates the real cadence.
+    Clamped { median: Duration },
+    /// Too few sampled gaps cluster around the median for it to stand for a
+    /// cadence — a stitched recording, or one full of restart gaps.
+    Irregular {
+        within: usize,
+        of: usize,
+        median: Duration,
+    },
+}
+
+/// How far from the median a gap may fall and still count as on-cadence.
+const CADENCE_TOLERANCE: f64 = 0.25;
+
+/// The fraction of gaps that must be on-cadence for the median to describe the
+/// recording.
+///
+/// With `CADENCE_TOLERANCE`, these two exist to stay silent on the case the
+/// median was chosen to absorb: one stalled sample in ten gaps leaves 90%
+/// on-cadence. Warning there would contradict the inference it reports on.
+const CADENCE_QUORUM: f64 = 0.60;
+
 /// Infer the recording's sampling interval from the first snapshots'
 /// timestamps, rewinding the reader afterwards.
 ///
@@ -91,7 +126,7 @@ const INTERVAL_SAMPLE_SNAPSHOTS: usize = 11;
 /// Uses the median delta, not the mean, so one stalled sample — a scheduling
 /// hiccup, a slow scrape — does not drag the answer off the real cadence.
 /// Returns `None` when there are fewer than two snapshots to compare.
-fn infer_interval(reader: &mut (impl io::Read + io::Seek)) -> Option<Duration> {
+fn infer_interval(reader: &mut (impl io::Read + io::Seek)) -> Option<Inferred> {
     use metriken_exposition::Snapshot;
 
     let mut times = Vec::with_capacity(INTERVAL_SAMPLE_SNAPSHOTS);
@@ -119,12 +154,39 @@ fn infer_interval(reader: &mut (impl io::Read + io::Seek)) -> Option<Duration> {
     deltas.sort_unstable();
     let median = deltas[deltas.len() / 2];
 
+    let on_cadence = deltas
+        .iter()
+        .filter(|d| {
+            **d >= median.mul_f64(1.0 - CADENCE_TOLERANCE)
+                && **d <= median.mul_f64(1.0 + CADENCE_TOLERANCE)
+        })
+        .count();
+
     // The clamp must stay: a sub-millisecond median would otherwise stamp
     // `sampling_interval_ms=0`. A measured cadence is clamped rather than
     // refused the way `interval_millis` refuses an explicit `--interval`, so
-    // that such a recording still converts.
+    // that such a recording still converts — with a concern attached, since
+    // nothing in the output file would otherwise show that it was clamped.
     let ms = (median.as_nanos() as f64 / 1e6).round() as u64;
-    Some(Duration::from_millis(ms.max(1)))
+
+    // Clamping wins when both apply: it is the more specific fact, and the one
+    // with no remedy.
+    let concern = if median < Duration::from_millis(1) {
+        Some(IntervalConcern::Clamped { median })
+    } else if (on_cadence as f64) < CADENCE_QUORUM * deltas.len() as f64 {
+        Some(IntervalConcern::Irregular {
+            within: on_cadence,
+            of: deltas.len(),
+            median,
+        })
+    } else {
+        None
+    };
+
+    Some(Inferred {
+        interval: Duration::from_millis(ms.max(1)),
+        concern,
+    })
 }
 
 /// Everything the conversion needs beyond the two paths.
@@ -149,6 +211,9 @@ pub(crate) struct Converted {
     pub interval: Duration,
     /// False when `--interval` supplied the value.
     pub interval_inferred: bool,
+    /// Always `None` for an explicit `--interval`: the operator asserted the
+    /// cadence, so the sample's shape is not evidence against it.
+    pub concern: Option<IntervalConcern>,
 }
 
 #[derive(Debug)]
@@ -406,12 +471,12 @@ fn convert_file(
                 std::fs::File::open(input)?
             };
 
-            let (interval, interval_inferred) = match opts.interval {
-                Some(explicit) => (explicit, false),
-                None => (
-                    infer_interval(&mut source).unwrap_or(FALLBACK_INTERVAL),
-                    true,
-                ),
+            let (interval, interval_inferred, concern) = match opts.interval {
+                Some(explicit) => (explicit, false, None),
+                None => match infer_interval(&mut source) {
+                    Some(got) => (got.interval, true, got.concern),
+                    None => (FALLBACK_INTERVAL, true, None),
+                },
             };
             // `infer_interval` rewinds too, but the conversion is wrong in a
             // way nothing downstream can see if the handle is mid-stream, so
@@ -433,6 +498,7 @@ fn convert_file(
                 rows,
                 interval,
                 interval_inferred,
+                concern,
             })
         }
     }
@@ -491,6 +557,26 @@ pub(crate) fn run(args: &clap::ArgMatches) {
                 done.rows,
                 done.interval,
             );
+            // Advisory, on stderr, exit code unchanged: the stamped value is
+            // the best reading of the recording, not a failure to produce one.
+            match done.concern {
+                Some(IntervalConcern::Clamped { median }) => eprintln!(
+                    "warning: snapshots are {median:?} apart, faster than the whole \
+                     milliseconds sampling_interval_ms can hold; it was stamped as \
+                     {:?}, so rates against this file understate the real cadence. \
+                     --interval cannot express this either.",
+                    done.interval,
+                ),
+                Some(IntervalConcern::Irregular { within, of, median }) => eprintln!(
+                    "warning: snapshot spacing is irregular — only {within} of {of} \
+                     sampled gaps are within {:.0}% of the {median:?} median, so no \
+                     single interval describes this recording. {:?} was stamped; pass \
+                     --interval to set it yourself.",
+                    CADENCE_TOLERANCE * 100.0,
+                    done.interval,
+                ),
+                None => {}
+            }
             // Say what is missing rather than letting it be discovered in the
             // viewer as absent help text and a blank hardware summary.
             let missing: Vec<&str> = [
@@ -656,16 +742,28 @@ mod tests {
             .collect()
     }
 
+    /// The inferred interval, asserting the sample raised no concern.
+    fn inferred_clean(bytes: Vec<u8>) -> Duration {
+        let mut r = Cursor::new(bytes);
+        let got = infer_interval(&mut r).expect("expected an interval");
+        assert_eq!(got.concern, None, "expected no concern");
+        got.interval
+    }
+
     #[test]
     fn infer_interval_finds_one_second() {
-        let mut r = Cursor::new(raw_stream(&cadence(5, 1_000_000_000)));
-        assert_eq!(infer_interval(&mut r), Some(Duration::from_millis(1000)));
+        assert_eq!(
+            inferred_clean(raw_stream(&cadence(5, 1_000_000_000))),
+            Duration::from_millis(1000)
+        );
     }
 
     #[test]
     fn infer_interval_finds_a_sub_second_cadence() {
-        let mut r = Cursor::new(raw_stream(&cadence(5, 250_000_000)));
-        assert_eq!(infer_interval(&mut r), Some(Duration::from_millis(250)));
+        assert_eq!(
+            inferred_clean(raw_stream(&cadence(5, 250_000_000))),
+            Duration::from_millis(250)
+        );
     }
 
     #[test]
@@ -680,14 +778,97 @@ mod tests {
             base + 5_000_000_000,
             base + 6_000_000_000,
         ];
+        // No concern: warning about the very sample the median absorbs would
+        // contradict the inference. This pins CADENCE_TOLERANCE/QUORUM.
+        assert_eq!(inferred_clean(raw_stream(&ts)), Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn infer_interval_flags_a_clamped_sub_millisecond_cadence() {
+        // 500us apart: unrepresentable in sampling_interval_ms, stamped as 1ms.
+        let mut r = Cursor::new(raw_stream(&cadence(5, 500_000)));
+        let got = infer_interval(&mut r).unwrap();
+
+        assert_eq!(got.interval, Duration::from_millis(1));
+        assert_eq!(
+            got.concern,
+            Some(IntervalConcern::Clamped {
+                median: Duration::from_micros(500)
+            })
+        );
+    }
+
+    #[test]
+    fn infer_interval_flags_spacing_with_no_dominant_cadence() {
+        // Half the gaps 1s, half 250ms — a recording stitched from two sources.
+        // Whatever the median lands on describes only half the file.
+        let base = 1_786_645_704_000_000_000u64;
+        let mut ts = vec![base];
+        for step in [
+            1_000_000_000u64,
+            250_000_000,
+            1_000_000_000,
+            250_000_000,
+            1_000_000_000,
+            250_000_000,
+        ] {
+            ts.push(ts.last().unwrap() + step);
+        }
         let mut r = Cursor::new(raw_stream(&ts));
-        assert_eq!(infer_interval(&mut r), Some(Duration::from_millis(1000)));
+        let got = infer_interval(&mut r).unwrap();
+
+        match got.concern {
+            Some(IntervalConcern::Irregular { within, of, .. }) => {
+                assert_eq!(of, 6, "six gaps sampled");
+                assert!(within < 4, "expected a minority on-cadence, got {within}");
+            }
+            other => panic!("expected Irregular, got {other:?}"),
+        }
     }
 
     #[test]
     fn infer_interval_returns_none_for_a_single_snapshot() {
         let mut r = Cursor::new(raw_stream(&cadence(1, 1_000_000_000)));
-        assert_eq!(infer_interval(&mut r), None);
+        assert!(infer_interval(&mut r).is_none());
+    }
+
+    #[test]
+    fn an_explicit_interval_never_raises_a_concern() {
+        // The operator asserted the cadence; the sample's shape is not evidence
+        // against it, and interval_millis already refused what it could not
+        // represent.
+        let dir = tempfile::tempdir().unwrap();
+        let base = 1_786_645_704_000_000_000u64;
+        let ts = [base, base + 1_000_000_000, base + 30_000_000_000];
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&ts));
+        let output = dir.path().join("out.parquet");
+
+        let opts = ConvertOptions {
+            interval: Some(Duration::from_millis(1000)),
+            ..Default::default()
+        };
+        let done = convert_file(&input, &output, &opts).unwrap();
+
+        assert_eq!(done.concern, None);
+    }
+
+    #[test]
+    fn a_concern_still_produces_a_converted_file() {
+        // The warning is advisory: the stamped value is the best reading
+        // available, not a failure.
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_input(dir.path(), "r.raw", &raw_stream(&cadence(5, 500_000)));
+        let output = dir.path().join("out.parquet");
+
+        let done = convert_file(&input, &output, &ConvertOptions::default()).unwrap();
+
+        assert!(done.concern.is_some());
+        assert_eq!(
+            footer(&output)
+                .get("sampling_interval_ms")
+                .map(String::as_str),
+            Some("1")
+        );
     }
 
     #[test]

--- a/src/parquet_tools/convert.rs
+++ b/src/parquet_tools/convert.rs
@@ -119,9 +119,10 @@ fn infer_interval(reader: &mut (impl io::Read + io::Seek)) -> Option<Duration> {
     deltas.sort_unstable();
     let median = deltas[deltas.len() / 2];
 
-    // Round to the nearest millisecond, since that is the resolution
-    // `sampling_interval_ms` records. Never round down to zero: a degenerate
-    // interval would make every rate in the viewer divide by nothing.
+    // The clamp must stay: a sub-millisecond median would otherwise stamp
+    // `sampling_interval_ms=0`. A measured cadence is clamped rather than
+    // refused the way `interval_millis` refuses an explicit `--interval`, so
+    // that such a recording still converts.
     let ms = (median.as_nanos() as f64 / 1e6).round() as u64;
     Some(Duration::from_millis(ms.max(1)))
 }
@@ -272,22 +273,13 @@ fn load_json(source: &Path, shape: JsonShape, what: &'static str) -> Result<Stri
 /// Matches `record`'s own `--interval` default.
 const FALLBACK_INTERVAL: Duration = Duration::from_millis(1000);
 
-/// Assemble the converter with the file-level metadata keys
-/// `recorder::build_parquet_converter` writes, so a converted recording is
-/// indistinguishable from one `record -f parquet` produced.
-///
-/// `source` is stamped before the user's `--metadata`, which lets
-/// `--metadata source=…` override it — the same precedence `record` gives.
 /// The value stamped into `sampling_interval_ms`, rounded to the nearest whole
 /// millisecond.
 ///
-/// `Duration::as_millis` truncates, which turns 1.5ms into 1ms and — the case
-/// that matters — any sub-millisecond interval into 0. A stamped 0 is worse
-/// than a wrong interval: it is a divide-by-nothing for every rate computed
-/// against the file, so it is refused rather than written.
+/// Below 1ms there is no honest answer, so the interval is refused: rounding
+/// 500us up to 1ms would understate every rate computed against the file by
+/// half, with nothing in the file to say so.
 fn interval_millis(interval: Duration) -> Result<u64, ConvertError> {
-    // Below 1ms there is no honest answer: rounding 500us up to 1ms would
-    // understate every rate by half, with nothing in the file to say so.
     if interval < Duration::from_millis(1) {
         return Err(ConvertError::IntervalTooSmall(interval));
     }
@@ -295,6 +287,12 @@ fn interval_millis(interval: Duration) -> Result<u64, ConvertError> {
     Ok((interval.as_nanos() as f64 / 1e6).round() as u64)
 }
 
+/// Assemble the converter with the file-level metadata keys
+/// `recorder::build_parquet_converter` writes, so a converted recording is
+/// indistinguishable from one `record -f parquet` produced.
+///
+/// `source` is stamped before the user's `--metadata`, which lets
+/// `--metadata source=…` override it — the same precedence `record` gives.
 fn build_converter(interval_ms: u64, opts: &ConvertOptions) -> MsgpackToParquet {
     let mut converter = MsgpackToParquet::with_options(
         ParquetOptions::new().max_batch_size(crate::parquet_metadata::MAX_ROW_GROUP_SIZE),
@@ -344,15 +342,13 @@ fn decompress_beside_output(
 
 /// Relax the staged file's 0600 to whatever plain file creation yields here.
 ///
-/// The conversion stages through a `NamedTempFile`, which is deliberately
-/// private, and `persist` keeps that mode. `record` writes its parquet with
-/// `File::create`, so a converted recording would otherwise be unreadable by
-/// the group that a recorded one is readable by — surprising, and only
-/// discovered by whoever cannot open the file.
+/// `NamedTempFile` is deliberately private and `persist` keeps that mode, so a
+/// converted recording would otherwise be unreadable by the group that can read
+/// a `record`-written one.
 ///
-/// The mode is taken from a reference file created in the same directory
-/// rather than by reading the process umask, which cannot be queried without
-/// temporarily setting it.
+/// The mode comes from a reference file created in the same directory rather
+/// than from the process umask, which cannot be read without temporarily
+/// setting it.
 #[cfg(unix)]
 fn apply_default_permissions(target: &Path, dir: &Path) -> io::Result<()> {
     let reference = dir.join(format!(".rezolus-convert-{}.perm", std::process::id()));
@@ -397,8 +393,9 @@ fn convert_file(
                 .filter(|p| !p.as_os_str().is_empty())
                 .unwrap_or(Path::new("."));
 
-            // Held for the duration: dropping it removes the decompressed
-            // intermediate, including on the error paths below.
+            // `_scratch` must stay bound until the conversion finishes:
+            // dropping it deletes the decompressed intermediate that `source`
+            // reads from. Holding it also cleans up on the error paths below.
             let _scratch;
             let mut source = if kind == InputKind::Zstd {
                 let (tmp, handle) = decompress_beside_output(input, out_dir)?;
@@ -504,12 +501,20 @@ pub(crate) fn run(args: &clap::ArgMatches) {
             .flatten()
             .collect();
             if !missing.is_empty() {
+                // `annotate` is only offered for systeminfo: it has no
+                // --descriptions route, so naming it for both would send the
+                // reader after a flag that does not exist.
+                let recovery = if opts.systeminfo.is_none() {
+                    " `rezolus parquet annotate <file> --systeminfo <path>` can add the \
+                     hardware summary later; descriptions can only be set here."
+                } else {
+                    " Descriptions can only be set here, by reconverting with --force."
+                };
                 println!(
-                    "Note: no {} in the output — a raw recording does not carry {}. \
-                     Supply them with --systeminfo/--descriptions, or add them later \
-                     with `rezolus parquet annotate`.",
+                    "Note: no {} in the output — a raw recording does not carry {}.{}",
                     missing.join(" or "),
                     if missing.len() == 1 { "it" } else { "them" },
+                    recovery,
                 );
             }
         }

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -1,5 +1,6 @@
 mod annotate;
 pub(crate) mod combine;
+mod convert;
 mod events;
 mod filter;
 mod metadata;
@@ -23,6 +24,7 @@ pub fn command() -> Command {
              metadata   Inspect a file's file-level/column metadata, schema, and geometry\n    \
              annotate   Embed service-extension KPIs, events, or source/node tags into a file\n    \
              combine    Merge multiple files (multi-node / multi-instance) or build an A/B tarball\n    \
+             convert    Turn a raw msgpack recording (from `record -f raw`) into parquet\n    \
              filter     Drop columns not needed by a file's service-extension KPIs (shrink it)\n\n\
              Run `rezolus parquet <subcommand> --help` for per-subcommand examples.",
         )
@@ -305,6 +307,91 @@ pub fn command() -> Command {
                 ),
         )
         .subcommand(
+            Command::new("convert")
+                .about("Convert a raw msgpack recording into parquet")
+                .long_about(
+                    "Convert a recording made with `rezolus record -f raw` (concatenated msgpack\n\
+                     snapshots) into a parquet file that the viewer, the MCP tools and the rest\n\
+                     of `rezolus parquet` can read.\n\n\
+                     The input may be plain or zstd-compressed; which one it is is detected from\n\
+                     the file's contents, not its name. The output defaults to the input path\n\
+                     with .raw/.zst dropped and .parquet appended.\n\n\
+                     The sampling interval is inferred from the snapshot timestamps unless\n\
+                     --interval says otherwise. A raw recording carries no systeminfo or metric\n\
+                     descriptions -- the recorder fetches those from the agent at record time --\n\
+                     so pass them with --systeminfo/--descriptions if you saved them, or add\n\
+                     them later with `rezolus parquet annotate`.\n\n\
+                     A .rez archive cannot be produced from a raw recording: it needs per-sampler\n\
+                     cadence and acquisition windows that a raw snapshot stream never carried.\n\n\
+                     EXAMPLES:\n    \
+                     # Convert a compressed recording (writes rezolus.parquet)\n    \
+                     rezolus parquet convert rezolus.raw.zst\n\n    \
+                     # Choose the output path\n    \
+                     rezolus parquet convert rezolus.raw -o run7.parquet\n\n    \
+                     # A recording made at a non-default cadence\n    \
+                     rezolus parquet convert rezolus.raw --interval 250ms\n\n    \
+                     # Stamp the hardware summary and help text saved alongside it\n    \
+                     rezolus parquet convert rezolus.raw --systeminfo sysinfo.json --descriptions help.json\n\n    \
+                     # Tag the recording the way `record --metadata` would\n    \
+                     rezolus parquet convert rezolus.raw -m source=llm-perf -m run=boat-7",
+                )
+                .arg(
+                    clap::Arg::new("FILE")
+                        .help("Raw recording to convert (plain or zstd-compressed)")
+                        .value_parser(value_parser!(PathBuf))
+                        .required(true)
+                        .index(1),
+                )
+                .arg(
+                    clap::Arg::new("output")
+                        .short('o')
+                        .long("output")
+                        .value_name("PATH")
+                        .help("Output parquet path (default: input with .raw/.zst replaced by .parquet)")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(clap::ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("interval")
+                        .short('i')
+                        .long("interval")
+                        .value_name("DURATION")
+                        .help("Sampling interval to stamp, like 1s or 250ms (default: inferred from the snapshot timestamps)")
+                        .value_parser(value_parser!(humantime::Duration))
+                        .action(clap::ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("systeminfo")
+                        .long("systeminfo")
+                        .value_name("PATH")
+                        .help("JSON hardware summary to embed, or - for stdin")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(clap::ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("descriptions")
+                        .long("descriptions")
+                        .value_name("PATH")
+                        .help("JSON map of metric name to help text to embed, or - for stdin")
+                        .value_parser(value_parser!(PathBuf))
+                        .action(clap::ArgAction::Set),
+                )
+                .arg(
+                    clap::Arg::new("metadata")
+                        .short('m')
+                        .long("metadata")
+                        .value_name("KEY=VALUE")
+                        .help("Add a file-level metadata tag as key=value; repeat for multiple tags")
+                        .action(clap::ArgAction::Append),
+                )
+                .arg(
+                    clap::Arg::new("force")
+                        .long("force")
+                        .help("Overwrite the output file if it already exists")
+                        .action(clap::ArgAction::SetTrue),
+                ),
+        )
+        .subcommand(
             Command::new("filter")
                 .about("Filter parquet columns to only those needed by service extension KPIs")
                 .long_about(
@@ -378,6 +465,10 @@ pub fn run(args: ArgMatches) {
             return;
         }
         Some(("combine", sub_args)) => combine::run(sub_args),
+        Some(("convert", sub_args)) => {
+            convert::run(sub_args);
+            return;
+        }
         Some(("filter", sub_args)) => {
             let registry = load_template_registry(
                 sub_args

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -311,33 +311,61 @@ pub fn command() -> Command {
                 .about("Convert a raw msgpack recording into parquet")
                 .long_about(
                     "Convert a recording made with `rezolus record -f raw` (concatenated msgpack\n\
-                     snapshots) into a parquet file that the viewer, the MCP tools and the rest\n\
-                     of `rezolus parquet` can read.\n\n\
+                     snapshots, one per sampling tick) into a parquet file that the viewer, the\n\
+                     MCP tools and the rest of `rezolus parquet` can read.\n\n\
+                     Raw is the cheapest capture mode: the recorder appends snapshots as they\n\
+                     arrive and finalizing is a byte copy rather than a conversion that grows\n\
+                     with run length, so long unattended captures record raw and convert\n\
+                     afterwards. Recording straight to parquet (`record -f parquet`) is simpler\n\
+                     for a short supervised run.\n\n\
                      The input may be plain or zstd-compressed; which one it is is detected from\n\
-                     the file's contents, not its name. The output defaults to the input path\n\
-                     with .raw/.zst dropped and .parquet appended.\n\n\
-                     The sampling interval is inferred from the snapshot timestamps unless\n\
-                     --interval says otherwise. A raw recording carries no systeminfo or metric\n\
-                     descriptions -- the recorder fetches those from the agent at record time --\n\
-                     so pass them with --systeminfo/--descriptions if you saved them, or add\n\
-                     them later with `rezolus parquet annotate`.\n\n\
+                     the file's contents, not its name. The output path defaults to the input\n\
+                     with a trailing .zst and then a trailing .raw stripped, and .parquet\n\
+                     appended: rezolus.raw.zst becomes rezolus.parquet, and a name with neither\n\
+                     suffix just gains one (capture.msgpack becomes capture.msgpack.parquet).\n\n\
+                     The sampling interval stamped into the file is inferred from the median gap\n\
+                     between snapshot timestamps unless --interval says otherwise. A recording\n\
+                     with fewer than two snapshots falls back to 1s, so pass --interval if such a\n\
+                     recording was made at another cadence.\n\n\
+                     A raw recording carries no systeminfo or metric descriptions: the recorder\n\
+                     fetches those over HTTP from the running rezolus agent while recording (its\n\
+                     /systeminfo and /metrics/descriptions endpoints) and they never enter the\n\
+                     snapshot stream. Without them the conversion still succeeds and every metric\n\
+                     still queries normally; what you lose is the viewer's hardware panel and the\n\
+                     help text beside each metric. Prefer stamping them here in one pass if you\n\
+                     saved them -- and if that agent is still running, the same two endpoints can\n\
+                     be curled now, at conversion time, to recover them. Afterwards, `rezolus parquet annotate\n\
+                     <file> --systeminfo <path>` can still add the hardware summary, but there is\n\
+                     no annotate route for descriptions: those can only be supplied here, which\n\
+                     means reconverting the original raw input over the output (--force).\n\n\
                      A .rez archive cannot be produced from a raw recording: it needs per-sampler\n\
                      cadence and acquisition windows that a raw snapshot stream never carried.\n\n\
                      EXAMPLES:\n    \
+                     # The producing side, for reference\n    \
+                     rezolus record -f raw --url http://localhost:4241 -o rezolus.raw\n\n    \
                      # Convert a compressed recording (writes rezolus.parquet)\n    \
                      rezolus parquet convert rezolus.raw.zst\n\n    \
                      # Choose the output path\n    \
                      rezolus parquet convert rezolus.raw -o run7.parquet\n\n    \
                      # A recording made at a non-default cadence\n    \
                      rezolus parquet convert rezolus.raw --interval 250ms\n\n    \
-                     # Stamp the hardware summary and help text saved alongside it\n    \
+                     # Save the two metadata blobs at record time, from the agent being recorded\n    \
+                     curl -s http://localhost:4241/systeminfo > sysinfo.json\n    \
+                     curl -s http://localhost:4241/metrics/descriptions > help.json\n\n    \
+                     # ...then stamp them into the conversion\n    \
                      rezolus parquet convert rezolus.raw --systeminfo sysinfo.json --descriptions help.json\n\n    \
+                     # Or pipe one of them straight in, with - for stdin\n    \
+                     curl -s http://localhost:4241/systeminfo | rezolus parquet convert rezolus.raw --systeminfo -\n\n    \
                      # Tag the recording the way `record --metadata` would\n    \
-                     rezolus parquet convert rezolus.raw -m source=llm-perf -m run=boat-7",
+                     rezolus parquet convert rezolus.raw -m source=llm-perf -m run=boat-7\n\n    \
+                     # Replace an output left by an earlier attempt\n    \
+                     rezolus parquet convert rezolus.raw --force\n\n    \
+                     # Descriptions were missed the first time -- reconvert over the old output\n    \
+                     rezolus parquet convert rezolus.raw --descriptions help.json --force",
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Raw recording to convert (plain or zstd-compressed)")
+                        .help("Raw recording to convert (plain or zstd-compressed). Must be a real file; stdin is not accepted here")
                         .value_parser(value_parser!(PathBuf))
                         .required(true)
                         .index(1),
@@ -347,16 +375,19 @@ pub fn command() -> Command {
                         .short('o')
                         .long("output")
                         .value_name("PATH")
-                        .help("Output parquet path (default: input with .raw/.zst replaced by .parquet)")
+                        .help("Output parquet path (default: input with a trailing .zst then .raw stripped and .parquet appended). Refuses to overwrite an existing file unless --force")
                         .value_parser(value_parser!(PathBuf))
                         .action(clap::ArgAction::Set),
                 )
                 .arg(
+                    // Deliberately no -i alias: `rezolus parquet metadata -i`
+                    // means the INPUT FILE, and an agent generalizing that to
+                    // `convert -i recording.raw` would otherwise get
+                    // "expected number at 0" from the duration parser.
                     clap::Arg::new("interval")
-                        .short('i')
                         .long("interval")
                         .value_name("DURATION")
-                        .help("Sampling interval to stamp, like 1s or 250ms (default: inferred from the snapshot timestamps)")
+                        .help("Sampling interval to stamp, as a number with a unit (ns, us, ms, s, m, h) -- 1s, 250ms. Stamped as whole milliseconds, rounded to the nearest; anything below 1ms is rejected. Default: inferred from the median gap between snapshot timestamps, or 1s if the recording holds fewer than two snapshots")
                         .value_parser(value_parser!(humantime::Duration))
                         .action(clap::ArgAction::Set),
                 )
@@ -364,7 +395,7 @@ pub fn command() -> Command {
                     clap::Arg::new("systeminfo")
                         .long("systeminfo")
                         .value_name("PATH")
-                        .help("JSON hardware summary to embed, or - for stdin")
+                        .help("JSON hardware summary to embed, as served by the agent's /systeminfo endpoint; any JSON value is accepted and stored verbatim. Use - for stdin (only one of --systeminfo/--descriptions can read stdin)")
                         .value_parser(value_parser!(PathBuf))
                         .action(clap::ArgAction::Set),
                 )
@@ -372,7 +403,7 @@ pub fn command() -> Command {
                     clap::Arg::new("descriptions")
                         .long("descriptions")
                         .value_name("PATH")
-                        .help("JSON map of metric name to help text to embed, or - for stdin")
+                        .help("Metric help text to embed, as served by the agent's /metrics/descriptions endpoint: a flat JSON object of name to string, {\"cpu_usage\":\"CPU time by state\"}. Use - for stdin (only one of --systeminfo/--descriptions can read stdin)")
                         .value_parser(value_parser!(PathBuf))
                         .action(clap::ArgAction::Set),
                 )
@@ -381,13 +412,13 @@ pub fn command() -> Command {
                         .short('m')
                         .long("metadata")
                         .value_name("KEY=VALUE")
-                        .help("Add a file-level metadata tag as key=value; repeat for multiple tags")
+                        .help("Add a file-level metadata tag as key=value; repeat for multiple tags. Split on the first =, so values may contain = and may be empty. Keys are free-form, but `source` is the one the viewer and MCP tools read to identify where a recording came from (it defaults to rezolus). Tags are applied after the two keys convert derives, `source` and `sampling_interval_ms`, so a tag with either name wins -- set the interval with --interval rather than -m sampling_interval_ms=")
                         .action(clap::ArgAction::Append),
                 )
                 .arg(
                     clap::Arg::new("force")
                         .long("force")
-                        .help("Overwrite the output file if it already exists")
+                        .help("Overwrite the output file if it already exists (without this, an existing output is an error and nothing is written)")
                         .action(clap::ArgAction::SetTrue),
                 ),
         )

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -326,7 +326,10 @@ pub fn command() -> Command {
                      The sampling interval stamped into the file is inferred from the median gap\n\
                      between snapshot timestamps unless --interval says otherwise. A recording\n\
                      with fewer than two snapshots falls back to 1s, so pass --interval if such a\n\
-                     recording was made at another cadence.\n\n\
+                     recording was made at another cadence. Inference warns on stderr when the\n\
+                     sampled gaps have no dominant cadence, or when they are closer together than\n\
+                     the whole milliseconds the stamped value can hold; the conversion still\n\
+                     succeeds in both cases.\n\n\
                      A raw recording carries no systeminfo or metric descriptions: the recorder\n\
                      fetches those over HTTP from the running rezolus agent while recording (its\n\
                      /systeminfo and /metrics/descriptions endpoints) and they never enter the\n\

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -380,10 +380,10 @@ pub fn command() -> Command {
                         .action(clap::ArgAction::Set),
                 )
                 .arg(
-                    // Deliberately no -i alias: `rezolus parquet metadata -i`
-                    // means the INPUT FILE, and an agent generalizing that to
-                    // `convert -i recording.raw` would otherwise get
-                    // "expected number at 0" from the duration parser.
+                    // `--interval` must never gain a `-i` alias: `parquet
+                    // metadata -i` means the input file, so `convert -i
+                    // recording.raw` would parse a path as a duration and
+                    // report "expected number at 0".
                     clap::Arg::new("interval")
                         .long("interval")
                         .value_name("DURATION")


### PR DESCRIPTION
## Summary

- Adds `rezolus parquet convert`, the offline complement to `record -f raw`. Raw-to-parquet conversion previously existed only *inside* `record` and `hindsight` at finalize time, so a raw file sitting on disk needed a hand-written program against `MsgpackToParquet` before anything could read it.
- Detects zstd by magic bytes rather than extension (these recordings get renamed on their way off the machine that produced them) and decompresses to a temp file beside the output, because `convert_file_handle` is two-pass and needs `Seek`.
- Infers the sampling interval from the median snapshot delta instead of assuming the recorder's 1s default — a 250ms recording stamped as 1s would make every rate in the viewer wrong by 4x with nothing on screen to say so. `--systeminfo`/`--descriptions` carry the two keys a raw stream cannot.
- Warns (on stderr, exit 0) when the inferred interval is a poor description of the recording: a sub-millisecond cadence clamped to the 1ms floor, or gaps that cluster around no dominant cadence.

Output is parquet only. A `.rez` needs per-sampler cadence and acquisition windows that a raw snapshot stream never carried, and synthesizing them would fabricate uncertainty bounds that look measured.

Design and rationale: `docs/parquet-convert-design.md`.

### Two deliberate divergences from `record`

- A malformed `--metadata` is an error rather than silently dropped (`record` uses `filter_map`). Quietly producing a recording missing the label you asked for is worse than refusing to start.
- Output permissions are reset after the staged temp file is persisted, so a converted recording is not more private (0600) than a recorded one.

### Interval warnings

Inference always produces a number, and until now produced it silently. The irregularity rule counts gaps within 25% of the median and warns below a 60% quorum. Those constants exist to stay silent on the case the median was chosen to absorb — a rule that warned about a single stalled sample would contradict the inference it reports on — and `infer_interval_ignores_a_stalled_sample` pins that.

The two warnings read differently on purpose: the irregular one names `--interval` as the fix, the clamped one must not, since `interval_millis` refuses an explicit sub-millisecond value too and there is nothing the operator could pass.

### Found by verification, not by review

The `document-feature` loop (5 blind agent simulations + a fresh-eyes critic, 3 rounds against the rendered `--help`) passed 15/15 simulations but surfaced two defects:

- **`-i` collided across sibling subcommands.** `parquet metadata -i FILE` means the input file; `convert -i 250ms` meant the interval. An agent generalizing between them got `expected number at 0` from the duration parser. `--interval` lost its short alias.
- **`--interval 500us` stamped `sampling_interval_ms=0`.** That key holds whole milliseconds and `as_millis` truncates, so every rate against such a file would divide by nothing. Inference had a floor; the explicit path did not.

A comment sweep before review caught two more: a docstring that had become attached to the wrong function during the interval fix (so `interval_millis` was documented as "Assemble the converter…" and `build_converter` had none), and a runtime message still telling users to add descriptions with `parquet annotate`, which has no `--descriptions` route.

## Test plan

- [x] 44 unit tests in `src/parquet_tools/convert.rs` (magic-byte sniffing incl. lying extensions, output-path derivation, interval inference incl. median-not-mean, clamped and irregular concerns, end-to-end plain + zstd with footer assertions, overwrite refusal, malformed inputs, permissions, JSON validation, `-m` parsing, sub-ms interval)
- [x] `cargo test` — 536 passed, 0 failed
- [x] `cargo clippy --all-targets` — no findings in the new module
- [x] `cargo fmt --check` — clean
- [x] Real 20m recording (16 MiB zstd → 220 MiB raw): converts in 7.9s to 1225 rows × 1189 columns, reads back in `parquet metadata`, answers `mcp query 'sum(rate(cpu_usage[1m]))'`, and raises **no** warning — real scheduling jitter does not trip the irregularity rule
- [x] Synthetic sub-millisecond and stitched-cadence recordings raise the expected warnings; an explicit `--interval` suppresses them; exit code stays 0
- [x] CLI paths exercised by hand: overwrite refusal, `--force`, `--interval`, `-m source=` override, parquet/`.rez` input rejection, malformed `--metadata`, stdin form

## Known limitation

A truncated raw input fails the whole conversion rather than salvaging the complete snapshots. That is the designed behavior, but a SIGKILLed recorder leaves a partial trailing snapshot — exactly how an unattended run ends — which makes the entire recording unconvertible. Worth deciding whether to switch to salvage-and-warn.

Follow-up (own PR, filed in `docs/backlog.md`): `annotate --descriptions`. `annotate` already takes `--systeminfo`, so a converted file can get its hardware summary back, but descriptions have no annotate route — the only recovery is a full `--force` reconvert for one footer key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
