### PR TITLE
feat(parquet): combine, filter and annotate v3 (SQLite) .rez archives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ target/release/rezolus parquet filter file.parquet -o slim.parquet   # drop colu
 #   tables appear as <sampler>/<group>);
 # combine a.rez b.rez -o out.rez assembles single-recording .rez into a multi-recording .rez (multi-host/A/B);
 # filter file.rez --samplers cpu_usage,scheduler -o slim.rez drops tables whose sampler is not listed
-#   (v2/tar archives only; a v3/SQLite archive errors clearly);
+#   (both containers; on a v3 archive a sampler's group tables are dropped together);
 # annotate file.rez --queries kpis.json embeds KPIs into each recording's manifest (--queries required for .rez).
 
 # MCP - AI analysis server or CLI commands
@@ -120,7 +120,7 @@ The binary operates in seven modes via subcommands:
 4. **Hindsight** (`src/hindsight/`) - Maintains a rolling `.rez` v3 buffer on disk (the streaming v3 writer with retention: everything older than `duration` is evicted each tick) for post-incident snapshots. The buffer is readable live by the viewer/MCP/`parquet metadata`; a snapshot is a `VACUUM INTO` copy taken without pausing the recording.
 5. **Viewer** (`src/viewer/`) - Web dashboard with PromQL query engine and TSDB (from `metriken-query` crate). Supports parquet files, `.rez` archives (a 2-recording `.rez` renders as an A/B baseline/experiment comparison, >2 shows the first two), live agent connections, and upload-only mode. Generates service KPI dashboards from `ServiceExtension` metadata.
 6. **MCP** (`src/mcp/`) - AI analysis tools (anomaly detection, correlation, PromQL queries, feature extraction). Runs as stdio server or one-shot CLI commands. `query` prints acquisition-window uncertainty bands `[lo, hi]` beside `rate()`/`irate()` values (scalar ops scale the band; series-op-series and non-rate queries show none). `extract-features` emits a deterministic, versioned overview record (JSON) summarizing a recording's Rezolus-native features.
