### PR TITLE
perf(agent): encode a snapshot body once, not once per request

### DIFF
--- a/src/agent/exposition/http/mod.rs
+++ b/src/agent/exposition/http/mod.rs
@@ -58,22 +58,18 @@ fn app(state: Arc<Mutex<SnapshotBuilder>>) -> Router {
         )
 }
 
-async fn msgpack(State(state): State<Arc<Mutex<SnapshotBuilder>>>) -> Vec<u8> {
+async fn msgpack(State(state): State<Arc<Mutex<SnapshotBuilder>>>) -> bytes::Bytes {
     let now = Instant::now();
 
     let mut snapshot_builder = state.lock().await;
-    let snapshot = snapshot_builder.build(now).await;
-
-    rmp_serde::encode::to_vec(&snapshot).expect("failed to serialize snapshot")
+    snapshot_builder.build_msgpack(now).await
 }
 
 async fn json(State(state): State<Arc<Mutex<SnapshotBuilder>>>) -> String {
     let now = Instant::now();
 
     let mut snapshot_builder = state.lock().await;
-    let snapshot = snapshot_builder.build(now).await;
-
-    serde_json::to_string(&snapshot).expect("failed to serialize snapshot")
+    snapshot_builder.build_json(now).await.to_string()
 }
 
 async fn root() -> String {

--- a/src/agent/exposition/http/snapshot.rs
+++ b/src/agent/exposition/http/snapshot.rs
@@ -11,9 +11,10 @@ use metriken_exposition::{
     SnapshotV3,
 };
 
+use bytes::Bytes;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, SystemTime};
 
 pub struct SnapshotBuilder {
@@ -28,6 +29,18 @@ pub struct SnapshotBuilder {
 struct CachedSnapshot {
     timestamp: Instant,
     snapshot: Snapshot,
+    /// The encoded bodies for this snapshot, filled on first request for each
+    /// format and reused for every later request that hits the same cached
+    /// snapshot.
+    ///
+    /// The TTL cache used to cache only the `Snapshot`, so a cache HIT still
+    /// re-encoded the whole body — measured at **3.47 MB per request** on a
+    /// 26-sampler host. `rmp_serde::encode::to_vec` starts from an empty `Vec`
+    /// and grows by doubling, so that was also a dozen reallocations and a
+    /// dozen copies per request, all of it discarded. Encoding once per
+    /// snapshot turns every subsequent request into a refcount bump.
+    msgpack: OnceLock<Bytes>,
+    json: OnceLock<Arc<str>>,
 }
 
 impl SnapshotBuilder {
@@ -82,6 +95,8 @@ impl SnapshotBuilder {
         self.cached = Some(CachedSnapshot {
             snapshot,
             timestamp: last,
+            msgpack: OnceLock::new(),
+            json: OnceLock::new(),
         });
     }
 
@@ -93,6 +108,41 @@ impl SnapshotBuilder {
         }
 
         &self.cached.as_ref().unwrap().snapshot
+    }
+
+    /// The msgpack body for the current snapshot, encoded at most once per
+    /// snapshot. Cloning the returned [`Bytes`] is a refcount bump, not a copy.
+    pub async fn build_msgpack(&mut self, now: Instant) -> Bytes {
+        let cached = {
+            self.build(now).await;
+            self.cached.as_ref().expect("build populates the cache")
+        };
+        cached
+            .msgpack
+            .get_or_init(|| {
+                Bytes::from(
+                    rmp_serde::encode::to_vec(&cached.snapshot)
+                        .expect("failed to serialize snapshot"),
+                )
+            })
+            .clone()
+    }
+
+    /// The JSON body for the current snapshot, encoded at most once per
+    /// snapshot. Cloning the returned `Arc<str>` is a refcount bump.
+    pub async fn build_json(&mut self, now: Instant) -> Arc<str> {
+        let cached = {
+            self.build(now).await;
+            self.cached.as_ref().expect("build populates the cache")
+        };
+        cached
+            .json
+            .get_or_init(|| {
+                serde_json::to_string(&cached.snapshot)
+                    .expect("failed to serialize snapshot")
+                    .into()
+            })
+            .clone()
     }
 }
 
@@ -4325,6 +4375,48 @@ mod tests {
         assert!(
             migrated.iter().all(|(_, _, w)| w.is_some()),
             "migrated packed metric gains a window in V2 — the only change"
+        );
+    }
+
+    /// A request that hits the TTL cache reuses the already-encoded body
+    /// instead of re-encoding it.
+    ///
+    /// The cache stored only the `Snapshot`, so every request re-serialized the
+    /// whole thing — measured at 3.47 MB per request on a 26-sampler host, and
+    /// `to_vec` grows from empty by doubling, so that was also about a dozen
+    /// reallocate-and-copy steps per request, all discarded. Identical
+    /// allocation identity is the direct evidence that no second encode
+    /// happened: a re-encode would necessarily produce a different buffer.
+    #[tokio::test]
+    async fn a_cache_hit_reuses_the_encoded_body_instead_of_re_encoding() {
+        // A long TTL so the second call is unambiguously a cache hit.
+        let config: Config = toml::from_str("[general]\nttl = \"60s\"\n").expect("valid config");
+        let mut builder = SnapshotBuilder::new(
+            Arc::new(config),
+            Arc::new(Vec::<Box<dyn Sampler>>::new().into_boxed_slice()),
+            None,
+        );
+
+        let now = Instant::now();
+        let first = builder.build_msgpack(now).await;
+        let second = builder.build_msgpack(now).await;
+
+        assert_eq!(first, second, "same snapshot must encode to the same bytes");
+        assert_eq!(
+            first.as_ptr(),
+            second.as_ptr(),
+            "a cache hit must hand back the SAME buffer — a different pointer \
+             means it re-encoded"
+        );
+
+        // A refresh past the TTL legitimately produces a new body; the reuse
+        // above must not be a stale-forever cache.
+        let later = now + Duration::from_secs(120);
+        let third = builder.build_msgpack(later).await;
+        assert_ne!(
+            first.as_ptr(),
+            third.as_ptr(),
+            "past the TTL the snapshot is rebuilt, so its body must be too"
         );
     }
 


### PR DESCRIPTION
The TTL cache stored the `Snapshot` but not its serialization, so a cache **hit** still re-encoded the entire body. On a 26-sampler host that body is **3.47 MB**, and `rmp_serde`'s `to_vec` grows from an empty `Vec` by doubling — about a dozen reallocate-and-copy steps per request, every byte discarded.

This caches the encoded body per format alongside the snapshot, filled on first request and reused until the snapshot is rebuilt. A hit becomes a refcount bump on a `Bytes`.

**Measured:** 500 requests against a cached snapshot went from **2064 KB** of RSS growth (4227 B/req) to **0 KB**.

The win is narrow but real: several consumers polling one agent inside the TTL window — exporter, viewer and hindsight against the same host — each previously paid a full 3.47 MB encode.

## This does not fix #1069, and it corrects that issue's diagnosis

At the default `ttl = "10ms"` every scrape rebuilds, so this cache is never consulted on that path. RSS grows identically before and after: **16 KB/scrape, 133 MB after 4000 scrapes.**

Investigating it turned up that #1069 **is not a leak**. `leaks` reports 0 unreachable bytes, and the live heap is flat across the growth — 475,555 nodes / 41,739 KB, *identical* at 200, 1000 and 2000 scrapes, while RSS climbed 69 → 98 MB. Nothing accumulates; it is allocator retention against a multi-MB per-refresh churn. Full measurements posted on [#1069](https://github.com/iopsystems/rezolus/issues/1069#issuecomment-5388755756).

Two candidate reductions were tried and **both failed to move it**: this encode cache, and a reused encode scratch buffer. The scratch buffer was **reverted rather than kept for a benefit it did not have**. That two independent encode-path reductions changed nothing is what rules the encode path out and points at the refresh path instead.

The right next step there is the Linux page-fault attribution the issue already asks for — glibc and macOS libmalloc retain very differently, and every number above is macOS, so a fix shaped by them could be shaped by the wrong allocator.

## Tests

672 unit + 7 + 4 integration pass; clippy clean. One new test, mutation-checked: a cache hit hands back the **same buffer** (identical allocation identity — a re-encode would necessarily produce a different one), and a refresh past the TTL produces a new one, so the reuse is not a stale-forever cache. Removing the `get_or_init` fails it.