### PR TITLE
feat(status): default to the local agent; fix agent's absent-[general] default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,11 @@ target/release/rezolus recording upgrade old.rez -o new.rez            # ...or t
 # annotate file.rez --queries kpis.json embeds KPIs into each recording's manifest (--queries required for .rez).
 
 # MCP - AI analysis server or CLI commands
+# Status - agent health check (exits 1 if any sampler is degraded/failed/pmu-limited)
+target/release/rezolus status                       # defaults to http://localhost:4241
+target/release/rezolus status web-01                # bare host/host:port is normalized
+target/release/rezolus status --json
+
 target/release/rezolus mcp                                                    # stdio server
 target/release/rezolus mcp describe-recording file.parquet                    # describe recording
 target/release/rezolus mcp describe-metrics file.parquet                      # list all metrics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.17.1-alpha.19"
+version = "5.17.1-alpha.20"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.17.1-alpha.19"
+version = "5.17.1-alpha.20"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/src/agent/config/general.rs
+++ b/src/agent/config/general.rs
@@ -32,7 +32,7 @@ pub enum SnapshotFormat {
     V3,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize)]
 pub struct General {
     #[serde(default = "listen")]
     listen: String,
@@ -63,6 +63,30 @@ pub struct General {
     // CPUs the reservation applies to (see `reserved_pmu_cpus`)
     #[serde(default)]
     reserved_pmu_cpus: Option<String>,
+}
+
+/// Written out rather than derived, because a derived `Default` would ignore
+/// every `#[serde(default = "...")]` above it and hand back empty strings.
+///
+/// That is not academic: serde reaches this impl for a config file that omits
+/// the `[general]` table entirely (the field-level defaults only apply once
+/// the table exists), so `rezolus a-config-without-general.toml` died with
+/// "ttl couldn't be parsed: value was empty" instead of using the documented
+/// defaults. The exporter and hindsight configs already spell theirs out; this
+/// is the same fix, and it keeps the two ways of reaching a default agreeing —
+/// the property `SnapshotFormat`'s `#[default]` was added to preserve.
+impl Default for General {
+    fn default() -> Self {
+        Self {
+            listen: listen(),
+            ttl: ttl(),
+            btf_path: None,
+            snapshot_format: default_snapshot_format(),
+            reserved_pmu_counters: 0,
+            pmu_priority: Vec::new(),
+            reserved_pmu_cpus: None,
+        }
+    }
 }
 
 impl General {
@@ -164,6 +188,44 @@ mod tests {
 
     fn general(toml: &str) -> General {
         toml::from_str(toml).expect("valid config")
+    }
+
+    /// `Default::default()` and "the config file said nothing" must agree.
+    ///
+    /// serde reaches the derived/hand-written `Default` when the whole
+    /// `[general]` table is missing, and the per-field `#[serde(default = …)]`
+    /// functions only when the table exists. While `Default` was derived those
+    /// two paths disagreed: a config without a `[general]` table produced empty
+    /// strings and the agent exited with "ttl couldn't be parsed: value was
+    /// empty" instead of listening on 0.0.0.0:4241.
+    #[test]
+    fn a_config_without_a_general_table_gets_the_documented_defaults() {
+        let absent = General::default();
+        let empty_table = general("");
+
+        assert_eq!(absent.listen, listen(), "listen");
+        assert_eq!(absent.ttl, ttl(), "ttl");
+        assert_eq!(absent.listen, empty_table.listen);
+        assert_eq!(absent.ttl, empty_table.ttl);
+        assert_eq!(absent.snapshot_format(), empty_table.snapshot_format());
+
+        // and they are usable, not merely equal: these parse.
+        assert!(!absent.listen.is_empty());
+        assert!(absent.ttl.parse::<humantime::Duration>().is_ok());
+    }
+
+    /// The same property one level up: a whole config file with no `[general]`
+    /// table at all is what an operator actually writes.
+    #[test]
+    fn a_whole_config_file_may_omit_general() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            #[serde(default)]
+            general: General,
+        }
+        let w: Wrapper = toml::from_str("[log]\nlevel = \"info\"\n").expect("parses");
+        assert_eq!(w.general.listen, listen());
+        assert_eq!(w.general.ttl, ttl());
     }
 
     #[test]

--- a/src/status_cli/mod.rs
+++ b/src/status_cli/mod.rs
@@ -7,6 +7,37 @@ use crate::agent::sampler_status::{
 use clap::{value_parser, Arg, ArgAction, Command};
 use std::time::Duration;
 
+/// The agent on this machine — the same endpoint `rezolus record --url`
+/// defaults to, so the two agree about what "no endpoint given" means.
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:4241";
+
+/// The agent's default port, supplied when an endpoint names only a host.
+const DEFAULT_PORT: u16 = 4241;
+
+/// Accept the short forms people actually type.
+///
+/// `reqwest` needs an absolute URL, so a bare `web-01` or `web-01:4241` used to
+/// fail with "builder error for url" — which names neither the problem nor the
+/// fix. Anything without a scheme gets `http://`, and a host with no port gets
+/// the agent's. An endpoint that already carries a scheme is left exactly as
+/// given: a caller who wrote `https://` or a path prefix means it.
+pub fn normalize_endpoint(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.contains("://") {
+        return trimmed.to_string();
+    }
+    // A port is a colon followed by digits only — this must not mistake the
+    // colon in a bare IPv6 literal for one.
+    let has_port = trimmed
+        .rsplit_once(':')
+        .is_some_and(|(_, port)| !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()));
+    if has_port {
+        format!("http://{trimmed}")
+    } else {
+        format!("http://{trimmed}:{DEFAULT_PORT}")
+    }
+}
+
 /// Render the one-line agent header: version, humanized uptime, humanized ttl.
 pub fn render_header(status: &AgentStatus) -> String {
     format!(
@@ -107,7 +138,10 @@ pub fn command() -> Command {
     Command::new("status")
         .about("Fetch and display agent status (version, uptime, sampler health)")
         .long_about(
-            "Ask a running agent how it is doing. Prints one header line — version, uptime\n\
+            "Ask a running agent how it is doing. With no argument it asks the agent on\n\
+             this machine (http://localhost:4241), the same endpoint `rezolus record`\n\
+             defaults to.\n\n\
+             Prints one header line — version, uptime\n\
              and the snapshot TTL — then a tally of samplers by state, and one line for each\n\
              sampler that is NOT healthy, with the reason.\n\n\
              States: healthy, degraded (running, but a probe or some CPUs are missing),\n\
@@ -120,17 +154,19 @@ pub fn command() -> Command {
              probe. A pmu-starved or disabled sampler on its own does not fail the check.\n\
              A network or parse error also exits non-zero, with the reason on stderr.\n\n\
              EXAMPLES:\n    \
-             # Is the local agent healthy?\n    \
-             rezolus status http://localhost:4241\n\n    \
+             # Is the agent on this machine healthy?\n    \
+             rezolus status\n\n    \
+             # Another host, written the short way\n    \
+             rezolus status web-01\n\n    \
              # Use it as a gate in a script\n    \
-             rezolus status http://localhost:4241 || echo \"agent is unhealthy\"\n\n    \
+             rezolus status || echo \"agent is unhealthy\"\n\n    \
              # The raw payload, for a machine to read\n    \
-             rezolus status http://localhost:4241 --json",
+             rezolus status --json",
         )
         .arg(
             Arg::new("ENDPOINT")
-                .help("Agent base URL, e.g. http://localhost:4241")
-                .required(true)
+                .help("Agent to ask (default http://localhost:4241). A bare host or host:port is fine — the scheme and the default port are filled in, so `rezolus status web-01` works")
+                .required(false)
                 .index(1)
                 .value_parser(value_parser!(String)),
         )
@@ -143,7 +179,10 @@ pub fn command() -> Command {
 }
 
 pub fn run(args: &clap::ArgMatches) {
-    let endpoint = args.get_one::<String>("ENDPOINT").unwrap();
+    let endpoint = args
+        .get_one::<String>("ENDPOINT")
+        .map(|e| normalize_endpoint(e))
+        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
     let json = args.get_flag("json");
     let url = format!("{}/status", endpoint.trim_end_matches('/'));
 
@@ -194,6 +233,44 @@ mod tests {
             expected: true,
             verdict,
         }
+    }
+
+    /// The short forms people type, and the one case that must NOT be
+    /// treated as a port: a bare IPv6 literal is all colons.
+    #[test]
+    fn normalize_endpoint_fills_in_scheme_and_port() {
+        // host only
+        assert_eq!(normalize_endpoint("localhost"), "http://localhost:4241");
+        assert_eq!(normalize_endpoint("web-01"), "http://web-01:4241");
+        assert_eq!(normalize_endpoint("127.0.0.1"), "http://127.0.0.1:4241");
+        // host:port
+        assert_eq!(
+            normalize_endpoint("localhost:9999"),
+            "http://localhost:9999"
+        );
+        // already absolute — left alone, scheme and path included
+        for already in [
+            "http://localhost:4241",
+            "https://agent.internal:4241",
+            "http://host:4241/prefix",
+        ] {
+            assert_eq!(normalize_endpoint(already), already);
+        }
+        // trailing slash and surrounding space are noise
+        assert_eq!(
+            normalize_endpoint("  localhost:4241/  "),
+            "http://localhost:4241"
+        );
+        // an IPv6 literal's colons are not a port
+        assert_eq!(normalize_endpoint("[::1]"), "http://[::1]:4241");
+        assert_eq!(normalize_endpoint("[::1]:4241"), "http://[::1]:4241");
+    }
+
+    /// The no-argument default and `record`'s must not drift apart: "the agent
+    /// on this machine" has to mean one thing across the binary.
+    #[test]
+    fn default_endpoint_matches_the_recorders() {
+        assert_eq!(DEFAULT_ENDPOINT, "http://localhost:4241");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Audited what every subcommand *requires*, looking for arguments that could carry a sensible default instead.

**`rezolus status` was the only endpoint-taking command that made you type one.** `rezolus record` has always defaulted to `http://localhost:4241`; `status` now does too, so checking the local agent is just `rezolus status`. It also takes the short forms people type:

```
rezolus status                  → local agent
rezolus status web-01           → http://web-01:4241
rezolus status localhost:9999   → http://localhost:9999
rezolus status https://a:4241   → untouched (a scheme means you meant it)
```

`rezolus status web-01` previously failed with `builder error for url`, which names neither the problem nor the fix. A bare IPv6 literal's colons are not mistaken for a port.

**Config-file arguments stay required.** There's no safe default — whether the file is at `/etc/rezolus/agent.toml` or `config/agent.toml` is a property of the deployment, not something to guess.

**But probing that question found a real defaults bug.** The agent's `General` *derived* its `Default`, and a derived `Default` ignores every `#[serde(default = "...")]` on the struct — it returns empty strings. serde reaches that impl when a config omits the `[general]` table entirely (field-level defaults apply only once the table exists), so such a file died with:

```
ttl couldn't be parsed: value was empty
```

instead of listening on `0.0.0.0:4241`. The exporter and hindsight configs already hand-write their `Default`; the agent now does too. This is precisely the hazard the `#[default]` on `SnapshotFormat` was added to head off — it just wasn't applied to `listen` and `ttl`.

## Audit result, for the record

| Requires | Verdict |
| --- | --- |
| `status <ENDPOINT>` | **Fixed** — now defaults + normalizes |
| `<CONFIG>` (agent, exporter, hindsight) | Left required by design; no safe default |
| `<FILE>` (6 `mcp`, 6 `recording` subcommands) | Left required; a recording path can't be guessed |
| `record`, `view`, `mcp` | Already default correctly |

The only `Url`-typed args in the tree are `record`'s two, both already defaulted.

## Test plan

- [x] `cargo test` — 700 + 2 + 7 + 4 passing, 0 failures
- [x] `cargo clippy --all-targets` — 2 warnings, unchanged from `main` baseline
- [x] `cargo fmt --check` clean
- [x] **Mutation-tested the agent fix:** re-deriving `Default` fails the new test with `left: "" / right: "0.0.0.0:4241"`. Restored, passes.
- [x] Verified live against a running agent: `rezolus status` with no args, plus `localhost`, `localhost:4241`, `http://localhost:4241`, `127.0.0.1` — all four return the header and exit 0
- [x] Verified a config file with no `[general]` table now starts the agent and serves on 4241 (it previously exited)
- [x] `normalize_endpoint` unit tests cover host-only, host:port, already-absolute, trailing slash/whitespace, and IPv6 literals

## Note

Unrelated and not fixed here: `status` renders TTL in whole seconds, so the default 10ms TTL always displays as `ttl 0s`. The precision is lost server-side in the `/status` payload (`ttl_seconds`), so fixing it means changing that field — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)