### PR TITLE
perf(rez): stop writing sidecar columns for metrics with no window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.15"
+version = "5.17.1-alpha.16"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.15"
+version = "5.17.1-alpha.16"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/hindsight/buffer.rs
+++ b/src/hindsight/buffer.rs
@@ -848,6 +848,11 @@ mod tests {
             buf.ingest(&s, ts, 0).unwrap();
             buf.maintain().unwrap();
         }
+        // Everything below reads the file through its OWN connection, so it
+        // sees what the writer has committed rather than what this buffer has
+        // handed off. Without the barrier the last ticks may still be in
+        // flight and the row count comes up short.
+        buf.sync().unwrap();
 
         assert_eq!(detect_rez_format(&path).unwrap(), RezFormat::V3Sqlite);
 

--- a/src/recorder/rez.rs
+++ b/src/recorder/rez.rs
@@ -259,19 +259,37 @@ fn table_to_batch(table: &RezTable) -> Result<(Arc<Schema>, RecordBatch), RezErr
             }
         }
 
-        let (begin, width) = window_offset_columns(&col.windows, &table.timestamps);
-        fields.push(Field::new(
-            format!("{}:window_begin", col.name),
-            DataType::Int64,
-            true,
-        ));
-        arrays.push(Arc::new(Int64Array::from(begin)));
-        fields.push(Field::new(
-            format!("{}:window_width", col.name),
-            DataType::UInt64,
-            true,
-        ));
-        arrays.push(Arc::new(UInt64Array::from(width)));
+        // Sidecars only where there is a window to put in them. **Most metrics
+        // do not have one** — whole samplers (`cpu_perf`, `cpu_bandwidth`,
+        // `cpu_frequency`, ...) are windowless, and the per-cgroup and per-task
+        // halves of `cpu_usage` are too — so emitting the pair unconditionally
+        // spent over half a wide table's columns on nulls.
+        //
+        // Absence and all-nulls read identically: both readers resolve a
+        // window per row through an `Option` that a missing column simply
+        // leaves `None`, which is also the path every pre-windows parquet
+        // already takes.
+        //
+        // The one behavioural difference is deliberate. An all-null sidecar
+        // still gets a per-row window resolved, and with no offset and no
+        // width that lands on `(base, base)` — a zero-width window, which
+        // claims the observation happened at an exact instant. It did not; we
+        // do not know when it happened. No sidecar says exactly that instead.
+        if col.windows.iter().any(Option::is_some) {
+            let (begin, width) = window_offset_columns(&col.windows, &table.timestamps);
+            fields.push(Field::new(
+                format!("{}:window_begin", col.name),
+                DataType::Int64,
+                true,
+            ));
+            arrays.push(Arc::new(Int64Array::from(begin)));
+            fields.push(Field::new(
+                format!("{}:window_width", col.name),
+                DataType::UInt64,
+                true,
+            ));
+            arrays.push(Arc::new(UInt64Array::from(width)));
+        }
     }
 
     let schema = Arc::new(Schema::new(fields));
@@ -1918,6 +1936,120 @@ mod table_tests {
         ]
         .into_iter()
         .collect()
