### PR TITLE
feat(agent): default snapshot_format to v3

### DIFF
--- a/config/agent.toml
+++ b/config/agent.toml
@@ -17,33 +17,36 @@ ttl = "10ms"
 # Example:
 # btf_path = "/path/to/vmlinux-5.15.0-generic.btf"
 
-# Snapshot wire format served on /metrics/binary. "v2" (default) is the flat
-# per-metric format; "v3" emits acquisition-group snapshots (transitional —
-# the default flips once samplers migrate; see
-# docs/journal/2026-08-17-window-sidecar-cost.md).
+# Snapshot wire format served on /metrics/binary and /metrics/json.
 #
-# Before flipping to "v3", make sure every consumer of this agent (exporter,
-# recorder, viewer, hindsight, or anything else hitting /metrics/binary or
-# /metrics/json) is running a build that understands SnapshotV3 — an older
-# build does not. Three concrete things that go wrong on a mismatched
-# consumer:
-#   - An exporter built before SnapshotV3 existed cannot decode a v3 payload
-#     at all. Older exporter builds served /metrics as HTTP 200 with an
-#     empty body forever, with nothing logged at any level — an
-#     undiagnosable fleet-wide blackout. A current exporter build logs this
-#     loudly (error level, every failed poll) instead of going dark, but an
-#     exporter build from before that fix still goes dark silently.
-#   - Acquisition windows are absent from v3 output for any metric whose
-#     sampler hasn't migrated to a declared acquisition group yet (which is
-#     effectively everything today) — rate()/irate() uncertainty bands lose
-#     precision for those metrics under v3 until each sampler migrates.
-#   - /metrics/json's shape changes wholesale under v3: a flat
-#     `{counters: [...], gauges: [...], histograms: [...]}` becomes
-#     `{groups: [{name, schema, counters, gauges, histograms}, ...]}`. Any
-#     tooling that parses /metrics/json directly (not through this repo's
-#     own viewer/MCP/parquet tooling, which already handle both) needs to be
-#     updated before this flips, not after.
-# snapshot_format = "v2"
+# "v3" (the default) groups metrics by the read that produced them, and each
+# group carries one acquisition window instead of every metric carrying its
+# own. That is what makes rate()/irate() uncertainty bands precise, and it
+# makes recordings substantially smaller and faster to query — measured at a
+# 50ms interval, a .rez archive is 0.39x the size and the same queries run in
+# 0.52-0.60x the time.
+#
+# "v2" is the older flat per-metric format. Set it only if something reading
+# this agent cannot handle v3 yet:
+#
+#   - Anything parsing /metrics/json DIRECTLY. Its shape changes wholesale:
+#     a flat `{counters: [...], gauges: [...], histograms: [...]}` becomes
+#     `{groups: [{name, schema, counters, gauges, histograms}, ...]}`. This
+#     repo's own consumers (exporter, recorder, viewer, MCP, hindsight)
+#     handle both and need no change; a homegrown scraper of that endpoint
+#     does.
+#
+#   - A consumer built before SnapshotV3 existed. It cannot decode a v3
+#     payload at all. Builds from that era served /metrics as HTTP 200 with
+#     an empty body forever and logged nothing at any level — an
+#     undiagnosable blackout. Current builds log the decode failure loudly on
+#     every failed poll instead, so a mismatch is noisy rather than silent,
+#     but only if the consumer is new enough to have that fix.
+#
+# Rolling back is safe and takes effect on restart: the format is chosen per
+# snapshot, nothing on disk records which one produced it, and recordings
+# already written stay readable either way.
+# snapshot_format = "v3"
 
 [scheduler]
 # By default, Rezolus will use the SCHED_RR realtime scheduling policy to ensure

--- a/src/agent/config/general.rs
+++ b/src/agent/config/general.rs
@@ -1,30 +1,34 @@
 use super::*;
 
 fn default_snapshot_format() -> SnapshotFormat {
-    SnapshotFormat::V2
+    SnapshotFormat::V3
 }
 
 /// The wire format used for metric snapshots served on `/metrics/binary`.
 ///
-/// `V2` is today's flat per-metric format. `V3` emits acquisition-group
-/// snapshots. This is transitional: the default flips to `V3` once samplers
-/// migrate; see docs/journal/2026-08-17-window-sidecar-cost.md.
+/// `V3` (the default) emits acquisition-group snapshots: metrics are grouped
+/// by the read that produced them, and the group carries one acquisition
+/// window rather than every metric carrying its own. `V2` is the older flat
+/// per-metric format, kept as an escape hatch for a fleet whose consumers
+/// have not caught up.
 ///
