### PR TITLE
feat(record): default to .rez, and let the output name pick the format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,13 +54,17 @@ sudo target/release/rezolus config/agent.toml
 # Exporter - Prometheus-compatible metrics endpoint
 sudo target/release/rezolus exporter config/exporter.toml
 
-# Recorder - capture metrics to parquet
-target/release/rezolus record http://localhost:4241 output.parquet
-target/release/rezolus record --metadata source=llm-perf http://host:9090/metrics output.parquet
+# Recorder - capture metrics to disk (.rez by default)
+target/release/rezolus record                                                           # localhost:4241 -> rezolus.rez
 target/release/rezolus record --url http://localhost:4241 -o out.rez --label arm=redis  # per-sampler .rez archive
-# Auto-detects Rezolus agent vs Prometheus endpoints. Supports --format {parquet|raw|rez},
-# --metadata key=value (repeatable), --label key=value (repeatable; tags a .rez recording,
-# source/host auto-populated), --interval, --duration. .rez output requires a rezolus/msgpack endpoint.
+target/release/rezolus record --url http://host:9090/metrics -o out.parquet --metadata source=llm-perf
+# Auto-detects Rezolus agent vs Prometheus endpoints. The -o extension picks the format
+# (.rez | .parquet | .raw); --format {rez|parquet|raw} is rarely needed and conflicting with
+# the extension is an error. With no -o, the output is rezolus.<ext> for the format in play.
+# .rez requires a single rezolus/msgpack endpoint; a run that chose no format at all falls
+# back to rezolus.parquet (with a note) for a Prometheus or multi-endpoint source.
+# Also: --metadata key=value (repeatable), --label key=value (repeatable; tags a .rez
+# recording, source/host auto-populated), --interval, --duration.
 
 # Viewer - web dashboard for parquet files, live agents, or upload mode
 target/release/rezolus view output.parquet [experiment.parquet] [--listen ADDR]
@@ -120,7 +124,7 @@ The binary operates in seven modes via subcommands:
 
 1. **Agent** (`src/agent/`) - Default. Collects system metrics via samplers.
 2. **Exporter** (`src/exporter/`) - Pulls from agent's msgpack endpoint, exposes Prometheus metrics.