+    }
+
+    /// Schema field names of an encoded table, in order.
+    fn schema_fields(bytes: Vec<u8>) -> Vec<String> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes)).unwrap();
+        reader
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect()
+    }
+
+    fn col(name: &str, values: Vec<Option<u64>>, windows: Vec<Option<Window>>) -> RezColumn {
+        RezColumn {
+            name: name.to_string(),
+            metadata: meta(name, "counter"),
+            values: RezValues::Counter(values),
+            windows,
+        }
+    }
+
+    // A metric without a window gets no sidecar columns. This is where the
+    // table's width actually goes: whole samplers are windowless, and so are
+    // the per-cgroup and per-task halves of `cpu_usage`, so emitting the pair
+    // unconditionally spent over half a wide table's columns on nulls.
+    #[test]
+    fn a_windowless_column_gets_no_sidecars() {
+        let table = RezTable {
+            sampler: "s".to_string(),
+            timestamps: vec![1_000, 2_000],
+            wall_offsets: vec![7, 7],
+            columns: vec![
+                col(
+                    "windowed",
+                    vec![Some(1), Some(2)],
+                    vec![
+                        Some(Window::new(900, 1_000)),
+                        Some(Window::new(1_900, 2_000)),
+                    ],
+                ),
+                col("windowless", vec![Some(3), Some(4)], vec![None, None]),
+            ],
+        };
+        let fields = schema_fields(write_table_parquet(&table).unwrap());
+
+        assert!(fields.contains(&"windowed:window_begin".to_string()));
+        assert!(fields.contains(&"windowed:window_width".to_string()));
+        assert!(
+            !fields.iter().any(|f| f.starts_with("windowless:window")),
+            "a column with no windows must not carry sidecars: {fields:?}"
+        );
+        // And the count, so the saving is pinned rather than implied:
+        // timestamp + :wall_offset + two values + one pair of sidecars.
+        assert_eq!(fields.len(), 6, "{fields:?}");
+    }
+
+    // A column keeps its sidecars if ANY row has a window — partial coverage is
+    // not the windowless case, and dropping the pair there would discard real
+    // observations.
+    #[test]
+    fn one_windowed_row_is_enough_to_keep_the_sidecars() {
+        let table = RezTable {
+            sampler: "s".to_string(),
+            timestamps: vec![1_000, 2_000],
+            wall_offsets: vec![7, 7],
+            columns: vec![col(
+                "sparse",
+                vec![Some(1), Some(2)],
+                vec![None, Some(Window::new(1_900, 2_000))],
+            )],
+        };
+        let fields = schema_fields(write_table_parquet(&table).unwrap());
+        assert!(
+            fields.contains(&"sparse:window_begin".to_string()),
+            "{fields:?}"
+        );
+
+        let back =
+            read_table_parquet("s".to_string(), write_table_parquet(&table).unwrap()).unwrap();
+        assert_eq!(
+            back.columns[0].windows,
+            vec![None, Some(Window::new(1_900, 2_000))],
+            "the row that had a window keeps it, the row that did not stays None"
+        );
+    }
+
+    // Windowedness can flip between one segment and the next — a metric that
+    // was read with a window in one seal period and without one in the next.
+    // The two segments then carry DIFFERENT schemas, which the segmented
+    // reader resolves as a union; this pins that the writer produces that
+    // union honestly rather than, say, carrying a stale sidecar forward.
+    #[test]
+    fn windowedness_may_differ_between_segments_of_one_table() {
+        let with = RezTable {
+            sampler: "s".to_string(),
+            timestamps: vec![1_000],
+            wall_offsets: vec![7],
+            columns: vec![col("m", vec![Some(1)], vec![Some(Window::new(900, 1_000))])],
+        };
+        let without = RezTable {
+            sampler: "s".to_string(),
+            timestamps: vec![2_000],
+            wall_offsets: vec![7],
+            columns: vec![col("m", vec![Some(2)], vec![None])],
+        };
+
+        let a = schema_fields(write_table_parquet(&with).unwrap());
+        let b = schema_fields(write_table_parquet(&without).unwrap());
+        assert!(a.contains(&"m:window_begin".to_string()), "{a:?}");
+        assert!(!b.contains(&"m:window_begin".to_string()), "{b:?}");
+        // The value column is common to both, which is what lets a reader
+        // union the two segments into one series.
+        assert!(a.contains(&"m".to_string()) && b.contains(&"m".to_string()));
     }
 
     #[test]

--- a/tests/hindsight_dump.rs
+++ b/tests/hindsight_dump.rs
@@ -63,7 +63,16 @@ const INTERVAL: Duration = Duration::from_millis(100);
 /// without this; the `-wal` measurement needs it to reach a checkpoint at all.
 /// The two tests that only care about row identity use a single counter and
 /// run in ~2 s.
-const WIDE: usize = 2000;
+///
+/// **Calibrated so a dump outlasts a tick period**, which the sealing tests
+/// assert as a fixture — a dump shorter than `INTERVAL` could not distinguish a
+/// writer that keeps running from one that pauses for every dump. Dump cost
+/// scales with archive size, so anything that makes tables narrower moves this:
+/// these counters carry no acquisition window, and when the writer stopped
+/// emitting sidecar columns for windowless metrics each one went from three
+/// columns to one, taking the average dump from comfortably over `INTERVAL` to
+/// 91 ms and making the fixture fail.
+const WIDE: usize = 6000;
 
 // ---------------------------------------------------------------------------
 // The stand-in agent, as in `record_lifecycle.rs`