-/// Before setting this to `V3`, see `config/agent.toml`'s longer comment on
-/// this key for the full operator guidance. Short version: every consumer
-/// (exporter, recorder, viewer, ...) needs a build that understands V3 — an
-/// exporter built before `SnapshotV3` existed cannot decode it (older
-/// builds went dark silently; current builds log the decode failure
-/// loudly instead); acquisition windows are absent from `V3` output for any
-/// metric whose sampler hasn't migrated to a declared group yet (which is
-/// effectively everything today); and `/metrics/json`'s shape changes
-/// wholesale (`groups: [...]` instead of flat `counters`/`gauges`/
-/// `histograms` arrays).
+/// Setting this back to `V2` is for one situation: a consumer that cannot
+/// yet read V3. See `config/agent.toml` for the operator detail. The short
+/// version is that `/metrics/json` changes shape wholesale — a flat
+/// `{counters, gauges, histograms}` becomes `{groups: [...]}` — so anything
+/// parsing that endpoint directly needs updating, and a consumer built
+/// before `SnapshotV3` existed cannot decode `/metrics/binary` at all.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SnapshotFormat {
-    #[default]
     V2,
+    /// Marked `#[default]` so `SnapshotFormat::default()` agrees with
+    /// `default_snapshot_format()`. They are reached by different paths — the
+    /// derive covers a `General` built without deserializing, the function
+    /// covers a config file that omits the key — and a fleet where those two
+    /// disagreed would serve different wire formats depending on how its
+    /// config happened to be loaded.
+    #[default]
     V3,
 }
 
