### PR TITLE
fix(gpu): stop shipping phantom all-null GPU tables on hosts without that vendor

### DIFF
--- a/src/agent/samplers/gpu/linux/amd/mod.rs
+++ b/src/agent/samplers/gpu/linux/amd/mod.rs
@@ -25,6 +25,22 @@ use rocm_smi::{ClockType, RocmSmi, TempSensor};
 use stats::*;
 
 fn init(config: Arc<Config>) -> SamplerResult {
+    // Zero FIRST, so every exit below leaves the group empty rather than at
+    // backing capacity. An unset bound falls back to `MAX_GPUS` × this
+    // sampler's metrics, and the V3 snapshot walk then declares that many
+    // members — phantom, all-null, and indistinguishable to a reader from a
+    // real GPU that simply had no reading. Those phantoms put a
+    // `gpu_amd_smi` table into every archive on every host, whose metric
+    // names then collide with `gpu_nvidia`'s vendor-neutral ones and make
+    // `avg(gpu_utilization)` ambiguous where it should just work.
+    //
+    // Setting it here rather than on each failure path is deliberate: the
+    // paths out of this function are "disabled", "no devices" and "init
+    // failed", and a future fourth would otherwise reintroduce the bug
+    // silently. `AmdInner::new` raises it to the real device count on
+    // success.
+    GPU_AMD_SMI_ACQ.set_member_bound(0);
+
     if !config.enabled(NAME) {
         return Ok(None);
     }

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -18,6 +18,14 @@ const MB: i64 = 1024 * KB;
 const MHZ: i64 = 1_000_000;
 
 fn init(config: Arc<Config>) -> SamplerResult {
+    // Zero FIRST — see the equivalent comment in the AMD sampler. Here the
+    // leak is via `?`: `Nvml::init()` failing on a host without the NVIDIA
+    // driver (`libnvidia-ml.so.1` absent) returns before
+    // `NvidiaInner::new` can set the real bound, leaving the group at
+    // backing capacity and putting a phantom all-null `gpu_nvidia` table
+    // into every archive.
+    GPU_NVIDIA_ACQ.set_member_bound(0);
+
     if !config.enabled(NAME) {
         return Ok(None);
     }

--- a/src/agent/timing.rs
+++ b/src/agent/timing.rs
@@ -127,8 +127,15 @@ pub(crate) struct AcquisitionGroup {
     pub sampler: &'static str,
     pub name: &'static str,
     slot: GroupWindowSlot,
-    // 0 = unbounded (walk the full backing array's `entries()`); nonzero =
-    // the real member-population bound. See `set_member_bound`/`member_bound`.
+    // `usize::MAX` = unbounded (walk the full backing array's `entries()`);
+    // anything else is the real member-population bound, INCLUDING ZERO.
+    //
+    // The sentinel is MAX rather than 0 because zero is a legitimate bound: a
+    // device sweep on a host with none of that vendor's hardware has exactly
+    // zero members. With 0 as the sentinel, such a group could not say so —
+    // `set_member_bound(0)` was indistinguishable from never calling it, and
+    // the walk fell back to backing capacity, declaring `MAX_GPUS`-worth of
+    // phantom all-null members. See `set_member_bound`/`member_bound`.
     member_bound: AtomicUsize,
     // Init-time flag: true means this group's acquisition IS the exposition
     // read itself (mmap-direct `PackedCounters`), not a sampler `refresh()`.
@@ -145,7 +152,7 @@ impl AcquisitionGroup {
             sampler,
             name,
             slot: GroupWindowSlot::new(),
-            member_bound: AtomicUsize::new(0),
+            member_bound: AtomicUsize::new(usize::MAX),
             reader_stamped: AtomicBool::new(false),
         }
     }
@@ -187,7 +194,7 @@ impl AcquisitionGroup {
             sampler,
             name,
             slot: GroupWindowSlot::new(),
-            member_bound: AtomicUsize::new(0),
+            member_bound: AtomicUsize::new(usize::MAX),
             reader_stamped: AtomicBool::new(true),
         }
     }
@@ -218,9 +225,14 @@ impl AcquisitionGroup {
 
     /// The group's member-population bound, if one has been set (`None`
     /// means unbounded: walk the full `entries()`).
+    ///
+    /// `Some(0)` is a real answer — "this group has no members" — and is
+    /// distinct from `None`. A GPU sampler on a host without that vendor's
+    /// hardware reports exactly that, and the difference is what keeps a
+    /// phantom all-null table out of every archive.
     pub(crate) fn member_bound(&self) -> Option<usize> {
         match self.member_bound.load(Ordering::Relaxed) {
-            0 => None,
+            usize::MAX => None,
             n => Some(n),
         }
     }

--- a/src/agent/timing.rs
+++ b/src/agent/timing.rs
@@ -439,6 +439,45 @@ mod tests {
     // debug build): the pre-fix tear was caught 0/30 runs at 200k
     // iterations, but 5/5 at 5M — and 5M costs ~0.42s on correct code. Do
     // not shrink either the iteration count or drop the arm64 requirement.
+    /// A group must be able to say it has ZERO members, distinctly from
+    /// having said nothing.
+    ///
+    /// The bound used 0 as its "unset" sentinel, so `set_member_bound(0)` was
+    /// indistinguishable from never calling it and the snapshot walk fell back
+    /// to the backing array's full capacity. A GPU vendor sampler on a host
+    /// without that vendor's hardware therefore declared `MAX_GPUS`-worth of
+    /// phantom, all-null members — which put a table into every archive whose
+    /// metric names collided with the other vendor's vendor-neutral ones, and
+    /// made `avg(gpu_utilization)` ambiguous on machines that had no GPU at
+    /// all.
+    ///
+    /// This is the same failure the acquisition-group design exists to avoid,
+    /// one level down: a sentinel colliding with a legitimate value. Zero
+    /// members is a real answer.
+    #[test]
+    fn a_group_can_declare_zero_members_distinctly_from_unset() {
+        static UNSET: AcquisitionGroup = AcquisitionGroup::new("s", "unset");
+        static ZERO: AcquisitionGroup = AcquisitionGroup::new("s", "zero");
+        static SOME: AcquisitionGroup = AcquisitionGroup::new("s", "some");
+
+        assert_eq!(
+            UNSET.member_bound(),
+            None,
+            "a group that never set a bound is unbounded: walk everything"
+        );
+
+        ZERO.set_member_bound(0);
+        assert_eq!(
+            ZERO.member_bound(),
+            Some(0),
+            "zero members must survive as zero, not decay into `unbounded` and \
+             walk the whole backing array"
+        );
+
+        SOME.set_member_bound(7);
+        assert_eq!(SOME.member_bound(), Some(7));
+    }
+
     #[test]
     fn group_slot_is_tear_free_under_contention() {
         // Writer stamps (n, n+1) pairs; readers must never observe a mixed pair.


### PR DESCRIPTION
A host with **no GPU at all** shipped a `gpu_amd_smi` table and a `gpu_nvidia`
table in every recording — 448 and 672 phantom, all-null members. Found while
adversarially reviewing #1080.

## Two defects, one behind the other

**1. The vendor samplers leaked backing capacity on their non-initializing
paths.** AMD returns early on `devices == 0`, before `set_member_bound`;
NVIDIA's `Nvml::init()?` propagates out on a host without the driver, likewise
before it. Both leave the bound unset. A *disabled* sampler did too — its group
is still registered on the linkme slice.

Fixed by zeroing the bound **first** in `init()` and letting success raise it,
so no current or future exit path can leak. The paths out are "disabled", "no
devices" and "init failed", and patching each one individually invites a fourth
to reintroduce it silently.

**2. That fix alone did nothing, because zero could not be expressed.**

```rust
match self.member_bound.load(Ordering::Relaxed) {
    0 => None,      // "unset"
    n => Some(n),
}
```

Zero was the *sentinel for unset*, so `set_member_bound(0)` was
indistinguishable from never calling it and the walk fell back to capacity
anyway. The sentinel moves to `usize::MAX`, and `Some(0)` becomes a real
answer: "this group has no members."

This is the failure the acquisition-group design exists to prevent, one level
down — a sentinel colliding with a legitimate value, exactly like the
value-sentinel membership that V3 replaced with registration. Zero members is
real data.

## Why it mattered

Those phantom tables are why `avg(gpu_utilization)` — 16 dashboard charts —
became ambiguous: `gpu_amd_smi` and `gpu_nvidia` share eight vendor-neutral
metric names, and both tables were present on every host regardless of
hardware. The collision was not a mixed-vendor problem; it fired on machines
with no GPU, and would have fired on an ordinary single-vendor box.

With this, it reverts to firing only on genuinely mixed-vendor hardware, where
it is a real ambiguity that wants label-based disambiguation — a separate,
later piece.

## Verified on a live host

Before: 54 groups, `gpu_amd_smi/gpu_amd_smi_devices members=448`,
`gpu_nvidia/gpu_nvidia_devices members=672`.

After: **52 groups, no GPU groups at all**, no GPU tables in the recording, and
`avg(gpu_utilization)` now answers "no metric present in this .rez" — accurate,
since the host has no GPU.

Mutation check: restoring the `0 => None` sentinel fails the new test.

`cargo test` green (670).
