### PR TITLE
fix(cpu_perf): open its per-CPU events as one perf event group

### DIFF
--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -772,37 +772,100 @@ where
 
             let mut perf_counters = PerfCounters::new(self.name);
 
-            for (name, event, target) in self.perf_events.into_iter() {
-                let map = skel.map(name);
+            // One perf event GROUP per CPU, not one independent event per
+            // (event, CPU).
+            //
+            // The kernel schedules a group all-or-nothing: either every member
+            // gets a counter or none do. Opened independently, a sampler whose
+            // events outnumber the free counters gets some of them placed and
+            // the rest pinned-but-never-scheduled, reading a frozen value
+            // forever. For `cpu_perf` that means `cycles` counts and
+            // `instructions` does not, and the IPC computed downstream is
+            // fabricated rather than missing — a wrong answer where a group
+            // gives no answer. Half a sampler is worse than none.
+            //
+            // This mirrors what `cpu_branch`, `cpu_l3`, `cpu_dtlb` and
+            // `cpu_frequency` already do; those open a leader and attach the
+            // rest with `build_with_group`. The BPF-builder path was the one
+            // that did not. `ReadFormat::GROUP` below reads as if it did — it
+            // only sets the read buffer's layout, and with no leader every
+            // event was its own singleton group.
+            //
+            // Only the leader carries `pinned`/`read_format`: they are group
+            // properties, applied to the whole group through it.
+            let maps: Vec<&libbpf_rs::Map<'_>> = self
+                .perf_events
+                .iter()
+                .map(|(name, _, _)| skel.map(name))
+                .collect();
 
-                for cpu in 0..cpus {
-                    if let Ok(mut counter) = event
-                        .inner
-                        .builder()
+            for cpu in 0..cpus {
+                let mut leader: Option<perf_event::Counter> = None;
+                let mut members: Vec<perf_event::Counter> = Vec::new();
+                let mut complete = true;
+
+                for (_, event, _) in self.perf_events.iter() {
+                    // Bound as an owned local: the setters take `&mut self` and
+                    // return `&mut Self`, so chaining straight off `builder()`
+                    // would borrow a temporary that dies at the end of the
+                    // statement.
+                    let mut builder = event.inner.builder();
+                    builder
                         .one_cpu(cpu)
                         .any_pid()
                         .exclude_hv(false)
-                        .exclude_kernel(false)
-                        .pinned(true)
-                        .read_format(
+                        .exclude_kernel(false);
+                    if leader.is_none() {
+                        builder.pinned(true).read_format(
                             ReadFormat::TOTAL_TIME_ENABLED
                                 | ReadFormat::TOTAL_TIME_RUNNING
                                 | ReadFormat::GROUP,
-                        )
-                        .build()
-                    {
-                        let _ = counter.enable();
-
-                        let fd = counter.as_raw_fd();
-
-                        let _ = map.update(
-                            &((cpu as u32).to_ne_bytes()),
-                            &(fd.to_ne_bytes()),
-                            MapFlags::ANY,
                         );
-
-                        perf_counters.push(cpu, counter, target);
                     }
+
+                    let built = match leader.as_mut() {
+                        Some(leader) => builder.build_with_group(leader),
+                        None => builder.build(),
+                    };
+
+                    match built {
+                        Ok(counter) => {
+                            if leader.is_none() {
+                                leader = Some(counter);
+                            } else {
+                                members.push(counter);
+                            }
+                        }
+                        Err(e) => {
+                            debug!(
+                                "{}: could not open the full perf event group on CPU{cpu}, \
+                                 taking none of it: {e}",
+                                self.name
+                            );
+                            complete = false;
+                            break;
+                        }
+                    }
+                }
+
+                // Anything short of the whole group is dropped rather than
+                // published half-measured; the counters close with the Vec.
+                let Some(mut leader) = leader.filter(|_| complete) else {
+                    continue;
+                };
+
+                let _ = leader.enable_group();
+
+                for (i, counter) in std::iter::once(leader).chain(members).enumerate() {
+                    let fd = counter.as_raw_fd();
+
+                    let _ = maps[i].update(
+                        &((cpu as u32).to_ne_bytes()),
+                        &(fd.to_ne_bytes()),
+                        MapFlags::ANY,
+                    );
+
+                    perf_counters.push(cpu, counter, self.perf_events[i].2);
                 }
             }
 


### PR DESCRIPTION
First step on #1053, kept separate because it stands on its own — no budget, no ranking, no new machinery.

`cpu_perf` opened `cycles` and `instructions` as **two independent pinned events**. The kernel places pinned events first-come-first-served, so on a host whose PMU is already full one of the pair can be placed and the other pinned but never scheduled, reading a frozen value forever. The IPC computed downstream from `instructions / cycles` is then **fabricated rather than missing** — which is what #1036 turned out to be. Half a sampler is worse than none.

A perf event group is scheduled all-or-nothing by the kernel. `cpu_branch`, `cpu_l3`, `cpu_dtlb` and `cpu_frequency` already open a leader and attach the rest with `build_with_group`; the BPF-builder path that `cpu_perf` uses was the only one that didn't. This brings it in line rather than introducing a technique.

## The thing that makes the old code look correct

It passed `ReadFormat::GROUP`. That only sets the **read buffer's layout** — with no leader, every event was its own singleton group and the flag bought nothing. Easy to read as "already grouped"; it isn't.

## Shape of the change

Loops invert (CPU outer, events inner) because a group is per CPU. Only the leader carries `pinned`/`read_format`, which are group properties applied through it. If any member fails to open, the whole group for that CPU is dropped rather than published half-measured.

## Verification, and its limit

Verified on a 32-core Linux host (Debian 13, kernel 6.12, AMD Zen 4). After the change `cpu_perf` is still fully populated — 64/64 across its sweep, 49/49 on each cgroup group — so nothing regressed.

⚠️ **`cargo check` on macOS proves nothing for this file.** `mod bpf` is `#[cfg(target_os = "linux")]`, so it isn't compiled there at all. A borrow error in my first version passed a clean macOS check and only appeared when built on Linux.

**Not claimed:** a before/after on the failure itself. Forcing the PMU to leave exactly one free counter needs a counter-hog tool this repo doesn't have, so the guarantee rests on kernel group semantics. The same host's output does show the property working where it's already used — grouped `cpu_branch` reports **0 of 64** (all-or-nothing), while `cpu_dtlb` reports **32 of 96** because its store-miss member is deliberately optional:

```
cpu_branch/cpu_branch_sweep       declared= 64  with_value=  0
cpu_dtlb/cpu_dtlb_sweep           declared= 96  with_value= 32
cpu_frequency/cpu_frequency_sweep declared= 96  with_value= 96
cpu_l3/cpu_l3_sweep               declared= 64  with_value= 64
cpu_perf/cpu_perf_sweep           declared= 64  with_value= 64
```

**No unit test:** opening real PMU events isn't something CI can do. 716 unit + 7 + 4 integration pass on Linux; clippy clean (the two `io::Error::other` and one `into_iter` warnings are pre-existing on main, in files this doesn't touch).

## Still open on #1053

The over-subscription itself. Reproduced on this host: the agent holds ~281 `perf_event` fds (~8/cpu against 6 hardware counters), and an independent system-wide `perf stat` gets `<not counted> (0.00%)` for both cycles and instructions while it runs. That needs the budget + ranking work, which is a much larger change.