### PR TITLE
feat(rez): answer cross-sampler queries instead of refusing them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,9 +2245,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcbf44acac27965eb5913c8834211c9ed8ac3de906bf720fa8df35a74ef14b4"
+checksum = "693e4599d1ff4ec546d45dff9c827074f70210f29131f1cd92c9c656450267cd"
 dependencies = [
  "arrow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libloading = "0.8"
 log = "0.4.29"
 metriken = "0.10.1"
 metriken-exposition = "0.19.0"
-metriken-query = { version = "0.19.0", default-features = false }
+metriken-query = { version = "0.19.1", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"

--- a/docs/journal/2026-08-21-cross-table-uncertainty.md
+++ b/docs/journal/2026-08-21-cross-table-uncertainty.md
@@ -1,7 +1,8 @@
 # Cross-table uncertainty: widen the band, drop the refusal
 
 - **Opened:** 2026-08-21
-- **Status:** **DESIGN.** Measured, not yet implemented.
+- **Status:** **IMPLEMENTED** (metriken PR #135; rezolus drops the refusal).
+  Two corrections since the entry was merged — see below.
 - **Arc:** closes the loop the acquisition-groups work opened
   ([stage 4](2026-08-20-stage4-native-v3-ingest.md)). Groups made each
   reading's window honest; this makes *combining* two readings honest.
@@ -80,9 +81,9 @@ and nowhere else. That is the whole rule:
    carries one.
 2. **Same table → no alignment term.** Zero, by construction.
 3. **Cross table → widen by the union span** of the two windows.
-4. **Cross cadence stays refused** (a 50 ms sampler against a 60 s
-   drivehealth sweep). The term is not small there, the right semantics are
-   a separate question, and nothing in the dashboards asks for it.
+4. **Cross cadence needs no special case** — see the second correction
+   below. It neither stays refused nor blows the band up; it decimates to the
+   slow side on its own.
 
 ### Correction (2026-08-21, after the entry was merged)
 
@@ -106,6 +107,47 @@ for the fact that `cpu_usage/cpu_usage_cpu` and `cpu_usage/cpu_usage_softirq`
 are *different tables*, read at different instants. So today's cross-table
 bands are **too narrow**, which is the one direction they must not be — and
 that is exactly what rule (3) fixes.
+
+### Correction 2 (2026-08-22): cross-cadence was wrong twice over
+
+The entry said cross-cadence combinations "stay refused" and, in discussion,
+that their band would explode and thereby signal meaninglessness. Both are
+wrong. Measured on a real archive, `cpu_usage` at ~0.199 s against
+`drivehealth` at ~19.6 s:
+
+```
+sum(irate(cpu_usage[5m])) / avg(drive_temperature)
+  → 3 points,  band [28558194, 28801420]   (~0.85% wide)
+sum(irate(cpu_usage[5m]))
+  → 29 points
+```
+
+The result comes out at the **slow side's cadence** — 3 points, not 29 —
+because `ZipMergeBinary` emits only where both sides have a point. Decimation
+is already the behaviour, for free, from timestamp intersection.
+
+And the band stays **tight**, because it reflects the two *acquisition
+windows* (both short — drivehealth's is its ~170 ms sweep), not the 19.6 s
+*interval* between readings. Cadence difference shows up as fewer output
+points; window width shows up as band width. Those are separate axes, and
+conflating them produced both errors.
+
+### The real cross-cadence question is sampling, not alignment
+
+What decimation would still buy is *meaning*, not safety. Rates are computed
+over the evaluation **step**, not the declared range — `rate(x[1s])`,
+`rate(x[30s])` and `irate(x[30s])` return byte-identical values, because
+`GridRate` computes `increase / step_s` and the range only gates whether
+enough samples exist. So the 3 surviving points above are fast-step rates
+sampled at 3 arbitrary instants, not averages over the period the slow reading
+spans.
+
+No band widening addresses that: a band measures acquisition uncertainty, not
+sampling representativeness. Such a result looks precise and is
+unrepresentative. The lever is the step, which is a caller parameter
+(`query_range(query, start, end, step)`) — so choosing it from the slowest
+referenced sampler's cadence is a rezolus-side change, tracked separately
+because it changes VALUES where this entry's rule changes only bands.
 
 ### Why the union span, not begin-to-begin
 

--- a/src/rez_reader.rs
+++ b/src/rez_reader.rs
@@ -272,13 +272,43 @@ impl RezReader {
                             .map(Routed::Union)
                             .map_err(|e| match e {
                                 UnionError::NonDisjoint { duplicates } => {
-                                    QueryError::ParseError(format!(
-                                        "query {query} references metric name(s) present in \
-                                         more than one acquisition-group table of the same \
-                                         sampler — the archive's own tables are not disjoint, \
-                                         which should never happen: {}",
-                                        duplicates.join(", ")
-                                    ))
+                                    // Two very different situations produce
+                                    // this, and conflating them tells the
+                                    // operator their archive is corrupt when
+                                    // it is not. Distinct SAMPLERS sharing a
+                                    // metric name is legitimate and shipped:
+                                    // `gpu_amd_smi` and `gpu_nvidia` both
+                                    // publish the vendor-neutral
+                                    // `gpu_utilization`, `gpu_temperature` and
+                                    // six more, because only one of them ever
+                                    // populates on a given host. Two group
+                                    // tables of ONE sampler sharing a name is
+                                    // a real archive defect.
+                                    let mut samplers: Vec<&str> = many
+                                        .iter()
+                                        .map(|t| rez::table_sampler(&t.sampler))
+                                        .collect();
+                                    samplers.sort();
+                                    samplers.dedup();
+                                    if samplers.len() > 1 {
+                                        QueryError::ParseError(format!(
+                                            "query {query} references metric name(s) published \
+                                             by more than one sampler ({}), so it is ambiguous \
+                                             which is meant: {}. This is not an archive fault — \
+                                             those samplers deliberately share vendor-neutral \
+                                             names. Query one of them at a time.",
+                                            samplers.join(", "),
+                                            duplicates.join(", ")
+                                        ))
+                                    } else {
+                                        QueryError::ParseError(format!(
+                                            "query {query} references metric name(s) present in \
+                                             more than one acquisition-group table of the same \
+                                             sampler — the archive's own tables are not \
+                                             disjoint, which should never happen: {}",
+                                            duplicates.join(", ")
+                                        ))
+                                    }
                                 }
                                 UnionError::Empty => {
                                     unreachable!("the `many` arm always has at least 2 owners")
@@ -667,6 +697,34 @@ mod tests {
     }
 
     /// Build a 2-sampler .rez fixture on disk; return (tempdir, path).
+    /// Two samplers publishing the SAME metric name — the `gpu_amd_smi` /
+    /// `gpu_nvidia` shape, where both vendors declare vendor-neutral names and
+    /// only one populates on any given host.
+    pub(super) fn two_sampler_rez_sharing_a_metric_name() -> (tempfile::TempDir, std::path::PathBuf)
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("shared.rez");
+        let rows: Vec<(Snapshot, u64)> = (0..3u64)
+            .map(|i| {
+                let ts = 1_000_000_000 * (i + 1);
+                let w = Some(Window::new(ts - 50_000_000, ts));
+                (
+                    snap(
+                        ts,
+                        vec![
+                            counter("shared_metric", "sampler_a", i * 10, w),
+                            counter("shared_metric", "sampler_b", i * 20, w),
+                        ],
+                        Vec::new(),
+                    ),
+                    ts,
+                )
+            })
+            .collect();
+        write_atomic_rez(&rows, &out);
+        (dir, out)
+    }
+
     pub(super) fn two_sampler_rez() -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let out = dir.path().join("two.rez");
@@ -2398,6 +2456,45 @@ mod tests {
                  all belong to one recording, so they union"
             );
         }
+    }
+
+    /// Two samplers publishing the same metric name must not be reported as a
+    /// corrupt archive.
+    ///
+    /// Shipped example: `gpu_amd_smi` and `gpu_nvidia` both publish
+    /// `gpu_utilization`, `gpu_temperature` and six more vendor-neutral names,
+    /// because only one of them ever populates on a given host. The dashboard
+    /// queries `avg(gpu_utilization)` in 16 places.
+    ///
+    /// Unioning across samplers made those queries reach
+    /// `UnionMetricsSource`'s disjointness check, whose message said the names
+    /// were in two group tables "of the same sampler" and that this "should
+    /// never happen". Both halves were false, and it blamed the operator's
+    /// archive for a deliberate design property. The query is still ambiguous
+    /// and still refused — it just has to say so truthfully.
+    #[test]
+    fn two_samplers_sharing_a_metric_name_is_not_reported_as_a_corrupt_archive() {
+        let (_d, path) = two_sampler_rez_sharing_a_metric_name();
+        let pool = BufferPool::new(64 * 1024 * 1024);
+        let reader = RezReader::open_with_pool(&path, pool).unwrap();
+
+        let err = reader
+            .query_range("shared_metric", 0.0, 10.0, 1.0)
+            .unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("more than one sampler"),
+            "the error must name the real cause — two samplers, one name: {msg}"
+        );
+        assert!(
+            !msg.contains("should never happen"),
+            "this DOES happen, by design, and saying otherwise sends the \
+             operator hunting a corrupt archive: {msg}"
+        );
+        assert!(
+            msg.contains("sampler_a") && msg.contains("sampler_b"),
+            "the error must name which samplers collide: {msg}"
+        );
     }
 
     #[test]

--- a/src/rez_reader.rs
+++ b/src/rez_reader.rs
@@ -210,13 +210,23 @@ impl RezReader {
     }
 
     /// Resolve the reader that answers every metric a query references: the
-    /// single owning table directly, or — when every owner shares one
-    /// sampler split across several group tables OF ONE RECORDING — a fresh
-    /// [`UnionMetricsSource`] over exactly those tables. Errors clearly when
-    /// a query spans two DIFFERENT samplers, the SAME sampler across two
-    /// DIFFERENT recordings of a multi-recording archive (cross-cadence /
-    /// cross-recording alignment is out of scope), or references no known
-    /// metric.
+    /// single owning table directly, or — when every owner lives in ONE
+    /// RECORDING — a fresh [`UnionMetricsSource`] over exactly those tables.
+    ///
+    /// Tables of different samplers union freely within a recording. They did
+    /// not always: a query spanning two samplers used to be refused as
+    /// "cross-timeline", because there was no way to say what treating two
+    /// separately-read values as simultaneous costs. The query engine now
+    /// prices that itself — operands whose acquisition edges differ have their
+    /// bands widened to the union of both spans — so the refusal has nothing
+    /// left to protect. Measured, the join costs 1.5–3.0 ms on a 32-core host,
+    /// under 1% of a 200 ms interval.
+    ///
+    /// Still refused: the SAME sampler across two DIFFERENT recordings of a
+    /// multi-recording (A/B) archive. Those are genuinely different timelines
+    /// — different agents, hosts or arms — and unioning them would let
+    /// first-wins silently answer from one recording. Errors too when the
+    /// query references no known metric.
     fn route(&self, query: &str) -> Result<Routed<'_>, QueryError> {
         let owners = self.owners(query)?;
         match owners.as_slice() {
@@ -239,10 +249,7 @@ impl RezReader {
                 // (or unsplit V3) table, so within one recording this
                 // reduces to today's behavior whenever nothing actually
                 // split.
-                let mut groups: Vec<(usize, &str)> = many
-                    .iter()
-                    .map(|t| (t.recording, rez::table_sampler(&t.sampler)))
-                    .collect();
+                let mut groups: Vec<usize> = many.iter().map(|t| t.recording).collect();
                 groups.sort();
                 groups.dedup();
                 match groups.as_slice() {
@@ -279,33 +286,26 @@ impl RezReader {
                             })
                     }
                     _ => {
-                        // Either two different samplers, or the same
-                        // sampler split across two different recordings —
-                        // tell them apart so the error is actually
-                        // actionable.
-                        let mut samplers: Vec<&str> = groups.iter().map(|(_, s)| *s).collect();
+                        // Only one case reaches here now: metrics drawn from
+                        // more than one RECORDING of a multi-recording
+                        // archive. Those are different agents, hosts or arms
+                        // on genuinely different timelines, and the widened
+                        // band does not make them comparable — unioning them
+                        // would let first-wins silently answer from one side.
+                        let mut samplers: Vec<&str> = many
+                            .iter()
+                            .map(|t| rez::table_sampler(&t.sampler))
+                            .collect();
                         samplers.sort();
                         samplers.dedup();
-                        let mut recordings: Vec<usize> = groups.iter().map(|(r, _)| *r).collect();
-                        recordings.sort();
-                        recordings.dedup();
-                        if samplers.len() == 1 {
-                            Err(QueryError::ParseError(format!(
-                                "query {query} references sampler {} from {} different \
-                                 recordings of this multi-recording .rez — cross-recording \
-                                 queries are not supported; query one recording at a time \
-                                 (see `RezReader::open_recordings`)",
-                                samplers[0],
-                                recordings.len()
-                            )))
-                        } else {
-                            Err(QueryError::ParseError(format!(
-                                "cross-timeline query spans samplers {} — per-sampler alignment \
-                                 (interpolate/decimate) is not yet supported; query one sampler \
-                                 at a time",
-                                samplers.join(", ")
-                            )))
-                        }
+                        Err(QueryError::ParseError(format!(
+                            "query {query} references metrics ({}) from {} different \
+                             recordings of this multi-recording .rez — cross-recording \
+                             queries are not supported; query one recording at a time \
+                             (see `RezReader::open_recordings`)",
+                            samplers.join(", "),
+                            groups.len()
+                        )))
                     }
                 }
             }
@@ -1043,14 +1043,29 @@ mod tests {
         assert!(reader
             .query_range("rate(reads[4s])", start, end, 1.0)
             .is_ok());
-        // And a query spanning both still errors naming both samplers.
-        let err = reader
-            .query_range("cpu_cycles + reads", start, end, 1.0)
-            .unwrap_err();
-        let msg = format!("{err:?}");
+        // …and a query spanning both, across a single-segment and a
+        // multi-segment table, answers through the union.
         assert!(
-            msg.contains("cpu_usage") && msg.contains("blockio_requests"),
-            "got: {msg}"
+            reader
+                .query_range("rate(cpu_cycles[2s]) + rate(reads[4s])", start, end, 1.0)
+                .is_ok(),
+            "a union over tables with different segment counts and cadences \
+             must answer"
+        );
+
+        // Known gap, asserted so it is a decision rather than a surprise:
+        // `UnionMetricsSource` does not serve BARE counter selectors, only
+        // rated ones. Bare gauges work (that is how `… / cpu_cores` resolves),
+        // and rating a counter is what essentially every real query does, so
+        // this has never been reachable in practice — the cross-sampler
+        // refusal used to mask it entirely. Delete this assertion when the
+        // union grows bare-counter support.
+        assert!(
+            reader
+                .query_range("cpu_cycles + reads", start, end, 1.0)
+                .is_err(),
+            "bare counter selectors across a union are still unsupported; if \
+             this now passes, the gap is closed and this assertion should go"
         );
     }
 
@@ -2280,18 +2295,41 @@ mod tests {
                  metric is unioned alongside it in the same query: solo={solo_json} \
                  via_union={union_json}"
             );
-            assert_eq!(
-                solo_json["result"][0]["intervals"], union_json["result"][0]["intervals"],
-                "cpu_softirq's own bands must not change either: solo={solo_json} \
-                 via_union={union_json}"
+            // The BAND may legitimately differ, and here it must: the union
+            // form is a binary op against a metric from a DIFFERENT table, so
+            // cpu_softirq's value is being combined with one read at another
+            // instant. That costs accuracy its solo band does not contain, and
+            // the widening prices it. What must never happen is the band
+            // getting NARROWER — claiming precision the join cannot support.
+            let solo_iv = solo_json["result"][0]["intervals"].as_array().unwrap();
+            let union_iv = union_json["result"][0]["intervals"].as_array().unwrap();
+            assert_eq!(solo_iv.len(), union_iv.len());
+            let mut widened = 0;
+            for (s_pt, u_pt) in solo_iv.iter().zip(union_iv) {
+                let (s_lo, s_hi) = (s_pt[0].as_f64().unwrap(), s_pt[1].as_f64().unwrap());
+                let (u_lo, u_hi) = (u_pt[0].as_f64().unwrap(), u_pt[1].as_f64().unwrap());
+                assert!(
+                    u_lo <= s_lo && u_hi >= s_hi,
+                    "a cross-table band must never be narrower than the solo \
+                     one: solo=({s_lo}, {s_hi}) union=({u_lo}, {u_hi})"
+                );
+                if u_lo < s_lo || u_hi > s_hi {
+                    widened += 1;
+                }
+            }
+            assert!(
+                widened > 0,
+                "at least one point must be widened, or the join is being \
+                 priced at zero: solo={solo_json} via_union={union_json}"
             );
         }
 
         #[test]
-        fn cross_sampler_query_still_errors_when_one_side_is_a_split_sampler() {
-            // A query spanning a split sampler's group AND a totally
-            // different sampler must still refuse — and must name each
-            // SAMPLER once, not once per physical group table.
+        fn a_split_sampler_group_and_another_sampler_union_together() {
+            // A query spanning one sampler's group table AND a different
+            // sampler's used to be refused. Both are tables of the SAME
+            // recording — one agent, one tick — so they union now, with each
+            // side's band widened to the span of both reads.
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("mixed.rez");
             let mut rec = recorder(&path, usize::MAX);
@@ -2347,36 +2385,37 @@ mod tests {
             rec.finalize((3_000_000_000, 0)).unwrap();
 
             let reader = open(&path);
-            let err = reader
-                .query_range("cpu_cycles + cpu_softirq + reads", 0.0, 10.0, 1.0)
-                .unwrap_err();
-            let msg = format!("{err:?}");
             assert!(
-                msg.contains("cpu_usage") && msg.contains("blockio_requests"),
-                "got: {msg}"
-            );
-            assert!(
-                !msg.contains("cpu_usage/percpu") && !msg.contains("cpu_usage/softirq"),
-                "the error must name the SAMPLER once, not each of its group \
-                 tables: {msg}"
+                reader
+                    .query_range(
+                        "rate(cpu_cycles[3s]) + rate(cpu_softirq[3s]) + rate(reads[3s])",
+                        0.0,
+                        10.0,
+                        1.0
+                    )
+                    .is_ok(),
+                "two group tables of one sampler and a third sampler's table \
+                 all belong to one recording, so they union"
             );
         }
     }
 
     #[test]
-    fn cross_sampler_query_errors_naming_both() {
+    fn cross_sampler_query_answers_through_the_union() {
         let (_d, path) = two_sampler_rez();
         let pool = BufferPool::new(64 * 1024 * 1024);
         let reader = RezReader::open_with_pool(&path, pool).unwrap();
-        // cpu_cycles (cpu_usage) and reads (blockio_requests) live in different
-        // tables; a query spanning both must error, naming both samplers.
-        let err = reader
-            .query_range("cpu_cycles + reads", 0.0, 10.0, 1.0)
-            .unwrap_err();
-        let msg = format!("{err:?}");
+        // `cpu_cycles` (cpu_usage) and `reads` (blockio_requests) live in
+        // different tables. This used to be refused as "cross-timeline",
+        // because nothing could say what treating two separately-read values
+        // as simultaneous costs. The query engine prices that itself now —
+        // operands whose acquisition edges differ have their bands widened to
+        // the union of both spans — so the query answers.
         assert!(
-            msg.contains("cpu_usage") && msg.contains("blockio_requests"),
-            "got: {msg}"
+            reader
+                .query_range("rate(cpu_cycles[2s]) + rate(reads[4s])", 0.0, 10.0, 1.0)
+                .is_ok(),
+            "a query spanning two samplers of one recording must answer"
         );
     }
 }


### PR DESCRIPTION
A `.rez` refused any query spanning two samplers — including the viewer's own
Frequency and IPC charts, which divide by `cpu_cores`. The refusal was not
caution about the data; it was the absence of arithmetic. There was no way to
say what treating two separately-read values as simultaneous costs, so the
query was declined rather than answered imprecisely.

metriken-query **0.19.1** supplies that arithmetic, so this drops the refusal.

## What changed

`route()` unions across samplers **within a recording**. Operands whose
acquisition edges differ get their bands widened to the union of both spans;
identical edges — the same read, since an acquisition group is one read with
one window — stay exactly as tight as before.

Still refused: the same sampler across two **recordings** of a multi-recording
archive. Those are different agents, hosts or arms on genuinely different
timelines, and no widening makes them comparable — unioning them would let
first-wins silently answer from one side.

## Measured on a live host

The three previously-refused dashboard queries now answer, with priced bands:

| query | value | band |
|---|---|---|
| `sum(irate(cpu_usage[5m])) / cpu_cores / 1e9` | 0.0388 | [0.0361, 0.0388] |
| Frequency chart | 5.38e9 | [4.64e9, 5.79e9] |
| DTLB MPKI | 0.4037 | [0.3749, 0.4346] |

The join itself costs 1.5–3.0 ms — under 1% of a 200 ms interval.

## Four tests changed, and how is the interesting part

- **Two** asserted the refusal → now assert the union answers.
- **`a_group_that_skipped_ticks_is_not_fabricated_across_by_the_union`** was the
  widening working correctly. It now asserts the invariant that matters: values
  byte-identical, band **never narrower**, and *at least one point actually
  widened*. Without that last clause the test would pass if the join were
  priced at zero.
- **`mixed_single_and_multi_segment_tables_are_queryable`** exposed a
  pre-existing gap the refusal had masked: `UnionMetricsSource` does not serve
  **bare counter selectors**, only rated ones. Bare *gauges* work (that is how
  `/ cpu_cores` resolves), and rating a counter is what real queries do — so
  this has never been reachable in practice. Asserted explicitly with a note to
  delete it when the gap closes, so it is a decision rather than a surprise.

## A second correction to the design entry

It claimed cross-cadence combinations "stay refused" and would blow the band
up. **Both wrong.** Measured, `cpu_usage` at ~0.199 s against `drivehealth` at
~19.6 s decimates to the slow side on its own — 3 points, not 29, straight out
of timestamp intersection — with a band **0.85% wide**, because the band tracks
acquisition *windows* (both short) and not the *interval* between readings.
Cadence difference changes the number of output points; window width changes
the band. Conflating those two axes produced both errors, and the entry now
says so in place rather than being quietly rewritten.

The genuinely open question it leaves is *sampling*, not alignment: rates are
computed over the evaluation **step**, not the declared range, so those 3
surviving points are fast-step rates at 3 instants rather than averages over
the period. That is a rezolus-side step choice, tracked separately because it
changes **values** where this changes only bands.

## Gate

`cargo test` green (676), fmt and clippy clean apart from one pre-existing
`dashboard` warning. The git pin is gone — back on published crates
(`metriken-query = "0.19.1"`), no git dependencies anywhere in the tree or
lockfile.