--- a/tests/hindsight_dump.rs
+++ b/tests/hindsight_dump.rs
@@ -70,9 +70,12 @@ const INTERVAL: Duration = Duration::from_millis(100);
 /// scales with archive size, so anything that makes tables narrower moves this:
 /// these counters carry no acquisition window, and when the writer stopped
 /// emitting sidecar columns for windowless metrics each one went from three
-/// columns to one, taking the average dump from comfortably over `INTERVAL` to
-/// 91 ms and making the fixture fail.
-const WIDE: usize = 6000;
+/// columns to one, taking the average dump to 91 ms against a 100 ms tick.
+///
+/// Raise it only as far as that needs. It is also the per-tick scrape cost of
+/// three daemons running in parallel, so overshooting starves the runner
+/// instead: at 6000 these tests died at startup on a 3-core CI box.
+const WIDE: usize = 3000;
 
 // ---------------------------------------------------------------------------
 // The stand-in agent, as in `record_lifecycle.rs`


### PR DESCRIPTION
## Summary

Every metric in a `.rez` table got a `:window_begin` and `:window_width` column whether or not it had an acquisition window — and most don't. Whole samplers (`cpu_perf`, `cpu_bandwidth`, `cpu_frequency`, `cpu_l3`, `cpu_dtlb`, `cpu_branch`) are windowless, as are the per-cgroup and per-task halves of `cpu_usage`. Over half of every wide table was carrying nothing.

The writer now emits the pair only for columns that actually have a window. Implements the first of the three changes scoped in [the design entry](https://github.com/iopsystems/rezolus/blob/main/docs/journal/2026-08-17-window-sidecar-cost.md) (#1063); the two agent-side ones are untouched and still gated on profiling the counter sweep.

## Measured against a live 32-core agent

| table | before | after | |
|---|---|---|---|
| `cpu_usage` | 6,436 | **2,963** | 2.17× |
| `syscall_counts` | 1,687 | **603** | 2.80× |
| `scheduler_runqueue` | 1,198 | 606 | 1.98× |
| `cpu_perf` | 631 | **219** | 2.88× |
| **all tables** | **12,893** | **6,156** | **2.09×** |
| 60 s archive | 36.9 MB | **29.3 MB** | −20.6% |

Same agent, same settings, before/after binaries built from `c07767fb` and this branch.

## The behaviour change, which is the real reason to do this

Absence and all-nulls read identically — both readers resolve a window per row through an `Option` that a missing column leaves `None`, the path every pre-windows parquet already takes. With one deliberate exception.

An all-null sidecar **still resolves a window**, landing on `(base, base)`: zero width, asserting the observation happened at an exact instant we do not know. Run through the rate bounds that doesn't collapse to the nominal — it fabricates an asymmetric band. On this branch's own before-binary:

```
sum(rate(cpu_cycles[1m]))
  First: 3269950434  [3269950434.000000, 8190749101.498776]
```

`cpu_cycles` carries no window at all, and the recorder was reporting a 2.5× uncertainty spread invented from nothing. After, the same query returns its 59 points with no band — which is what "we do not know when this was acquired" should look like.

Worth knowing before merge: the six windowless samplers lose their brackets in `mcp query` output and their bands in the viewer. That's the intended correction, not a regression.

## Test plan

- [x] `cargo test` — 590 + 7 + 5 green, including the end-to-end hindsight dump suite driving the real daemon
- [x] `cargo clippy --all-targets` clean, zero build warnings, `cargo fmt --check`
- [x] New: a windowless column emits no sidecars; a column with **any** windowed row keeps them; windowedness differing between segments of one table; a column-count assertion pinning the saving
- [x] End-to-end on a live agent — column counts, archive size, and `mcp query` band behaviour for a windowed and a windowless metric
- [x] Verified both readers treat absence as all-null: `metriken-query` `parse_schema` attaches sidecar indices as `Option` (`parquet.rs:1416`), and in-tree `read_table_parquet` uses `unwrap_or_default()`

## Note on one test that moved

Three dump tests failed after this change, and the fixture check is the one that fired: it requires each dump to outlast a tick period, since a dump shorter than `INTERVAL` couldn't distinguish a writer that keeps running from one that pauses for every dump. Dump cost scales with archive size, so narrowing the tables took the average dump to 91 ms against a 100 ms tick.

`WIDE` is recalibrated with a comment explaining the coupling, so whoever next makes tables narrower finds out why that constant exists rather than rediscovering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
