### PR TITLE
feat(parquet): upgrade v1/v2 .rez archives to v3, and stop writing tar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,12 @@ target/release/rezolus parquet convert rezolus.raw --systeminfo sysinfo.json --d
 target/release/rezolus parquet combine a.parquet b.parquet -o combined.parquet       # row-merge multi-source
 target/release/rezolus parquet combine a.parquet b.parquet --ab baseline=redis experiment=valkey -o out.parquet.ab.tar  # A/B tarball (values are source names)
 target/release/rezolus parquet filter file.parquet -o slim.parquet   # drop columns not needed by KPIs
+target/release/rezolus parquet upgrade old.rez                       # v1/v2 tar .rez -> v3 SQLite (in place)
+target/release/rezolus parquet upgrade old.rez -o new.rez            # ...or to a new file
 # .rez archives: metadata describes the manifest (recordings, labels, tables + cadence; V3 group
 #   tables appear as <sampler>/<group>);
 # combine a.rez b.rez -o out.rez assembles single-recording .rez into a multi-recording .rez (multi-host/A/B);
+#   v1/v2 tar inputs are upgraded to v3 on the way in, so containers can be mixed freely;
 # filter file.rez --samplers cpu_usage,scheduler -o slim.rez drops tables whose sampler is not listed
 #   (both containers; on a v3 archive a sampler's group tables are dropped together);
 # annotate file.rez --queries kpis.json embeds KPIs into each recording's manifest (--queries required for .rez).

--- a/src/agent/timing.rs
+++ b/src/agent/timing.rs
@@ -446,10 +446,23 @@ mod tests {
         });
 
         barrier.wait();
+        // Read at least MIN_READS times — that floor is the tear detection and
+        // must not shrink — then keep going until the writer has demonstrably
+        // moved. The writer's progress is a scheduling outcome, not a property
+        // of the lock: on a loaded machine it gets starved, and CI has seen 88
+        // distinct stamps across the 5M reads, which says nothing about
+        // tearing. Bounded, so a genuinely stuck writer still fails the
+        // non-vacuity check below rather than spinning forever.
+        const MIN_READS: u64 = 5_000_000;
+        const MIN_ADVANCES: u64 = 100;
+        const MAX_READS: u64 = 100_000_000;
+
+        let mut reads = 0u64;
         let mut observed = 0u64; // Some(_) loads: contention actually exercised
         let mut advanced = 0u64; // distinct begin_ns values: writer made progress
         let mut last_begin = None;