-3. **Recorder** (`src/recorder/`) - Writes metrics to parquet files. Auto-detects Rezolus vs Prometheus sources. Supports `--metadata key=value` and `--format {parquet|raw|rez}`. The `.rez` format (`-o out.rez` or `--format rez`) writes a per-sampler archive (see "`.rez` archive format" below); `--label key=value` tags a `.rez` recording.
+3. **Recorder** (`src/recorder/`) - Writes metrics to disk. Auto-detects Rezolus vs Prometheus sources. The output extension picks the format (`.rez` default, `.parquet`, `.raw`); `--format` is the explicit form and contradicting the extension is an error. Defaults to `rezolus.rez` when no `-o` is given, falling back to `rezolus.parquet` for a Prometheus or multi-endpoint source only when nothing pinned the format. Supports `--metadata key=value`; `--label key=value` tags a `.rez` recording (see "`.rez` archive format" below).
 4. **Hindsight** (`src/hindsight/`) - Maintains a rolling `.rez` v3 buffer on disk (the streaming v3 writer with retention: everything older than `duration` is evicted each tick) for post-incident snapshots. The buffer is readable live by the viewer/MCP/`parquet metadata`; a snapshot is a `VACUUM INTO` copy taken without pausing the recording.
 5. **Viewer** (`src/viewer/`) - Web dashboard with PromQL query engine and TSDB (from `metriken-query` crate). Supports parquet files, `.rez` archives (a 2-recording `.rez` renders as an A/B baseline/experiment comparison, >2 shows the first two), live agent connections, and upload-only mode. Generates service KPI dashboards from `ServiceExtension` metadata.
 6. **MCP** (`src/mcp/`) - AI analysis tools (anomaly detection, correlation, PromQL queries, feature extraction). Runs as stdio server or one-shot CLI commands. `query` prints acquisition-window uncertainty bands `[lo, hi]` beside `rate()`/`irate()` values (scalar ops scale the band; series-op-series combines both operands' bands by interval arithmetic, and operands from *different* acquisition tables have their bands widened to the union of both spans first — identical edges mean the same read, so the common case widens by nothing; non-rate/non-histogram queries have no band). See `docs/journal/2026-08-21-cross-table-uncertainty.md`. `extract-features` emits a deterministic, versioned overview record (JSON) summarizing a recording's Rezolus-native features.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.17"
+version = "5.17.1-alpha.18"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.17"
+version = "5.17.1-alpha.18"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ management — see [HTTP Endpoint](#http-endpoint-optional) below.
 
 ### Recorder
 
-Records metrics into a Parquet file for benchmarking, lab tests, or offline
-workload characterization. It auto-detects Rezolus agent vs Prometheus sources
-and supports custom file-level metadata.
+Records metrics to disk for benchmarking, lab tests, or offline workload
+characterization. It auto-detects Rezolus agent vs Prometheus sources and
+supports custom file-level metadata.
 
 Like `perf record`, it can wrap a workload and capture for exactly its lifetime,
 finalizing when the command exits:
@@ -185,17 +185,17 @@ rezolus record -- ./my-benchmark --threads 8
 ```
 
 By default this records the local agent (`http://localhost:4241`) into
-`rezolus.parquet`. Override the endpoint with `--url` and the output with `-o`:
+`rezolus.rez`. Override the endpoint with `--url` and the output with `-o`:
 
 ```bash
-rezolus record --url http://host:4241 -o run.parquet -- ./driver
+rezolus record --url http://host:4241 -o run.rez -- ./driver
 ```
 
 Or record a fixed window instead, until `--duration` elapses or you press
 ctrl-c:
 
 ```bash
-rezolus record --interval 1s --duration 15m --url http://localhost:4241 -o rezolus.parquet
+rezolus record --interval 1s --duration 15m --url http://localhost:4241 -o run.rez
 ```
 
 When wrapping a command, `--duration` also acts as a safety cap: if the command
@@ -203,17 +203,46 @@ outlives it, recording stops and the command — along with any worker processes
 it spawned — is terminated. The positional `<URL> <OUTPUT>` form still works but
 is deprecated in favor of `--url`/`-o`.
 
-#### `.rez` recordings
+#### Output formats
 
-Giving the output a `.rez` extension (or passing `--format rez`) writes a
-per-sampler archive instead of a single parquet file: each sampler gets its own
-table at its own cadence, with per-metric acquisition windows the query engine
-uses to bound `rate()`. It requires a Rezolus (msgpack) endpoint, and
-`--label k=v` tags the recording (`source` and `host` are filled in for you):
+The output path's extension picks the format, so `--format` is rarely needed;
+with no `-o` at all the recording goes to `rezolus.<ext>` for the format in
+play, which by default means `rezolus.rez`.
+
+| Extension | What it is | When |
+| --- | --- | --- |
+| `.rez` | **Default.** A per-sampler archive: one table per sampler, each at its own cadence, carrying the acquisition windows the query engine uses to bound `rate()`. | Recording a Rezolus agent. Prefer it. |
+| `.parquet` | One columnar table on a single uniform clock. | A Prometheus source, several endpoints at once, or other parquet tooling. |
+| `.raw` | The msgpack snapshots as scraped, concatenated. | Capture now, decide later — convert with `rezolus recording convert`. |
+
+Passing a `--format` that contradicts the extension (say `--format parquet` with
+`-o out.rez`) is an error rather than a silent choice between them. And because
+`.rez` needs a single Rezolus (msgpack) endpoint, a run that chose *no* format
+at all — no `--format`, no `-o` — falls back to `rezolus.parquet` and says so
+when the endpoint turns out to be Prometheus or there is more than one of them.
+Pass `--format rez` to make `.rez` a requirement instead.
+
+A `.rez` output path must not already exist — the recorder refuses rather than
+truncate, since the archive is committed as it goes and has no staging file. A
+parquet or raw output is overwritten. There is no `--force`.
+
+When wrapping a command, rezolus passes its stdio straight through and exits
+with the command's own status, so `rezolus record -o bench.rez -- ./bench.sh &&
+analyze bench.rez` gates on the benchmark; the exception is the `--duration`
+cap, which exits 124 if it has to kill the command.
+
+#### Tagging a recording
+
+`-m/--metadata k=v` writes file-level metadata and applies to every format.
+`-l/--label k=v` applies to `.rez` only — it tags the recording inside the
+archive (`source` and `host` are filled in for you), and a two-recording `.rez`
+drives the viewer's A/B comparison, which is what `--label arm=redis` is for:
 
 ```bash
 rezolus record --url http://localhost:4241 -o out.rez --label arm=redis
 ```
+
+#### `.rez` durability
 
 `.rez` recordings are written to disk in segments as they run, so stopping
 costs the same whether the recording ran for a minute or a day. Ctrl-c and
@@ -224,8 +253,7 @@ recording stops just as promptly as a millisecond one, comfortably inside a
 container's stop grace, and never proportional to the recording's length.
 
 A `.rez` is a single SQLite file that is valid at every instant, so there is no
-`.partial` staging file — and the output path must not already exist. Every
-sample is committed as it is taken, so if the recorder is SIGKILLed or the
+`.partial` staging file. Every sample is committed as it is taken, so if the recorder is SIGKILLed or the
 machine dies the recording is readable where it sits, missing at most one
 sampling interval:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,8 @@ fn main() {
              \x20              Run with no subcommand: `rezolus <config.toml>`.\n    \
              exporter   Re-expose an agent's metrics on a Prometheus-compatible endpoint.\n    \
              hindsight  Keep an on-disk ring buffer for after-the-fact incident snapshots.\n    \
-             record     Scrape an endpoint to a parquet file (optionally wrapping a command).\n    \
+             record     Scrape an endpoint to a recording on disk — a .rez archive by default,\n\
+             \x20              or parquet (optionally wrapping a command).\n    \
              view       Serve a web dashboard for a recording or a live agent.\n    \
              mcp        AI analysis tools (PromQL, anomaly detection, correlation, feature\n\
              \x20              extraction) over a file.\n    \
@@ -90,8 +91,8 @@ fn main() {
              # Run the agent (needs root for eBPF on Linux)\n    \
              sudo rezolus config/agent.toml\n\n    \
              # Record the local agent for 5 minutes, then view it\n    \
-             rezolus record --duration 5m -o out.parquet\n    \
-             rezolus view out.parquet",
+             rezolus record --duration 5m -o out.rez\n    \
+             rezolus view out.rez",
         )
         .subcommand_negates_reqs(true)
         .arg(
@@ -137,7 +138,16 @@ fn main() {
             parquet_tools::run(args.clone());
         }
         Some(("record", args)) => {
-            let config = recorder::RecordingConfig::from_args(args).expect("failed to configure");
+            // A usage error here is the user's typo, not a bug: `expect` sent
+            // it out as a panic with a backtrace, burying the one line that
+            // says what to fix.
+            let config = match recorder::RecordingConfig::from_args(args) {
+                Ok(config) => config,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(2);
+                }
+            };
 
             recorder::run(config)
         }

--- a/src/parquet_tools/convert.rs
+++ b/src/parquet_tools/convert.rs
@@ -591,7 +591,7 @@ pub(crate) fn run(args: &clap::ArgMatches) {
                 // --descriptions route, so naming it for both would send the
                 // reader after a flag that does not exist.
                 let recovery = if opts.systeminfo.is_none() {
-                    " `rezolus parquet annotate <file> --systeminfo <path>` can add the \
+                    " `rezolus recording annotate <file> --systeminfo <path>` can add the \
                      hardware summary later; descriptions can only be set here."
                 } else {
                     " Descriptions can only be set here, by reconverting with --force."

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -18,7 +18,7 @@ pub fn command() -> Command {
     // `recording` is the name; `parquet` is kept as an alias because it is
     // what every existing script types. The rename is not cosmetic — these
     // subcommands stopped being parquet-specific once `.rez` arrived, and
-    // `rezolus parquet upgrade old.rez` describes neither its input nor its
+    // `rezolus recording upgrade old.rez` describes neither its input nor its
     // output. A `.rez` holds parquet segments, but the file you hand these
     // commands is a recording.
     Command::new("recording")
@@ -31,7 +31,7 @@ pub fn command() -> Command {
              metadata   Inspect a file's file-level/column metadata, schema, and geometry\n    \
              annotate   Embed service-extension KPIs, events, or source/node tags into a file\n    \
              combine    Merge multiple files (multi-node / multi-instance) or build an A/B tarball\n    \
-             convert    Turn a raw msgpack recording (from `record -f raw`) into parquet\n    \
+             convert    Turn a raw msgpack recording (from `record -o out.raw`) into parquet\n    \
              filter     Drop columns not needed by a file's service-extension KPIs (shrink it)\n    \
              upgrade    Convert a v1/v2 (tar) `.rez` archive to the v3 (SQLite) container\n\n\
              Run `rezolus recording <subcommand> --help` for per-subcommand examples.\n\n\
@@ -40,7 +40,7 @@ pub fn command() -> Command {
         .subcommand_required(true)
         .subcommand(
             Command::new("annotate")
-                .about("Add service extension metadata to a parquet file")
+                .about("Add service extension KPIs, events or source/node tags to a recording (.parquet or .rez)")
                 .long_about(
                     "Rewrite a parquet recording in place, adding metadata the viewer reads.\n\
                      Use it to attach service-extension KPI dashboards, tag the file's\n\
@@ -54,19 +54,19 @@ pub fn command() -> Command {
                      clearly rather than being silently mishandled.\n\n\
                      EXAMPLES:\n    \
                      # Attach KPIs from the built-in template for this file's source\n    \
-                     rezolus parquet annotate rezolus.parquet\n\n    \
+                     rezolus recording annotate rezolus.parquet\n\n    \
                      # Attach KPIs from a custom service-extension JSON file\n    \
-                     rezolus parquet annotate rezolus.parquet --queries ext.json\n\n    \
+                     rezolus recording annotate rezolus.parquet --queries ext.json\n\n    \
                      # Attach KPIs and also drop columns the KPIs don't need\n    \
-                     rezolus parquet annotate rezolus.parquet --queries ext.json --filter\n\n    \
+                     rezolus recording annotate rezolus.parquet --queries ext.json --filter\n\n    \
                      # Set the source name on a file that has none\n    \
-                     rezolus parquet annotate service.parquet --source vllm\n\n    \
+                     rezolus recording annotate service.parquet --source vllm\n\n    \
                      # Add a single timeline event\n    \
-                     rezolus parquet annotate rezolus.parquet --event 'time=2026-05-12T15:23Z,kind=restart,description=\"deploy\"'\n\n    \
+                     rezolus recording annotate rezolus.parquet --event 'time=2026-05-12T15:23Z,kind=restart,description=\"deploy\"'\n\n    \
                      # Remove a previously added annotation\n    \
-                     rezolus parquet annotate rezolus.parquet --undo\n\n    \
+                     rezolus recording annotate rezolus.parquet --undo\n\n    \
                      # Embed KPIs into each recording of a .rez archive (--queries required)\n    \
-                     rezolus parquet annotate out.rez --queries kpis.json",
+                     rezolus recording annotate out.rez --queries kpis.json",
                 )
                 .arg(
                     clap::Arg::new("FILE")
@@ -166,7 +166,7 @@ pub fn command() -> Command {
         )
         .subcommand(
             Command::new("combine")
-                .about("Combine multiple parquet files (multi-node rezolus and/or multi-instance services)")
+                .about("Combine recordings: multi-node/multi-instance parquet, an A/B tarball, or a multi-recording .rez")
                 .long_about(
                     "Merge two or more parquet recordings into a single file. Requires at least\n\
                      two inputs and an output path (-o).\n\n\
@@ -187,13 +187,13 @@ pub fn command() -> Command {
                      clearly instead of silently mis-assembling.\n\n\
                      EXAMPLES:\n    \
                      # Row-merge a rezolus agent file with a service file\n    \
-                     rezolus parquet combine rezolus.parquet service.parquet -o combined.parquet\n\n    \
+                     rezolus recording combine rezolus.parquet service.parquet -o combined.parquet\n\n    \
                      # Merge several rezolus nodes, pinning which one the viewer shows first\n    \
-                     rezolus parquet combine node1.parquet node2.parquet -o cluster.parquet --pinned node1\n\n    \
+                     rezolus recording combine node1.parquet node2.parquet -o cluster.parquet --pinned node1\n\n    \
                      # Package two captures as an A/B tarball for compare mode\n    \
-                     rezolus parquet combine a.parquet b.parquet --ab baseline=redis experiment=valkey -o out.parquet.ab.tar\n\n    \
+                     rezolus recording combine a.parquet b.parquet --ab baseline=redis experiment=valkey -o out.parquet.ab.tar\n\n    \
                      # Assemble two single-recording .rez into one multi-recording .rez\n    \
-                     rezolus parquet combine baseline.rez experiment.rez -o ab.rez",
+                     rezolus recording combine baseline.rez experiment.rez -o ab.rez",
                 )
                 .arg(
                     clap::Arg::new("FILES")
@@ -257,7 +257,7 @@ pub fn command() -> Command {
         )
         .subcommand(
             Command::new("metadata")
-                .about("Display file and column metadata for a parquet file")
+                .about("Display file and column metadata for a recording (.parquet, or a .rez manifest)")
                 .long_about(
                     "Print the metadata of a parquet recording: file-level key/values (source,\n\
                      sampling interval, systeminfo, descriptions, …), the column schema with\n\
@@ -271,13 +271,13 @@ pub fn command() -> Command {
                      --json emits the raw manifest.\n\n\
                      EXAMPLES:\n    \
                      # Everything about a recording\n    \
-                     rezolus parquet metadata -i rezolus.parquet\n\n    \
+                     rezolus recording metadata -i rezolus.parquet\n\n    \
                      # Only file-level metadata, as JSON\n    \
-                     rezolus parquet metadata -i rezolus.parquet --file --json\n\n    \
+                     rezolus recording metadata -i rezolus.parquet --file --json\n\n    \
                      # Just the value of one metadata key\n    \
-                     rezolus parquet metadata -i rezolus.parquet --field source\n\n    \
+                     rezolus recording metadata -i rezolus.parquet --field source\n\n    \
                      # Describe a .rez archive's manifest\n    \
-                     rezolus parquet metadata -i out.rez",
+                     rezolus recording metadata -i out.rez",
                 )
                 .arg(
                     clap::Arg::new("input")
@@ -323,13 +323,13 @@ pub fn command() -> Command {
             Command::new("convert")
                 .about("Convert a raw msgpack recording into parquet")
                 .long_about(
-                    "Convert a recording made with `rezolus record -f raw` (concatenated msgpack\n\
+                    "Convert a recording made with `rezolus record -o out.raw` (concatenated msgpack\n\
                      snapshots, one per sampling tick) into a parquet file that the viewer, the\n\
-                     MCP tools and the rest of `rezolus parquet` can read.\n\n\
+                     MCP tools and the rest of `rezolus recording` can read.\n\n\
                      Raw is the cheapest capture mode: the recorder appends snapshots as they\n\
                      arrive and finalizing is a byte copy rather than a conversion that grows\n\
                      with run length, so long unattended captures record raw and convert\n\
-                     afterwards. Recording straight to parquet (`record -f parquet`) is simpler\n\
+                     afterwards. Recording straight to parquet (`record -o out.parquet`) is simpler\n\
                      for a short supervised run.\n\n\
                      The input may be plain or zstd-compressed; which one it is is detected from\n\
                      the file's contents, not its name. The output path defaults to the input\n\
@@ -350,7 +350,7 @@ pub fn command() -> Command {
                      still queries normally; what you lose is the viewer's hardware panel and the\n\
                      help text beside each metric. Prefer stamping them here in one pass if you\n\
                      saved them -- and if that agent is still running, the same two endpoints can\n\
-                     be curled now, at conversion time, to recover them. Afterwards, `rezolus parquet annotate\n\
+                     be curled now, at conversion time, to recover them. Afterwards, `rezolus recording annotate\n\
                      <file> --systeminfo <path>` can still add the hardware summary, but there is\n\
                      no annotate route for descriptions: those can only be supplied here, which\n\
                      means reconverting the original raw input over the output (--force).\n\n\
@@ -358,26 +358,26 @@ pub fn command() -> Command {
                      cadence and acquisition windows that a raw snapshot stream never carried.\n\n\
                      EXAMPLES:\n    \
                      # The producing side, for reference\n    \
-                     rezolus record -f raw --url http://localhost:4241 -o rezolus.raw\n\n    \
+                     rezolus record --url http://localhost:4241 -o rezolus.raw\n\n    \
                      # Convert a compressed recording (writes rezolus.parquet)\n    \
-                     rezolus parquet convert rezolus.raw.zst\n\n    \
+                     rezolus recording convert rezolus.raw.zst\n\n    \
                      # Choose the output path\n    \
-                     rezolus parquet convert rezolus.raw -o run7.parquet\n\n    \
+                     rezolus recording convert rezolus.raw -o run7.parquet\n\n    \
                      # A recording made at a non-default cadence\n    \
-                     rezolus parquet convert rezolus.raw --interval 250ms\n\n    \
+                     rezolus recording convert rezolus.raw --interval 250ms\n\n    \
                      # Save the two metadata blobs at record time, from the agent being recorded\n    \
                      curl -s http://localhost:4241/systeminfo > sysinfo.json\n    \
                      curl -s http://localhost:4241/metrics/descriptions > help.json\n\n    \
                      # ...then stamp them into the conversion\n    \
-                     rezolus parquet convert rezolus.raw --systeminfo sysinfo.json --descriptions help.json\n\n    \
+                     rezolus recording convert rezolus.raw --systeminfo sysinfo.json --descriptions help.json\n\n    \
                      # Or pipe one of them straight in, with - for stdin\n    \
-                     curl -s http://localhost:4241/systeminfo | rezolus parquet convert rezolus.raw --systeminfo -\n\n    \
+                     curl -s http://localhost:4241/systeminfo | rezolus recording convert rezolus.raw --systeminfo -\n\n    \
                      # Tag the recording the way `record --metadata` would\n    \
-                     rezolus parquet convert rezolus.raw -m source=llm-perf -m run=boat-7\n\n    \
+                     rezolus recording convert rezolus.raw -m source=llm-perf -m run=boat-7\n\n    \
                      # Replace an output left by an earlier attempt\n    \
-                     rezolus parquet convert rezolus.raw --force\n\n    \
+                     rezolus recording convert rezolus.raw --force\n\n    \
                      # Descriptions were missed the first time -- reconvert over the old output\n    \
-                     rezolus parquet convert rezolus.raw --descriptions help.json --force",
+                     rezolus recording convert rezolus.raw --descriptions help.json --force",
                 )
                 .arg(
                     clap::Arg::new("FILE")
@@ -440,7 +440,7 @@ pub fn command() -> Command {
         )
         .subcommand(
             Command::new("filter")
-                .about("Filter parquet columns to only those needed by service extension KPIs")
+                .about("Shrink a recording to what its KPIs need: parquet columns, or .rez samplers")
                 .long_about(
                     "Shrink a parquet recording by dropping every metric column not referenced by\n\
                      its service-extension KPIs. The KPI set is taken from the file's embedded\n\
@@ -449,11 +449,11 @@ pub fn command() -> Command {
                      file and leave the original untouched.\n\n\
                      EXAMPLES:\n    \
                      # Filter in place using the file's embedded KPIs\n    \
-                     rezolus parquet filter rezolus.parquet\n\n    \
+                     rezolus recording filter rezolus.parquet\n\n    \
                      # Write a slimmed copy, keeping the original\n    \
-                     rezolus parquet filter rezolus.parquet -o slim.parquet\n\n    \
+                     rezolus recording filter rezolus.parquet -o slim.parquet\n\n    \
                      # Filter to the columns a custom KPI set needs\n    \
-                     rezolus parquet filter rezolus.parquet --queries ext.json -o slim.parquet",
+                     rezolus recording filter rezolus.parquet --queries ext.json -o slim.parquet",
                 )
                 .arg(
                     clap::Arg::new("FILE")
@@ -694,7 +694,7 @@ mod command_name_tests {
     ///
     /// The rename is the point — these subcommands stopped being
     /// parquet-specific once `.rez` arrived — but every existing script and
-    /// runbook types `rezolus parquet ...`, and breaking those to make a name
+    /// runbook types `rezolus recording ...`, and breaking those to make a name
     /// tidier is not a trade worth making. Both spellings must reach the same
     /// subcommand, and clap must resolve the alias to the canonical name so
     /// `main`'s dispatch needs only one arm.

--- a/src/recorder/config.rs
+++ b/src/recorder/config.rs
@@ -38,12 +38,95 @@ pub struct RecordingConfig {
     pub endpoints: Vec<EndpointConfig>,
     /// When set, record only while this command runs (perf-record style).
     pub command: Option<Vec<String>>,
+    /// True when the format came from the default rather than from `--format`
+    /// or an output extension. Only such a run may fall back from `.rez` to
+    /// parquet for an endpoint `.rez` cannot record.
+    pub format_defaulted: bool,
 }
 
 /// Default endpoint used when neither `--url` nor a positional URL is given.
 const DEFAULT_URL: &str = "http://localhost:4241";
-/// Default output file used when neither `-o` nor a positional OUTPUT is given.
-const DEFAULT_OUTPUT: &str = "rezolus.parquet";
+
+/// Default output file for a format, used when neither `-o` nor a positional
+/// OUTPUT is given. The stem is constant; the extension follows the format so
+/// the file never lies about what is inside it.
+fn default_output_for(format: Format) -> PathBuf {
+    PathBuf::from(match format {
+        Format::Rez => "rezolus.rez",
+        Format::Parquet => "rezolus.parquet",
+        Format::Raw => "rezolus.raw",
+    })
+}
+
+/// The format an output path's extension names, if it names one. An unknown
+/// extension has no opinion, leaving `--format` (or the parquet fallback) to
+/// decide.
+fn format_from_extension(path: &Path) -> Option<Format> {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("rez") => Some(Format::Rez),
+        Some("parquet") => Some(Format::Parquet),
+        Some("raw") => Some(Format::Raw),
+        _ => None,
+    }
+}
+
+/// A resolved `(format, output)` pair.
+#[derive(Debug)]
+pub struct OutputPlan {
+    pub format: Format,
+    pub output: PathBuf,
+    /// True only when nothing pinned the format: no `--format`, and no output
+    /// path to read an extension off. Those runs default to `.rez`, and only
+    /// those may be demoted to parquet when the endpoint cannot be recorded
+    /// into a `.rez` (see `recorder::run`).
+    pub defaulted: bool,
+}
+
+/// Resolve the output format and path.
+///
+/// `--format` and the output extension are both authoritative, so when both
+/// name a format and disagree the command is rejected rather than silently
+/// resolved one way: writing a `.rez` archive to a file called `out.parquet`
+/// (which is what the old extension-wins rule did) breaks every tool
+/// downstream that dispatches on the name.
+fn resolve_format_and_output(
+    explicit_format: Option<Format>,
+    output: Option<&Path>,
+) -> Result<OutputPlan, String> {
+    let Some(path) = output else {
+        let format = explicit_format.unwrap_or(Format::Rez);
+        return Ok(OutputPlan {
+            format,
+            output: default_output_for(format),
+            defaulted: explicit_format.is_none(),
+        });
+    };
+
+    let from_ext = format_from_extension(path);
+    if let (Some(flag), Some(ext)) = (explicit_format, from_ext) {
+        if flag != ext {
+            return Err(format!(
+                "--format {} conflicts with the output path {}; drop one of them",
+                format_name(flag),
+                path.display()
+            ));
+        }
+    }
+
+    Ok(OutputPlan {
+        format: explicit_format.or(from_ext).unwrap_or(Format::Parquet),
+        output: path.to_path_buf(),
+        defaulted: false,
+    })
+}
+
+pub fn format_name(format: Format) -> &'static str {
+    match format {
+        Format::Rez => "rez",
+        Format::Parquet => "parquet",
+        Format::Raw => "raw",
+    }
+}
 
 /// Resolve the recording URL from the `--url` flag and the deprecated
 /// positional URL. Returns `(url, positional_was_used)`. Errors if both are
@@ -60,18 +143,20 @@ fn resolve_url(flag: Option<&Url>, positional: Option<&Url>) -> Result<(Url, boo
 }
 
 /// Resolve the output path from `-o/--output` and the deprecated positional
-/// OUTPUT. Returns `(path, positional_was_used)`. Errors if both are supplied.
+/// OUTPUT. Returns `(path, positional_was_used)`; `None` means neither was
+/// given, which is what lets the format pick the default filename. Errors if
+/// both are supplied.
 fn resolve_output(
     flag: Option<&Path>,
     positional: Option<&Path>,
-) -> Result<(PathBuf, bool), String> {
+) -> Result<(Option<PathBuf>, bool), String> {
     match (flag, positional) {
         (Some(_), Some(_)) => {
             Err("specify either -o/--output or the positional OUTPUT, not both".to_string())
         }
-        (Some(p), None) => Ok((p.to_path_buf(), false)),
-        (None, Some(p)) => Ok((p.to_path_buf(), true)),
-        (None, None) => Ok((PathBuf::from(DEFAULT_OUTPUT), false)),
+        (Some(p), None) => Ok((Some(p.to_path_buf()), false)),
+        (None, Some(p)) => Ok((Some(p.to_path_buf()), true)),
+        (None, None) => Ok((None, false)),
     }
 }
 
@@ -82,10 +167,7 @@ impl RecordingConfig {
             .get_one::<humantime::Duration>("INTERVAL")
             .unwrap_or(&humantime::Duration::from_str("1s").unwrap());
         let duration = args.get_one::<humantime::Duration>("DURATION").copied();
-        let format = args
-            .get_one::<Format>("FORMAT")
-            .copied()
-            .unwrap_or(Format::Parquet);
+        let explicit_format = args.get_one::<Format>("FORMAT").copied();
         let separate = args.get_flag("SEPARATE");
         let metadata: Vec<(String, String)> = args
             .get_many::<String>("METADATA")
@@ -112,7 +194,8 @@ impl RecordingConfig {
         // prefers its TOML output when -o is not given).
         let out_flag = args.get_one::<PathBuf>("OUTPUT_FLAG").map(|p| p.as_path());
         let out_pos = args.get_one::<PathBuf>("OUTPUT").map(|p| p.as_path());
-        let (resolved_output, output_deprecated) = resolve_output(out_flag, out_pos)?;
+        let (explicit_output, output_deprecated) = resolve_output(out_flag, out_pos)?;
+        let plan = resolve_format_and_output(explicit_format, explicit_output.as_deref())?;
 
         // Mode 1: --config file.toml
         if let Some(config_path) = args.get_one::<PathBuf>("CONFIG_FILE") {
@@ -132,19 +215,22 @@ impl RecordingConfig {
                     interval
                 };
 
-            let format =
-                if args.value_source("FORMAT") == Some(clap::parser::ValueSource::CommandLine) {
-                    format
-                } else if let Some(ref s) = toml_cfg.recording.format {
-                    match s.as_str() {
+            // The TOML `[recording]` table stands in for the flags it
+            // mirrors: its `format` is as explicit as `--format`, and its
+            // `output` is mandatory, so a config-file run is never a
+            // defaulted-format run.
+            let config_format = match explicit_format {
+                Some(f) => Some(f),
+                None => match toml_cfg.recording.format {
+                    Some(ref s) => Some(match s.as_str() {
                         "parquet" => Format::Parquet,
                         "raw" => Format::Raw,
                         "rez" => Format::Rez,
                         other => return Err(format!("unknown format in config: {other}")),
-                    }
-                } else {
-                    format
-                };
+                    }),
+                    None => None,
+                },
+            };
 
             let separate =
                 if args.value_source("SEPARATE") == Some(clap::parser::ValueSource::CommandLine) {
@@ -157,23 +243,24 @@ impl RecordingConfig {
                 return Err("config file must define at least one endpoint".to_string());
             }
 
-            let output = if args.get_one::<PathBuf>("OUTPUT_FLAG").is_some() {
-                resolved_output.clone()
-            } else {
-                PathBuf::from(toml_cfg.recording.output)
+            let config_output = match explicit_output {
+                Some(ref p) => p.clone(),
+                None => PathBuf::from(toml_cfg.recording.output),
             };
+            let plan = resolve_format_and_output(config_format, Some(&config_output))?;
 
             return Ok(RecordingConfig {
                 interval,
                 duration,
-                format,
+                format: plan.format,
                 verbose,
-                output,
+                output: plan.output,
                 separate,
                 metadata,
                 labels,
                 endpoints: toml_cfg.endpoints,
                 command: command.clone(),
+                format_defaulted: plan.defaulted,
             });
         }
 
@@ -190,14 +277,15 @@ impl RecordingConfig {
             return Ok(RecordingConfig {
                 interval,
                 duration,
-                format,
+                format: plan.format,
                 verbose,
-                output: resolved_output.clone(),
+                output: plan.output,
                 separate,
                 metadata,
                 labels,
                 endpoints,
                 command: command.clone(),
+                format_defaulted: plan.defaulted,
             });
         }
 
@@ -228,14 +316,15 @@ impl RecordingConfig {
         Ok(RecordingConfig {
             interval,
             duration,
-            format,
+            format: plan.format,
             verbose,
-            output: resolved_output,
+            output: plan.output,
             separate,
             metadata,
             labels,
             endpoints: vec![endpoint],
             command,
+            format_defaulted: plan.defaulted,
         })
     }
 }
@@ -344,6 +433,46 @@ mod tests {
         }
     }
 
+    /// `--node` / `--instance` are gone, and a script still passing them must
+    /// FAIL rather than be silently ignored.
+    ///
+    /// They were added by #795 ("labeling at capture time") but no reader was
+    /// ever written for either, in that commit or any since — so they spent
+    /// their whole life accepting a value and dropping it. The keys they were
+    /// meant to set are plain file metadata (`node`, `instance`, the same ones
+    /// `recording combine` reads), so `--metadata node=web-01` was always the
+    /// working form. Erroring is the point: someone who typed `--node` was
+    /// already not getting what they asked for, and silence is how that went
+    /// unnoticed for four months.
+    #[test]
+    fn node_and_instance_are_rejected_now_that_the_dead_flags_are_gone() {
+        let parse = |args: &[&str]| crate::recorder::command().try_get_matches_from(args);
+
+        assert!(parse(&["record", "--url", "http://localhost:4241"]).is_ok());
+
+        for flag in ["--node", "--instance"] {
+            assert!(
+                parse(&["record", "--url", "http://localhost:4241", flag, "web-01"]).is_err(),
+                "{flag} must be rejected outright, not accepted and ignored"
+            );
+        }
+
+        // The replacement still works and lands as a metadata pair.
+        let matches = parse(&[
+            "record",
+            "--url",
+            "http://localhost:4241",
+            "--metadata",
+            "node=web-01",
+        ])
+        .unwrap();
+        let cfg = RecordingConfig::from_args(&matches).unwrap();
+        assert_eq!(
+            cfg.metadata,
+            vec![("node".to_string(), "web-01".to_string())]
+        );
+    }
+
     #[test]
     fn resolve_url_defaults_to_localhost() {
         let (url, deprecated) = resolve_url(None, None).unwrap();
@@ -375,17 +504,117 @@ mod tests {
     }
 
     #[test]
-    fn resolve_output_defaults_to_rezolus_parquet() {
+    fn resolve_output_has_no_path_of_its_own_until_the_format_is_known() {
         let (out, dep) = resolve_output(None, None).unwrap();
-        assert_eq!(out, PathBuf::from("rezolus.parquet"));
+        assert_eq!(out, None);
         assert!(!dep);
+    }
+
+    /// A bare `rezolus record` writes a `.rez` archive, and marks the run as
+    /// defaulted so the recorder may fall back to parquet if the endpoint
+    /// turns out to be one `.rez` cannot record.
+    #[test]
+    fn no_output_and_no_format_defaults_to_rez() {
+        let plan = resolve_format_and_output(None, None).unwrap();
+        assert_eq!(plan.format, Format::Rez);
+        assert_eq!(plan.output, PathBuf::from("rezolus.rez"));
+        assert!(plan.defaulted);
+    }
+
+    /// `--format X` with no `-o` names the file after the format, so the
+    /// extension never lies about the contents. `--format raw` used to write
+    /// its msgpack stream to a file called `rezolus.parquet`.
+    #[test]
+    fn an_explicit_format_names_the_default_file_after_itself() {
+        for (format, name) in [
+            (Format::Rez, "rezolus.rez"),
+            (Format::Parquet, "rezolus.parquet"),
+            (Format::Raw, "rezolus.raw"),
+        ] {
+            let plan = resolve_format_and_output(Some(format), None).unwrap();
+            assert_eq!(plan.format, format);
+            assert_eq!(plan.output, PathBuf::from(name));
+            assert!(
+                !plan.defaulted,
+                "{name}: an explicit --format is a choice, not a default"
+            );
+        }
+    }
+
+    #[test]
+    fn the_output_extension_picks_the_format() {
+        for (name, format) in [
+            ("out.rez", Format::Rez),
+            ("out.parquet", Format::Parquet),
+            ("out.raw", Format::Raw),
+        ] {
+            let plan = resolve_format_and_output(None, Some(Path::new(name))).unwrap();
+            assert_eq!(plan.format, format, "{name}");
+            assert_eq!(plan.output, PathBuf::from(name));
+            assert!(!plan.defaulted, "{name}: the path is a choice too");
+        }
+    }
+
+    /// An extension nobody recognizes is not an opinion, so parquet stays the
+    /// fallback for a named path — `.rez` is only ever chosen by a name that
+    /// says `.rez`, or by having nothing to go on at all.
+    #[test]
+    fn an_unknown_extension_leaves_the_format_to_the_flag() {
+        let plan = resolve_format_and_output(None, Some(Path::new("out.dat"))).unwrap();
+        assert_eq!(plan.format, Format::Parquet);
+        assert!(!plan.defaulted);
+
+        let plan =
+            resolve_format_and_output(Some(Format::Rez), Some(Path::new("out.dat"))).unwrap();
+        assert_eq!(plan.format, Format::Rez);
+        assert_eq!(plan.output, PathBuf::from("out.dat"));
+    }
+
+    /// Silently resolving this either way produces a file whose name lies:
+    /// a `.rez` archive called `out.parquet`, or a parquet table called
+    /// `out.rez`. Everything downstream dispatches on that name.
+    #[test]
+    fn a_format_contradicting_the_extension_is_rejected() {
+        let err = resolve_format_and_output(Some(Format::Parquet), Some(Path::new("out.rez")))
+            .expect_err("--format parquet with a .rez path must not be resolved silently");
+        assert!(err.contains("conflicts"), "{err}");
+
+        let err = resolve_format_and_output(Some(Format::Rez), Some(Path::new("out.parquet")))
+            .expect_err("--format rez with a .parquet path must not be resolved silently");
+        assert!(err.contains("conflicts"), "{err}");
+
+        // Agreeing is fine, and stays fine.
+        let plan =
+            resolve_format_and_output(Some(Format::Rez), Some(Path::new("out.rez"))).unwrap();
+        assert_eq!(plan.format, Format::Rez);
+    }
+
+    /// A config-file run always has an output (the TOML field is mandatory),
+    /// so it is never a defaulted-format run and never falls back.
+    #[test]
+    fn a_config_file_run_is_never_defaulted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("endpoints.toml");
+        std::fs::write(
+            &path,
+            "[recording]\noutput = \"run.parquet\"\n\n[[endpoints]]\nurl = \"http://localhost:4241\"\n",
+        )
+        .unwrap();
+
+        let matches = crate::recorder::command()
+            .try_get_matches_from(["record", "--config", path.to_str().unwrap()])
+            .unwrap();
+        let cfg = RecordingConfig::from_args(&matches).unwrap();
+        assert_eq!(cfg.format, Format::Parquet);
+        assert_eq!(cfg.output, PathBuf::from("run.parquet"));
+        assert!(!cfg.format_defaulted);
     }
 
     #[test]
     fn resolve_output_positional_is_deprecated() {
         let pos = PathBuf::from("legacy.parquet");
         let (out, dep) = resolve_output(None, Some(&pos)).unwrap();
-        assert_eq!(out, pos);
+        assert_eq!(out, Some(pos));
         assert!(dep);
     }
 

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -33,45 +33,108 @@ pub fn command() -> Command {
              endpoint.\n\n\
              WHAT TO RECORD (choose one): --url for a single endpoint (default\n\
              http://localhost:4241), --endpoint (repeatable) for several at once, or --config\n\
-             for a TOML file. Write the result with -o/--output (default rezolus.parquet).\n\
-             (The positional URL and OUTPUT still work but are deprecated; prefer --url / -o.)\n\n\
+             for a TOML file. Exactly one: passing two of them is a parse error, not a\n\
+             merge — and the deprecated positional URL counts as --url for that rule, as\n\
+             positional OUTPUT counts as -o. Prefer the flags.\n\n\
+             --url is shorthand for a single endpoint with no modifiers; reach for a single\n\
+             --endpoint when you need source=, role= or protocol= on it, which is still a\n\
+             one-endpoint recording and still eligible for .rez. --config conflicts only with\n\
+             --url/--endpoint: every other flag still applies alongside it, and -o, --interval\n\
+             and --format override the file\'s [recording] table. There is no duration key —\n\
+             a bounded config-driven run passes --duration on the command line.\n\n\
              HOW LONG TO RECORD (choose one): --duration for a fixed window, nothing to run\n\
              until Ctrl-C, or `-- <command>` to record for exactly the lifetime of a wrapped\n\
              command (perf-record style) — it stops when the command exits.\n\n\
+             A wrapped command keeps this terminal: its stdin/stdout/stderr pass straight\n\
+             through, and rezolus exits with the command\'s own exit status, so\n\
+             `rezolus record -o bench.rez -- ./bench.sh && analyze bench.rez` gates on the\n\
+             benchmark exactly as it would without the wrapper. The one substitution is the\n\
+             --duration cap: if it fires and the command is killed, rezolus exits 124.\n\n\
+             WHAT IT WRITES: the output path is -o/--output, and its extension picks the\n\
+             format, so --format is rarely needed. With no -o at all the recording goes to\n\
+             rezolus.<ext> for the format in play — by default rezolus.rez. (A \"sampler\" below\n\
+             is one metric collector — cpu_usage, scheduler, blockio — and each reads on its\n\
+             own schedule rather than on one global clock.)\n\n    \
+             .rez      (default) A per-sampler archive: one table per sampler, each at its own\n    \
+             \x20         cadence, carrying the window each read covered so PromQL rate()\n    \
+             \x20         queries in `rezolus view` and `rezolus mcp` can report uncertainty\n    \
+             \x20         bounds instead of a bare number. Needs a single rezolus (msgpack)\n    \
+             \x20         endpoint. Prefer it.\n    \
+             .parquet  One columnar table on a single uniform clock. Use it for a Prometheus\n    \
+             \x20         source, for several endpoints at once, or for other parquet tooling.\n    \
+             .raw      The msgpack snapshots as scraped, concatenated (a Prometheus source\n    \
+             \x20         is converted to snapshots on the way in, so either source works).\n    \
+             \x20         Cheapest thing the recorder can do: it appends and never rewrites.\n    \
+             \x20         Turn it into parquet later with `rezolus recording convert` — which\n    \
+             \x20         you can redo, re-stamping metadata, since the raw input is kept.\n\n\
+             Any other extension (-o capture.dat, or no extension at all) is not an error and\n\
+             not .rez: it means parquet, unless --format says otherwise. A --format that\n\
+             contradicts the extension (say --format parquet with -o out.rez) IS an error,\n\
+             rather than a silent choice between them.\n\n\
+             When the format was not chosen at all — no --format, no -o — and the endpoint\n\
+             turns out to be Prometheus, or there is more than one endpoint, the recording\n\
+             falls back to rezolus.parquet and says so on stderr. Pass --format rez (or an\n\
+             -o ending in .rez) to make a .rez archive a requirement instead: then the same\n\
+             situation is an error and nothing is recorded.\n\n\
+             OVERWRITING: a .rez output path must NOT already exist — the recorder refuses\n\
+             rather than truncate, because the archive is committed as it goes and has no\n\
+             staging file. A parquet or raw output IS overwritten. There is no --force; remove\n\
+             the old file or pick a new path.\n\n\
              EXAMPLES:\n    \
+             # Record the local agent until ctrl-c (defaults: localhost:4241 -> rezolus.rez)\n    \
+             rezolus record\n\n    \
              # Record a local agent for 5 minutes\n    \
-             rezolus record --url http://localhost:4241 -o out.parquet --duration 5m\n\n    \
-             # Record a Prometheus endpoint, tagging the source in the file metadata\n    \
-             rezolus record --url http://host:9090/metrics -o out.parquet --metadata source=llm-perf\n\n    \
-             # Record only while a benchmark runs, then stop (defaults: localhost:4241 -> rezolus.parquet)\n    \
-             rezolus record -- ./bench.sh --iters 100\n\n    \
-             # Same, writing to a named file\n    \
-             rezolus record -o bench.parquet -- ./bench.sh\n\n    \
+             rezolus record --url http://localhost:4241 -o out.rez --duration 5m\n\n    \
+             # Record only while a benchmark runs, then stop\n    \
+             rezolus record -o bench.rez -- ./bench.sh --iters 100\n\n    \
+             # Tag a recording as one arm of an A/B comparison\n    \
+             rezolus record -o redis.rez --label arm=redis -- ./bench.sh\n\n    \
              # High-resolution capture: sample every 100ms for 30 seconds\n    \
-             rezolus record --url http://localhost:4241 -o out.parquet --interval 100ms --duration 30s\n\n    \
-             # Record several endpoints into separate per-endpoint files\n    \
-             rezolus record --separate --endpoint http://localhost:4241 --endpoint http://svc:9090/metrics,source=svc -o combined.parquet\n\n    \
-             # Write a per-sampler .rez archive (each sampler at its own cadence, with\n    \
-             # per-metric acquisition windows), tagging the recording with labels\n    \
-             rezolus record --url http://localhost:4241 -o out.rez --label arm=redis --label host=node1\n\
-             \n\
-             The .rez format (chosen by a .rez output extension or --format rez) holds one\n\
-             parquet table per sampler, each at its own cadence. It requires a\n\
-             rezolus/msgpack endpoint (not Prometheus). --label k=v (repeatable) tags the\n\
-             recording; source and host are auto-populated.\n\n\
+             rezolus record -o out.rez --interval 100ms --duration 30s\n\n    \
+             # Record a Prometheus endpoint to parquet, tagging the source in the metadata\n    \
+             rezolus record --url http://host:9090/metrics -o out.parquet --metadata source=llm-perf\n\n    \
+             # Record several endpoints into ONE combined parquet file\n    \
+             rezolus record --endpoint http://localhost:4241 --endpoint http://svc:9090/metrics,source=svc -o run.parquet\n\n    \
+             # ...or one file per endpoint: writes run_rezolus.parquet and run_svc.parquet\n    \
+             rezolus record --separate --endpoint http://localhost:4241 --endpoint http://svc:9090/metrics,source=svc -o run.parquet\n\n    \
+             # Capture raw msgpack now, convert later\n    \
+             rezolus record -o run.raw --duration 1m && rezolus recording convert run.raw\n\n    \
+             # Require a .rez: fail rather than quietly fall back to parquet\n    \
+             rezolus record --url http://host:4241 --format rez --duration 5m\n\n    \
+             # Take the endpoints and the output from a file\n    \
+             rezolus record --config rec.toml\n    \
+             #   [recording]\n    \
+             #   output = \"run.parquet\"   # required; its extension picks the format\n    \
+             #   interval = \"1s\"          # optional\n    \
+             #   separate = false         # optional\n    \
+             #   [[endpoints]]\n    \
+             #   url = \"http://localhost:4241\"\n    \
+             #   [[endpoints]]\n    \
+             #   url = \"http://svc:9090/metrics\"\n    \
+             #   source = \"svc\"           # optional, as are role = and protocol =\n\n\
+             TAGGING: -m/--metadata k=v writes file-level metadata and applies to EVERY\n\
+             format. -l/--label k=v applies to .rez only (it is dropped for parquet and raw):\n\
+             it tags the recording inside the archive, source and host are auto-populated,\n\
+             and a two-recording .rez drives the viewer\'s A/B comparison — which is what\n\
+             --label arm=redis is for. The source= on an --endpoint is a third thing again:\n\
+             it names which endpoint a metric came from in a multi-endpoint recording.\n\n\
+             To label a recording for a multi-node or multi-instance `rezolus recording\n\
+             combine`, set the metadata keys it reads: --metadata node=web-01 and\n\
+             --metadata instance=0. (`record --node` / `--instance` were removed: they were\n\
+             never wired to anything, and these are what they were meant to set.)\n\n\
+             ABOUT .rez:\n\n\
              .rez recordings are written to disk as they run, so stopping costs the same\n\
              whether the recording ran for a minute or a day. Ctrl-c and SIGTERM (e.g. a\n\
              docker stop) are clean stops: the signal interrupts the wait between samples\n\
              straight away, so finalizing costs only the write of the still-open segments —\n\
-             at any --interval, comfortably inside a container's stop grace, and never\n\
-             proportional to the recording's length.\n\n\
+             at any --interval, comfortably inside a container\'s stop grace, and never\n\
+             proportional to the recording\'s length.\n\n\
              A .rez is a single SQLite file, valid at every instant. There is no .partial,\n\
              so the output path must not already exist, and every sample is committed as it\n\
              is taken: a SIGKILL or a power loss costs at most one sampling interval, for\n\
-             every sampler. `rezolus parquet metadata -i out.rez` reports an interrupted\n\
+             every sampler. `rezolus recording metadata -i out.rez` reports an interrupted\n\
              recording as \"not cleanly finalized\" and how many samples are still in its\n\
-             write-ahead log. Pass --rez-version 2 to write the previous tar container\n\
-             instead (staged at <output>.partial, recoverable only to its last checkpoint).",
+             write-ahead log.",
         )
         .arg(
             clap::Arg::new("URL")
@@ -105,7 +168,7 @@ pub fn command() -> Command {
         .arg(
             clap::Arg::new("SEPARATE")
                 .long("separate")
-                .help("Write one parquet file per endpoint instead of combining; each is named <OUTPUT-stem>_<source>.<ext> alongside the output path (source falls back to host-port, e.g. localhost-4241, when not set via source=)")
+                .help("Write one file per endpoint instead of combining; each is named <OUTPUT-stem>_<source>.<ext> alongside the output path. Without an explicit source=, a rezolus agent endpoint is named \"rezolus\" and a Prometheus one falls back to its host-port (e.g. svc-9090). For parquet or raw output only — .rez records a single endpoint")
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(
@@ -136,36 +199,23 @@ pub fn command() -> Command {
             clap::Arg::new("FORMAT")
                 .long("format")
                 .short('f')
-                .help("Output format: parquet (columnar, queryable), raw (concatenated msgpack snapshots), or rez (per-sampler .rez archive; also selected by a .rez output extension, requires a rezolus/msgpack endpoint)")
+                .help("Output format: rez (per-sampler archive, the default), parquet (one columnar table), or raw (concatenated msgpack snapshots). Usually unnecessary — the -o extension picks the format, and giving both a --format and a conflicting extension is an error. rez requires a single rezolus/msgpack endpoint")
                 .action(clap::ArgAction::Set)
-                .default_value("parquet")
                 .value_parser(value_parser!(Format)),
         )
         .arg(
             clap::Arg::new("METADATA")
                 .long("metadata")
                 .short('m')
-                .help("Add a file-level metadata tag as key=value (e.g. source=llm-perf); repeat for multiple tags")
+                .help("Add a file-level metadata tag as key=value (e.g. source=llm-perf); repeat for multiple tags. Applies to every output format")
                 .action(clap::ArgAction::Append),
         )
         .arg(
             clap::Arg::new("LABEL")
                 .long("label")
                 .short('l')
-                .help("Tag the recording with a label as key=value (e.g. arm=redis, role=server); repeat for multiple. A value without `=` is ignored. `source` and `host` are auto-populated. Used by .rez output.")
+                .help("Tag the recording with a label as key=value (e.g. arm=redis, role=server); repeat for multiple. A value without `=` is ignored. `source` and `host` are auto-populated. .rez output ONLY — dropped for parquet and raw, where --metadata is the equivalent")
                 .action(clap::ArgAction::Append),
-        )
-        .arg(
-            clap::Arg::new("NODE")
-                .long("node")
-                .help("Node name for rezolus agent data (written to parquet metadata)")
-                .action(clap::ArgAction::Set),
-        )
-        .arg(
-            clap::Arg::new("INSTANCE")
-                .long("instance")
-                .help("Instance name for service data (written to parquet metadata)")
-                .action(clap::ArgAction::Set),
         )
         .arg(
             clap::Arg::new("URL_FLAG")
@@ -179,7 +229,7 @@ pub fn command() -> Command {
             clap::Arg::new("OUTPUT_FLAG")
                 .long("output")
                 .short('o')
-                .help("Path to the output file (default rezolus.parquet)")
+                .help("Path to the output file; its extension picks the format (.rez, .parquet, .raw). Defaults to rezolus.<format>, i.e. rezolus.rez")
                 .action(clap::ArgAction::Set)
                 .value_parser(value_parser!(PathBuf))
                 .conflicts_with("OUTPUT"),
@@ -691,10 +741,39 @@ struct EndpointWriter {
 /// correspondingly long stall.
 const MAX_SCRAPE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Handle a run that asked for (or defaulted to) `.rez` output that this
+/// endpoint set cannot produce: either rewrite `config` to record parquet and
+/// carry on, or exit non-zero.
+///
+/// The distinction is who chose `.rez`. `--format rez` or an `-o out.rez` is a
+/// request the recorder must not quietly substitute — a pipeline that goes on
+/// to read `out.rez` would find a parquet file, or nothing. But `.rez` is also
+/// what a bare `rezolus record` picks with nothing to go on, and demanding a
+/// flag before it will record a Prometheus endpoint (which worked before `.rez`
+/// became the default) is a regression for no gain: nothing downstream has been
+/// promised a filename yet, so the recorder picks the format that fits.
+///
+/// The refusal exits 1 rather than returning, because a `record && analyze`
+/// pipeline sees only the exit code: this used to print the error and exit 0,
+/// leaving the next command to read whatever `out.rez` a previous run left
+/// behind.
+fn demote_from_rez(config: &mut RecordingConfig, reason: &str) {
+    if !config.format_defaulted {
+        eprintln!("error: {reason}");
+        std::process::exit(1);
+    }
+    config.format = Format::Parquet;
+    config.output = PathBuf::from("rezolus.parquet");
+    eprintln!(
+        "note: {reason}; recording parquet to {} instead (pass --format rez to require a .rez archive)",
+        config.output.display()
+    );
+}
+
 /// Runs the Rezolus `recorder` which pulls metrics from one or more endpoints
 /// and writes them to parquet file(s). Supports Rezolus msgpack and Prometheus
 /// text format endpoints, with auto-detection.
-pub fn run(config: RecordingConfig) {
+pub fn run(mut config: RecordingConfig) {
     let _log_drain = configure_logging(verbosity_to_level(config.verbose));
 
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -735,40 +814,44 @@ pub fn run(config: RecordingConfig) {
         }
     };
 
-    let out_dir = output_dir(&config.output);
-
     let mut endpoints: Vec<EndpointState> = config
         .endpoints
         .iter()
         .map(|ep| EndpointState::new(ep.clone()))
         .collect();
 
-    // `.rez` per-sampler archive mode: selected by a `.rez` output extension or
-    // `--format rez`.
-    let rez_mode = rez::wants_rez(&config.output, config.format);
+    // `.rez` per-sampler archive mode. By this point the output extension has
+    // already been folded into the format, so the format is the whole answer.
+    let mut rez_mode = rez::wants_rez(config.format);
 
     if rez_mode {
         // `.rez` ingest reads msgpack snapshots; an explicitly-prometheus
-        // endpoint yields none, so reject it up front (before probing) rather
-        // than recording an empty archive. Auto-detected prometheus is rejected
-        // right after the probe, below.
-        if let Some(ep) = endpoints
+        // endpoint yields none, so settle it up front (before probing) rather
+        // than recording an empty archive. Auto-detected prometheus is handled
+        // right after the probe, below. Multi-source/A-B `.rez` is deferred, so
+        // more than one endpoint is the other blocker — also checked before
+        // probing, so a misconfiguration costs no network round-trips.
+        let blocker = if let Some(ep) = endpoints
             .iter()
             .find(|e| matches!(e.config.protocol, Some(Protocol::Prometheus)))
         {
-            eprintln!(
-                "error: .rez output requires a rezolus (msgpack) endpoint; {} is configured protocol=prometheus",
+            Some(format!(
+                "{} is configured protocol=prometheus, and .rez requires a rezolus (msgpack) endpoint",
                 ep.config.url
-            );
-            return;
-        }
-        // Multi-source/A-B `.rez` is deferred; require one endpoint. Checked
-        // before probing so a misconfiguration costs no network round-trips.
-        if endpoints.len() > 1 {
-            eprintln!("error: .rez output currently supports a single endpoint");
-            return;
+            ))
+        } else if endpoints.len() > 1 {
+            Some(".rez output currently supports a single endpoint".to_string())
+        } else {
+            None
+        };
+
+        if let Some(reason) = blocker {
+            demote_from_rez(&mut config, &reason);
+            rez_mode = false;
         }
     }
+
+    let out_dir = output_dir(&config.output);
 
     // Probe all endpoints (best-effort startup)
     rt.block_on(async {
@@ -842,17 +925,24 @@ pub fn run(config: RecordingConfig) {
         // `.rez` is single-endpoint (guarded above) and at least one endpoint is
         // active (checked above), so the active endpoint is *the* endpoint. It
         // can therefore never activate later via the Pending path.
-        if let Some(ep) = endpoints
+        let non_msgpack = endpoints
+            .iter()
+            .find(|ep| ep.status == EndpointStatus::Active)
+            .filter(|ep| ep.protocol() != Some(&Protocol::Msgpack))
+            .map(|ep| {
+                format!(
+                    "{} answered as prometheus, and .rez requires a rezolus (msgpack) endpoint",
+                    ep.config.url
+                )
+            });
+
+        if let Some(reason) = non_msgpack {
+            demote_from_rez(&mut config, &reason);
+            rez_mode = false;
+        } else if let Some(ep) = endpoints
             .iter()
             .find(|ep| ep.status == EndpointStatus::Active)
         {
-            if ep.protocol() != Some(&Protocol::Msgpack) {
-                eprintln!(
-                    "error: .rez output requires a rezolus (msgpack) endpoint; {} answered as prometheus",
-                    ep.config.url
-                );
-                return;
-            }
             match start_rez_recorder(&config, ep, clock_anchor_wall_ns) {
                 Ok(rec) => rez_recorder = Some(rec),
                 Err(e) => {
@@ -1690,7 +1780,8 @@ mod tests {
             Some(vec!["echo".to_string(), "hello".to_string()])
         );
         // Defaults apply when no --url/-o are given.
-        assert_eq!(config.output, PathBuf::from("rezolus.parquet"));
+        assert_eq!(config.output, PathBuf::from("rezolus.rez"));
+        assert_eq!(config.format, Format::Rez);
         assert_eq!(config.endpoints.len(), 1);
         assert_eq!(config.endpoints[0].url.as_str(), "http://localhost:4241/");
     }
@@ -1777,6 +1868,7 @@ mod tests {
             labels: vec![("arm".to_string(), "redis".to_string())],
             endpoints: Vec::new(),
             command: None,
+            format_defaulted: false,
         }
     }
 

--- a/src/recorder/rez.rs
+++ b/src/recorder/rez.rs
@@ -1884,8 +1884,8 @@ pub fn recording_dir_slug(labels: &BTreeMap<String, String>) -> String {
 
 /// True when the recording should be written as a `.rez` archive: either the
 /// output path ends in `.rez` or `--format rez` was given.
-pub fn wants_rez(output: &Path, format: crate::Format) -> bool {
-    format == crate::Format::Rez || output.extension().and_then(|e| e.to_str()) == Some("rez")
+pub fn wants_rez(format: crate::Format) -> bool {
+    format == crate::Format::Rez
 }
 
 #[cfg(test)]
@@ -3438,14 +3438,17 @@ mod finalize_tests {
 mod selection_tests {
     use super::*;
     use crate::Format;
-    use std::path::Path;
 
+    /// The `.rez` extension is folded into the format by
+    /// `RecordingConfig::resolve_format_and_output`, so by the time the
+    /// recorder asks, the format is the only thing left to consult — an
+    /// extension that disagreed with an explicit `--format` was rejected at
+    /// parse time rather than quietly overriding it here.
     #[test]
-    fn extension_or_format_selects_rez() {
-        assert!(wants_rez(Path::new("out.rez"), Format::Parquet));
-        assert!(wants_rez(Path::new("out.parquet"), Format::Rez));
-        assert!(!wants_rez(Path::new("out.parquet"), Format::Parquet));
-        assert!(!wants_rez(Path::new("out.raw"), Format::Raw));
+    fn format_alone_selects_rez() {
+        assert!(wants_rez(Format::Rez));
+        assert!(!wants_rez(Format::Parquet));
+        assert!(!wants_rez(Format::Raw));
     }
 }
 


### PR DESCRIPTION
## Summary

- **`rezolus record` defaults to `rezolus.rez`.** The format is resolved once, from the output extension (`.rez`/`.parquet`/`.raw`) or an explicit `--format`, and the default filename follows whichever won — so `--format raw` no longer writes msgpack into a file called `rezolus.parquet`. A `--format` that contradicts the extension is now an error; previously the extension silently beat the flag, so `--format parquet -o out.rez` produced an archive nothing downstream would open by that name.
- **Graceful fallback, strict when pinned.** `.rez` needs a single msgpack endpoint, so a run that pinned nothing (no `--format`, no `-o`) falls back to `rezolus.parquet` with a note for a Prometheus or multi-endpoint source — `rezolus record -- ./bench` against Prometheus keeps working. Pinning `.rez` makes it a requirement instead.
- **Two latent bugs fixed in the lines being rewritten.** The `.rez`-impossible refusal printed an error and exited **0**, so `record -o out.rez && analyze out.rez` walked on to whatever a previous run left at that path; it exits 1 now. And a `record` usage error panicked with a backtrace instead of printing the one line saying what to fix.
- **Removes `record --node` / `--instance`.** #795 added them for "labeling at capture time", but only the arg definitions landed — `git log -S` finds no reader in that commit or any since, so they spent four months accepting a value and dropping it. The keys they meant to set are ordinary file metadata (`node`/`instance`, the same ones `recording combine` reads), so `--metadata node=web-01` was always the working form. They are now rejected rather than ignored, with a test, because silence is how this went unnoticed.
- **Help rewritten against what the code does.** Drops the stale `--rez-version 2` claim (that flag is already rejected). Documents overwrite semantics per format, wrapped-command stdio/exit-status passthrough, `--metadata` (all formats) vs `--label` (`.rez` only), and corrects `--separate`'s filename claim — a rezolus agent's file is `_rezolus`, not `_host-port`. `recording`'s examples led with the deprecated `parquet` alias throughout, and four subcommand summaries said "parquet file" for commands that accept `.rez`.

### Behavior changes

| Invocation | Before | After |
| --- | --- | --- |
| `rezolus record` | `rezolus.parquet` | `rezolus.rez` |
| `--format raw`, no `-o` | msgpack in `rezolus.parquet` | `rezolus.raw` |
| `-o out.raw`, no `--format` | parquet content | raw |
| `--format parquet -o out.rez` | silently wrote `.rez` | error, exit 2 |
| Prometheus / multi-endpoint, format unpinned | n/a | falls back to `rezolus.parquet` + note |
| `--format rez` vs Prometheus | error, exit **0** | error, exit **1** |
| `--node` / `--instance` | accepted, ignored | rejected, exit 2 |

## Test plan

- [x] `cargo test` — 696 + 7 + 4 passing, 0 failures
- [x] `cargo clippy` — 2 warnings, unchanged from `main` baseline
- [x] `cargo fmt --check` clean
- [x] New unit tests: format/output resolution (defaults, extension inference, unknown extension, contradiction rejection, config-file runs never defaulted), and `--node`/`--instance` rejection with the `--metadata` replacement asserted
- [x] Exercised end-to-end against a live agent and a stub Prometheus endpoint: default → `rezolus.rez`; `--format raw` → `rezolus.raw`; `-o capture.dat` → parquet; contradiction → clean error; Prometheus and two-endpoint fallbacks → `rezolus.parquet` with the note; `--format rez` vs Prometheus → exit 1; `.rez` refuses an existing path (exit 1) while parquet/raw truncate; `--separate` → `run_rezolus.parquet` + `run_svc.parquet`; `--config` with `-o`/`--duration` overrides; `.raw` from a Prometheus source round-trips through `recording convert`
- [x] Help text verified by blind subagent simulation (9 tasks over 2 rounds, all passing) plus 2 fresh-eyes critic passes; every critic finding checked against source before acting — one critic claim (`.raw` requires msgpack) was wrong and was not applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)