-7. **Parquet** (`src/parquet_tools/`) - File operations: `metadata` (inspect; on a `.rez`, describes the manifest), `annotate` (add service extension KPIs; on a `.rez`, `--queries` embeds them into each recording's manifest), `combine` (merge multi-source files, build an A/B tarball, or assemble single-recording `.rez` into a multi-recording `.rez`), `filter` (drop columns not needed by KPIs; on a `.rez`, `--samplers` drops every table whose sampler is not listed — v2/tar archives only), `convert` (raw msgpack recording, plain or zstd, into parquet — the offline complement to `record -f raw`). Those four accept `.rez` inputs; `convert` takes raw input only and emits parquet only.
+7. **Parquet** (`src/parquet_tools/`) - File operations: `metadata` (inspect; on a `.rez`, describes the manifest), `annotate` (add service extension KPIs; on a `.rez`, `--queries` embeds them into each recording's manifest), `combine` (merge multi-source files, build an A/B tarball, or assemble single-recording `.rez` into a multi-recording `.rez`), `filter` (drop columns not needed by KPIs; on a `.rez`, `--samplers` drops every table whose sampler is not listed), `convert` (raw msgpack recording, plain or zstd, into parquet — the offline complement to `record -f raw`). Those four accept `.rez` inputs; `convert` takes raw input only and emits parquet only.
 
 ### Sampler Architecture
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,10 @@ rezolus parquet metadata -i out.rez   # reports "not cleanly finalized"
 ```
 
 Pass `--rez-version 2` to write the previous tar container instead, which stages
-at `<output>.partial` and is recoverable only up to its last checkpoint.
+at `<output>.partial` and is recoverable only up to its last checkpoint. There
+is no longer a reason to reach for it: `parquet combine`, `filter` and
+`annotate` all read and rewrite both containers, so the default needs no
+opt-out to stay workable.
 
 ### Viewer
 

--- a/src/agent/timing.rs
+++ b/src/agent/timing.rs
@@ -525,20 +525,31 @@ mod tests {
         // unrelated work — e.g. `create_v3`'s emit loop processing every
         // OTHER group before reaching this one. Without `mark_end()`, that
         // deferred-publish delay leaks into the reported width.
+        // Asserted RELATIVELY, against the elapsed time this thread actually
+        // observed, rather than against an absolute ceiling on the width. A
+        // `sleep(3ms)` is a floor, not a duration: on a loaded machine — CI
+        // running this test beside the parquet/SQLite fixture tests, say — it
+        // returns after 20ms+, and an absolute bound then fails a mechanism
+        // that worked perfectly. What `mark_end()` promises is that the span
+        // AFTER it is excluded, and that is exactly what `total - width`
+        // measures, however slowly the sleeps themselves run.
         static SLOT: GroupWindowSlot = GroupWindowSlot::new();
+        let started = std::time::Instant::now();
         let mut acq = AcquisitionGuard::begin(&SLOT);
         std::thread::sleep(std::time::Duration::from_millis(3)); // the group's own read span
         acq.mark_end();
         std::thread::sleep(std::time::Duration::from_millis(50)); // unrelated walk work, NOT this group's read
         acq.finish();
+        let total_ns = started.elapsed().as_nanos() as u64;
 
         let w = SLOT.load().expect("finish() stamped the slot");
         assert!(w.begin_ns > 0, "wall-clock begin");
         assert!(
-            w.width_ns() < 20_000_000,
-            "width must reflect the ~3ms read span marked by mark_end(), not the ~50ms \
-             publish delay after it: {}",
-            w.width_ns()
+            total_ns.saturating_sub(w.width_ns()) >= 40_000_000,
+            "the ~50ms between mark_end() and finish() must be EXCLUDED from the width: \
+             total {total_ns}ns, width {}ns, difference {}ns",
+            w.width_ns(),
+            total_ns.saturating_sub(w.width_ns())
         );
         assert!(
             w.width_ns() >= 2_000_000,

--- a/src/hindsight/buffer.rs
+++ b/src/hindsight/buffer.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use metriken_exposition::Snapshot;
 
 use super::state::TimeRange;
-use crate::recorder::rez_sqlite::{RezDb, SegmentMeta};
+use crate::recorder::rez_sqlite::RezDb;
 use crate::recorder::rez_stream::SealPolicy;
 use crate::recorder::rez_v3_writer::{ManifestSeed, RezV3Writer, StreamRecorderV3};
 
@@ -364,58 +364,21 @@ fn copy_range(
     end: u64,
     listed: &dyn Fn(),
 ) -> Result<(), String> {
+    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, CopySpec};
     let mut dst = RezDb::create(staged)?;
     src.read_snapshot(|src| {
-        let recordings = src.read_recordings()?;
+        // Pins the snapshot before a single segment BLOB is copied:
+        // `read_recordings` is the first read, so `BEGIN DEFERRED` takes its
+        // read mark here.
+        let _pinned = src.read_recordings()?;
         listed();
         dst.transaction(|tx| {
-            for rec in &recordings {
-                let id = tx.insert_recording(&rec.meta)?;
-                for sampler in src.all_samplers(rec.id)? {
-                    let mut seq = 0u64;
-                    for segment in src.segments_overlapping(rec.id, &sampler, start, end)? {
-                        tx.insert_segment(id, &sampler, seq, &segment.meta, &segment.bytes)?;
-                        seq += 1;
-                    }
-                    // The tail is the newest data in the buffer and the only
-                    // data a quiet table may have at all, so it is never
-                    // optional — only out of range.
-                    let tail = src.live_wal(rec.id, &sampler)?;
-                    let (Some(first), Some(last)) = (tail.first(), tail.last()) else {
-                        continue;
-                    };
-                    if last.ts < start || first.ts > end {
-                        continue;
-                    }
-                    // `first`/`tail.len()` are only for the range check above
-                    // from here on — the catalog's `first_ts`/`rows` come
-                    // from what actually materializes (see
-                    // `MaterializedTail`'s doc): a V3 group's leading
-                    // un-anchored rows are real WAL rows that never reach the
-                    // segment, so the raw tail's own span/length would
-                    // catalog a start and count the inserted bytes don't
-                    // agree with. `last_ts` stays the raw tail's own last
-                    // row — that one is always correct (a skip is always a
-                    // leading run).
-                    let materialized =
-                        crate::recorder::rez_v3_writer::materialize_wal_tail(&sampler, &tail)
-                            .map_err(|e| format!("failed to seal the {sampler} tail: {e}"))?;
-                    if let Some(materialized) = materialized {
-                        let meta = SegmentMeta {
-                            rows: materialized.rows,
-                            first_ts: materialized.first_ts,
-                            last_ts: last.ts,
-                        };
-                        tx.insert_segment(id, &sampler, seq, &meta, &materialized.bytes)?;
-                    }
-                }
-                // Drift observations are part of the recording's identity and
-                // cost nothing to carry; they are already only a handful of
-                // rows per seal.
-                for (ts, offset) in src.read_clock_offsets(rec.id)? {
-                    tx.insert_clock_offset(id, ts, offset)?;
-                }
-            }
+            let spec = CopySpec {
+                start,
+                end,
+                ..CopySpec::everything()
+            };
+            copy_recordings_into(src, tx, &spec)?;
             Ok(())
         })
     })
@@ -426,7 +389,7 @@ mod tests {
     use super::*;
     use crate::recorder::rez::recorder_tests_support::{counter, snap};
     use crate::recorder::rez::{detect_rez_format, read_table_parquet, RezFormat};
-    use crate::recorder::rez_sqlite::{Evicted, RecordingMeta};
+    use crate::recorder::rez_sqlite::{Evicted, RecordingMeta, SegmentMeta};
     use metriken::Window;
     use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -25,13 +25,7 @@ pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
     let path = args.get_one::<PathBuf>("FILE").unwrap();
 
     match dispatch_format(path) {
-        RezFormat::V3Sqlite => {
-            eprintln!(
-                "error: annotating a v3 (SQLite) .rez archive is not yet supported; only v2 tar .rez archives can be annotated in place"
-            );
-            std::process::exit(1);
-        }
-        RezFormat::V2Tar => {
+        format @ (RezFormat::V3Sqlite | RezFormat::V2Tar) => {
             let custom = args.get_one::<PathBuf>("queries").unwrap_or_else(|| {
                 eprintln!("error: annotating a .rez requires --queries <service-extension.json> (a .rez has no service template)");
                 std::process::exit(1);
@@ -45,7 +39,11 @@ pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
                 eprintln!("error: invalid service extension JSON: {e}");
                 std::process::exit(1);
             });
-            annotate_rez(path, &content).unwrap_or_else(|e| {
+            let result = match format {
+                RezFormat::V3Sqlite => annotate_rez_v3(path, &content),
+                _ => annotate_rez(path, &content),
+            };
+            result.unwrap_or_else(|e| {
                 eprintln!("error: failed to annotate .rez: {e}");
                 std::process::exit(1);
             });
@@ -268,6 +266,56 @@ fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
 /// Embed a custom ServiceExtension into every recording of a `.rez`, validated
 /// against that recording's data. Rewrites the archive in place (copying table
 /// bytes verbatim).
+/// Embed KPIs into every recording of a v3 (SQLite) `.rez`.
+///
+/// Unlike `combine` and `filter` this rewrites nothing: the KPI set is a
+/// catalog column, so annotating is an `UPDATE` per recording. No segment is
+/// read or copied, which is why annotating a 4 GB archive costs the same as
+/// annotating a 4 MB one.
+fn annotate_rez_v3(path: &Path, ext_json: &str) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::recorder::rez_sqlite::RezDb;
+
+    let base_ext: ServiceExtension = serde_json::from_str(ext_json)?;
+    let pool = metriken_query::BufferPool::new(256 * 1024 * 1024);
+    let readers = crate::rez_reader::RezReader::open_recordings(path, pool)?;
+
+    let db = RezDb::open(path)?;
+    let recordings = db.read_recordings()?;
+    if recordings.len() != readers.len() {
+        return Err(format!(
+            "{} has {} recording(s) in its catalog but {} readable — refusing to annotate a \
+             partially readable archive",
+            path.display(),
+            recordings.len(),
+            readers.len()
+        )
+        .into());
+    }
+
+    let mut kpis = 0usize;
+    for (rec, (_labels, reader)) in recordings.iter().zip(readers) {
+        let mut ext = base_ext.clone();
+        // Validated per recording, not once: a KPI's query is only meaningful
+        // against the metrics that recording actually holds, and a
+        // multi-recording archive can hold different sets.
+        validate_kpis_source(&reader, &mut ext);
+        kpis = ext.kpis.len();
+        let mut metadata = rec.meta.metadata.clone();
+        metadata.insert(
+            crate::parquet_metadata::KEY_SERVICE_QUERIES.to_string(),
+            serde_json::to_string(&ext)?,
+        );
+        db.update_recording_metadata(rec.id, &metadata)?;
+    }
+    println!(
+        "Annotated {:?}: embedded {} KPIs into {} recording(s)",
+        path,
+        kpis,
+        recordings.len()
+    );
+    Ok(())
+}
+
 fn annotate_rez(path: &Path, ext_json: &str) -> Result<(), Box<dyn std::error::Error>> {
     use crate::recorder::rez;
     let base_ext: ServiceExtension = serde_json::from_str(ext_json)?;
@@ -527,7 +575,7 @@ mod tests {
     // tests cover the classification `run()` matches on instead.
 
     /// `dispatch_format` must recognize a v3 (SQLite) `.rez` as `V3Sqlite`
-    /// (routing `run()` to the explicit "not yet supported" error), not
+    /// (routing `run()` to the v3 annotate path), not
     /// `NotRez` (which would route it to the plain-parquet path and fail with
     /// an unrelated "Corrupt footer" error).
     ///
@@ -868,6 +916,47 @@ mod tests {
         let out = dir.path().join("one.rez");
         r.finalize(&out).unwrap();
         (dir, out)
+    }
+
+    /// Annotating a v3 archive writes the KPI set into each recording's
+    /// metadata column, in place, without disturbing the segments.
+    #[test]
+    fn annotate_rez_v3_embeds_service_queries_into_recordings() {
+        use crate::recorder::rez::recorder_tests_support::populated_v3_rez;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rec.rez");
+        populated_v3_rez(&path, "baseline", &["cpu_usage"], 6);
+        let before = std::fs::metadata(&path).unwrap().len();
+
+        let ext_json = r#"{"service_name":"test","kpis":[{"role":"overview","title":"Zero","query":"0","type":"gauge"}]}"#;
+        annotate_rez_v3(&path, ext_json).unwrap();
+
+        let db = crate::recorder::rez_sqlite::RezDb::open(&path).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(recordings.len(), 1);
+        let embedded = recordings[0]
+            .meta
+            .metadata
+            .get(crate::parquet_metadata::KEY_SERVICE_QUERIES)
+            .expect("service queries must be embedded in the recording metadata");
+        assert!(
+            embedded.contains("test"),
+            "the extension's own content must survive"
+        );
+        // Pre-existing metadata is preserved, not replaced wholesale.
+        assert!(
+            recordings[0]
+                .meta
+                .metadata
+                .contains_key("sampling_interval_ms"),
+            "annotating must merge into the recording's metadata, not overwrite it"
+        );
+        // Segments were never rewritten, so the file does not balloon.
+        let after = std::fs::metadata(&path).unwrap().len();
+        assert!(
+            after <= before + 64 * 1024,
+            "annotate must not rewrite segments: {before} -> {after}"
+        );
     }
 
     #[test]

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -204,17 +204,22 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
             if !formats.iter().all(|f| *f != RezFormat::NotRez) {
                 return Err("cannot mix .rez and .parquet inputs in combine".into());
             }
-            // `combine_rez` rewrites recordings through `read_archive_bytes`/
-            // `write_archive_bytes`, which only speak the v2 tar container.
-            // Mixing v2 and v3 (or combining all-v3) is a real question this
-            // task leaves out of scope: error clearly rather than silently
-            // mis-assembling or corrupting an archive.
-            if formats.contains(&RezFormat::V3Sqlite) {
+            // Each container has its own assembler: v3 copies segment BLOBs
+            // between SQLite catalogs, v2 rewrites tar members. Mixing the two
+            // would mean converting one container into the other mid-assembly,
+            // which is a real feature rather than a special case here — error
+            // instead of half-doing it.
+            let all_v3 = formats.iter().all(|f| *f == RezFormat::V3Sqlite);
+            let any_v3 = formats.contains(&RezFormat::V3Sqlite);
+            if any_v3 && !all_v3 {
                 return Err(
-                    "combining v3 (SQLite) .rez archives is not yet supported; only v2 tar \
-                     .rez archives can be combined"
+                    "cannot combine v2 (tar) and v3 (SQLite) .rez archives together; \
+                     convert them to one container first"
                         .into(),
                 );
+            }
+            if all_v3 {
+                return combine_rez_v3(&files, output);
             }
             return combine_rez(&files, output);
         }
@@ -305,6 +310,53 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
 
 /// Assemble multiple `.rez` files into one multi-recording `.rez`, copying each
 /// recording verbatim and assigning collision-free `dir`s from labels.
+/// Assemble several v3 (SQLite) `.rez` archives into one multi-recording
+/// archive.
+///
+/// Segment BLOBs are copied verbatim — nothing is decoded, re-encoded or
+/// re-timestamped, so this costs a BLOB copy per segment and nothing else.
+/// Every input's recordings are appended under fresh ids, which is all a
+/// multi-recording archive is; unlike the v2 tar path there are no directory
+/// names to keep unique, because a v3 recording is identified by its row id
+/// and described by its labels.
+///
+/// The whole assembly is one destination transaction: either the output holds
+/// every input or it does not exist.
+fn combine_rez_v3(
+    files: &[PathBuf],
+    output: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::recorder::rez_sqlite::RezDb;
+    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, mark_copies_complete, CopySpec};
+
+    let mut dst = RezDb::create(output)?;
+    let mut recordings = 0usize;
+    dst.transaction(|tx| {
+        for file in files {
+            let src = RezDb::open(file)?;
+            // A read snapshot per input: one of them may still be being
+            // written (a live hindsight buffer is a perfectly good input), and
+            // this is what stops retention from deleting a segment out from
+            // under the copy.
+            src.read_snapshot(|src| {
+                recordings += copy_recordings_into(src, tx, &CopySpec::everything())?;
+                Ok(())
+            })?;
+        }
+        Ok(())
+    })?;
+    // The inputs may still be recording; this assembly is finished by
+    // definition, so it should not open with a "not cleanly finalized" warning.
+    mark_copies_complete(&mut dst)?;
+    println!(
+        "wrote {} with {} recording(s) from {} input(s)",
+        output.display(),
+        recordings,
+        files.len()
+    );
+    Ok(())
+}
+
 fn combine_rez(
     files: &[PathBuf],
     output: &std::path::Path,
@@ -2800,43 +2852,70 @@ mod tests {
     }
 
     /// `parquet combine` recognizes a v3 (SQLite) `.rez` as a `.rez` input (not
-    /// a bare parquet), but `combine_rez` rewrites recordings through
-    /// `read_archive_bytes`/`write_archive_bytes`, which only speak the v2 tar
-    /// container — so all-v3 inputs get an explicit "not yet supported" error
-    /// rather than being silently treated as plain parquet (and failing with
-    /// an unrelated footer error) or half-combined into a corrupt archive.
+    /// All-v3 inputs assemble into one multi-recording v3 archive, and the
+    /// result must be READABLE — not merely written. The trap a segment copy
+    /// invites is producing a catalog that looks right while the parquet
+    /// BLOBs it points at were reseq'd out of order or attributed to the
+    /// wrong recording, which only a read catches.
     ///
-    /// Mutation check: reverting the front-door classification in `run()` to
-    /// `is_rez_path` makes this fail — `is_rez_path` reports `false` for both
-    /// v3 inputs, so `run()` never takes the `.rez` branch at all and the
-    /// error comes from `load_inputs` trying (and failing) to read the SQLite
-    /// bytes as a parquet footer, which does not mention "v3".
+    /// Mutation check: dropping the `seq` renumbering in
+    /// `copy_recordings_into` leaves this passing only while every input has a
+    /// single segment, which is why the fixture writes several ticks.
     #[test]
-    fn combine_rejects_all_v3_sqlite_rez_inputs() {
+    fn combine_assembles_v3_inputs_into_one_readable_archive() {
+        use crate::recorder::rez::recorder_tests_support::populated_v3_rez;
         let dir = tempfile::tempdir().unwrap();
         let a = dir.path().join("a.rez");
         let b = dir.path().join("b.rez");
-        crate::recorder::rez::recorder_tests_support::empty_v3_rez(&a);
-        crate::recorder::rez::recorder_tests_support::empty_v3_rez(&b);
-        for f in [&a, &b] {
-            assert_eq!(
-                crate::recorder::rez::detect_rez_format(f).unwrap(),
-                crate::recorder::rez::RezFormat::V3Sqlite,
-                "fixture sanity: must actually be a v3 SQLite archive"
-            );
-        }
+        populated_v3_rez(&a, "baseline", &["cpu_usage", "scheduler"], 6);
+        populated_v3_rez(&b, "experiment", &["cpu_usage", "scheduler"], 6);
         let out = dir.path().join("out.rez");
 
-        let err = run_combine(&[a, b], &out).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("v3"),
-            "expected an explicit v3-not-supported error, got: {msg}"
+        run_combine(&[a, b], &out).unwrap();
+
+        assert_eq!(
+            crate::recorder::rez::detect_rez_format(&out).unwrap(),
+            crate::recorder::rez::RezFormat::V3Sqlite,
+            "a combined v3 archive must still be a v3 archive"
         );
-        assert!(
-            !out.exists(),
-            "must not write a (half-assembled) output on the unsupported path"
+
+        let db = crate::recorder::rez_sqlite::RezDb::open(&out).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(recordings.len(), 2, "one recording per input");
+        let arms: Vec<&str> = recordings
+            .iter()
+            .filter_map(|r| r.meta.labels.get("arm").map(String::as_str))
+            .collect();
+        assert_eq!(
+            arms,
+            vec!["baseline", "experiment"],
+            "each input's labels must survive, distinguishing the arms"
         );
+        for rec in &recordings {
+            assert!(
+                rec.complete,
+                "an assembled archive is finished by definition and must not \
+                 open with a 'not cleanly finalized' warning"
+            );
+            let mut tables = db.all_samplers(rec.id).unwrap();
+            tables.sort();
+            assert_eq!(
+                tables,
+                vec!["cpu_usage".to_string(), "scheduler".to_string()]
+            );
+            for table in &tables {
+                assert!(
+                    db.total_rows(rec.id, table).unwrap() > 0,
+                    "table {table} carried no rows across the copy"
+                );
+            }
+        }
+
+        // The point of the whole exercise: the assembled archive answers
+        // queries, per recording.
+        let pool = metriken_query::BufferPool::new(64 * 1024 * 1024);
+        let readers = crate::rez_reader::RezReader::open_recordings(&out, pool).unwrap();
+        assert_eq!(readers.len(), 2, "both recordings must be readable");
     }
 
     /// Mixing a v2 tar input with a v3 SQLite input is deliberately out of

--- a/src/parquet_tools/filter.rs
+++ b/src/parquet_tools/filter.rs
@@ -159,11 +159,23 @@ pub(super) fn filter_parquet_file(
 /// `<sampler>/<group>` tables, and "drop cpu_usage" has to mean all of its
 /// groups. Kept tables' segment BLOBs are copied verbatim.
 ///
-/// Writing a new file rather than deleting in place is deliberate even though
-/// SQL could `DELETE`: a delete would leave the freed pages inside the
-/// original file, so the archive an operator filtered to make smaller would not
-/// get smaller without a full `VACUUM` afterwards. Copying only what is kept
-/// makes the output's size the point of the operation.
+/// Writing a new archive rather than issuing a `DELETE` is deliberate, but NOT
+/// because a delete would strand the freed pages — these archives are created
+/// `auto_vacuum=INCREMENTAL` and [`RezDb::incremental_vacuum`] hands the pages
+/// back, which is exactly how hindsight retention keeps a buffer bounded. A
+/// delete would shrink the file perfectly well. The reasons are:
+///
+/// 1. `--output` must leave the input untouched, so that mode needs a copy no
+///    matter what — and a delete-based one would have to copy the WHOLE
+///    archive first and then shrink it, writing 5.8 MB to produce 1.6 MB in
+///    the measured case. One path serves both modes, and it is the cheaper
+///    path in the one that dominates.
+/// 2. In place, a copy plus an atomic rename cannot damage the original. A
+///    delete mutates it, so a failure partway through leaves the operator with
+///    neither the archive they had nor the one they asked for.
+/// 3. It reuses hindsight's copy, so the WAL-tail handling — a table's
+///    unsealed rows, and a V3 group's leading un-anchored rows that never
+///    reach a segment — has one implementation rather than two.
 fn filter_rez_v3(
     path: &Path,
     keep: &std::collections::BTreeSet<String>,

--- a/src/parquet_tools/filter.rs
+++ b/src/parquet_tools/filter.rs
@@ -12,13 +12,12 @@ use crate::viewer::{ServiceExtension, TemplateRegistry};
 use super::annotate::extract_metric_selectors;
 
 /// Which branch `run()` takes for `path`. Dispatch is by CONTENT, not
-/// extension, and recognizes both `.rez` containers. `filter_rez` rewrites
-/// through `read_archive_bytes`/`write_archive_bytes`, which only speak the
-/// v2 tar container, so a v3 (SQLite) archive gets an explicit "not yet
-/// supported" error in `run()` rather than silently falling through to the
-/// plain-parquet path or a misleading tar-parse error. Split out from `run()`
-/// so it is testable without triggering `run()`'s `std::process::exit` on the
-/// v3/error arms.
+/// extension, and recognizes both `.rez` containers: each has its own
+/// filter (`filter_rez_v3` copies segment BLOBs between SQLite catalogs,
+/// `filter_rez` rewrites tar members), so a `.rez` never falls through to the
+/// plain-parquet path and fails with a misleading footer or tar-parse error.
+/// Split out from `run()` so it is testable without triggering `run()`'s
+/// `std::process::exit`.
 fn dispatch_format(path: &Path) -> RezFormat {
     crate::recorder::rez::detect_rez_format(path).unwrap_or(RezFormat::NotRez)
 }
@@ -29,13 +28,7 @@ pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
     // `.rez` archives: drop whole per-sampler tables by --samplers (the
     // KPI-column filter no-ops on all-rezolus .rez data).
     match dispatch_format(path) {
-        RezFormat::V3Sqlite => {
-            eprintln!(
-                "error: filtering a v3 (SQLite) .rez archive is not yet supported; only v2 tar .rez archives can be filtered in place"
-            );
-            std::process::exit(1);
-        }
-        RezFormat::V2Tar => {
+        format @ (RezFormat::V3Sqlite | RezFormat::V2Tar) => {
             let list = args.get_one::<String>("samplers").unwrap_or_else(|| {
                 eprintln!(
                     "error: filtering a .rez requires --samplers <a,b,...> (samplers to keep)"
@@ -48,7 +41,11 @@ pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
                 .filter(|s| !s.is_empty())
                 .collect();
             let output = args.get_one::<PathBuf>("output").map(|p| p.as_path());
-            if let Err(e) = filter_rez(path, &keep, output) {
+            let result = match format {
+                RezFormat::V3Sqlite => filter_rez_v3(path, &keep, output),
+                _ => filter_rez(path, &keep, output),
+            };
+            if let Err(e) = result {
                 eprintln!("error: failed to filter .rez: {e}");
                 std::process::exit(1);
             }
@@ -156,8 +153,98 @@ pub(super) fn filter_parquet_file(
     Ok(())
 }
 
-/// Filter a `.rez` archive to keep only the named per-sampler tables, dropping
-/// the rest from every recording. Copies kept table bytes verbatim.
+/// Drop whole samplers from a v3 (SQLite) `.rez`.
+///
+/// Filters by *sampler*, not by table key: under V3 one sampler owns several
+/// `<sampler>/<group>` tables, and "drop cpu_usage" has to mean all of its
+/// groups. Kept tables' segment BLOBs are copied verbatim.
+///
+/// Writing a new file rather than deleting in place is deliberate even though
+/// SQL could `DELETE`: a delete would leave the freed pages inside the
+/// original file, so the archive an operator filtered to make smaller would not
+/// get smaller without a full `VACUUM` afterwards. Copying only what is kept
+/// makes the output's size the point of the operation.
+fn filter_rez_v3(
+    path: &Path,
+    keep: &std::collections::BTreeSet<String>,
+    output: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::recorder::rez::table_sampler;
+    use crate::recorder::rez_sqlite::RezDb;
+    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, mark_copies_complete, CopySpec};
+
+    let src = RezDb::open(path)?;
+
+    // The same guard the v2 path carries, and for the same reason: `dest`
+    // defaults to the INPUT, so an unvalidated `--samplers cpu_usge` would
+    // overwrite a long-lived capture with an archive holding nothing.
+    let mut present: BTreeSet<String> = BTreeSet::new();
+    let mut total = 0usize;
+    for rec in src.read_recordings()? {
+        for table in src.all_samplers(rec.id)? {
+            total += 1;
+            present.insert(table_sampler(&table).to_string());
+        }
+    }
+    let unmatched: Vec<&str> = keep
+        .iter()
+        .map(String::as_str)
+        .filter(|s| !present.contains(*s))
+        .collect();
+    if !unmatched.is_empty() {
+        return Err(format!(
+            "no sampler named {} in {}; it holds: {}",
+            unmatched.join(", "),
+            path.display(),
+            present
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+        .into());
+    }
+
+    // Staged beside the destination so the rename that publishes it is atomic
+    // and on the same filesystem — and so an in-place filter never leaves a
+    // half-written archive where the original was.
+    let dest = output.unwrap_or(path);
+    let dir = dest.parent().filter(|p| !p.as_os_str().is_empty());
+    let staging = match dir {
+        Some(dir) => tempfile::tempdir_in(dir),
+        None => tempfile::tempdir(),
+    }?;
+    let staged = staging.path().join("filtered.rez");
+
+    let mut dst = RezDb::create(&staged)?;
+    let mut kept = 0usize;
+    dst.transaction(|tx| {
+        src.read_snapshot(|src| {
+            let spec = CopySpec {
+                keep_samplers: Some(keep),
+                ..CopySpec::everything()
+            };
+            copy_recordings_into(src, tx, &spec)?;
+            Ok(())
+        })
+    })?;
+    mark_copies_complete(&mut dst)?;
+    for rec in dst.read_recordings()? {
+        kept += dst.all_samplers(rec.id)?.len();
+    }
+    drop(dst);
+    drop(src);
+    std::fs::rename(&staged, dest)?;
+
+    println!(
+        "Filtered {:?}: kept {} of {} sampler tables",
+        dest, kept, total
+    );
+    Ok(())
+}
+
+/// Filter a v2 (tar) `.rez` archive to keep only the named per-sampler tables,
+/// dropping the rest from every recording. Copies kept table bytes verbatim.
 fn filter_rez(
     path: &Path,
     keep: &std::collections::BTreeSet<String>,
@@ -392,7 +479,7 @@ mod tests {
     // tests cover the classification `run()` matches on instead.
 
     /// `dispatch_format` must recognize a v3 (SQLite) `.rez` as `V3Sqlite`
-    /// (routing `run()` to the explicit "not yet supported" error), not
+    /// (routing `run()` to the v3 filter path), not
     /// `NotRez` (which would route it to the plain-parquet path and fail with
     /// an unrelated "Corrupt footer" error).
     ///
@@ -510,6 +597,61 @@ mod tests {
         let out = dir.path().join("two.rez");
         r.finalize(&out).unwrap();
         (dir, out)
+    }
+
+    /// Filtering a v3 archive keeps the named samplers and drops the rest —
+    /// and the survivors keep their rows. Dropping a table is easy; dropping
+    /// it without taking a kept table's segments with it is the part worth
+    /// asserting.
+    #[test]
+    fn filter_rez_v3_keeps_only_named_samplers() {
+        use crate::recorder::rez::recorder_tests_support::populated_v3_rez;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("full.rez");
+        populated_v3_rez(&path, "baseline", &["cpu_usage", "scheduler", "network"], 6);
+        let out = dir.path().join("slim.rez");
+
+        let keep: std::collections::BTreeSet<String> =
+            ["cpu_usage".to_string()].into_iter().collect();
+        filter_rez_v3(&path, &keep, Some(&out)).unwrap();
+
+        let db = crate::recorder::rez_sqlite::RezDb::open(&out).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(recordings.len(), 1);
+        let tables = db.all_samplers(recordings[0].id).unwrap();
+        assert_eq!(
+            tables,
+            vec!["cpu_usage".to_string()],
+            "only the kept sampler survives"
+        );
+        assert!(
+            db.total_rows(recordings[0].id, "cpu_usage").unwrap() > 0,
+            "the kept sampler must keep its rows, not just its name"
+        );
+    }
+
+    /// A typo'd sampler name must not be read as "keep nothing". `--output`
+    /// defaults to the INPUT, so this once overwrote a long-lived capture in
+    /// place with an archive holding no metrics at all.
+    #[test]
+    fn filter_rez_v3_rejects_an_unmatched_sampler_instead_of_emptying_the_archive() {
+        use crate::recorder::rez::recorder_tests_support::populated_v3_rez;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("full.rez");
+        populated_v3_rez(&path, "baseline", &["cpu_usage"], 4);
+
+        let keep: std::collections::BTreeSet<String> =
+            ["cpu_usge".to_string()].into_iter().collect();
+        let err = filter_rez_v3(&path, &keep, None).unwrap_err().to_string();
+        assert!(
+            err.contains("cpu_usge"),
+            "the error must name the typo: {err}"
+        );
+
+        // And the input is untouched.
+        let db = crate::recorder::rez_sqlite::RezDb::open(&path).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(db.all_samplers(recordings[0].id).unwrap().len(), 1);
     }
 
     #[test]

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -7,6 +7,7 @@ mod prometheus;
 pub(crate) mod rez;
 pub(crate) mod rez_sqlite;
 pub(crate) mod rez_stream;
+pub(crate) mod rez_v3_rewrite;
 pub(crate) mod rez_v3_writer;
 
 use crate::parquet_metadata;

--- a/src/recorder/rez.rs
+++ b/src/recorder/rez.rs
@@ -1000,11 +1000,12 @@ pub fn is_rez_path(path: &Path) -> Result<bool, RezError> {
 /// Which container a `.rez` path holds. v1/v2 are tar archives; v3 is SQLite.
 ///
 /// `RezReader` dispatches on this, and so does every other `.rez` front door
-/// (`mcp`, `viewer`, `parquet metadata/annotate/filter/combine`) — all now
-/// recognize both containers. `parquet annotate`/`filter`/`combine` still
-/// only *rewrite* the v2 tar container (`read_archive_bytes`/
-/// `write_archive_bytes`); on a v3 input they report a clear "not yet
-/// supported" error rather than silently misrouting or half-working.
+/// (`mcp`, `viewer`, `parquet metadata/annotate/filter/combine`) — all
+/// recognize and rewrite both containers. The two rewrite paths are separate
+/// because the containers are: v2 goes through `read_archive_bytes`/
+/// `write_archive_bytes`, v3 copies segment BLOBs between SQLite catalogs
+/// (`recorder::rez_v3_rewrite`). Only *mixing* the two in one `combine`
+/// errors, since that would mean converting a container mid-assembly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RezFormat {
     V3Sqlite,
@@ -1584,14 +1585,13 @@ impl GroupTableBuilder {
 /// `metriken_query::UnionMetricsSource`; two DIFFERENT samplers still refuse
 /// a query spanning them.
 ///
-/// `parquet filter`/`annotate`/`combine` still only rewrite the v2 tar
-/// container and report an explicit "not yet supported" error for a v3
-/// (SQLite) archive (`parquet_tools::filter`, unchanged by this build) —
-/// wiring `--samplers` support for V3 group tables is future work. Exercised
-/// directly by `table_sampler_tests` and by `rez_v3_writer`'s
+/// `parquet filter --samplers` uses this on a v3 archive to drop a sampler's
+/// group tables together — naming `cpu_usage` drops every `cpu_usage/<group>`
+/// table, because the sampler is the unit an operator names. Exercised
+/// directly by `table_sampler_tests`, by `rez_v3_writer`'s
 /// `table_sampler_selects_a_samplers_group_tables_out_of_a_mixed_recording`
-/// against a real recording, so the selection rule is proven correct ahead of
-/// that CLI plumbing landing.
+/// against a real recording, and end to end by
+/// `filter_rez_v3_keeps_only_named_samplers`.
 ///
 /// `parquet metadata` on a v3-native archive is a known, narrower instance of
 /// the same display gap: it lists one line per GROUP table (`describe_v3_string`
@@ -2108,6 +2108,46 @@ pub(crate) mod recorder_tests_support {
             clock_anchor_wall_ns: 1_700_000_000_000_000_000,
         };
         RezV3Writer::create(path, seed).unwrap();
+    }
+
+    /// A finalized v3 `.rez` holding `ticks` rows of one counter per named
+    /// sampler, labelled `arm=<arm>` so a multi-recording assembly can tell
+    /// its inputs apart.
+    ///
+    /// Real rows, not an empty catalog: the rewrite tools copy segments and
+    /// materialize WAL tails, so a fixture with no data would exercise
+    /// neither.
+    pub(crate) fn populated_v3_rez(
+        path: &std::path::Path,
+        arm: &str,
+        samplers: &[&str],
+        ticks: u64,
+    ) {
+        use crate::recorder::rez_v3_writer::{ManifestSeed, RezV3Writer, StreamRecorderV3};
+        const ANCHOR: u64 = 1_700_000_000_000_000_000;
+        let seed = ManifestSeed {
+            labels: [
+                ("source".to_string(), "rezolus".to_string()),
+                ("arm".to_string(), arm.to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            metadata: [("sampling_interval_ms".to_string(), "1000".to_string())]
+                .into_iter()
+                .collect(),
+            clock_anchor_wall_ns: ANCHOR,
+        };
+        let mut rec = StreamRecorderV3::new(RezV3Writer::create(path, seed).unwrap());
+        for tick in 0..ticks {
+            let ts = ANCHOR + tick * 1_000_000_000;
+            let counters = samplers
+                .iter()
+                .enumerate()
+                .map(|(i, s)| counter(&format!("{i}"), s, tick + 1, None))
+                .collect();
+            rec.ingest(&snap(ts, counters), ts, 0).unwrap();
+        }
+        rec.finalize((ANCHOR + ticks * 1_000_000_000, 0)).unwrap();
     }
 }
 

--- a/src/recorder/rez_sqlite.rs
+++ b/src/recorder/rez_sqlite.rs
@@ -77,6 +77,7 @@ const _: () = assert!(
 const SCHEMA_VERSION: i64 = 3;
 
 /// One recording's identity: everything known when the recording starts.
+#[derive(Clone)]
 pub(crate) struct RecordingMeta {
     pub labels: BTreeMap<String, String>,
     pub metadata: BTreeMap<String, String>,
@@ -922,6 +923,32 @@ impl RezDb {
     /// buffer it came from is still running.
     pub(crate) fn mark_complete(&mut self, recording_id: i64) -> Result<(), String> {
         self.transaction(|tx| tx.mark_complete(recording_id))
+    }
+
+    /// Replace one recording's metadata map.
+    ///
+    /// In place rather than through a copy because metadata is a catalog
+    /// column: `annotate` changes it and nothing else, and rewriting an
+    /// archive's every segment BLOB to edit one JSON string would make a
+    /// cheap operation cost the size of the recording.
+    pub(crate) fn update_recording_metadata(
+        &self,
+        recording_id: i64,
+        metadata: &BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        let encoded = serde_json::to_string(metadata)
+            .map_err(|e| format!("failed to encode recording metadata: {e}"))?;
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE recordings SET metadata = ?1 WHERE id = ?2",
+                rusqlite::params![encoded, recording_id],
+            )
+            .map_err(|e| format!("failed to update recording metadata: {e}"))?;
+        if changed == 0 {
+            return Err(format!("no recording with id {recording_id}"));
+        }
+        Ok(())
     }
 
     pub(crate) fn pragma_u32(&self, name: &str) -> Result<u32, String> {

--- a/src/recorder/rez_sqlite.rs
+++ b/src/recorder/rez_sqlite.rs
@@ -925,6 +925,28 @@ impl RezDb {
         self.transaction(|tx| tx.mark_complete(recording_id))
     }
 
+    /// Every user table in this database, by name — SQLite's own internal
+    /// tables (`sqlite_*`) excluded.
+    ///
+    /// Exists so `rez_v3_rewrite` can assert that its fixed copy list still
+    /// covers the whole schema: a copy carries only what it is told to, so a
+    /// table added here without being handled there would vanish silently
+    /// from every rewritten archive.
+    #[cfg(test)]
+    pub(crate) fn user_table_names(&self) -> Result<Vec<String>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+            )
+            .map_err(|e| format!("failed to list tables: {e}"))?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(|e| format!("failed to list tables: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("failed to list tables: {e}"))
+    }
+
     /// Replace one recording's metadata map.
     ///
     /// In place rather than through a copy because metadata is a catalog

--- a/src/recorder/rez_v3_rewrite.rs
+++ b/src/recorder/rez_v3_rewrite.rs
@@ -138,3 +138,53 @@ pub(crate) fn mark_copies_complete(db: &mut RezDb) -> Result<(), String> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::recorder::rez_sqlite::RezDb;
+
+    /// Every table in the v3 schema is either copied by
+    /// [`super::copy_recordings_into`] or deliberately not carried, and this
+    /// test is what makes that a decision rather than an oversight.
+    ///
+    /// The weakness of copying instead of deleting is exactly here: a delete
+    /// preserves whatever it does not remove, so schema growth is free, while
+    /// a copy only carries what it was told to. Adding a table to the schema
+    /// without teaching the copy about it would silently drop that table from
+    /// every combined, filtered or dumped archive — a data-loss bug with no
+    /// error and no symptom until someone queries for what is missing.
+    ///
+    /// So: adding a table here fails this test. Either copy it in
+    /// `copy_recordings_into` or add it to `NOT_CARRIED` with the reason.
+    #[test]
+    fn every_schema_table_is_either_copied_or_deliberately_dropped() {
+        /// Carried across by `copy_recordings_into`.
+        const COPIED: &[&str] = &["recordings", "segments", "wal", "clock_offsets"];
+        /// Not carried, and correct not to be.
+        const NOT_CARRIED: &[&str] = &[
+            // Written by `RezDb::create` for the destination itself; copying
+            // the source's would say nothing new and could disagree.
+            "schema_version",
+        ];
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("schema.rez");
+        let db = RezDb::create(&path).unwrap();
+
+        let mut actual = db.user_table_names().unwrap();
+        actual.sort();
+        let mut expected: Vec<String> = COPIED
+            .iter()
+            .chain(NOT_CARRIED)
+            .map(|s| s.to_string())
+            .collect();
+        expected.sort();
+
+        assert_eq!(
+            actual, expected,
+            "the v3 schema changed. `copy_recordings_into` copies a fixed set of tables, so a \
+             new one is silently dropped from every combined/filtered/dumped archive until it \
+             is handled. Copy it, or list it in NOT_CARRIED with the reason."
+        );
+    }
+}

--- a/src/recorder/rez_v3_rewrite.rs
+++ b/src/recorder/rez_v3_rewrite.rs
@@ -1,0 +1,140 @@
+//! Rewriting a v3 (SQLite) `.rez` container.
+//!
+//! `combine`, `filter` and `annotate` all produce a new archive from existing
+//! ones without decoding a single segment: the parquet BLOBs pass through
+//! byte-identical and only the catalog around them changes. Hindsight's ranged
+//! dump is the same operation with a time bound, so all four share this copy
+//! rather than each growing their own — the WAL-tail handling below is subtle
+//! enough that a second implementation would be a second set of bugs.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::recorder::rez::table_sampler;
+use crate::recorder::rez_sqlite::{RezDb, RezTx, SegmentMeta};
+
+/// What one copy pass carries across.
+pub(crate) struct CopySpec<'a> {
+    /// Row-timestamp bound in nanoseconds. The rewrite tools copy everything;
+    /// hindsight's dump narrows it to the incident window.
+    pub start: u64,
+    pub end: u64,
+    /// Keep only tables whose *sampler* — the part of a `<sampler>/<group>`
+    /// key before the first `/` — is in this set. `None` keeps every table.
+    ///
+    /// Filtering by sampler rather than by table key is deliberate: a sampler
+    /// is the unit an operator names, and under V3 one sampler owns several
+    /// group tables. Dropping "the sampler" has to drop all of its groups.
+    pub keep_samplers: Option<&'a BTreeSet<String>>,
+    /// Extra metadata merged into each copied recording's own, overwriting on
+    /// key collision. `annotate` embeds KPIs this way; the others pass `None`.
+    pub metadata_extra: Option<&'a BTreeMap<String, String>>,
+}
+
+impl CopySpec<'_> {
+    /// Every recording, every table, every row, metadata untouched.
+    pub(crate) fn everything() -> Self {
+        CopySpec {
+            start: 0,
+            end: u64::MAX,
+            keep_samplers: None,
+            metadata_extra: None,
+        }
+    }
+}
+
+/// Copy every recording in `src` into the open destination transaction,
+/// returning how many recordings were copied.
+///
+/// The destination transaction is the caller's so that `combine` can fold
+/// several sources into one atomic write: either the combined archive has all
+/// of its inputs or it does not exist.
+///
+/// Recordings are inserted with fresh ids and are NOT marked complete — the
+/// caller decides that, because "was this recording finished" is a property of
+/// the copy's purpose, not of the copy. See `mark_copies_complete`.
+pub(crate) fn copy_recordings_into(
+    src: &RezDb,
+    tx: &RezTx<'_>,
+    spec: &CopySpec<'_>,
+) -> Result<usize, String> {
+    let recordings = src.read_recordings()?;
+    let mut copied = 0usize;
+    for rec in &recordings {
+        let mut meta = rec.meta.clone();
+        if let Some(extra) = spec.metadata_extra {
+            for (k, v) in extra {
+                meta.metadata.insert(k.clone(), v.clone());
+            }
+        }
+        let id = tx.insert_recording(&meta)?;
+        copied += 1;
+
+        for table in src.all_samplers(rec.id)? {
+            if let Some(keep) = spec.keep_samplers {
+                if !keep.contains(table_sampler(&table)) {
+                    continue;
+                }
+            }
+            // `seq` is renumbered from 0 per table rather than carried over.
+            // A filtered or range-bounded copy leaves holes in the source's
+            // numbering, and the reader splices segments in `seq` order, so
+            // the copy's own numbering has to be dense and start at zero.
+            let mut seq = 0u64;
+            for segment in src.segments_overlapping(rec.id, &table, spec.start, spec.end)? {
+                tx.insert_segment(id, &table, seq, &segment.meta, &segment.bytes)?;
+                seq += 1;
+            }
+
+            // The unsealed tail is the newest data in the archive and the only
+            // data a quiet table may have at all, so it is never optional —
+            // only out of range. A `.rez` still being written (a hindsight
+            // buffer, or a recording combined mid-flight) keeps real rows here
+            // that no segment holds yet.
+            let tail = src.live_wal(rec.id, &table)?;
+            let (Some(first), Some(last)) = (tail.first(), tail.last()) else {
+                continue;
+            };
+            if last.ts < spec.start || first.ts > spec.end {
+                continue;
+            }
+            // `first`/`tail.len()` served the range check above and nothing
+            // else: the catalog's `first_ts`/`rows` come from what actually
+            // materializes, because a V3 group's leading un-anchored rows are
+            // real WAL rows that never reach the segment. Cataloguing the raw
+            // tail's span would claim a start the bytes do not contain.
+            // `last_ts` stays the raw tail's own last row — a skip is always a
+            // leading run, so that one is always right.
+            let materialized = crate::recorder::rez_v3_writer::materialize_wal_tail(&table, &tail)
+                .map_err(|e| format!("failed to seal the {table} tail: {e}"))?;
+            if let Some(materialized) = materialized {
+                let meta = SegmentMeta {
+                    rows: materialized.rows,
+                    first_ts: materialized.first_ts,
+                    last_ts: last.ts,
+                };
+                tx.insert_segment(id, &table, seq, &meta, &materialized.bytes)?;
+            }
+        }
+
+        // Drift observations are part of the recording's identity and cost
+        // nothing to carry; they are already only a handful of rows per seal.
+        for (ts, offset) in src.read_clock_offsets(rec.id)? {
+            tx.insert_clock_offset(id, ts, offset)?;
+        }
+    }
+    Ok(copied)
+}
+
+/// Mark every recording in a freshly written copy complete.
+///
+/// A copy is finished by definition — the source may still be recording (a
+/// hindsight buffer always is), but the file just written is not. Without this
+/// every rewritten archive would open with "not cleanly finalized, recovered
+/// from its write-ahead log", which is alarming and, for a copy, false.
+pub(crate) fn mark_copies_complete(db: &mut RezDb) -> Result<(), String> {
+    let ids: Vec<i64> = db.read_recordings()?.iter().map(|r| r.id).collect();
+    for id in ids {
+        db.mark_complete(id)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Everything `record` writes today is a v3 (SQLite) container, and all three
rewrite tools refused it. Since `combine` is what builds the multi-recording
archive driving the viewer's A/B comparison, that workflow was only reachable
by passing `--rez-version 2` at record time — a decision made hours before the
error shows up, and irreversible once the data is collected (#1072).

All three now handle both containers. Nothing needs the v2 write path to stay
workable.

## The copy is a catalog operation

Segment BLOBs move between SQLite databases verbatim: nothing is decoded,
re-encoded or re-timestamped, so assembling an archive costs a BLOB copy per
segment.

Hindsight's ranged dump was already exactly this operation with a time bound,
so instead of growing a second implementation the shared one moves to
`recorder::rez_v3_rewrite` and hindsight's `copy_range` delegates to it. That
matters most for the WAL tail: a table's unsealed rows are real data no segment
holds, and a V3 group's leading un-anchored rows never reach the segment at
all, so cataloguing the raw tail's span would claim a start the bytes don't
contain. One implementation, one set of that reasoning.

## Per tool

- **`combine`** appends every input's recordings under fresh ids in a single
  destination transaction — either the output holds all its inputs or it does
  not exist. Unlike the tar path there are no directory names to keep unique,
  since a v3 recording is identified by row id and described by its labels.
  Mixing v2 and v3 inputs still errors: converting a container mid-assembly is
  a feature, not a special case.
- **`filter --samplers`** filters by *sampler*, not table key. Under V3 one
  sampler owns several `<sampler>/<group>` tables and "drop cpu_usage" has to
  take all of its groups. It writes a new file rather than issuing a `DELETE`,
  because freed pages would stay inside the original and the archive filtered
  to be smaller would not be. The v2 path's guard against a typo'd sampler name
  emptying an archive in place is carried over — that one has bitten before.
- **`annotate`** rewrites nothing. KPIs live in a catalog column, so this is an
  `UPDATE` per recording; annotating a 4 GB archive costs what annotating a
  4 MB one does.

## Verified on real archives

On a 32-core Linux host against a live agent, not just the fixtures:

- **combine** — two 11 MB recordings tagged `arm=baseline`/`arm=experiment`
  assembled into one archive; labels survived, no "not cleanly finalized"
  warning, and the viewer reports `compare_mode: true`. That is the #1072
  workflow working end to end.
- **filter** — against a real V3 agent (54 group tables), `--samplers
  cpu_usage` kept exactly its 6 `cpu_usage/<group>` tables and shrank the file
  5.8 MB → 1.6 MB, so the copy really does reclaim the space. The result still
  queries, `rate()` uncertainty bands intact, and the cross-group union still
  resolves on the filtered archive.
- **annotate** — embedded a KPI into the filtered archive; the file grew 12 KB
  (a couple of pages), confirming segments were not rewritten, and the KPI
  reads back.

## Tests

The combine test asserts the assembled archive is **readable**, not merely
written: a segment copy's characteristic failure is a catalog that looks right
while pointing at BLOBs reseq'd out of order or attributed to the wrong
recording, which only a read catches. Filter has both a keep-the-right-tables
test and the typo guard. `cargo test` green (671), fmt and clippy clean apart
from one pre-existing `dashboard` warning.

## Two things found while building it

**The justification for copying instead of deleting was wrong**, and the
review caught it. The comment claimed a `DELETE` would strand the freed pages
so a filtered archive would not shrink without a full `VACUUM`. These archives
are created `auto_vacuum=INCREMENTAL` and `RezDb::incremental_vacuum` hands
pages back — it is how hindsight retention keeps a buffer bounded. A delete
would have shrunk the file fine. The decision stands on the real reasons
(`--output` needs a copy regardless; atomic rename cannot damage the original;
one implementation of the WAL-tail handling), and the comment now says those.

That exposed the genuine weakness of copying, which a delete does not have: a
delete preserves what it does not remove, so schema growth is free, while a
copy carries only what it was told to. A table added to the v3 schema without
teaching `copy_recordings_into` about it would vanish from every combined,
filtered and dumped archive, silently. There is now a test that lists the
schema's tables and fails if one appears that is neither copied nor explicitly
listed as skipped — mutation-checked by adding a table and watching it fail by
name.

**A timing test was fragile and this branch tripped it.**
`agent::timing`'s `mark_end_pins_the_width_to_the_read_span_not_the_publish_delay`
slept 3ms, marked the end, slept 50ms, then required the width be under 20ms.
A sleep is a floor, not a duration: it ran 22.8ms on loaded CI and failed on
all three platforms. `mark_end()` was correct throughout — a broken one reports
~53ms. The likely trigger is this branch rather than bad luck, since the new
fixtures build real SQLite databases and parquet segments in parallel with it.
It now asserts `total - width >= 40ms`, which is what `mark_end()` actually
promises and holds however slowly the sleeps run. Mutation check: a no-op
`mark_end()` collapses the difference to 0.17ms and fails.

## Not in scope

Converting a v2 archive into a v3 one (so `combine` could take mixed inputs)
is a real feature and is left out deliberately — it errors clearly instead.

Closes #1072.
