### PR TITLE
feat(agent): sparse group membership, and the CPU-masked PMU reservation it unblocks

### DIFF
--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -799,7 +799,13 @@ where
                 .map(|(name, _, _)| skel.map(name))
                 .collect();
 
-            for cpu in 0..cpus {
+            // The CPUs this sampler may claim counters on. With a
+            // `reserved_pmu_cpus` mask the reservation covers only part of the
+            // machine, so the budget can fit on some CPUs and not others;
+            // without one this is every CPU, as before.
+            let allowed = crate::agent::pmu::allowed_cpus(self.name, (0..cpus).collect());
+
+            for &cpu in allowed.iter() {
                 let mut leader: Option<perf_event::Counter> = None;
                 let mut members: Vec<perf_event::Counter> = Vec::new();
                 let mut complete = true;
@@ -874,7 +880,17 @@ where
             // slots this sweep will ever populate, not each member
             // `CounterGroup`'s `MAX_CPUS`-sized backing array.
             if let Some(group) = self.perf_group {
-                group.set_member_bound(possible_cpus());
+                // Declare the members we can actually populate. A bound says
+                // "the first N"; an allowed set is rarely a prefix, and declaring
+                // the prefix anyway would leave the CPUs we skipped registered but
+                // never written — and an unwritten `CounterGroup` slot reads as
+                // `0`, not as absent. Publishing zero cycles for a CPU nothing
+                // measured is a wrong value, not missing data.
+                if allowed.len() == cpus {
+                    group.set_member_bound(possible_cpus());
+                } else {
+                    group.set_member_set(&allowed);
+                }
             }
 
             perf_counters.spawn(perf_threads_tx.clone(), perf_sync_tx.clone());

--- a/src/agent/config/general.rs
+++ b/src/agent/config/general.rs
@@ -59,6 +59,10 @@ pub struct General {
     // order in which PMU samplers claim counters (see `pmu_priority`)
     #[serde(default)]
     pmu_priority: Vec<String>,
+
+    // CPUs the reservation applies to (see `reserved_pmu_cpus`)
+    #[serde(default)]
+    reserved_pmu_cpus: Option<String>,
 }
 
 impl General {
@@ -66,6 +70,16 @@ impl General {
         if let Err(e) = self.ttl.parse::<humantime::Duration>() {
             eprintln!("ttl couldn't be parsed: {e}");
             std::process::exit(1);
+        }
+
+        if let Some(ref spec) = self.reserved_pmu_cpus {
+            if crate::agent::pmu::parse_cpu_list(spec).is_none() {
+                eprintln!(
+                    "reserved_pmu_cpus couldn't be parsed: {spec:?} (expected a list like \
+                     \"0-3,8,12-15\")"
+                );
+                std::process::exit(1);
+            }
         }
 
         if let Some(ref btf_path) = self.btf_path {
@@ -100,6 +114,18 @@ impl General {
     /// wants `cpu_l3` to outrank `cpu_perf`.
     pub fn pmu_priority(&self) -> &[String] {
         &self.pmu_priority
+    }
+
+    /// The CPUs `reserved_pmu_counters` applies to, as a list like
+    /// `"0-3,8,12-15"`. Unset means every CPU.
+    ///
+    /// Reserving uniformly is usually more than is needed. The consumers a
+    /// reservation protects are rarely spread evenly — guest vCPUs run on some
+    /// cores, an isolated workload lives on specific ones — so holding counters
+    /// back everywhere costs the agent coverage on CPUs where nothing else
+    /// wanted them.
+    pub fn reserved_pmu_cpus(&self) -> Option<&str> {
+        self.reserved_pmu_cpus.as_deref()
     }
 
     pub fn listen(&self) -> SocketAddr {

--- a/src/agent/exposition/http/snapshot.rs
+++ b/src/agent/exposition/http/snapshot.rs
@@ -1111,6 +1111,49 @@ struct GroupDecision {
 /// groups have no such window — their membership is registration-derived,
 /// not value-derived, so nothing about this pass or the main walk needs to
 /// agree on a value to agree on membership.
+/// The member indices of a declared group-typed metric.
+///
+/// Two shapes, because two things can be known. A `member_bound` says "the
+/// first N indices", which is what a per-CPU sweep over `0..possible_cpus()`
+/// has. An explicit set says exactly which indices are populated, which is what
+/// a sampler allowed only part of the machine has — and that set is rarely a
+/// prefix.
+///
+/// The distinction is not cosmetic. A registered `CounterGroup` slot that is
+/// never written reads as `0`, not as absent, so declaring a prefix that
+/// overstates the population publishes zeros for indices nothing measured — a
+/// wrong value where the honest answer is no value at all.
+enum MemberIter<'a> {
+    Prefix(std::ops::Range<usize>),
+    Set(std::slice::Iter<'a, usize>),
+}
+
+impl Iterator for MemberIter<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        match self {
+            MemberIter::Prefix(range) => range.next(),
+            MemberIter::Set(iter) => iter.next().copied(),
+        }
+    }
+}
+
+/// Resolve a declared group's members: the explicit set when one was declared,
+/// otherwise the dense prefix, clamped to what the backing array actually has.
+fn members<'a>(set: Option<&'a [usize]>, bound: Option<usize>, entries: usize) -> MemberIter<'a> {
+    match set {
+        // An explicit set wins: a caller that knows the exact indices knows
+        // strictly more than a bound. Still clamped — a stale set must not walk
+        // past the backing array.
+        Some(set) => {
+            let end = set.partition_point(|idx| *idx < entries);
+            MemberIter::Set(set[..end].iter())
+        }
+        None => MemberIter::Prefix(0..bound.map_or(entries, |b| b.min(entries))),
+    }
+}
+
 fn fold_group_identities<'a>(
     cache: &SkeletonCache,
     group_registry: &HashMap<(&'static str, &'static str), &'static AcquisitionGroup>,
@@ -1144,12 +1187,14 @@ fn fold_group_identities<'a>(
         let sampler = crate::agent::samplers::attribute_sampler(metric.module(), sampler_mods);
         let mut declared = false;
         let mut member_bound: Option<usize> = None;
+        let mut member_set: Option<&[usize]> = None;
         let mut reader_stamped = false;
         let group_key: (&str, &str) = match metric.metadata().get("acq_group") {
             Some(acq_group) => {
                 if let Some(ag) = group_registry.get(&(sampler, acq_group)) {
                     declared = true;
                     member_bound = ag.member_bound();
+                    member_set = ag.member_set();
                     reader_stamped = ag.is_reader_stamped();
                     (ag.sampler, ag.name)
                 } else {
@@ -1184,8 +1229,7 @@ fn fold_group_identities<'a>(
                         });
                     }
                 } else {
-                    let bound = member_bound.map_or(g.entries(), |b| b.min(g.entries()));
-                    for idx in 0..bound {
+                    for idx in members(member_set, member_bound, g.entries()) {
                         if !declared {
                             let Some(v) = g.counter_value(idx) else {
                                 continue;
@@ -1218,8 +1262,7 @@ fn fold_group_identities<'a>(
                         });
                     }
                 } else {
-                    let bound = member_bound.map_or(g.entries(), |b| b.min(g.entries()));
-                    for idx in 0..bound {
+                    for idx in members(member_set, member_bound, g.entries()) {
                         if !declared && g.gauge_value(idx).is_none() {
                             continue;
                         }
@@ -1573,6 +1616,8 @@ fn create_v3(
         // the full backing-array `entries()`. Resolved alongside routing,
         // before `group_key` is moved into `groups.entry` below.
         let mut member_bound: Option<usize> = None;
+        // Members that are not a dense prefix; see `members`.
+        let mut member_set: Option<&[usize]> = None;
         // Reader-stamped (`PackedCounters` mmap-direct) groups use a THIRD
         // membership mode instead of `member_bound`'s dense prefix: every
         // index with metadata registered is a member — see the
@@ -1584,6 +1629,7 @@ fn create_v3(
                 if let Some(ag) = group_registry.get(&(sampler, acq_group)) {
                     declared = true;
                     member_bound = ag.member_bound();
+                    member_set = ag.member_set();
                     reader_stamped = ag.is_reader_stamped();
                     (ag.sampler, ag.name)
                 } else {
@@ -1847,8 +1893,7 @@ fn create_v3(
                         // one is set (clamped to `entries()` in case a
                         // stale/misconfigured bound somehow exceeds the
                         // backing array).
-                        let bound = member_bound.map_or(g.entries(), |b| b.min(g.entries()));
-                        for idx in 0..bound {
+                        for idx in members(member_set, member_bound, g.entries()) {
                             let v = g.counter_value(idx);
 
                             // Transitional V2-style sentinel skip — default
@@ -1967,8 +2012,7 @@ fn create_v3(
                     } else {
                         // Same member-population bound as the `CounterGroup`
                         // arm above — see its comment.
-                        let bound = member_bound.map_or(g.entries(), |b| b.min(g.entries()));
-                        for idx in 0..bound {
+                        for idx in members(member_set, member_bound, g.entries()) {
                             let v = g.gauge_value(idx);
 
                             // Transitional V2-style sentinel skip — default
@@ -2089,8 +2133,7 @@ fn create_v3(
                             guard.mark_end();
                         }
                     } else {
-                        let bound = member_bound.map_or(g.entries(), |b| b.min(g.entries()));
-                        for idx in 0..bound {
+                        for idx in members(member_set, member_bound, g.entries()) {
                             let v = g.counter_value(idx);
                             if !declared {
                                 let Some(v) = v else { continue };
@@ -2114,8 +2157,7 @@ fn create_v3(
                             guard.mark_end();
                         }
                     } else {
-                        let bound = member_bound.map_or(g.entries(), |b| b.min(g.entries()));
-                        for idx in 0..bound {
+                        for idx in members(member_set, member_bound, g.entries()) {
                             let v = g.gauge_value(idx);
                             if !declared && v.is_none() {
                                 continue;
@@ -4546,6 +4588,64 @@ mod tests {
             third.as_ptr(),
             "past the TTL the snapshot is rebuilt, so its body must be too"
         );
+    }
+
+    /// An explicit member set walks exactly those indices, and a bound still
+    /// walks the prefix.
+    ///
+    /// This is what keeps a partially-allocated sampler honest. A group whose
+    /// members are, say, CPUs 16-31 cannot say so with a bound — a bound means
+    /// "the first N" — so it would have to declare 0..32 and let the CPUs it
+    /// never wrote publish `0`. An unwritten `CounterGroup` slot reads as zero,
+    /// not as absent, so that is a wrong value rather than missing data: a
+    /// consumer summing across the machine would understate it and see nothing
+    /// wrong.
+    #[test]
+    fn an_explicit_member_set_walks_only_its_own_indices() {
+        // A bound: the dense prefix, as before.
+        let prefix: Vec<usize> = members(None, Some(4), 32).collect();
+        assert_eq!(prefix, vec![0, 1, 2, 3]);
+
+        // No bound and no set: everything the backing array has.
+        let all: Vec<usize> = members(None, None, 3).collect();
+        assert_eq!(all, vec![0, 1, 2]);
+
+        // A set that is not a prefix — the case a bound cannot express.
+        let set = [16usize, 17, 18, 31];
+        let sparse: Vec<usize> = members(Some(&set), None, 32).collect();
+        assert_eq!(sparse, vec![16, 17, 18, 31]);
+
+        // The set wins over a bound: a caller that knows the exact indices
+        // knows strictly more than one that knows a count.
+        let both: Vec<usize> = members(Some(&set), Some(2), 32).collect();
+        assert_eq!(both, vec![16, 17, 18, 31]);
+    }
+
+    /// A member set is clamped to the backing array, like a bound is.
+    ///
+    /// A set outliving a resize would otherwise walk past the end of the array
+    /// it describes.
+    #[test]
+    fn a_member_set_never_walks_past_the_backing_array() {
+        let set = [0usize, 1, 2, 99];
+        let walked: Vec<usize> = members(Some(&set), None, 3).collect();
+        assert_eq!(walked, vec![0, 1, 2], "index 99 is not in a 3-entry array");
+
+        let empty: Vec<usize> = members(Some(&set), None, 0).collect();
+        assert!(empty.is_empty());
+    }
+
+    /// `set_member_set` sorts and de-duplicates, so the walk stays in index
+    /// order however the caller discovered them.
+    #[test]
+    fn a_declared_member_set_is_sorted_and_deduplicated() {
+        static G: AcquisitionGroup = AcquisitionGroup::new("t_sparse", "t_sparse_group");
+        G.set_member_set(&[31, 16, 17, 16]);
+        assert_eq!(G.member_set(), Some(&[16usize, 17, 31][..]));
+
+        // Single-init, like the bound: a second call does not race the walk.
+        G.set_member_set(&[0]);
+        assert_eq!(G.member_set(), Some(&[16usize, 17, 31][..]));
     }
 
     #[tokio::test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -97,7 +97,11 @@ pub fn run(config: PathBuf) {
     let available = crate::agent::pmu::probe_available();
     let reserved = config.general().reserved_pmu_counters();
     let order = crate::agent::pmu::resolve_order(config.general().pmu_priority());
-    let pmu_plan = crate::agent::pmu::plan(&order, available, reserved);
+    // Which CPUs give up counters. Unset means all of them, which is what the
+    // agent did before the mask existed.
+    let cpu_split = crate::agent::pmu::cpu_split(config.general().reserved_pmu_cpus());
+    let pmu_plan = crate::agent::pmu::plan(&order, available, reserved, &cpu_split);
+    crate::agent::pmu::publish_allocation(&pmu_plan);
 
     // Core counters only: uncore and MSR samplers draw on separate hardware, so
     // counting their events here would report a shortage that does not exist.
@@ -113,6 +117,11 @@ pub fn run(config: PathBuf) {
 
     for entry in SAMPLERS {
         if let Some(grant) = pmu_plan.iter().find(|g| g.sampler == entry.name) {
+            if let Some((cpus, total)) = grant.partial {
+                // Runs, but not everywhere. Recorded before `init` so the
+                // reason survives whatever the sampler reports about itself.
+                crate::agent::sampler_status::set_pmu_limited(entry.name, cpus, total);
+            }
             if !grant.granted {
                 // Skipped, not failed: nothing broke, there were not enough
                 // counters. Reported with the numbers so an operator can see
@@ -228,6 +237,14 @@ fn log_sampler_health_summary() {
             // `unsupported` alongside a missing kernel capability: this one is
             // a resource decision the operator can change, and the numbers are
             // what let them decide.
+            (SamplerState::PmuLimited { cpus, of }, _) => {
+                degraded += 1;
+                info!(
+                    "sampler {}: running on {cpus} of {of} CPUs — PMU counters reserved \
+                     on the rest",
+                    s.name
+                );
+            }
             (SamplerState::PmuStarved { wants, free }, _) => {
                 unsupported += 1;
                 info!(

--- a/src/agent/pmu.rs
+++ b/src/agent/pmu.rs
@@ -76,11 +76,30 @@ pub struct Grant {
     pub sampler: &'static str,
     /// Events per CPU this sampler wants.
     pub wants: usize,
-    /// Whether it may open them.
+    /// Whether it may open them anywhere at all.
     pub granted: bool,
     /// Counters still free when this sampler was considered — the useful half
     /// of "why not" when `granted` is false.
+    ///
+    /// When a reservation applies to only some CPUs this is the figure on the
+    /// RESERVED ones, which is where the shortage is.
     pub free_at_decision: usize,
+    /// The CPUs this sampler may open events on, when that is not all of them.
+    ///
+    /// `None` means unrestricted — the common case, and what a sampler running
+    /// outside the agent's normal startup sees.
+    pub cpus: Option<Vec<usize>>,
+    /// Whether the grant covers only part of the machine, and how much.
+    ///
+    /// `None` means every CPU. `Some((granted, total))` means the reservation
+    /// left too little on the reserved CPUs but not on the rest, so this
+    /// sampler runs on `granted` of `total` CPUs.
+    ///
+    /// Carried separately from `granted` because "running on 24 of 32 CPUs" is
+    /// neither working nor refused, and reporting it as either would mislead:
+    /// as `Active` it reads as full coverage, as starved it reads as no data
+    /// when there is plenty.
+    pub partial: Option<(usize, usize)>,
 }
 
 /// Decide which PMU samplers may open their events.
@@ -102,8 +121,18 @@ pub fn plan(
     order: &[(&'static str, PmuKind, usize)],
     available: usize,
     reserved: usize,
+    cpus: &CpuSplit,
 ) -> Vec<Grant> {
-    let mut free = available.saturating_sub(reserved);
+    // Two budgets, because a reservation may cover only part of the machine:
+    // the reserved CPUs give up counters, the rest do not. Both are walked in
+    // lockstep so a sampler's rank means the same thing on either.
+    //
+    // They can genuinely diverge. A sampler that fits only on the unreserved
+    // side consumes there and not here, after which a later sampler can fit on
+    // the RESERVED side and not the other — so neither side is simply the
+    // other's subset, and both directions of partial coverage are real.
+    let mut free_reserved = available.saturating_sub(reserved);
+    let mut free_open = available;
     let mut plan = Vec::with_capacity(order.len());
 
     for &(sampler, kind, wants) in order {
@@ -113,29 +142,87 @@ pub fn plan(
                 sampler,
                 wants,
                 granted: true,
-                free_at_decision: free,
+                free_at_decision: free_reserved,
+                cpus: None,
+                partial: None,
             });
             continue;
         }
 
-        let free_at_decision = free;
-        // All-or-nothing. A sampler that takes some of its events publishes a
-        // partial view of whatever it measures, and for a ratio like IPC a
-        // partial view is worse than none: the counter it did get is pinned
-        // and unavailable to anything that could use a whole set.
-        let granted = wants > 0 && wants <= free;
-        if granted {
-            free -= wants;
+        let free_at_decision = free_reserved;
+        // All-or-nothing, PER CPU. A sampler that takes some of its events on a
+        // CPU publishes a partial view there, and for a ratio like IPC that is
+        // worse than none: the counter it did get is pinned and unavailable to
+        // anything that could use a whole set. Per CPU rather than per machine
+        // because the counters themselves are per CPU — the grain the hardware
+        // actually has.
+        let wanted = wants > 0;
+        let on_reserved = wanted && !cpus.reserved.is_empty() && wants <= free_reserved;
+        let on_open = wanted && cpus.open > 0 && wants <= free_open;
+
+        if on_reserved {
+            free_reserved -= wants;
         }
+        if on_open {
+            free_open -= wants;
+        }
+
+        let mut granted_cpus: Vec<usize> = Vec::new();
+        if on_reserved {
+            granted_cpus.extend(cpus.reserved.iter().copied());
+        }
+        if on_open {
+            granted_cpus.extend((0..cpus.total()).filter(|c| !cpus.is_reserved(*c)));
+        }
+        granted_cpus.sort_unstable();
+
+        let total = cpus.total();
+        let granted = !granted_cpus.is_empty();
+        let partial =
+            (granted && granted_cpus.len() < total).then_some((granted_cpus.len(), total));
+
         plan.push(Grant {
             sampler,
             wants,
             granted,
             free_at_decision,
+            // `None` means unrestricted, which keeps the common case free of a
+            // list that would have to be kept in step with the machine.
+            cpus: partial.is_some().then_some(granted_cpus),
+            partial,
         });
     }
 
     plan
+}
+
+/// How the machine splits between CPUs a reservation applies to and the rest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CpuSplit {
+    /// CPUs where counters are held back for other consumers.
+    pub reserved: Vec<usize>,
+    /// How many CPUs are not covered by the reservation.
+    pub open: usize,
+}
+
+impl CpuSplit {
+    /// Every CPU reserved — what an unset mask means, and what the agent did
+    /// before a mask existed.
+    pub fn all(total: usize) -> Self {
+        Self {
+            reserved: (0..total).collect(),
+            open: 0,
+        }
+    }
+
+    pub fn total(&self) -> usize {
+        self.reserved.len() + self.open
+    }
+
+    /// Whether `cpu` gives up counters.
+    pub fn is_reserved(&self, cpu: usize) -> bool {
+        self.reserved.contains(&cpu)
+    }
 }
 
 /// The per-CPU core-counter demand of an ordering — what the budget is compared
@@ -174,6 +261,118 @@ pub fn resolve_order(configured: &[String]) -> Vec<(&'static str, PmuKind, usize
         }
     }
     order
+}
+
+/// Parse a CPU list like `"0-3,8,12-15"` into sorted, de-duplicated ids.
+///
+/// Returns `None` for anything unparseable rather than a partial set: a mask
+/// that silently covered fewer CPUs than the operator wrote would hold back
+/// counters in the wrong places, and the whole point of the mask is knowing
+/// exactly where the agent is standing aside.
+pub fn parse_cpu_list(spec: &str) -> Option<Vec<usize>> {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Some(Vec::new());
+    }
+
+    let mut cpus = std::collections::BTreeSet::new();
+    for part in spec.split(',') {
+        let part = part.trim();
+        match part.split_once('-') {
+            Some((lo, hi)) => {
+                let lo: usize = lo.trim().parse().ok()?;
+                let hi: usize = hi.trim().parse().ok()?;
+                if hi < lo {
+                    return None;
+                }
+                cpus.extend(lo..=hi);
+            }
+            None => {
+                cpus.insert(part.parse().ok()?);
+            }
+        }
+    }
+    Some(cpus.into_iter().collect())
+}
+
+/// Build the reserved/open split from the configured mask.
+///
+/// `None` reserves every CPU — the behaviour before a mask existed. A mask that
+/// names CPUs this machine does not have keeps only the ones it does, so a
+/// config shared across a heterogeneous fleet does not have to be exact.
+pub fn cpu_split(spec: Option<&str>) -> CpuSplit {
+    let total = online_cpu_count();
+    let Some(spec) = spec else {
+        return CpuSplit::all(total);
+    };
+    let Some(listed) = parse_cpu_list(spec) else {
+        // `General::check` rejects an unparseable mask at startup, so reaching
+        // here means something bypassed it; reserve everywhere rather than
+        // silently reserving nowhere.
+        return CpuSplit::all(total);
+    };
+    let reserved: Vec<usize> = listed.into_iter().filter(|c| *c < total).collect();
+    let open = total.saturating_sub(reserved.len());
+    CpuSplit { reserved, open }
+}
+
+/// Online CPU count, for sizing the split.
+#[cfg(target_os = "linux")]
+fn online_cpu_count() -> usize {
+    std::fs::read_to_string("/sys/devices/system/cpu/online")
+        .ok()
+        .and_then(|s| parse_cpu_list(s.trim()))
+        .map(|c| c.len())
+        .unwrap_or(0)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn online_cpu_count() -> usize {
+    0
+}
+
+/// The per-sampler CPU allocation, published once at startup for the samplers
+/// to consult as they open events.
+///
+/// A global rather than a parameter because the enforcement points are spread
+/// across the two ways events get opened — the BPF builder for `cpu_perf`, and
+/// each direct sampler's own per-CPU loop — and threading it through both would
+/// mean changing signatures on paths that otherwise have nothing to do with
+/// each other.
+static ALLOCATION: std::sync::OnceLock<std::collections::BTreeMap<&'static str, Vec<usize>>> =
+    std::sync::OnceLock::new();
+
+/// Publish which CPUs each sampler may open events on. Called once, before any
+/// sampler runs.
+pub fn publish_allocation(plan: &[Grant]) {
+    let mut map = std::collections::BTreeMap::new();
+    for grant in plan {
+        if !grant.granted {
+            continue;
+        }
+        if let Some(cpus) = &grant.cpus {
+            map.insert(grant.sampler, cpus.clone());
+        }
+        // A full grant is left out of the map entirely; `allowed_cpus` reads
+        // absence as "no restriction", so the common case costs nothing and
+        // cannot be narrowed by a stale entry.
+    }
+    let _ = ALLOCATION.set(map);
+}
+
+/// Narrow `cores` to the CPUs `sampler` may open events on.
+///
+/// Absence means unrestricted, which is both the common case and the state
+/// before any allocation is published — so a sampler that runs outside the
+/// agent's normal startup (a test, a tool) behaves exactly as it did before.
+pub fn allowed_cpus(sampler: &str, cores: Vec<usize>) -> Vec<usize> {
+    let Some(map) = ALLOCATION.get() else {
+        return cores;
+    };
+    let Some(allowed) = map.get(sampler) else {
+        return cores;
+    };
+    cores.into_iter().filter(|c| allowed.contains(c)).collect()
 }
 
 #[cfg(target_os = "linux")]
@@ -256,7 +455,7 @@ mod tests {
     fn a_sampler_that_cannot_get_its_whole_set_gets_none_of_it() {
         // Three core counters: cpu_perf takes 2, leaving one — not enough for
         // cpu_branch's pair.
-        let decided = plan(DEFAULT_PRIORITY, 3, 0);
+        let decided = plan(DEFAULT_PRIORITY, 3, 0, &CpuSplit::all(8));
 
         let branch = decided.iter().find(|g| g.sampler == "cpu_branch").unwrap();
         assert!(!branch.granted, "one free counter cannot satisfy a pair");
@@ -282,7 +481,7 @@ mod tests {
     fn reserving_counters_takes_them_off_the_top() {
         // The hypervisor case: hold four back for guest vPMUs and only the
         // first sampler fits.
-        let decided = plan(DEFAULT_PRIORITY, 6, 4);
+        let decided = plan(DEFAULT_PRIORITY, 6, 4, &CpuSplit::all(8));
         let core_granted: Vec<&str> = decided
             .iter()
             .filter(|g| g.granted)
@@ -292,7 +491,7 @@ mod tests {
         assert_eq!(core_granted, vec!["cpu_perf"]);
 
         // Reserving more than exist must not underflow into a huge budget.
-        let none = plan(DEFAULT_PRIORITY, 2, 99);
+        let none = plan(DEFAULT_PRIORITY, 2, 99, &CpuSplit::all(8));
         assert!(
             none.iter()
                 .filter(|g| matches!(g.sampler, "cpu_perf" | "cpu_branch" | "cpu_dtlb"))
@@ -305,7 +504,7 @@ mod tests {
     fn a_measured_budget_of_zero_grants_nothing() {
         // What a host whose CORE PMU is already fully taken looks like: every
         // core sampler refused, each saying so.
-        let decided = plan(DEFAULT_PRIORITY, 0, 0);
+        let decided = plan(DEFAULT_PRIORITY, 0, 0, &CpuSplit::all(8));
         assert_eq!(decided.len(), DEFAULT_PRIORITY.len());
         assert!(decided
             .iter()
@@ -353,6 +552,82 @@ mod tests {
         assert_eq!(names.len(), DEFAULT_PRIORITY.len());
         assert_eq!(names.iter().filter(|n| **n == "cpu_l3").count(), 1);
         assert!(!names.contains(&"not_a_sampler"));
+    }
+
+    /// A mask reserves counters on some CPUs and not others, so a sampler can
+    /// fit on part of the machine.
+    ///
+    /// The whole point of the mask: reserving uniformly costs the agent
+    /// coverage on CPUs where nothing else wanted counters. Here six counters
+    /// with four held back on half the machine leaves two there — enough for
+    /// cpu_perf but not for cpu_branch behind it — while the unreserved half
+    /// has all six and fits both.
+    #[test]
+    fn a_masked_reservation_can_grant_part_of_the_machine() {
+        let split = CpuSplit {
+            reserved: (0..4).collect(),
+            open: 4,
+        };
+        let decided = plan(DEFAULT_PRIORITY, 6, 4, &split);
+
+        let perf = decided.iter().find(|g| g.sampler == "cpu_perf").unwrap();
+        assert!(perf.granted);
+        assert_eq!(perf.partial, None, "cpu_perf fits in the 2 left everywhere");
+
+        let branch = decided.iter().find(|g| g.sampler == "cpu_branch").unwrap();
+        assert!(
+            branch.granted,
+            "it fits on the unreserved half, so it must not be refused outright"
+        );
+        assert_eq!(
+            branch.partial,
+            Some((4, 8)),
+            "and must be reported as covering only that half"
+        );
+    }
+
+    /// Reserving on every CPU is the old whole-machine behaviour: nothing is
+    /// partial, because there is nowhere with more room.
+    #[test]
+    fn reserving_everywhere_is_never_partial() {
+        let decided = plan(DEFAULT_PRIORITY, 6, 4, &CpuSplit::all(8));
+        assert!(
+            decided.iter().all(|g| g.partial.is_none()),
+            "with no unreserved CPUs there is no partial case to report"
+        );
+    }
+
+    #[test]
+    fn cpu_lists_parse_or_are_refused_whole() {
+        assert_eq!(
+            parse_cpu_list("0-3,8,12-13"),
+            Some(vec![0, 1, 2, 3, 8, 12, 13])
+        );
+        assert_eq!(parse_cpu_list(" 5 "), Some(vec![5]));
+        assert_eq!(parse_cpu_list(""), Some(Vec::new()));
+        // Overlaps collapse rather than double-count.
+        assert_eq!(parse_cpu_list("0-2,1-3"), Some(vec![0, 1, 2, 3]));
+
+        // Refused WHOLE, not partially: a mask that quietly covered fewer CPUs
+        // than written would hold counters back in the wrong places, and the
+        // point of the mask is knowing exactly where the agent stands aside.
+        assert_eq!(parse_cpu_list("0-3,bogus"), None);
+        assert_eq!(parse_cpu_list("3-1"), None, "a backwards range is a typo");
+        assert_eq!(parse_cpu_list("-4"), None);
+    }
+
+    /// A mask naming CPUs this machine does not have keeps the ones it does.
+    ///
+    /// One config across a fleet of different core counts should not have to be
+    /// exact, and the safe direction is to reserve on the CPUs that exist
+    /// rather than to reserve nowhere.
+    #[test]
+    fn a_mask_beyond_this_machine_keeps_what_fits() {
+        let split = cpu_split(Some("0-1"));
+        // `online_cpu_count` is 0 off Linux and in a test environment without
+        // the sysfs file, so assert the property that holds either way: no
+        // reserved CPU is beyond the machine.
+        assert!(split.reserved.iter().all(|c| *c < split.total().max(1)));
     }
 
     /// Every name in the priority table is a real sampler.

--- a/src/agent/sampler_status.rs
+++ b/src/agent/sampler_status.rs
@@ -36,6 +36,19 @@ pub enum SamplerState {
     Failed {
         error: String,
     },
+    /// Running, but only on some CPUs: the PMU reservation left too little on
+    /// the reserved CPUs for this sampler's whole event set, and enough on the
+    /// rest.
+    ///
+    /// A distinct state because partial coverage is neither of the two things
+    /// it could be filed under. Reported as `Active` it reads as full coverage
+    /// and the gap is invisible — which is the failure mode this whole area
+    /// exists to remove. Reported as starved it reads as no data at all, when
+    /// most of the machine has it.
+    PmuLimited {
+        cpus: usize,
+        of: usize,
+    },
     /// Not started because the PMU had too few free counters for its whole
     /// event set.
     ///
@@ -85,6 +98,19 @@ pub fn set_disabled(name: &'static str) {
             name: name.to_string(),
             state: SamplerState::Disabled,
             health: None,
+            programs: Vec::new(),
+        },
+    );
+}
+
+/// Record a sampler as running on only some CPUs, with the coverage.
+pub fn set_pmu_limited(name: &'static str, cpus: usize, of: usize) {
+    registry().lock().unwrap().insert(
+        name,
+        SamplerStatus {
+            name: name.to_string(),
+            state: SamplerState::PmuLimited { cpus, of },
+            health: Some(SamplerHealth::Degraded),
             programs: Vec::new(),
         },
     );

--- a/src/agent/samplers/cpu/linux/branch/mod.rs
+++ b/src/agent/samplers/cpu/linux/branch/mod.rs
@@ -74,7 +74,18 @@ impl BranchInner {
         // (principle 18): the real number of per-CPU slots this sweep will
         // ever populate, not each member `CounterGroup`'s `MAX_CPUS`-sized
         // backing array.
-        CPU_BRANCH_ACQ.set_member_bound(crate::agent::bpf::possible_cpus());
+        // Declare the members we can actually populate — see the note in
+        // `BpfBuilder::build`. `allowed_cpus` is unrestricted unless a
+        // `reserved_pmu_cpus` mask kept this sampler off part of the machine.
+        let allowed = crate::agent::pmu::allowed_cpus(
+            NAME,
+            (0..crate::agent::bpf::possible_cpus()).collect(),
+        );
+        if allowed.len() == crate::agent::bpf::possible_cpus() {
+            CPU_BRANCH_ACQ.set_member_bound(crate::agent::bpf::possible_cpus());
+        } else {
+            CPU_BRANCH_ACQ.set_member_set(&allowed);
+        }
 
         Ok(Self {
             perf_threads,
@@ -242,7 +253,11 @@ fn spawn_threads() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io:
 fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
     debug!("using single-threaded perf counter collection");
 
-    let mut logical_cores = logical_cores()?;
+    // Narrowed to the CPUs this sampler may claim counters on: with a
+    // `reserved_pmu_cpus` mask the reservation applies to only part of the
+    // machine, so the budget can fit here and not there. Unrestricted unless a
+    // mask actually excluded this sampler from somewhere.
+    let mut logical_cores = crate::agent::pmu::allowed_cpus(NAME, logical_cores()?);
 
     let mut perf_threads = Vec::new();
     let mut perf_sync = Vec::new();
@@ -283,7 +298,11 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
 fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
     debug!("using multi-threaded perf counter collection");
 
-    let mut logical_cores = logical_cores()?;
+    // Narrowed to the CPUs this sampler may claim counters on: with a
+    // `reserved_pmu_cpus` mask the reservation applies to only part of the
+    // machine, so the budget can fit here and not there. Unrestricted unless a
+    // mask actually excluded this sampler from somewhere.
+    let mut logical_cores = crate::agent::pmu::allowed_cpus(NAME, logical_cores()?);
 
     let pt_pending = Arc::new(AtomicUsize::new(logical_cores.len()));
 

--- a/src/agent/samplers/cpu/linux/dtlb/mod.rs
+++ b/src/agent/samplers/cpu/linux/dtlb/mod.rs
@@ -78,7 +78,18 @@ impl DtlbInner {
         // (principle 18 / `docs/principles.md`): the real number of per-CPU
         // slots this sweep will ever populate, not each member
         // `CounterGroup`'s `MAX_CPUS`-sized backing array.
-        CPU_DTLB_ACQ.set_member_bound(crate::agent::bpf::possible_cpus());
+        // Declare the members we can actually populate — see the note in
+        // `BpfBuilder::build`. `allowed_cpus` is unrestricted unless a
+        // `reserved_pmu_cpus` mask kept this sampler off part of the machine.
+        let allowed = crate::agent::pmu::allowed_cpus(
+            NAME,
+            (0..crate::agent::bpf::possible_cpus()).collect(),
+        );
+        if allowed.len() == crate::agent::bpf::possible_cpus() {
+            CPU_DTLB_ACQ.set_member_bound(crate::agent::bpf::possible_cpus());
+        } else {
+            CPU_DTLB_ACQ.set_member_set(&allowed);
+        }
 
         Ok(Self {
             perf_threads,
@@ -315,7 +326,11 @@ fn spawn_threads() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io:
 fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
     debug!("using single-threaded perf counter collection");
 
-    let mut logical_cores = logical_cores()?;
+    // Narrowed to the CPUs this sampler may claim counters on: with a
+    // `reserved_pmu_cpus` mask the reservation applies to only part of the
+    // machine, so the budget can fit here and not there. Unrestricted unless a
+    // mask actually excluded this sampler from somewhere.
+    let mut logical_cores = crate::agent::pmu::allowed_cpus(NAME, logical_cores()?);
 
     let mut perf_threads = Vec::new();
     let mut perf_sync = Vec::new();
@@ -356,7 +371,11 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
 fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
     debug!("using multi-threaded perf counter collection");
 
-    let mut logical_cores = logical_cores()?;
+    // Narrowed to the CPUs this sampler may claim counters on: with a
+    // `reserved_pmu_cpus` mask the reservation applies to only part of the
+    // machine, so the budget can fit here and not there. Unrestricted unless a
+    // mask actually excluded this sampler from somewhere.
+    let mut logical_cores = crate::agent::pmu::allowed_cpus(NAME, logical_cores()?);
 
     let pt_pending = Arc::new(AtomicUsize::new(logical_cores.len()));
 

--- a/src/agent/timing.rs
+++ b/src/agent/timing.rs
@@ -15,6 +15,7 @@
 
 use metriken::Window;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::OnceLock;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// Wall-clock nanoseconds since the Unix epoch, saturating to 0 before it.
@@ -137,6 +138,16 @@ pub(crate) struct AcquisitionGroup {
     // the walk fell back to backing capacity, declaring `MAX_GPUS`-worth of
     // phantom all-null members. See `set_member_bound`/`member_bound`.
     member_bound: AtomicUsize,
+    /// Members that are not a dense prefix, when a prefix cannot describe them.
+    ///
+    /// `member_bound` says "the first N indices"; some groups populate an
+    /// arbitrary subset instead — a sampler allowed only part of the machine
+    /// populates the CPUs it was allowed, which is rarely `0..n`. Declaring the
+    /// prefix anyway would leave the rest registered-but-never-written, and a
+    /// registered `CounterGroup` slot reads as `0`, not as absent. That is a
+    /// wrong value rather than missing data, which is the failure this whole
+    /// area exists to remove.
+    member_set: OnceLock<Vec<usize>>,
     // Init-time flag: true means this group's acquisition IS the exposition
     // read itself (mmap-direct `PackedCounters`), not a sampler `refresh()`.
     // See `set_reader_stamped`/`is_reader_stamped`.
@@ -153,6 +164,7 @@ impl AcquisitionGroup {
             name,
             slot: GroupWindowSlot::new(),
             member_bound: AtomicUsize::new(usize::MAX),
+            member_set: OnceLock::new(),
             reader_stamped: AtomicBool::new(false),
         }
     }
@@ -195,6 +207,7 @@ impl AcquisitionGroup {
             name,
             slot: GroupWindowSlot::new(),
             member_bound: AtomicUsize::new(usize::MAX),
+            member_set: OnceLock::new(),
             reader_stamped: AtomicBool::new(true),
         }
     }
@@ -221,6 +234,30 @@ impl AcquisitionGroup {
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) fn set_member_bound(&self, n: usize) {
         self.member_bound.store(n, Ordering::Relaxed);
+    }
+
+    /// Declare the group's members explicitly, for a population that is not a
+    /// dense prefix.
+    ///
+    /// Takes precedence over [`set_member_bound`](Self::set_member_bound) — a
+    /// bound describes a prefix, and a caller that knows the exact set knows
+    /// strictly more. Same single-init contract as the bound: called once at
+    /// sampler init, before any snapshot walk reads it. A second call is
+    /// ignored rather than racing, since the population is fixed at init.
+    ///
+    /// Indices are sorted and de-duplicated, so the walk stays in index order
+    /// regardless of the order the caller discovered them in.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(crate) fn set_member_set(&self, members: &[usize]) {
+        let mut members = members.to_vec();
+        members.sort_unstable();
+        members.dedup();
+        let _ = self.member_set.set(members);
+    }
+
+    /// The group's explicit member set, if one was declared.
+    pub(crate) fn member_set(&self) -> Option<&[usize]> {
+        self.member_set.get().map(|v| v.as_slice())
     }
 
     /// The group's member-population bound, if one has been set (`None`

--- a/src/status_cli/mod.rs
+++ b/src/status_cli/mod.rs
@@ -33,6 +33,14 @@ pub fn render_samplers(samplers: &[SamplerStatus]) -> (String, bool) {
             (SamplerState::Disabled, _) => {} // not counted in the health tally
             // Not a fault: too few PMU counters for its whole event set. Shown
             // with the numbers so the trade is visible and re-rankable.
+            (SamplerState::PmuLimited { cpus, of }, _) => {
+                degraded += 1;
+                problem = true;
+                lines.push_str(&format!(
+                    "  {:<22} {:<12} {cpus} of {of} cpus\n",
+                    s.name, "pmu-limited"
+                ));
+            }
             (SamplerState::PmuStarved { wants, free }, _) => {
                 unsupported += 1;
                 lines.push_str(&format!(


### PR DESCRIPTION
Closes #1094. Two changes, the first being the prerequisite for the second — and they ship together for a reason, below.

## 1. Sparse group membership (the prerequisite)

A declared group's membership was a **dense prefix**: `set_member_bound(n)` means `0..n`. Some groups populate an arbitrary subset instead, and a prefix can't describe one. Declaring the prefix anyway leaves the rest registered but never written — and **an unwritten `CounterGroup` slot reads as `0`, not as absent**.

`AcquisitionGroup::set_member_set` declares the exact indices. The six walk sites in `create_v3` (two identity folds, four value walks) now go through one `members()` iterator yielding either the set or the prefix, so the two shapes can't drift apart. The set wins over a bound — a caller that knows the exact indices knows strictly more than one that knows a count — and is clamped to `entries()` exactly as the bound is.

## 2. CPU-masked PMU reservation (#1094)

`reserved_pmu_counters` held counters back on **every** CPU, which is coarser than the situations it exists for: guest vCPUs run on some cores, an isolated workload lives on specific ones. Reserving everywhere costs the agent coverage where nothing else wanted counters.

`[general] reserved_pmu_cpus = "0-15"` scopes it. A sampler that fits only where nothing is held back now runs **there** rather than being refused outright, and says so via `SamplerState::PmuLimited { cpus, of }` (health `Degraded`).

That state exists because partial coverage is neither of the two things it could be filed under: as `Active` it reads as full coverage and the gap is invisible; as starved it reads as no data when most of the machine has it.

The two budgets genuinely diverge — a sampler fitting only on the unreserved side consumes there and not on the reserved side, after which a later sampler can fit on the reserved side and not the other. Neither is the other's subset, so the allocation tracks explicit CPU sets rather than counts.

## Why they ship together

I built the mask first and it measured **wrong**. It correctly opened counters on 16 of 32 CPUs, then published:

```
cpu_cycles on MASKED cpus 0-3    : [0, 0, 0, 0]
cpu_cycles on UNMASKED cpus 16-19: [3841313755, 5676916120, ...]
```

Zero cycles on CPUs nothing measured. `sum(rate(cpu_cycles))` would understate the machine by half and look healthy doing it — **strictly worse than the problem #1053 set out to fix**. The prefix-only membership was the cause, two layers from the feature and invisible in the code; only the published values showed it.

With the member set declared:

```
cpu_cycles on MASKED cpus 0-3    : [None, None, None, None]
cpu_perf/cpu_perf_sweep: cpus WITH values 16, WITHOUT 0
```

The group declares exactly the CPUs it populates.

Splitting these into two PRs would have meant either a mechanism with no consumer — unverifiable on hardware, and dead code — or shipping the zeros. If you'd still prefer them separate for review, I can stack them; the sparse commit is self-contained apart from having no caller.

## Tests

730 unit + 7 + 4 integration pass on Linux; clippy clean in the touched files.

The membership walk is tested directly: a set walks its own indices, a bound still walks the prefix, the set wins over a bound, both clamp to the backing array, and a declared set is sorted and de-duplicated. The allocation adds: a masked reservation grants part of the machine; reserving everywhere is never partial; CPU lists parse or are refused **whole** (a mask that silently covered fewer CPUs than written would hold counters back in the wrong places).