@@ -108,8 +112,28 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_format_defaults_to_v2_when_absent() {
+    fn snapshot_format_defaults_to_v3_when_absent() {
         let g = general("");
+        assert_eq!(g.snapshot_format(), SnapshotFormat::V3);
+    }
+
+    /// The two defaults must agree.
+    ///
+    /// `#[serde(default = "default_snapshot_format")]` covers a config file
+    /// that omits the key; `#[derive(Default)]` on the enum covers a `General`
+    /// built without deserializing at all. They are reached by different paths,
+    /// and a fleet where they disagreed would serve different wire formats
+    /// depending on how its config happened to be loaded.
+    #[test]
+    fn the_serde_default_and_the_derived_default_agree() {
+        assert_eq!(default_snapshot_format(), SnapshotFormat::default());
+    }
+
+    /// v2 stays reachable. It is the escape hatch for a consumer that cannot
+    /// read v3 yet, so it has to keep parsing, not merely keep existing.
+    #[test]
+    fn snapshot_format_v2_is_still_selectable() {
+        let g = general("snapshot_format = \"v2\"\n");
         assert_eq!(g.snapshot_format(), SnapshotFormat::V2);
     }
 

--- a/src/agent/exposition/http/snapshot.rs
+++ b/src/agent/exposition/http/snapshot.rs
@@ -4329,20 +4329,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn v3_flag_switches_the_builder() {
+    async fn snapshot_format_selects_the_builder() {
         // An empty document defaults `general` via `Default::default()`
         // (empty strings), not the field-level `#[serde(default = ...)]`
         // helpers — those only apply when a `[general]` table is present.
         // Supply an explicit (empty) table so `ttl`/`listen` get their real
         // defaults.
-        let v2_config: Config = toml::from_str("[general]\n").expect("valid config");
+        let default_config: Config = toml::from_str("[general]\n").expect("valid config");
+        let mut default_builder = SnapshotBuilder::new(
+            Arc::new(default_config),
+            Arc::new(Vec::<Box<dyn Sampler>>::new().into_boxed_slice()),
+            None,
+        );
+        let snap = default_builder.build(Instant::now()).await;
+        assert!(matches!(snap, Snapshot::V3(_)), "the default format is v3");
+
+        // And the escape hatch still reaches the old builder.
+        let v2_config: Config =
+            toml::from_str("[general]\nsnapshot_format = \"v2\"\n").expect("valid config");
         let mut v2_builder = SnapshotBuilder::new(
             Arc::new(v2_config),
             Arc::new(Vec::<Box<dyn Sampler>>::new().into_boxed_slice()),
             None,
         );
         let snap = v2_builder.build(Instant::now()).await;
-        assert!(matches!(snap, Snapshot::V2(_)), "default format is v2");
+        assert!(matches!(snap, Snapshot::V2(_)), "v2 is still selectable");
 
         let v3_config: Config =
             toml::from_str("[general]\nsnapshot_format = \"v3\"\n").expect("valid config");

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -571,36 +571,6 @@ fn upgrade_rez(
     Ok(())
 }
 
-#[cfg(test)]
-mod command_name_tests {
-    /// `parquet` keeps working as an alias for `recording`.
-    ///
-    /// The rename is the point — these subcommands stopped being
-    /// parquet-specific once `.rez` arrived — but every existing script and
-    /// runbook types `rezolus parquet ...`, and breaking those to make a name
-    /// tidier is not a trade worth making. Both spellings must reach the same
-    /// subcommand, and clap must resolve the alias to the canonical name so
-    /// `main`'s dispatch needs only one arm.
-    #[test]
-    fn parquet_still_reaches_the_recording_subcommand() {
-        let app = clap::Command::new("rezolus").subcommand(super::command());
-
-        for spelling in ["recording", "parquet"] {
-            let m = app
-                .clone()
-                .try_get_matches_from(["rezolus", spelling, "metadata", "-i", "x.parquet"])
-                .unwrap_or_else(|e| panic!("`rezolus {spelling} metadata` must parse: {e}"));
-            let (name, sub) = m.subcommand().expect("a subcommand matched");
-            assert_eq!(
-                name, "recording",
-                "clap must report the canonical name for `{spelling}`, so `main` \
-                 dispatches on one arm rather than two"
-            );
-            assert_eq!(sub.subcommand_name(), Some("metadata"));
-        }
-    }
-}
-
 pub fn run(args: ArgMatches) {
     use crate::viewer::load_template_registry;
 
@@ -716,4 +686,34 @@ fn read_parquet_footer(
     let schema = builder.schema().clone();
     let reader = builder.build()?;
     Ok((metadata, schema, reader))
+}
+
+#[cfg(test)]
+mod command_name_tests {
+    /// `parquet` keeps working as an alias for `recording`.
+    ///
+    /// The rename is the point — these subcommands stopped being
+    /// parquet-specific once `.rez` arrived — but every existing script and
+    /// runbook types `rezolus parquet ...`, and breaking those to make a name
+    /// tidier is not a trade worth making. Both spellings must reach the same
+    /// subcommand, and clap must resolve the alias to the canonical name so
+    /// `main`'s dispatch needs only one arm.
+    #[test]
+    fn parquet_still_reaches_the_recording_subcommand() {
+        let app = clap::Command::new("rezolus").subcommand(super::command());
+
+        for spelling in ["recording", "parquet"] {
+            let m = app
+                .clone()
+                .try_get_matches_from(["rezolus", spelling, "metadata", "-i", "x.parquet"])
+                .unwrap_or_else(|e| panic!("`rezolus {spelling} metadata` must parse: {e}"));
+            let (name, sub) = m.subcommand().expect("a subcommand matched");
+            assert_eq!(
+                name, "recording",
+                "clap must report the canonical name for `{spelling}`, so `main` \
+                 dispatches on one arm rather than two"
+            );
+            assert_eq!(sub.subcommand_name(), Some("metadata"));
+        }
+    }
 }


### PR DESCRIPTION
Every consumer in this repo reads v3, every sampler declares acquisition
groups, and the rewrite tools convert older recordings rather than producing
them. The flag has been the only thing standing between a default install and
windows that are actually per-acquisition.

## What the default buys

Measured at a 50 ms interval over 300 s, same agent, same workload:

| | v3 / v2 |
|---|---|
| archive size | **0.386×** |
| query latency (3 rate queries) | **0.52–0.60×** |
| cross-group union query | **0.49×** |
| scrape wall time | **0.44×** |
| agent CPU | 0.59% vs 1.75% |
| agent RSS | 1.02× (parity) |

And `rate()`/`irate()` uncertainty bands become precise rather than
approximated, which is the point of the whole exercise: a group is one read, so
its window is the real acquisition interval instead of a per-metric guess.

## Verified on a live host

Started an agent with **no `snapshot_format` key at all**, so the default is
what runs:

- `/metrics/json` serves the v3 shape — 54 groups.
- The **exporter**, the one consumer never previously exercised under v3, polls
  it happily: HTTP 200, 657 KB of metrics, no decode failures logged.

Diffing exported metric names against an exporter fed by the v2 production
agent showed two differences, both explained and neither a regression:

- `cgroup_cpu_bandwidth_*`, `cgroup_cpu_throttled*` and
  `scheduler_discarded_samples` appear only under v3 — they are new metrics in
  the newer build, not a format effect.
- `cpu_branch_instructions` / `cpu_branch_misses` appear only under v2 — this
  is **PMU contention**, not v3. Confirmed by running the *same build* in v2
  mode on the same host: it also has zero `cpu_branch_*`. A third agent
  competing for hardware counters with the production agent cannot open them,
  whatever wire format it serves.

That last check also surfaced a real and intended format difference: v2 omits a
value-less metric entirely, while v3 declares it with a `None` value. That is
"membership from registration, not value sentinels" working as designed — v3
can distinguish "this metric exists but was not read" from "this metric does
not exist", where v2 cannot. The exporter skips nulls either way, so scraped
output is unchanged.

## Rolling back

`snapshot_format = "v2"` still works and takes effect on restart. The format is
chosen per snapshot, nothing on disk records which one produced it, and
recordings already written stay readable either way. `config/agent.toml`
documents the two situations that call for it: tooling that parses
`/metrics/json` directly (its shape changes wholesale — a flat
`{counters, gauges, histograms}` becomes `{groups: [...]}`), and any consumer
built before `SnapshotV3` existed, which cannot decode `/metrics/binary` at
all.

## Also

The two defaults are now pinned to agree by a test. The serde default covers a
config that omits the key; the derived `Default` covers a `General` built
without deserializing. They are reached by different paths, and a fleet where
they disagreed would serve different wire formats depending on how its config
happened to load.

One drive-by: clippy's `items_after_test_module` was firing on the alias test
module I added in #1075, so it moves to the end of its file. No behavior
change.