-        for _ in 0..5_000_000 {
+        while reads < MAX_READS && (reads < MIN_READS || advanced <= MIN_ADVANCES) {
+            reads += 1;
             if let Some(w) = slot.load() {
                 assert_eq!(w.end_ns, w.begin_ns + 1, "torn read: {w:?}");
                 observed += 1;
@@ -467,8 +480,8 @@ mod tests {
             "reader saw too few stamps ({observed}) — not exercising contention"
         );
         assert!(
-            advanced > 100,
-            "writer made no visible progress ({advanced}) — vacuous run"
+            advanced > MIN_ADVANCES,
+            "writer made no visible progress ({advanced}) in {reads} reads — vacuous run"
         );
     }
 

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -282,7 +282,7 @@ fn annotate_rez_any(
     )?;
     let staged = staging.path().join("upgraded.rez");
     crate::recorder::rez_v3_rewrite::upgrade_tar_to_v3(path, &staged)?;
-    annotate_rez_v3(&staged, ext_json)?;
+    annotate_rez_v3_at(&staged, path, ext_json)?;
     // Staged beside the target so this rename is atomic and same-filesystem:
     // the original survives untouched until the annotated copy is complete.
     std::fs::rename(&staged, path)?;
@@ -300,6 +300,18 @@ fn annotate_rez_any(
 /// read or copied, which is why annotating a 4 GB archive costs the same as
 /// annotating a 4 MB one.
 fn annotate_rez_v3(path: &Path, ext_json: &str) -> Result<(), Box<dyn std::error::Error>> {
+    annotate_rez_v3_at(path, path, ext_json)
+}
+
+/// `annotate_rez_v3`, with the archive being written and the name to report
+/// separated. They differ when a tar archive is annotated: the work happens on
+/// an upgraded staging copy, but the operator asked about — and will go on
+/// using — the original path, so that is the one worth naming.
+fn annotate_rez_v3_at(
+    path: &Path,
+    display: &Path,
+    ext_json: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     use crate::recorder::rez_sqlite::RezDb;
 
     let base_ext: ServiceExtension = serde_json::from_str(ext_json)?;
@@ -336,7 +348,7 @@ fn annotate_rez_v3(path: &Path, ext_json: &str) -> Result<(), Box<dyn std::error
     }
     println!(
         "Annotated {:?}: embedded {} KPIs into {} recording(s)",
-        path,
+        display,
         kpis,
         recordings.len()
     );

--- a/src/parquet_tools/annotate.rs
+++ b/src/parquet_tools/annotate.rs
@@ -39,10 +39,7 @@ pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
                 eprintln!("error: invalid service extension JSON: {e}");
                 std::process::exit(1);
             });
-            let result = match format {
-                RezFormat::V3Sqlite => annotate_rez_v3(path, &content),
-                _ => annotate_rez(path, &content),
-            };
+            let result = annotate_rez_any(path, format, &content);
             result.unwrap_or_else(|e| {
                 eprintln!("error: failed to annotate .rez: {e}");
                 std::process::exit(1);
@@ -266,6 +263,36 @@ fn validate_kpis(path: &Path, ext: &mut ServiceExtension) {
 /// Embed a custom ServiceExtension into every recording of a `.rez`, validated
 /// against that recording's data. Rewrites the archive in place (copying table
 /// bytes verbatim).
+/// Annotate a `.rez` of either container, always leaving a v3 one behind.
+///
+/// A v1/v2 (tar) archive is upgraded in place first: annotating is a rewrite,
+/// and the tar container is no longer something this binary writes.
+fn annotate_rez_any(
+    path: &Path,
+    format: RezFormat,
+    ext_json: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if format != RezFormat::V2Tar {
+        return annotate_rez_v3(path, ext_json);
+    }
+    let staging = tempfile::tempdir_in(
+        path.parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new(".")),
+    )?;
+    let staged = staging.path().join("upgraded.rez");
+    crate::recorder::rez_v3_rewrite::upgrade_tar_to_v3(path, &staged)?;
+    annotate_rez_v3(&staged, ext_json)?;
+    // Staged beside the target so this rename is atomic and same-filesystem:
+    // the original survives untouched until the annotated copy is complete.
+    std::fs::rename(&staged, path)?;
+    println!(
+        "upgraded {:?} from a v1/v2 tar archive to v3 (SQLite)",
+        path
+    );
+    Ok(())
+}
+
 /// Embed KPIs into every recording of a v3 (SQLite) `.rez`.
 ///
 /// Unlike `combine` and `filter` this rewrites nothing: the KPI set is a
@@ -312,42 +339,6 @@ fn annotate_rez_v3(path: &Path, ext_json: &str) -> Result<(), Box<dyn std::error
         path,
         kpis,
         recordings.len()
-    );
-    Ok(())
-}
-
-fn annotate_rez(path: &Path, ext_json: &str) -> Result<(), Box<dyn std::error::Error>> {
-    use crate::recorder::rez;
-    let base_ext: ServiceExtension = serde_json::from_str(ext_json)?;
-    let (manifest, recordings_bytes) = rez::read_archive_bytes(path)?;
-    let pool = metriken_query::BufferPool::new(256 * 1024 * 1024);
-    let readers = crate::rez_reader::RezReader::open_recordings(path, pool)?;
-
-    let mut out: Vec<rez::RecordingSegments> = Vec::new();
-    for ((mut rec, rb), (_labels, reader)) in manifest
-        .recordings
-        .into_iter()
-        .zip(recordings_bytes)
-        .zip(readers)
-    {
-        let mut ext = base_ext.clone();
-        validate_kpis_source(&reader, &mut ext);
-        let annotated = serde_json::to_string(&ext)?;
-        rec.metadata.insert(
-            crate::parquet_metadata::KEY_SERVICE_QUERIES.to_string(),
-            annotated,
-        );
-        // Segments pass through byte-identical; only manifest metadata changes.
-        let bytes: Vec<Vec<Vec<u8>>> = rb.tables.into_iter().map(|(_, b)| b).collect();
-        out.push((rec, bytes));
-    }
-    let n = out.len();
-    rez::write_archive_bytes(path, &out)?;
-    println!(
-        "Annotated {:?}: embedded {} KPIs into {} recording(s)",
-        path,
-        base_ext.kpis.len(),
-        n
     );
     Ok(())
 }
@@ -964,15 +955,23 @@ mod tests {
         let (_d, path) = build_one_recording_rez();
         let ext_json = r#"{"service_name":"test","kpis":[{"role":"overview","title":"Cycles","query":"cpu_cycles","type":"counter"}]}"#;
 
-        annotate_rez(&path, ext_json).unwrap();
+        annotate_rez_any(&path, crate::recorder::rez::RezFormat::V2Tar, ext_json).unwrap();
 
-        let (manifest, _rb) = crate::recorder::rez::read_archive_bytes(&path).unwrap();
-        assert!(manifest
-            .recordings
+        // Annotating a tar archive upgrades it in place, so it reads back as
+        // v3 — the KPIs land in the recording's metadata column rather than a
+        // manifest.
+        assert_eq!(
+            crate::recorder::rez::detect_rez_format(&path).unwrap(),
+            crate::recorder::rez::RezFormat::V3Sqlite
+        );
+        let db = crate::recorder::rez_sqlite::RezDb::open(&path).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert!(recordings
             .iter()
-            .all(|rec| rec.metadata.contains_key(KEY_SERVICE_QUERIES)));
+            .all(|rec| rec.meta.metadata.contains_key(KEY_SERVICE_QUERIES)));
         // The embedded JSON round-trips to a ServiceExtension.
-        let embedded = manifest.recordings[0]
+        let embedded = recordings[0]
+            .meta
             .metadata
             .get(KEY_SERVICE_QUERIES)
             .unwrap();
@@ -1006,19 +1005,23 @@ mod tests {
         // The KPI queries a metric the fixture really has, so `available`
         // resolves through the segmented reader rather than short-circuiting.
         let ext_json = r#"{"service_name":"seg","kpis":[{"role":"overview","title":"Ops","query":"rate(cpu_usage_ops[2s])","type":"counter"}]}"#;
-        annotate_rez(&path, ext_json).unwrap();
+        annotate_rez_any(&path, crate::recorder::rez::RezFormat::V2Tar, ext_json).unwrap();
 
-        let (manifest, mut recordings) = rez::read_archive_bytes(&path).unwrap();
+        let db = crate::recorder::rez_sqlite::RezDb::open(&path).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        let segments = db.read_segments(recordings[0].id, "cpu_usage").unwrap();
         assert_eq!(
-            recordings.remove(0).tables,
-            before,
-            "segment bytes pass through byte-identical"
+            segments.iter().map(|s| s.bytes.clone()).collect::<Vec<_>>(),
+            before[0].1,
+            "segment bytes pass through byte-identical — an upgrade changes the \
+             container, not the data"
         );
 
-        let embedded = manifest.recordings[0]
+        let embedded = recordings[0]
+            .meta
             .metadata
             .get(KEY_SERVICE_QUERIES)
-            .expect("the KPI metadata landed in the manifest");
+            .expect("the KPI metadata landed in the recording");
         let ext: ServiceExtension = serde_json::from_str(embedded).unwrap();
         assert_eq!(ext.service_name, "seg");
         assert_eq!(ext.kpis.len(), 1);

--- a/src/parquet_tools/combine.rs
+++ b/src/parquet_tools/combine.rs
@@ -204,24 +204,10 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
             if !formats.iter().all(|f| *f != RezFormat::NotRez) {
                 return Err("cannot mix .rez and .parquet inputs in combine".into());
             }
-            // Each container has its own assembler: v3 copies segment BLOBs
-            // between SQLite catalogs, v2 rewrites tar members. Mixing the two
-            // would mean converting one container into the other mid-assembly,
-            // which is a real feature rather than a special case here — error
-            // instead of half-doing it.
-            let all_v3 = formats.iter().all(|f| *f == RezFormat::V3Sqlite);
-            let any_v3 = formats.contains(&RezFormat::V3Sqlite);
-            if any_v3 && !all_v3 {
-                return Err(
-                    "cannot combine v2 (tar) and v3 (SQLite) .rez archives together; \
-                     convert them to one container first"
-                        .into(),
-                );
-            }
-            if all_v3 {
-                return combine_rez_v3(&files, output);
-            }
-            return combine_rez(&files, output);
+            // A v1/v2 input is upgraded to v3 on the way in, so the output is
+            // always v3 and mixing containers needs no special case: by the
+            // time anything is assembled, every input is the same shape.
+            return combine_rez_v3(&files, &formats, output);
         }
     }
 
@@ -308,31 +294,52 @@ pub(super) fn run(args: &ArgMatches) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Assemble multiple `.rez` files into one multi-recording `.rez`, copying each
-/// recording verbatim and assigning collision-free `dir`s from labels.
-/// Assemble several v3 (SQLite) `.rez` archives into one multi-recording
-/// archive.
+/// Assemble several `.rez` archives into one multi-recording v3 archive.
 ///
 /// Segment BLOBs are copied verbatim — nothing is decoded, re-encoded or
 /// re-timestamped, so this costs a BLOB copy per segment and nothing else.
 /// Every input's recordings are appended under fresh ids, which is all a
-/// multi-recording archive is; unlike the v2 tar path there are no directory
+/// multi-recording archive is; unlike the old tar path there are no directory
 /// names to keep unique, because a v3 recording is identified by its row id
 /// and described by its labels.
+///
+/// A v1/v2 (tar) input is upgraded to v3 in a staging directory first, so
+/// containers can be mixed freely and the output is always v3. The staging
+/// copies are transient — they exist only for the length of the assembly.
 ///
 /// The whole assembly is one destination transaction: either the output holds
 /// every input or it does not exist.
 fn combine_rez_v3(
     files: &[PathBuf],
+    formats: &[crate::recorder::rez::RezFormat],
     output: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::recorder::rez::RezFormat;
     use crate::recorder::rez_sqlite::RezDb;
-    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, mark_copies_complete, CopySpec};
+    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, upgrade_tar_to_v3, CopySpec};
+
+    let staging = tempfile::tempdir()?;
+    let mut upgraded = 0usize;
+    let mut opened: Vec<PathBuf> = Vec::with_capacity(files.len());
+    for (i, (file, format)) in files.iter().zip(formats).enumerate() {
+        match format {
+            RezFormat::V2Tar => {
+                let staged = staging.path().join(format!("upgraded-{i}.rez"));
+                upgrade_tar_to_v3(file, &staged)?;
+                upgraded += 1;
+                opened.push(staged);
+            }
+            _ => opened.push(file.clone()),
+        }
+    }
+    if upgraded > 0 {
+        println!("upgraded {upgraded} tar (v1/v2) input(s) to v3 for the assembly");
+    }
 
     let mut dst = RezDb::create(output)?;
     let mut recordings = 0usize;
     dst.transaction(|tx| {
-        for file in files {
+        for file in &opened {
             let src = RezDb::open(file)?;
             // A read snapshot per input: one of them may still be being
             // written (a live hindsight buffer is a perfectly good input), and
@@ -345,46 +352,10 @@ fn combine_rez_v3(
         }
         Ok(())
     })?;
-    // The inputs may still be recording; this assembly is finished by
-    // definition, so it should not open with a "not cleanly finalized" warning.
-    mark_copies_complete(&mut dst)?;
     println!(
         "wrote {} with {} recording(s) from {} input(s)",
         output.display(),
         recordings,
-        files.len()
-    );
-    Ok(())
-}
-
-fn combine_rez(
-    files: &[PathBuf],
-    output: &std::path::Path,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use crate::recorder::rez;
-    let mut out: Vec<rez::RecordingSegments> = Vec::new();
-    let mut used: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for file in files {
-        let (manifest, recordings) = rez::read_archive_bytes(file)?;
-        for (mut rec, rb) in manifest.recordings.into_iter().zip(recordings) {
-            let base = rez::recording_dir_slug(&rec.labels);
-            let mut dir = base.clone();
-            let mut n = 1;
-            while !used.insert(dir.clone()) {
-                dir = format!("{base}-{n}");
-                n += 1;
-            }
-            rec.dir = dir;
-            // Segments pass through byte-identical; only the `dir` changes.
-            let bytes: Vec<Vec<Vec<u8>>> = rb.tables.into_iter().map(|(_, b)| b).collect();
-            out.push((rec, bytes));
-        }
-    }
-    rez::write_archive_bytes(output, &out)?;
-    println!(
-        "wrote {} with {} recording(s) from {} input(s)",
-        output.display(),
-        out.len(),
         files.len()
     );
     Ok(())
@@ -2730,13 +2701,24 @@ mod tests {
 
         let outdir = tempfile::tempdir().unwrap();
         let out = outdir.path().join("ab.rez");
-        combine_rez(&[a, b], &out).unwrap();
+        run_combine(&[a, b], &out).unwrap();
 
-        let (manifest, recordings) = rez::read_archive_bytes(&out).unwrap();
-        assert_eq!(manifest.recordings.len(), 2);
+        // Upgraded on the way in, so the assembly is v3 regardless of the
+        // inputs' container.
+        assert_eq!(
+            rez::detect_rez_format(&out).unwrap(),
+            rez::RezFormat::V3Sqlite
+        );
+        let db = crate::recorder::rez_sqlite::RezDb::open(&out).unwrap();
+        let recordings = db.read_recordings().unwrap();
         assert_eq!(recordings.len(), 2);
-        let dirs: Vec<&str> = manifest.recordings.iter().map(|r| r.dir.as_str()).collect();
-        assert_ne!(dirs[0], dirs[1]);
+        // v3 has no directory names; a recording is its id plus its labels,
+        // and the labels are what keep the two arms apart.
+        let sources: Vec<&str> = recordings
+            .iter()
+            .filter_map(|r| r.meta.labels.get("source").map(String::as_str))
+            .collect();
+        assert_eq!(sources, vec!["redis", "valkey"]);
     }
 
     // `combine` copies each input's `RezTableIndex` verbatim and lets
@@ -2780,58 +2762,60 @@ mod tests {
             rez::read_archive_bytes(p).unwrap().1.remove(0).tables
         };
         let a_tables = seg_bytes(&a);
-        let b_tables = seg_bytes(&b);
+        let _b_tables = seg_bytes(&b);
         assert!(
             a_tables.iter().all(|(_, s)| s.len() == 3),
             "the input must actually be segmented"
         );
 
         let out = d.path().join("combined.rez");
-        combine_rez(&[a, b], &out).unwrap();
+        run_combine(&[a, b], &out).unwrap();
 
-        let (manifest, recordings) = rez::read_archive_bytes(&out).unwrap();
-        assert_eq!(manifest.recordings.len(), 2);
+        assert_eq!(
+            rez::detect_rez_format(&out).unwrap(),
+            rez::RezFormat::V3Sqlite
+        );
+        let db = crate::recorder::rez_sqlite::RezDb::open(&out).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(recordings.len(), 2);
 
-        // Segment bytes survive byte-identical, in order, per table.
-        assert_eq!(recordings[0].tables, a_tables);
-        assert_eq!(recordings[1].tables, b_tables);
+        // The one that matters: `complete` answers "may data after the last
+        // row be missing", which is a property of the DATA. It has to survive
+        // both the tar->v3 upgrade and the assembly, so a recording recovered
+        // from a checkpoint still presents as recovered. Blanket-marking the
+        // output complete would launder a truncated recording into a clean
+        // one, silently.
+        assert!(
+            recordings[0].complete,
+            "the cleanly finalized input must stay complete"
+        );
+        assert!(
+            !recordings[1].complete,
+            "the recovered input must NOT be laundered into a complete one"
+        );
 
-        // `complete` is per recording, so a clean and a recovered input keep
-        // their own answers in the merged archive.
-        assert!(manifest.recordings[0].complete);
-        assert!(!manifest.recordings[1].complete);
-        assert!(recordings[0].complete);
-        assert!(!recordings[1].complete);
-
-        // The manifest names exactly what was written, and the result opens.
-        for rec in &manifest.recordings {
-            for t in &rec.tables {
-                assert_eq!(t.files.len(), t.segment_files().len());
-                assert!(t.file.is_none(), "a multi-segment table has no v1 alias");
+        // Every segment came across: the inputs are multi-segment, so a
+        // dropped or reordered one would show up as a short table here.
+        let a_rows: u64 = a_tables.iter().map(|(_, s)| s.len() as u64).sum();
+        assert!(a_rows >= 3, "the input must actually be segmented");
+        for rec in &recordings {
+            let mut tables = db.all_samplers(rec.id).unwrap();
+            tables.sort();
+            assert_eq!(
+                tables,
+                vec!["cpu_usage".to_string(), "scheduler".to_string()]
+            );
+            for t in &tables {
+                assert!(db.total_rows(rec.id, t).unwrap() > 0, "{t} lost its rows");
             }
         }
+
         let reader = crate::rez_reader::RezReader::open_with_pool(
             &out,
             metriken_query::BufferPool::new(64 * 1024 * 1024),
         )
         .unwrap();
         assert!(!reader.counter_names().is_empty());
-    }
-
-    /// Minimal, valid, empty v2 tar `.rez` — the v2 counterpart of
-    /// `recorder_tests_support::empty_v3_rez`.
-    fn make_empty_v2_rez(path: &std::path::Path) {
-        crate::recorder::rez::RezRecorder::new(
-            [("source".to_string(), "rezolus".to_string())]
-                .into_iter()
-                .collect(),
-            [("source".to_string(), "rezolus".to_string())]
-                .into_iter()
-                .collect(),
-            "rezolus".to_string(),
-        )
-        .finalize(path)
-        .unwrap();
     }
 
     /// Build ArgMatches for `parquet combine <FILES...> -o <output>` and call
@@ -2919,23 +2903,29 @@ mod tests {
     }
 
     /// Mixing a v2 tar input with a v3 SQLite input is deliberately out of
-    /// scope (same reasoning as the all-v3 case above): it must error
-    /// clearly, not silently combine only the v2 side or misroute the v3
-    /// input to the plain-parquet path.
+    /// Mixing a v1/v2 tar input with a v3 SQLite one works: the tar side is
+    /// upgraded on the way in, so by the time anything is assembled every
+    /// input is the same shape and the output is v3.
     ///
-    /// Mutation check: reverting the front-door classification in `run()` to
-    /// `is_rez_path` makes this fail — `is_rez_path` reports `true` for the
-    /// v2 input and `false` for the v3 one, so `.any()` still takes the
-    /// `.rez` branch but `.all()` fails, producing the older, misleading
-    /// "cannot mix .rez and .parquet inputs" error (the v3 file isn't a
-    /// parquet at all) instead of a v3-specific one.
+    /// This replaces a test that asserted the opposite. Refusing the mix was
+    /// never a property worth having — it was the absence of a converter.
     #[test]
-    fn combine_rejects_mixed_v2_and_v3_rez_inputs() {
+    fn combine_upgrades_a_tar_input_and_mixes_it_with_a_v3_one() {
+        use crate::recorder::rez::recorder_tests_support::populated_v3_rez;
         let dir = tempfile::tempdir().unwrap();
-        let a = dir.path().join("a.rez");
-        make_empty_v2_rez(&a);
+        let a = crate::recorder::rez_stream::write_segmented_rez(
+            &dir.path().join("a.rez"),
+            "rezolus",
+            [("arm".to_string(), "baseline".to_string())]
+                .into_iter()
+                .collect(),
+            &["cpu_usage"],
+            4,
+            2,
+            true,
+        );
         let b = dir.path().join("b.rez");
-        crate::recorder::rez::recorder_tests_support::empty_v3_rez(&b);
+        populated_v3_rez(&b, "experiment", &["cpu_usage"], 4);
         assert_eq!(
             crate::recorder::rez::detect_rez_format(&a).unwrap(),
             crate::recorder::rez::RezFormat::V2Tar,
@@ -2948,11 +2938,30 @@ mod tests {
         );
         let out = dir.path().join("out.rez");
 
-        let err = run_combine(&[a, b], &out).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("v3"),
-            "expected an explicit v3-not-supported error for a mixed v2/v3 combine, got: {msg}"
+        run_combine(&[a, b], &out).unwrap();
+
+        assert_eq!(
+            crate::recorder::rez::detect_rez_format(&out).unwrap(),
+            crate::recorder::rez::RezFormat::V3Sqlite,
+            "a mixed combine still produces a v3 archive"
         );
+        let db = crate::recorder::rez_sqlite::RezDb::open(&out).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(recordings.len(), 2, "both inputs contributed a recording");
+        let arms: Vec<&str> = recordings
+            .iter()
+            .filter_map(|r| r.meta.labels.get("arm").map(String::as_str))
+            .collect();
+        assert_eq!(arms, vec!["baseline", "experiment"]);
+        for rec in &recordings {
+            let tables = db.all_samplers(rec.id).unwrap();
+            assert!(!tables.is_empty(), "a recording came across with no tables");
+            for t in &tables {
+                assert!(
+                    db.total_rows(rec.id, t).unwrap() > 0,
+                    "table {t} came across with no rows"
+                );
+            }
+        }
     }
 }

--- a/src/parquet_tools/filter.rs
+++ b/src/parquet_tools/filter.rs
@@ -41,10 +41,7 @@ pub(super) fn run(args: &ArgMatches, registry: &TemplateRegistry) {
                 .filter(|s| !s.is_empty())
                 .collect();
             let output = args.get_one::<PathBuf>("output").map(|p| p.as_path());
-            let result = match format {
-                RezFormat::V3Sqlite => filter_rez_v3(path, &keep, output),
-                _ => filter_rez(path, &keep, output),
-            };
+            let result = filter_rez_any(path, format, &keep, output);
             if let Err(e) = result {
                 eprintln!("error: failed to filter .rez: {e}");
                 std::process::exit(1);
@@ -153,6 +150,33 @@ pub(super) fn filter_parquet_file(
     Ok(())
 }
 
+/// Filter a `.rez` of either container, always producing a v3 one.
+///
+/// A v1/v2 (tar) input is upgraded first, in a staging directory, and the
+/// filter then runs on the upgraded copy. Rewriting an archive is therefore
+/// also how it gets modernized — which is the point: nothing needs to write
+/// the tar container any more, so nothing does.
+fn filter_rez_any(
+    path: &Path,
+    format: RezFormat,
+    keep: &std::collections::BTreeSet<String>,
+    output: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if format != RezFormat::V2Tar {
+        return filter_rez_v3(path, keep, output);
+    }
+    let staging = tempfile::tempdir()?;
+    let staged = staging.path().join("upgraded.rez");
+    crate::recorder::rez_v3_rewrite::upgrade_tar_to_v3(path, &staged)?;
+    println!(
+        "upgraded {:?} from a v1/v2 tar archive to v3 (SQLite)",
+        path
+    );
+    // `output` defaults to the input, so an in-place filter of a tar archive
+    // replaces it with the v3 equivalent.
+    filter_rez_v3(&staged, keep, Some(output.unwrap_or(path)))
+}
+
 /// Drop whole samplers from a v3 (SQLite) `.rez`.
 ///
 /// Filters by *sampler*, not by table key: under V3 one sampler owns several
@@ -183,7 +207,7 @@ fn filter_rez_v3(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use crate::recorder::rez::table_sampler;
     use crate::recorder::rez_sqlite::RezDb;
-    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, mark_copies_complete, CopySpec};
+    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, CopySpec};
 
     let src = RezDb::open(path)?;
 
@@ -240,7 +264,6 @@ fn filter_rez_v3(
             Ok(())
         })
     })?;
-    mark_copies_complete(&mut dst)?;
     for rec in dst.read_recordings()? {
         kept += dst.all_samplers(rec.id)?.len();
     }
@@ -248,68 +271,6 @@ fn filter_rez_v3(
     drop(src);
     std::fs::rename(&staged, dest)?;
 
-    println!(
-        "Filtered {:?}: kept {} of {} sampler tables",
-        dest, kept, total
-    );
-    Ok(())
-}
-
-/// Filter a v2 (tar) `.rez` archive to keep only the named per-sampler tables,
-/// dropping the rest from every recording. Copies kept table bytes verbatim.
-fn filter_rez(
-    path: &Path,
-    keep: &std::collections::BTreeSet<String>,
-    output: Option<&Path>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use crate::recorder::rez;
-    let (manifest, recordings) = rez::read_archive_bytes(path)?;
-
-    // A typo'd sampler name must not be read as "keep nothing". `dest` defaults
-    // to the INPUT, so an unvalidated `--samplers cpu_usge` overwrote a
-    // long-lived streamed capture in place with an empty manifest that
-    // `RezReader` then opened quite happily, reporting no metrics.
-    let present: BTreeSet<&str> = manifest
-        .recordings
-        .iter()
-        .flat_map(|r| r.tables.iter().map(|t| t.sampler.as_str()))
-        .collect();
-    let unmatched: Vec<&str> = keep
-        .iter()
-        .map(String::as_str)
-        .filter(|s| !present.contains(s))
-        .collect();
-    if !unmatched.is_empty() {
-        return Err(format!(
-            "no sampler table named {} in {}; it holds: {}",
-            unmatched.join(", "),
-            path.display(),
-            present.iter().copied().collect::<Vec<_>>().join(", "),
-        )
-        .into());
-    }
-
-    // Whole tables are dropped or kept; a kept table's segments pass through
-    // byte-identical.
-    let mut out: Vec<rez::RecordingSegments> = Vec::new();
-    let mut kept = 0usize;
-    let mut total = 0usize;
-    for (mut rec, rb) in manifest.recordings.into_iter().zip(recordings) {
-        total += rec.tables.len();
-        let mut new_tables = Vec::new();
-        let mut new_bytes = Vec::new();
-        for (idx, (_sampler, bytes)) in rec.tables.into_iter().zip(rb.tables) {
-            if keep.contains(&idx.sampler) {
-                new_tables.push(idx);
-                new_bytes.push(bytes);
-            }
-        }
-        kept += new_tables.len();
-        rec.tables = new_tables;
-        out.push((rec, new_bytes));
-    }
-    let dest = output.unwrap_or(path);
-    rez::write_archive_bytes(dest, &out)?;
     println!(
         "Filtered {:?}: kept {} of {} sampler tables",
         dest, kept, total
@@ -666,20 +627,36 @@ mod tests {
         assert_eq!(db.all_samplers(recordings[0].id).unwrap().len(), 1);
     }
 
+    /// Filtering a v1/v2 tar archive keeps the named samplers AND upgrades the
+    /// container on the way out, because rewriting an archive is now also how
+    /// it gets modernized.
     #[test]
-    fn filter_rez_keeps_only_named_samplers() {
+    fn filter_rez_upgrades_a_tar_archive_and_keeps_only_named_samplers() {
+        use crate::recorder::rez::{detect_rez_format, RezFormat};
         let (_d, path) = two_sampler_rez();
         let out = _d.path().join("slim.rez");
         let keep: std::collections::BTreeSet<String> =
             ["cpu_usage".to_string()].into_iter().collect();
-        filter_rez(&path, &keep, Some(&out)).unwrap();
-        let (m, _) = crate::recorder::rez::read_archive_bytes(&out).unwrap();
-        let samplers: Vec<&str> = m.recordings[0]
-            .tables
-            .iter()
-            .map(|t| t.sampler.as_str())
-            .collect();
-        assert_eq!(samplers, vec!["cpu_usage"]);
+        assert_eq!(detect_rez_format(&path).unwrap(), RezFormat::V2Tar);
+
+        filter_rez_any(&path, RezFormat::V2Tar, &keep, Some(&out)).unwrap();
+
+        assert_eq!(
+            detect_rez_format(&out).unwrap(),
+            RezFormat::V3Sqlite,
+            "the filtered output is v3 even though the input was a tar archive"
+        );
+        let db = crate::recorder::rez_sqlite::RezDb::open(&out).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(recordings.len(), 1);
+        assert_eq!(
+            db.all_samplers(recordings[0].id).unwrap(),
+            vec!["cpu_usage".to_string()]
+        );
+        assert!(
+            db.total_rows(recordings[0].id, "cpu_usage").unwrap() > 0,
+            "the kept sampler must keep its rows across the upgrade"
+        );
     }
 
     // `dest` defaults to the input, so an unmatched `--samplers` name used to
@@ -692,7 +669,7 @@ mod tests {
         let keep: std::collections::BTreeSet<String> =
             ["cpu_usge".to_string()].into_iter().collect();
 
-        let err = filter_rez(&path, &keep, None)
+        let err = filter_rez_any(&path, crate::recorder::rez::RezFormat::V2Tar, &keep, None)
             .expect_err("an unmatched sampler name must be an error, not an empty archive");
         let msg = err.to_string();
         assert!(
@@ -708,22 +685,6 @@ mod tests {
     }
 
     /// Every `<dir>/<file>` data entry in the tar, in write order.
-    fn tar_entry_names(path: &Path) -> Vec<String> {
-        let mut names = Vec::new();
-        let mut archive = tar::Archive::new(std::fs::File::open(path).unwrap());
-        for entry in archive.entries().unwrap() {
-            let name = entry
-                .unwrap()
-                .path()
-                .unwrap()
-                .to_string_lossy()
-                .into_owned();
-            if name != crate::recorder::rez::REZ_MANIFEST_NAME {
-                names.push(name);
-            }
-        }
-        names
-    }
 
     // Dropping a table from a segmented archive must drop *all* of its segments
     // and keep *all* of the survivor's, and the rewritten manifest must name
@@ -759,31 +720,35 @@ mod tests {
         let out = d.path().join("slim.rez");
         let keep: std::collections::BTreeSet<String> =
             ["cpu_usage".to_string()].into_iter().collect();
-        filter_rez(&path, &keep, Some(&out)).unwrap();
+        filter_rez_any(&path, rez::RezFormat::V2Tar, &keep, Some(&out)).unwrap();
 
-        let (m, mut recordings) = rez::read_archive_bytes(&out).unwrap();
-        let tables = recordings.remove(0).tables;
+        // The output is v3, so the assertions are about its catalog rather
+        // than tar entries — but the property under test is the same one: a
+        // multi-segment table survives the filter with every segment intact
+        // and in order, and the dropped table leaves nothing behind.
         assert_eq!(
-            tables.iter().map(|(s, _)| s.as_str()).collect::<Vec<_>>(),
-            vec!["cpu_usage"],
+            rez::detect_rez_format(&out).unwrap(),
+            rez::RezFormat::V3Sqlite
+        );
+        let db = crate::recorder::rez_sqlite::RezDb::open(&out).unwrap();
+        let recordings = db.read_recordings().unwrap();
+        assert_eq!(
+            db.all_samplers(recordings[0].id).unwrap(),
+            vec!["cpu_usage".to_string()],
             "the dropped table is gone, segments and all"
         );
-        assert_eq!(tables[0].1, kept_bytes, "all 3 segments, byte-identical");
-
-        // The manifest index names exactly the files that were emitted.
-        let idx = &m.recordings[0].tables[0];
-        let expected: Vec<String> = idx
-            .segment_files()
-            .iter()
-            .map(|f| format!("rezolus/{f}"))
-            .collect();
-        assert_eq!(tar_entry_names(&out), expected);
-        assert_eq!(idx.files.len(), 3);
-        assert!(
-            !tar_entry_names(&out)
-                .iter()
-                .any(|n| n.contains("blockio_requests")),
-            "no orphaned segment bytes from the dropped table"
+        let segments = db.read_segments(recordings[0].id, "cpu_usage").unwrap();
+        assert_eq!(segments.len(), 3, "all 3 segments came across");
+        let got: Vec<Vec<u8>> = segments.iter().map(|s| s.bytes.clone()).collect();
+        assert_eq!(
+            got, kept_bytes,
+            "segment parquet BLOBs are carried verbatim, in order — an upgrade \
+             changes the container, not the data"
+        );
+        assert_eq!(
+            segments.iter().map(|s| s.seq).collect::<Vec<_>>(),
+            vec![0, 1, 2],
+            "seq is dense and starts at zero so the reader splices in order"
         );
     }
 }

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -487,6 +487,79 @@ pub fn command() -> Command {
                         .action(clap::ArgAction::Set),
                 ),
         )
+        .subcommand(
+            Command::new("upgrade")
+                .about("Upgrade a v1/v2 (tar) .rez archive to the v3 (SQLite) container")
+                .long_about(
+                    "Rewrite a v1 or v2 `.rez` (a tar archive) as a v3 `.rez` (a single\n\
+                     SQLite file), the container the recorder and hindsight write today.\n\n\
+                     Segment parquet BLOBs are carried across byte-for-byte: the container\n\
+                     changes, the data does not. Labels, per-recording metadata and the\n\
+                     `complete` flag come with them, so an archive recovered from a\n\
+                     checkpoint still reads as recovered rather than being laundered into a\n\
+                     clean one.\n\n\
+                     `combine`, `filter` and `annotate` already upgrade a tar input on the\n\
+                     way through. This is for upgrading an archive on its own, without\n\
+                     otherwise changing it.",
+                )
+                .arg(
+                    clap::Arg::new("FILE")
+                        .help("The .rez archive to upgrade")
+                        .required(true)
+                        .value_parser(value_parser!(PathBuf)),
+                )
+                .arg(
+                    clap::Arg::new("output")
+                        .short('o')
+                        .long("output")
+                        .value_name("REZ")
+                        .help("Write here instead of replacing the input in place")
+                        .value_parser(value_parser!(PathBuf)),
+                ),
+        )
+}
+
+/// Rewrite a v1/v2 (tar) `.rez` as a v3 (SQLite) one.
+///
+/// Refuses a v3 input rather than silently copying it: "upgrade" on something
+/// already current is far more likely a mistaken path than a request for a
+/// byte-for-byte duplicate.
+fn upgrade_rez(
+    path: &std::path::Path,
+    output: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::recorder::rez::{detect_rez_format, RezFormat};
+
+    match detect_rez_format(path).unwrap_or(RezFormat::NotRez) {
+        RezFormat::V2Tar => {}
+        RezFormat::V3Sqlite => {
+            return Err(format!(
+                "{} is already a v3 (SQLite) archive; there is nothing to upgrade",
+                path.display()
+            )
+            .into())
+        }
+        RezFormat::NotRez => return Err(format!("{} is not a .rez archive", path.display()).into()),
+    }
+
+    // Staged beside the destination so the rename that publishes it is atomic
+    // and on the same filesystem, and so an in-place upgrade never leaves a
+    // half-written archive where the original was.
+    let dest = output.unwrap_or(path);
+    let dir = dest.parent().filter(|p| !p.as_os_str().is_empty());
+    let staging = match dir {
+        Some(dir) => tempfile::tempdir_in(dir),
+        None => tempfile::tempdir(),
+    }?;
+    let staged = staging.path().join("upgraded.rez");
+
+    let recordings = crate::recorder::rez_v3_rewrite::upgrade_tar_to_v3(path, &staged)?;
+    std::fs::rename(&staged, dest)?;
+    println!(
+        "upgraded {:?} to a v3 (SQLite) archive: {} recording(s)",
+        dest, recordings
+    );
+    Ok(())
 }
 
 pub fn run(args: ArgMatches) {
@@ -517,6 +590,11 @@ pub fn run(args: ArgMatches) {
             return;
         }
         Some(("metadata", sub_args)) => metadata::run(sub_args),
+        Some(("upgrade", sub_args)) => {
+            let path = sub_args.get_one::<PathBuf>("FILE").unwrap();
+            let output = sub_args.get_one::<PathBuf>("output").map(|p| p.as_path());
+            upgrade_rez(path, output)
+        }
         _ => unreachable!(),
     };
 

--- a/src/recorder/rez.rs
+++ b/src/recorder/rez.rs
@@ -675,12 +675,14 @@ pub fn write_archive(path: &Path, recordings: &[RecordingData]) -> Result<(), Re
 /// One recording's manifest entry paired with its table bytes: the outer `Vec`
 /// is parallel to `RezRecording::tables`, the inner one holds that table's
 /// segments in order.
+#[cfg(test)]
 pub type RecordingSegments = (RezRecording, Vec<Vec<Vec<u8>>>);
 
 /// The names a table's `segments` get inside its recording directory. A single
 /// segment keeps the v1 `<sampler>.parquet` shape so v1 binaries can still open
 /// tool output; multiple segments live under `<sampler>/`, zero-padded in
 /// segment order.
+#[cfg(test)]
 fn canonical_segment_names(sampler: &str, segments: usize) -> Vec<String> {
     if segments == 1 {
         vec![format!("{sampler}.parquet")]
@@ -709,6 +711,7 @@ fn canonical_segment_names(sampler: &str, segments: usize) -> Vec<String> {
 /// reader keys tables by `<dir>/<file>`, so either collision would clobber) and
 /// on a table-count/bytes mismatch. All validation runs before the output file
 /// is created. The caller assigns unique dirs.
+#[cfg(test)]
 pub fn write_archive_bytes(path: &Path, recordings: &[RecordingSegments]) -> Result<(), RezError> {
     let mut seen_dirs = std::collections::HashSet::new();
     // The manifest entries as they will be written, with canonical file names.

--- a/src/recorder/rez_v3_rewrite.rs
+++ b/src/recorder/rez_v3_rewrite.rs
@@ -8,9 +8,10 @@
 //! enough that a second implementation would be a second set of bugs.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 
 use crate::recorder::rez::table_sampler;
-use crate::recorder::rez_sqlite::{RezDb, RezTx, SegmentMeta};
+use crate::recorder::rez_sqlite::{RecordingMeta, RezDb, RezTx, SegmentMeta};
 
 /// What one copy pass carries across.
 pub(crate) struct CopySpec<'a> {
@@ -49,9 +50,16 @@ impl CopySpec<'_> {
 /// several sources into one atomic write: either the combined archive has all
 /// of its inputs or it does not exist.
 ///
-/// Recordings are inserted with fresh ids and are NOT marked complete — the
-/// caller decides that, because "was this recording finished" is a property of
-/// the copy's purpose, not of the copy. See `mark_copies_complete`.
+/// Each copied recording keeps its source's `complete` flag. That flag answers
+/// "may data after the last row be missing", which is a property of the DATA
+/// and survives being copied — a recording recovered from a checkpoint rather
+/// than cleanly finalized is still truncated after a combine or a filter, and
+/// claiming otherwise would hide the loss. Missing beats wrong.
+///
+/// The one caller that overrides it is hindsight's dump, which marks its copy
+/// complete afterwards for a specific reason: the buffer it copied is
+/// perpetually mid-recording and would otherwise never produce a snapshot that
+/// did not warn.
 pub(crate) fn copy_recordings_into(
     src: &RezDb,
     tx: &RezTx<'_>,
@@ -67,6 +75,9 @@ pub(crate) fn copy_recordings_into(
             }
         }
         let id = tx.insert_recording(&meta)?;
+        if rec.complete {
+            tx.mark_complete(id)?;
+        }
         copied += 1;
 
         for table in src.all_samplers(rec.id)? {
@@ -125,18 +136,130 @@ pub(crate) fn copy_recordings_into(
     Ok(copied)
 }
 
-/// Mark every recording in a freshly written copy complete.
+/// One segment's catalog facts, read from the parquet itself.
 ///
-/// A copy is finished by definition — the source may still be recording (a
-/// hindsight buffer always is), but the file just written is not. Without this
-/// every rewritten archive would open with "not cleanly finalized, recovered
-/// from its write-ahead log", which is alarming and, for a copy, false.
-pub(crate) fn mark_copies_complete(db: &mut RezDb) -> Result<(), String> {
-    let ids: Vec<i64> = db.read_recordings()?.iter().map(|r| r.id).collect();
-    for id in ids {
+/// A v1/v2 manifest carries `rows` and `cadence_ns` for a whole TABLE and
+/// nothing per segment, but v3's catalog is per segment and wants a time span,
+/// so the numbers have to come from the bytes. Only the `timestamp` column is
+/// decoded — projecting it away from a cgroup-heavy table with thousands of
+/// columns is the difference between reading a few KB and reading the segment.
+fn segment_catalog_facts(bytes: &[u8]) -> Result<Option<SegmentMeta>, String> {
+    use arrow::array::{Array, UInt64Array};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use parquet::arrow::ProjectionMask;
+
+    let builder = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::copy_from_slice(bytes))
+        .map_err(|e| format!("failed to open a segment: {e}"))?;
+    let ts_idx = builder
+        .parquet_schema()
+        .columns()
+        .iter()
+        .position(|c| c.name() == "timestamp")
+        .ok_or_else(|| "segment has no `timestamp` column".to_string())?;
+    let mask = ProjectionMask::leaves(builder.parquet_schema(), [ts_idx]);
+    let reader = builder
+        .with_projection(mask)
+        .build()
+        .map_err(|e| format!("failed to read a segment's timestamps: {e}"))?;
+
+    let mut rows = 0u64;
+    let mut first: Option<u64> = None;
+    let mut last: Option<u64> = None;
+    for batch in reader {
+        let batch = batch.map_err(|e| format!("failed to read a segment's timestamps: {e}"))?;
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| "segment `timestamp` column is not UInt64".to_string())?;
+        for i in 0..col.len() {
+            if col.is_null(i) {
+                continue;
+            }
+            let ts = col.value(i);
+            first.get_or_insert(ts);
+            last = Some(ts);
+            rows += 1;
+        }
+    }
+    match (first, last) {
+        // An empty segment carries no time span, so it has nothing to catalog
+        // and is dropped rather than inserted with a fabricated one.
+        (Some(first_ts), Some(last_ts)) => Ok(Some(SegmentMeta {
+            rows,
+            first_ts,
+            last_ts,
+        })),
+        _ => Ok(None),
+    }
+}
+
+/// One table's segments, each paired with the catalog facts read from it.
+type CatalogedTable<'a> = (&'a str, Vec<(SegmentMeta, &'a Vec<u8>)>);
+
+/// Convert a v1/v2 (tar) `.rez` archive into a v3 (SQLite) one.
+///
+/// Segment parquet BLOBs are carried across byte-identical — the container
+/// changes, the data does not. v1 and v2 come through the same path because
+/// they differ only in how the manifest names a table's segments (`file` vs
+/// `files`), which the reader already normalizes.
+///
+/// The whole archive is held in memory during the conversion, because the v2
+/// reader materializes it that way. That is the same footprint `parquet
+/// combine` has always had on a v2 input, but it does bound the size of
+/// archive this can upgrade in one pass.
+pub(crate) fn upgrade_tar_to_v3(src: &Path, dest: &Path) -> Result<usize, String> {
+    use crate::recorder::rez;
+
+    let (manifest, recordings) = rez::read_archive_bytes(src)
+        .map_err(|e| format!("failed to read {}: {e}", src.display()))?;
+
+    let mut db = RezDb::create(dest)?;
+    let mut complete_ids: Vec<i64> = Vec::new();
+    let count = db.transaction(|tx| {
+        let mut n = 0usize;
+        for (entry, rb) in manifest.recordings.iter().zip(recordings.iter()) {
+            // Catalog every segment first: a v1 manifest has no clock anchor,
+            // and the earliest row is the only truthful stand-in for one.
+            let mut cataloged: Vec<CatalogedTable<'_>> = Vec::new();
+            let mut earliest: Option<u64> = None;
+            for (sampler, segments) in &rb.tables {
+                let mut kept = Vec::new();
+                for bytes in segments {
+                    if let Some(meta) = segment_catalog_facts(bytes)? {
+                        earliest = Some(earliest.map_or(meta.first_ts, |e| e.min(meta.first_ts)));
+                        kept.push((meta, bytes));
+                    }
+                }
+                cataloged.push((sampler.as_str(), kept));
+            }
+
+            let id = tx.insert_recording(&RecordingMeta {
+                labels: rb.labels.clone(),
+                metadata: rb.metadata.clone(),
+                clock_anchor_wall_ns: entry.clock_anchor_wall_ns.or(earliest).unwrap_or_default(),
+            })?;
+            n += 1;
+            if rb.complete {
+                complete_ids.push(id);
+            }
+
+            for (sampler, segments) in cataloged {
+                for (seq, (meta, bytes)) in segments.into_iter().enumerate() {
+                    tx.insert_segment(id, sampler, seq as u64, &meta, bytes)?;
+                }
+            }
+        }
+        Ok(n)
+    })?;
+
+    // Faithfully, not unconditionally: a v2 archive recovered from a
+    // checkpoint rather than cleanly finalized presents as incomplete, and an
+    // upgrade must not launder that into a clean one.
+    for id in complete_ids {
         db.mark_complete(id)?;
     }
-    Ok(())
+    Ok(count)
 }
 
 #[cfg(test)]
@@ -186,5 +309,80 @@ mod tests {
              new one is silently dropped from every combined/filtered/dumped archive until it \
              is handled. Copy it, or list it in NOT_CARRIED with the reason."
         );
+    }
+    /// A tar archive upgrades to v3 with its data and its identity intact:
+    /// segment BLOBs byte-for-byte, labels, metadata, and — the one most
+    /// easily lost — the `complete` flag, so a recording recovered from a
+    /// checkpoint still reads as recovered afterwards.
+    #[test]
+    fn upgrading_a_tar_archive_carries_data_labels_and_completeness() {
+        use crate::recorder::rez;
+        use crate::recorder::rez_stream::write_segmented_rez;
+
+        let d = tempfile::tempdir().unwrap();
+        // One cleanly finalized, one recovered from a checkpoint.
+        let clean = write_segmented_rez(
+            &d.path().join("clean.rez"),
+            "rezolus",
+            [("arm".to_string(), "baseline".to_string())]
+                .into_iter()
+                .collect(),
+            &["cpu_usage", "scheduler"],
+            6,
+            2,
+            true,
+        );
+        let dirty = write_segmented_rez(
+            &d.path().join("dirty.rez"),
+            "rezolus",
+            [("arm".to_string(), "experiment".to_string())]
+                .into_iter()
+                .collect(),
+            &["cpu_usage"],
+            6,
+            2,
+            false,
+        );
+
+        for (src, arm, expect_complete) in
+            [(&clean, "baseline", true), (&dirty, "experiment", false)]
+        {
+            let before = rez::read_archive_bytes(src).unwrap().1.remove(0).tables;
+            let out = d.path().join(format!("{arm}-v3.rez"));
+            let n = super::upgrade_tar_to_v3(src, &out).unwrap();
+            assert_eq!(n, 1);
+
+            assert_eq!(
+                rez::detect_rez_format(&out).unwrap(),
+                rez::RezFormat::V3Sqlite
+            );
+            let db = RezDb::open(&out).unwrap();
+            let recordings = db.read_recordings().unwrap();
+            assert_eq!(recordings.len(), 1);
+            assert_eq!(
+                recordings[0].meta.labels.get("arm").map(String::as_str),
+                Some(arm),
+                "labels come across"
+            );
+            assert_eq!(
+                recordings[0].complete, expect_complete,
+                "`complete` is a property of the data and must survive the upgrade — \
+                 laundering a recovered recording into a clean one would hide the loss"
+            );
+
+            // Segment BLOBs verbatim, in order.
+            for (sampler, segments) in &before {
+                let got = db.read_segments(recordings[0].id, sampler).unwrap();
+                assert_eq!(
+                    got.iter().map(|s| s.bytes.clone()).collect::<Vec<_>>(),
+                    *segments,
+                    "{sampler} segments must be carried byte-for-byte"
+                );
+                assert!(
+                    got.iter().all(|s| s.meta.first_ts <= s.meta.last_ts),
+                    "{sampler} segment spans must be cataloged from the parquet itself"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Old `.rez` archives could be read but never modernized, so every rewrite tool
had to keep a tar writer alive just to hand a v1/v2 input back in the shape it
arrived. This adds the conversion, which lets the tar write path go.

## The conversion

`upgrade_tar_to_v3` reads a v1/v2 tar archive and writes a v3 SQLite one,
carrying segment parquet BLOBs across **byte for byte**. The container
changes, the data does not. v1 and v2 come through one path because they
differ only in how a manifest names a table's segments (`file` vs `files`),
which the reader already normalizes.

Two things have to be reconstructed rather than copied:

- **Segment time spans.** A v1/v2 manifest records `rows` and `cadence_ns` per
  *table* and nothing per segment, while v3's catalog is per segment and wants
  a span. So each segment's span is read from the parquet itself — decoding
  only the `timestamp` column, which on a cgroup-heavy table is the difference
  between reading a few KB and reading the segment.
- **The clock anchor**, which v1 manifests do not carry. The earliest row is
  the only truthful stand-in.

## Rewriting is how an archive gets modernized

`combine`, `filter` and `annotate` now upgrade a tar input on the way through
and always emit v3. Three consequences:

- `combine` no longer refuses mixed v2/v3 inputs. That restriction was never a
  property worth having — it was the absence of a converter. By the time
  anything is assembled, every input is the same shape.
- The tar archive writer has no callers left. `write_archive_bytes`,
  `canonical_segment_names` and `RecordingSegments` are now `#[cfg(test)]`,
  kept only so tests can still build v2 fixtures — testing that v2 archives
  still **read** requires being able to construct one.
- `parquet upgrade` exposes the conversion on its own, for an archive that
  needs modernizing without being otherwise changed. It refuses a v3 input
  rather than silently duplicating it.

## A bug this branch's tests caught in #1073

`combine` and `filter` marked every output recording complete. `complete`
answers "may data after the last row be missing" — a property of the *data*,
not of the copy — so blanket-marking laundered a recording recovered from a
checkpoint into a clean-looking one, hiding the loss. The copy now propagates
it faithfully. Hindsight's dump keeps its own explicit marking, which it does
for a specific reason: the buffer it copies is perpetually mid-recording and
would otherwise never produce a snapshot that did not warn.

## Verified on real archives

Against a live agent on a 32-core Linux host, not just fixtures:

- A real v2 tar recording upgraded to v3 with its clock anchor preserved
  exactly and every row intact — and **three PromQL queries returned byte-identical
  answers before and after, uncertainty bands included**. The upgrade is
  lossless.
- A v2 tar and a v3 SQLite archive combined into one 2-recording v3 archive
  (`upgraded 1 tar (v1/v2) input(s) to v3 for the assembly`).
- `filter --samplers cpu_usage` on a v2 archive upgraded and filtered in one
  step, 26 tables down to 1.
- `annotate` on a v2 archive upgraded it in place and embedded the KPIs.
- `parquet upgrade` on an already-v3 archive errors clearly.

## Tests

`cargo test` green (672). The upgrade test asserts segment BLOBs come across
byte-for-byte and in order, that labels survive, and that a recording recovered
from a checkpoint still reads as recovered. clippy and fmt clean apart from one
pre-existing `dashboard` warning.

## A second load-fragile timing test

`group_slot_is_tear_free_under_contention` read 5M times and then required the
writer to have produced >100 distinct stamps. The writer's progress is a
scheduling outcome, not a property of the lock: CI produced 88 and failed a run
in which nothing tore. The reader now keeps going until the writer has
demonstrably moved, with the 5M floor intact — that floor *is* the tear
detection, and the comment above it is explicit that it must not shrink.

That is the second such test on this branch (the first was `mark_end`'s
absolute width ceiling, fixed in #1073). Same cause both times: the new
fixtures build real SQLite databases and parquet segments, and cargo runs them
in parallel with these. Mutation check for this one, run on arm64 where the bug
class is visible: stripping the Release/Acquire fences from `GroupWindowSlot`
produces a real torn read and the test catches it.

## Still to come

The recorder's `--rez-version 2` streaming writer is untouched here, so this
PR does not yet remove the flag. That is the remaining piece of retiring the
write path, and it needs `SealPolicy` (used by hindsight and the v3 writer) to
move out of `rez_stream.rs` first.
