### PR TITLE
docs(cli): correct six false help claims, and guard the class with a test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.18"
+version = "5.17.1-alpha.19"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.18"
+version = "5.17.1-alpha.19"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/exporter/mod.rs
+++ b/src/exporter/mod.rs
@@ -32,7 +32,8 @@ pub fn command() -> Command {
              re-exposes the metrics in Prometheus text format for a Prometheus/VictoriaMetrics\n\
              scraper to collect.\n\n\
              Configuration is a TOML file (the only argument). It sets the agent to read from\n\
-             ([general] source, default 127.0.0.1:4241), the address to serve `/metrics` on\n\
+             ([general] source, default 0.0.0.0:4241 — the shipped config sets\n\
+             127.0.0.1:4241), the address to serve `/metrics` on\n\
              ([general] listen, default 0.0.0.0:4242), and whether to expose full histogram\n\
              buckets vs. summary percentiles ([prometheus]).\n\n\
              Set [general] interval (default 1s) to match your Prometheus scrape interval:\n\

--- a/src/hindsight/mod.rs
+++ b/src/hindsight/mod.rs
@@ -23,7 +23,7 @@ pub fn command() -> Command {
              The buffer is an ordinary `.rez` recording with retention: everything older than\n\
              the lookback is evicted every tick, so the file stays bounded. It is readable\n\
              while it is being written — `rezolus view`, the MCP tools and\n\
-             `rezolus parquet metadata` all open it live — and a snapshot is a consistent\n\
+             `rezolus recording metadata` all open it live — and a snapshot is a consistent\n\
              point-in-time copy taken without pausing the recording.\n\n\
              Configuration is a TOML file (the only argument). It sets the sampling interval\n\
              ([general] interval, e.g. 1s), how far back the buffer reaches ([general] duration,\n\

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -663,7 +663,8 @@ pub fn command() -> Command {
     Command::new("mcp")
         .about("Run Rezolus MCP server for AI analysis or execute analysis commands")
         .long_about(
-            "AI-assisted analysis of a parquet recording. With no subcommand, runs as a Model\n\
+            "AI-assisted analysis of a recording — a .parquet file or a .rez archive, told\n\
+             apart by content rather than by name. With no subcommand, runs as a Model\n\
              Context Protocol server over stdio for an LLM client. Each subcommand also runs\n\
              one-shot from the CLI, printing the same analysis to stdout.\n\n\
              SUBCOMMANDS:\n    \
@@ -705,7 +706,7 @@ pub fn command() -> Command {
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Parquet file to analyze")
+                        .help("Recording to analyze: a .parquet file or a .rez archive")
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
@@ -735,7 +736,7 @@ pub fn command() -> Command {
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Parquet file to describe")
+                        .help("Recording to describe: a .parquet file or a .rez archive")
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
@@ -754,7 +755,7 @@ pub fn command() -> Command {
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Parquet file to analyze")
+                        .help("Recording to analyze: a .parquet file or a .rez archive")
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
@@ -766,11 +767,16 @@ pub fn command() -> Command {
                 .long_about(
                     "Detect anomalies in time series data using MAD, CUSUM, and FFT analysis.\n\n\
                      If QUERY is provided, analyzes that specific metric.\n\
-                     If QUERY is omitted, performs exhaustive analysis on all metrics in the recording."
+                     If QUERY is omitted, performs exhaustive analysis on all metrics in the recording.\n\n\
+                     EXAMPLES:\n    \
+                     # Sweep every metric in the recording\n    \
+                     rezolus mcp detect-anomalies out.rez\n\n    \
+                     # Focus on one metric\n    \
+                     rezolus mcp detect-anomalies out.rez cpu_usage"
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Parquet file to analyze")
+                        .help("Recording to analyze: a .parquet file or a .rez archive")
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
@@ -794,12 +800,20 @@ pub fn command() -> Command {
                      available metrics and common query examples.\n\n\
                      rate()/irate() values print an acquisition-window uncertainty band\n\
                      [lo, hi] next to the value (derived from per-observation acquisition\n\
-                     windows). A scalar op scales the band (e.g. rate(x)*k); series-op-series\n\
-                     and non-rate queries show no band."
+                     windows). A scalar op scales the band (e.g. rate(x)*k), and a\n\
+                     series-op-series combines both operands' bands by interval arithmetic —\n\
+                     widening first to the union span when the two came from different\n\
+                     acquisition tables. Queries with no rate() and no histogram have no band\n\
+                     to show.\n\n\
+                     EXAMPLES:\n    \
+                     # Total cycles per second across all CPUs\n    \
+                     rezolus mcp query out.rez 'sum(rate(cpu_cycles[1m]))'\n\n    \
+                     # A ratio: both operands' bands are combined\n    \
+                     rezolus mcp query out.rez 'sum(irate(cpu_usage[1m])) / cpu_cores'"
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Parquet file to query")
+                        .help("Recording to query: a .parquet file or a .rez archive")
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
@@ -820,11 +834,16 @@ pub fn command() -> Command {
                      regime shifts, acquisition-window uncertainty, correlations, resource \
                      rankings, subsystem coverage) as JSON on stdout. The record is the \
                      input half of a recording assessment. Requires a recording of at \
-                     least 10 seconds.",
+                     least 10 seconds.\n\n\
+                     EXAMPLES:\n    \
+                     # Emit the feature record\n    \
+                     rezolus mcp extract-features out.rez\n\n    \
+                     # Keep it for an assessment step\n    \
+                     rezolus mcp extract-features out.rez > features.json",
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Path to a parquet or .rez recording")
+                        .help("Recording to analyze: a .parquet file or a .rez archive")
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),

--- a/src/parquet_tools/mod.rs
+++ b/src/parquet_tools/mod.rs
@@ -49,9 +49,9 @@ pub fn command() -> Command {
                      override with --queries <file.json>. --undo strips a prior annotation.\n\n\
                      A .rez archive is also accepted: --queries embeds a ServiceExtension (KPIs)\n\
                      into each recording's manifest metadata. Since a .rez is source=rezolus with\n\
-                     no built-in template, --queries is required for a .rez. Only v2 (tar) .rez\n\
-                     archives can be annotated in place today; a v3 (SQLite) archive errors\n\
-                     clearly rather than being silently mishandled.\n\n\
+                     no built-in template, --queries is required for a .rez. Either container\n\
+                     works, and what is left behind is always v3 (SQLite): annotating is a\n\
+                     rewrite, so a v1/v2 tar archive is upgraded on the way through and says so.\n\n\
                      EXAMPLES:\n    \
                      # Attach KPIs from the built-in template for this file's source\n    \
                      rezolus recording annotate rezolus.parquet\n\n    \
@@ -178,13 +178,13 @@ pub fn command() -> Command {
                      output should end in `.parquet.ab.tar`, and you map each side with\n\
                      `baseline=<src> experiment=<src>` where <src> is a file's embedded SOURCE\n\
                      NAME (not its filename) — set with `annotate --source`, seen with\n\
-                     `parquet metadata --field source`. In the example below a.parquet's source\n\
+                     `recording metadata --field source`. In the example below a.parquet's source\n\
                      is `redis` and b.parquet's is `valkey`.\n\n\
                      .rez inputs: given single-recording `.rez` archives and a `.rez` output,\n\
                      combine assembles them into one multi-recording `.rez` (for multi-host or\n\
-                     A/B), preserving each recording's labels. Only v2 (tar) .rez archives can be\n\
-                     combined today; a v3 (SQLite) input, or a mix of v2 and v3 inputs, errors\n\
-                     clearly instead of silently mis-assembling.\n\n\
+                     A/B), preserving each recording's labels. Either container works, and\n\
+                     they mix freely: each v1/v2 tar input is upgraded to v3 on the way in, so\n\
+                     the assembled output is always v3 (SQLite).\n\n\
                      EXAMPLES:\n    \
                      # Row-merge a rezolus agent file with a service file\n    \
                      rezolus recording combine rezolus.parquet service.parquet -o combined.parquet\n\n    \
@@ -442,9 +442,14 @@ pub fn command() -> Command {
             Command::new("filter")
                 .about("Shrink a recording to what its KPIs need: parquet columns, or .rez samplers")
                 .long_about(
-                    "Shrink a parquet recording by dropping every metric column not referenced by\n\
-                     its service-extension KPIs. The KPI set is taken from the file's embedded\n\
-                     annotation (or a matching built-in template); override with --queries.\n\n\
+                    "Shrink a recording by dropping what its service-extension KPIs do not need.\n\n\
+                     For a parquet file that means metric COLUMNS: the KPI set comes from the\n\
+                     file's embedded annotation (or a matching built-in template), and --queries\n\
+                     overrides it.\n\n\
+                     For a .rez archive it means whole SAMPLERS instead, listed with --samplers\n\
+                     (which is required there, and ignored for parquet) — a .rez is all-rezolus\n\
+                     data, so there is no KPI column set to filter against. Either container\n\
+                     works and the output is always v3 (SQLite).\n\n\
                      By default the input is rewritten in place; pass -o/--output to write a new\n\
                      file and leave the original untouched.\n\n\
                      EXAMPLES:\n    \
@@ -453,11 +458,13 @@ pub fn command() -> Command {
                      # Write a slimmed copy, keeping the original\n    \
                      rezolus recording filter rezolus.parquet -o slim.parquet\n\n    \
                      # Filter to the columns a custom KPI set needs\n    \
-                     rezolus recording filter rezolus.parquet --queries ext.json -o slim.parquet",
+                     rezolus recording filter rezolus.parquet --queries ext.json -o slim.parquet\n\n    \
+                     # Keep only two samplers of a .rez, writing a slimmed copy\n    \
+                     rezolus recording filter out.rez --samplers cpu_usage,scheduler -o slim.rez",
                 )
                 .arg(
                     clap::Arg::new("FILE")
-                        .help("Parquet file to filter")
+                        .help("Recording to filter: a .parquet file, or a .rez archive (which needs --samplers)")
                         .value_parser(value_parser!(PathBuf))
                         .required(true)
                         .index(1),
@@ -491,7 +498,7 @@ pub fn command() -> Command {
                     clap::Arg::new("samplers")
                         .long("samplers")
                         .value_name("A,B,...")
-                        .help("For .rez archives: comma-separated sampler names to KEEP; all other per-sampler tables are dropped (required for .rez, ignored for parquet). Only v2 (tar) .rez archives can be filtered today; a v3 (SQLite) archive errors clearly.")
+                        .help("For .rez archives: comma-separated sampler names to KEEP; every other sampler's tables are dropped (required for .rez, ignored for parquet). Filtering is by sampler, so a sampler's group tables go together. Either container works; the output is always v3 (SQLite)")
                         .value_parser(value_parser!(String))
                         .action(clap::ArgAction::Set),
                 ),
@@ -509,7 +516,14 @@ pub fn command() -> Command {
                      clean one.\n\n\
                      `combine`, `filter` and `annotate` already upgrade a tar input on the\n\
                      way through. This is for upgrading an archive on its own, without\n\
-                     otherwise changing it.",
+                     otherwise changing it. A v3 input is refused rather than copied:\n\
+                     \"upgrade\" on something already current is far more likely a mistaken\n\
+                     path than a request for a duplicate.\n\n\
+                     EXAMPLES:\n    \
+                     # Upgrade in place\n    \
+                     rezolus recording upgrade old.rez\n\n    \
+                     # ...or leave the original alone\n    \
+                     rezolus recording upgrade old.rez -o new.rez",
                 )
                 .arg(
                     clap::Arg::new("FILE")

--- a/src/status_cli/mod.rs
+++ b/src/status_cli/mod.rs
@@ -106,6 +106,27 @@ pub fn render_samplers(samplers: &[SamplerStatus]) -> (String, bool) {
 pub fn command() -> Command {
     Command::new("status")
         .about("Fetch and display agent status (version, uptime, sampler health)")
+        .long_about(
+            "Ask a running agent how it is doing. Prints one header line — version, uptime\n\
+             and the snapshot TTL — then a tally of samplers by state, and one line for each\n\
+             sampler that is NOT healthy, with the reason.\n\n\
+             States: healthy, degraded (running, but a probe or some CPUs are missing),\n\
+             failed (not running), unsupported (this kernel or machine cannot run it),\n\
+             pmu-limited (running on fewer CPUs than asked, because PMU counters are\n\
+             scarce) and pmu-starved (no counters left for it at all). Disabled samplers\n\
+             are not counted.\n\n\
+             EXIT STATUS: 0 when nothing is wrong, 1 when any sampler is degraded, failed\n\
+             or pmu-limited — so this works as a health check in a script or a readiness\n\
+             probe. A pmu-starved or disabled sampler on its own does not fail the check.\n\
+             A network or parse error also exits non-zero, with the reason on stderr.\n\n\
+             EXAMPLES:\n    \
+             # Is the local agent healthy?\n    \
+             rezolus status http://localhost:4241\n\n    \
+             # Use it as a gate in a script\n    \
+             rezolus status http://localhost:4241 || echo \"agent is unhealthy\"\n\n    \
+             # The raw payload, for a machine to read\n    \
+             rezolus status http://localhost:4241 --json",
+        )
         .arg(
             Arg::new("ENDPOINT")
                 .help("Agent base URL, e.g. http://localhost:4241")

--- a/tests/help_text.rs
+++ b/tests/help_text.rs
@@ -1,0 +1,248 @@
+//! Help text is an interface, so hold it to an interface's standard.
+//!
+//! Rezolus is increasingly driven by agents that read `--help` and act on it.
+//! For them a stale help string is not cosmetic: it is a wrong tool call, or a
+//! refusal to attempt something that works. This repo has now shipped that bug
+//! three separate times — `record --rez-version` (removed, still advertised),
+//! `record --node`/`--instance` (advertised, never implemented), and three
+//! `recording` subcommands claiming v3 `.rez` "errors clearly" long after v3
+//! worked.
+//!
+//! The two checks here are the mechanical half of that problem — the half a
+//! machine can settle. Both would have caught the flag cases above the day they
+//! landed:
+//!
+//! 1. every flag a help text *mentions* is a flag that command actually defines
+//! 2. every example invocation *in* a help text uses only real flags
+//!
+//! What they cannot check is whether a true-looking sentence is true — that
+//! `.rez` output refuses an existing path, that a wrapped command's exit status
+//! passes through. Those need someone to read the code, and the
+//! `document-feature` skill exists for that. These tests just make sure the
+//! cheap, decidable failures never reach a user.
+
+use std::collections::BTreeSet;
+use std::process::Command;
+
+/// Every subcommand path in the tree, discovered rather than hardcoded so a
+/// new one is covered the day it is added.
+fn command_paths() -> Vec<Vec<String>> {
+    let mut paths = vec![vec![]];
+    for top in subcommands_of(&[]) {
+        let path = vec![top];
+        for sub in subcommands_of(&path) {
+            let mut p = path.clone();
+            p.push(sub);
+            paths.push(p);
+        }
+        paths.push(path);
+    }
+    paths
+}
+
+fn bin() -> String {
+    env!("CARGO_BIN_EXE_rezolus").to_string()
+}
+
+fn help_for(path: &[String]) -> String {
+    let out = Command::new(bin())
+        .args(path)
+        .arg("--help")
+        .output()
+        .unwrap_or_else(|e| panic!("running `rezolus {} --help`: {e}", path.join(" ")));
+    // clap prints long help to stdout; a parse failure would land on stderr.
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// The `Commands:` block lists subcommands one per line, name first.
+fn subcommands_of(path: &[String]) -> Vec<String> {
+    let help = help_for(path);
+    let Some(rest) = help.split_once("\nCommands:\n") else {
+        return Vec::new();
+    };
+    rest.1
+        .lines()
+        .take_while(|l| !l.trim().is_empty())
+        .filter_map(|l| l.split_whitespace().next())
+        .filter(|n| *n != "help")
+        .map(|n| n.to_string())
+        .collect()
+}
+
+/// Flags clap registered, read back off its own `Options:`/`Arguments:` layout:
+/// a definition starts a line, indented, as `--flag` or `-f, --flag`.
+fn defined_flags(help: &str) -> BTreeSet<String> {
+    let mut flags = BTreeSet::new();
+    for line in help.lines() {
+        let indent = line.len() - line.trim_start().len();
+        if !(2..=6).contains(&indent) {
+            continue;
+        }
+        let t = line.trim_start();
+        // `-f, --flag`
+        if let Some(rest) = t
+            .strip_prefix('-')
+            .filter(|r| r.len() > 2 && r.as_bytes()[1] == b',')
+        {
+            flags.insert(format!("-{}", &rest[..1]));
+            if let Some(long) = rest[2..].split_whitespace().next() {
+                // clap suffixes a repeatable flag with `...`
+                flags.insert(long.trim_end_matches('.').to_string());
+            }
+            continue;
+        }
+        if t.starts_with("--") {
+            if let Some(long) = t.split_whitespace().next() {
+                flags.insert(long.trim_end_matches([',', '.']).to_string());
+            }
+        }
+    }
+    // Present on every clap command whether or not it lists them here.
+    for universal in ["-h", "--help", "-V", "--version"] {
+        flags.insert(universal.to_string());
+    }
+    flags
+}
+
+/// Long flags a help text refers to in prose or examples.
+fn mentioned_flags(help: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let bytes = help.as_bytes();
+    let mut i = 0;
+    while i + 2 < bytes.len() {
+        if bytes[i] == b'-' && bytes[i + 1] == b'-' && bytes[i + 2].is_ascii_alphanumeric() {
+            // not mid-word (e.g. `foo--bar`) and not the bare `--` separator
+            let prev_ok = i == 0 || !(bytes[i - 1] as char).is_ascii_alphanumeric();
+            if prev_ok {
+                let start = i;
+                i += 2;
+                while i < bytes.len()
+                    && ((bytes[i] as char).is_ascii_alphanumeric() || bytes[i] == b'-')
+                {
+                    i += 1;
+                }
+                let flag = help[start..i].trim_end_matches('-');
+                if flag.len() > 2 {
+                    out.insert(flag.to_string());
+                }
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Flags a help text may name without defining them.
+///
+/// Two legitimate reasons exist, and both are load-bearing rather than
+/// loopholes: a page points at a *sibling* command's flag ("set with
+/// `annotate --source`"), or it names a flag precisely to say it does NOT
+/// exist ("there is no --force"). Anything else is the bug this test is for.
+fn is_cross_reference(help: &str, flag: &str, own: &BTreeSet<String>) -> bool {
+    if own.contains(flag) {
+        return true;
+    }
+    // A family named collectively: `--proxy-*` covers --proxy-allow and
+    // --proxy-allow-any. The trailing `-` survives the wildcard being stripped.
+    if help.contains(&format!("{flag}-*")) && own.iter().any(|f| f.starts_with(flag)) {
+        return true;
+    }
+    // Flags belonging to some other command in the tree, or to a user's own
+    // wrapped command (`-- ./bench.sh --iters 100`).
+    for line in help.lines() {
+        if !line.contains(flag) {
+            continue;
+        }
+        let l = line.trim();
+        let names_another_command = l.contains("rezolus ") || l.contains('`');
+        let denies_it = l.contains("no ") || l.contains("removed") || l.contains("were never");
+        if !(names_another_command || denies_it) {
+            return false;
+        }
+    }
+    true
+}
+
+#[test]
+fn every_flag_a_help_text_mentions_is_a_flag_that_command_defines() {
+    let mut problems = Vec::new();
+    for path in command_paths() {
+        let help = help_for(&path);
+        let defined = defined_flags(&help);
+        for flag in mentioned_flags(&help) {
+            if !is_cross_reference(&help, &flag, &defined) {
+                problems.push(format!(
+                    "`rezolus {} --help` refers to {flag}, which it does not define",
+                    path.join(" ")
+                ));
+            }
+        }
+    }
+    assert!(problems.is_empty(), "\n{}", problems.join("\n"));
+}
+
+#[test]
+fn every_example_invocation_uses_only_flags_its_command_defines() {
+    let tops: BTreeSet<String> = subcommands_of(&[]).into_iter().collect();
+    let mut problems = Vec::new();
+    let mut examples = 0usize;
+
+    for path in command_paths() {
+        let help = help_for(&path);
+        for line in help.lines() {
+            let line = line.trim();
+            let Some(rest) = line.strip_prefix("rezolus ") else {
+                continue;
+            };
+            // Stop at a shell operator: what follows is a different command.
+            let rest = rest
+                .split(" && ")
+                .next()
+                .unwrap()
+                .split(" | ")
+                .next()
+                .unwrap()
+                .split(" > ")
+                .next()
+                .unwrap();
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if toks.is_empty() || !tops.contains(toks[0]) {
+                continue; // `rezolus config/agent.toml`, the agent form
+            }
+            let mut cmd = vec![toks[0].to_string()];
+            let mut i = 1;
+            if let Some(second) = toks.get(1) {
+                if !second.starts_with('-') && subcommands_of(&cmd).iter().any(|s| s == second) {
+                    cmd.push(second.to_string());
+                    i = 2;
+                }
+            }
+            examples += 1;
+            let defined = defined_flags(&help_for(&cmd));
+            for tok in &toks[i..] {
+                if *tok == "--" {
+                    break; // everything after is the user's wrapped command
+                }
+                if !tok.starts_with('-') || *tok == "-" {
+                    continue;
+                }
+                let name = tok.split('=').next().unwrap();
+                if !defined.contains(name) {
+                    problems.push(format!(
+                        "example in `rezolus {} --help` passes {name} to `rezolus {}`, \
+                         which does not define it\n    {line}",
+                        path.join(" "),
+                        cmd.join(" ")
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        examples > 20,
+        "only found {examples} examples — parser broke"
+    );
+    assert!(problems.is_empty(), "\n{}", problems.join("\n"));
+}


### PR DESCRIPTION
## Summary

Audited all 20 help pages, checking every falsifiable claim against code or a live run. Six were wrong.

**The serious one — three commands say a working feature is broken.** `filter`, `combine` and `annotate` each carry the sentence *"Only v2 (tar) .rez archives can be … today; a v3 (SQLite) archive errors clearly."* All three handle v3 and have since the v3 rollout:

```
filter   → Filtered "slim.rez": kept 1 of 13 sampler tables         exit 0
combine  → wrote both.rez with 2 recording(s) from 2 input(s)       exit 0
annotate → Annotated "ann2.rez": embedded 13 KPIs into 1 recording  exit 0
```

This is the worst variety of stale help: an agent reading it won't attempt an operation that works.

**`mcp query` says series-op-series has no uncertainty band.** It does — `sum(irate(cpu_usage[1m])) / sum(irate(cpu_usage[1m]))` prints `[0.999564, 1.000436]`. `docs/journal/2026-08-21-cross-table-uncertainty.md` records correcting this exact sentence in CLAUDE.md; the help was missed.

**`exporter` states the wrong default.** `[general] source` defaults to `0.0.0.0:4241` in code (`src/exporter/config/mod.rs:34`); `127.0.0.1:4241` is what the shipped config sets. Both now stated, separately.

**Three incompleteness fixes.** `mcp` called itself parquet-only across its summary and five FILE args despite dispatching `.rez` by content; `recording filter` mentioned `.rez` only in a flag description; two `parquet` alias references survived #1097's sweep (which keyed on the literal `rezolus parquet ` and missed both).

**Plus `status`, which had no `long_about` at all** — including the fact that it exits 1 when any sampler is degraded/failed/pmu-limited, making it usable as a health gate. That was documented nowhere. Four other pages were missing EXAMPLES blocks.

## The guard

`tests/help_text.rs` adds the mechanical half of the problem — the half a machine can settle:

1. every flag a help text *mentions* is one that command defines
2. every example invocation uses only real flags

Both discover the command tree rather than hardcoding it, so a new subcommand is covered the day it's added. This repo has now shipped this bug class three times (`--rez-version`, `--node`/`--instance`, the v3 trio); these checks catch the first two categories outright.

They cannot check whether a true-looking *sentence* is true — that still needs a reader, which is what the `document-feature` skill is for. The test says so, so nobody mistakes it for full coverage.

## Test plan

- [x] `cargo test` — 696 + 2 + 7 + 4 passing, 0 failures
- [x] `cargo clippy --all-targets` — 2 warnings, unchanged from `main` baseline
- [x] `cargo fmt --check` clean
- [x] **Mutation-tested both guards** rather than trusting that they pass: re-injecting `Pass --rez-version 2` into `record`'s help fails check 1 (`refers to --rez-version, which it does not define`), and a typo'd `--feild` in a `recording metadata` example fails check 2. Both pass again on the restored tree — a guard that cannot fail is worthless.
- [x] Every claim rewritten here was verified by running it: v3 filter/combine/annotate against a real v3 archive, the series-op-series band against a live recording, the exporter default read out of `config/mod.rs`, `mcp describe-recording out.rez` for `.rez` dispatch
- [x] Re-rendered all 20 pages after the fix and confirmed each finding is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)