### PR TITLE
fix(agent): report a capability the machine lacks as unsupported, not failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.18.1-alpha.0"
+version = "5.18.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.18.1-alpha.0"
+version = "5.18.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -63,7 +63,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.17.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -147,9 +147,7 @@ pub fn run(config: PathBuf) {
             // "this machine cannot" is not "this broke". A sampler says so by
             // returning `Unsupported`; everything else is still a failure.
             Err(e) => match e.downcast_ref::<crate::agent::sampler_status::Unsupported>() {
-                Some(u) => {
-                    crate::agent::sampler_status::set_unsupported(entry.name, u.0.clone())
-                }
+                Some(u) => crate::agent::sampler_status::set_unsupported(entry.name, u.0.clone()),
                 None => crate::agent::sampler_status::set_failed(entry.name, e.to_string()),
             },
         }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -144,7 +144,14 @@ pub fn run(config: PathBuf) {
                 samplers.push(s);
             }
             Ok(None) => crate::agent::sampler_status::set_disabled(entry.name),
-            Err(e) => crate::agent::sampler_status::set_failed(entry.name, e.to_string()),
+            // "this machine cannot" is not "this broke". A sampler says so by
+            // returning `Unsupported`; everything else is still a failure.
+            Err(e) => match e.downcast_ref::<crate::agent::sampler_status::Unsupported>() {
+                Some(u) => {
+                    crate::agent::sampler_status::set_unsupported(entry.name, u.0.clone())
+                }
+                None => crate::agent::sampler_status::set_failed(entry.name, e.to_string()),
+            },
         }
     }
 
@@ -291,6 +298,10 @@ fn log_sampler_health_summary() {
                     })
                     .collect();
                 info!("sampler {}: unsupported — {}", s.name, probes.join(", "));
+            }
+            (SamplerState::Unsupported { reason }, _) => {
+                unsupported += 1;
+                info!("sampler {}: unsupported — {reason}", s.name);
             }
             (_, Some(SamplerHealth::Healthy)) => healthy += 1,
             (SamplerState::Disabled, None) => {}

--- a/src/agent/sampler_status.rs
+++ b/src/agent/sampler_status.rs
@@ -62,7 +62,39 @@ pub enum SamplerState {
         wants: usize,
         free: usize,
     },
+    /// Not started because this machine or kernel cannot support it — no L3
+    /// cache domains, no GPU of that vendor, an architecture the probe does not
+    /// cover.
+    ///
+    /// Deliberately not `Failed`, for the reason `PmuStarved` is not: nothing
+    /// broke. A missing capability reported as a fault sends an operator
+    /// looking for a problem that does not exist, and — because `rezolus
+    /// status` exits non-zero on a failed sampler — fails a readiness probe on
+    /// a machine that is working exactly as it can. Deliberately not `Disabled`
+    /// either: nobody turned it off, and an operator reading `disabled` would
+    /// reasonably go looking for the config that did.
+    Unsupported {
+        reason: String,
+    },
 }
+
+/// Returned from a sampler's `init` to say "this machine cannot do this",
+/// rather than "this broke".
+///
+/// Init returns `anyhow::Result`, and every error out of it used to become
+/// `Failed`. This is the marker that lets the one meaningful distinction
+/// survive that funnel: `run()` downcasts to it and records `Unsupported`
+/// instead.
+#[derive(Debug)]
+pub struct Unsupported(pub String);
+
+impl std::fmt::Display for Unsupported {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for Unsupported {}
 
 /// Status of a single BPF program within a sampler.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -126,6 +158,22 @@ pub fn set_pmu_starved(name: &'static str, wants: usize, free: usize) {
         SamplerStatus {
             name: name.to_string(),
             state: SamplerState::PmuStarved { wants, free },
+            health: Some(SamplerHealth::Unsupported),
+            programs: Vec::new(),
+        },
+    );
+}
+
+/// Record a sampler as unsupported on this machine, with the reason.
+///
+/// Health is `Unsupported` — informational, "this capability is unavailable
+/// here" — so it does not count against the health rollup or the exit status.
+pub fn set_unsupported(name: &'static str, reason: String) {
+    registry().lock().unwrap().insert(
+        name,
+        SamplerStatus {
+            name: name.to_string(),
+            state: SamplerState::Unsupported { reason },
             health: Some(SamplerHealth::Unsupported),
             programs: Vec::new(),
         },

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -66,7 +66,7 @@ struct CpuL3Inner {
 }
 
 impl CpuL3Inner {
-    pub fn new() -> Result<Self, std::io::Error> {
+    pub fn new() -> anyhow::Result<Self> {
         let (perf_threads, perf_sync) = spawn_threads()?;
 
         // Boot-fixed population bound, same rationale as `CpuCounters::new`
@@ -265,15 +265,18 @@ fn l3_domains() -> Result<Vec<Vec<usize>>, std::io::Error> {
     Ok(l3_domains)
 }
 
-fn get_l3_caches() -> Result<Vec<L3Cache>, std::io::Error> {
+fn get_l3_caches() -> anyhow::Result<Vec<L3Cache>> {
     let mut l3_domains = l3_domains()?;
 
     if l3_domains.is_empty() {
+        // Not an error: plenty of CPUs have no L3 at all, and reporting that as
+        // a failure makes a healthy machine look broken (and, via `rezolus
+        // status`, fail a readiness probe).
         debug!("no L3 cache domains found");
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "no L3 cache domains found",
-        ));
+        return Err(crate::agent::sampler_status::Unsupported(
+            "no L3 cache domains found".to_string(),
+        )
+        .into());
     }
 
     let mut l3_caches = Vec::new();
@@ -286,10 +289,7 @@ fn get_l3_caches() -> Result<Vec<L3Cache>, std::io::Error> {
 
     if l3_caches.is_empty() {
         debug!("failed to create perf counters for any L3 cache domain");
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "failed to create L3 cache perf counters",
-        ));
+        return Err(anyhow::anyhow!("failed to create L3 cache perf counters"));
     }
 
     Ok(l3_caches)
@@ -404,7 +404,7 @@ fn get_events() -> Option<(LowLevelEvent, LowLevelEvent)> {
     }
 }
 
-fn spawn_threads() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
+fn spawn_threads() -> anyhow::Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>)> {
     // on virtualized environments, it is typically better to use multiple
     // threads to read the perf counters to get more consistent snapshot latency
     if is_virt() {
@@ -414,7 +414,7 @@ fn spawn_threads() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io:
     }
 }
 
-fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
+fn spawn_threads_single() -> anyhow::Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>)> {
     debug!("using single-threaded perf counter collection");
 
     let mut caches = get_l3_caches()?;
@@ -440,7 +440,7 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     Ok((perf_threads, perf_sync))
 }
 
-fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), std::io::Error> {
+fn spawn_threads_multi() -> anyhow::Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>)> {
     debug!("using multi-threaded perf counter collection");
 
     let mut caches = get_l3_caches()?;

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -30,7 +30,20 @@ fn init(config: Arc<Config>) -> SamplerResult {
         return Ok(None);
     }
 
-    let inner = NvidiaInner::new()?;
+    let inner = NvidiaInner::new().map_err(|e| match e {
+        // No driver on this host: `libnvidia-ml.so.1` absent, the kernel module
+        // not loaded, or NVML's library missing. That is a machine without an
+        // NVIDIA GPU stack, not a fault — reporting it as failed makes every
+        // GPU-less host look broken and, because a failed sampler exits
+        // non-zero, fails `rezolus status` as a readiness probe. Any other NVML
+        // error is a real failure and still reported as one.
+        NvmlError::LibloadingError(_) | NvmlError::DriverNotLoaded | NvmlError::LibraryNotFound => {
+            anyhow::Error::from(crate::agent::sampler_status::Unsupported(format!(
+                "no NVIDIA driver on this host ({e})"
+            )))
+        }
+        other => anyhow::Error::from(other),
+    })?;
 
     Ok(Some(Box::new(Nvidia {
         inner: inner.into(),

--- a/src/status_cli/mod.rs
+++ b/src/status_cli/mod.rs
@@ -264,7 +264,11 @@ mod tests {
     #[test]
     fn an_unsupported_sampler_is_not_a_failure_and_does_not_set_exit_status() {
         let (text, problem) = render_samplers(&[
-            sampler("cpu_usage", SamplerState::Active, Some(SamplerHealth::Healthy)),
+            sampler(
+                "cpu_usage",
+                SamplerState::Active,
+                Some(SamplerHealth::Healthy),
+            ),
             sampler(
                 "cpu_l3",
                 SamplerState::Unsupported {
@@ -280,8 +284,14 @@ mod tests {
         );
         assert!(text.contains("unsupported"), "{text}");
         assert!(text.contains("no L3 cache domains found"), "{text}");
-        assert!(text.contains("1 unsupported"), "counted in the tally:\n{text}");
-        assert!(text.contains("0 failed"), "and not in the failed tally:\n{text}");
+        assert!(
+            text.contains("1 unsupported"),
+            "counted in the tally:\n{text}"
+        );
+        assert!(
+            text.contains("0 failed"),
+            "and not in the failed tally:\n{text}"
+        );
         // The sampler's own line, not the tally line, is what must not say
         // "failed" — the tally always carries the word.
         let line = text
@@ -301,7 +311,10 @@ mod tests {
             },
             Some(SamplerHealth::Failed),
         )]);
-        assert!(problem, "a genuine failure must still exit non-zero:\n{text}");
+        assert!(
+            problem,
+            "a genuine failure must still exit non-zero:\n{text}"
+        );
         assert!(text.contains("failed"), "{text}");
     }
 

--- a/src/status_cli/mod.rs
+++ b/src/status_cli/mod.rs
@@ -72,6 +72,17 @@ pub fn render_samplers(samplers: &[SamplerStatus]) -> (String, bool) {
                     s.name, "pmu-limited"
                 ));
             }
+            // Not a fault: the machine or kernel cannot do this. Counted as
+            // unsupported and, crucially, `problem` is left alone — a host
+            // without an L3 cache domain must not fail a readiness probe for
+            // having the hardware it has.
+            (SamplerState::Unsupported { reason }, _) => {
+                unsupported += 1;
+                lines.push_str(&format!(
+                    "  {:<22} {:<12} {reason}\n",
+                    s.name, "unsupported"
+                ));
+            }
             (SamplerState::PmuStarved { wants, free }, _) => {
                 unsupported += 1;
                 lines.push_str(&format!(

--- a/src/status_cli/mod.rs
+++ b/src/status_cli/mod.rs
@@ -246,6 +246,65 @@ mod tests {
         }
     }
 
+    fn sampler(name: &str, state: SamplerState, health: Option<SamplerHealth>) -> SamplerStatus {
+        SamplerStatus {
+            name: name.into(),
+            state,
+            health,
+            programs: Vec::new(),
+        }
+    }
+
+    /// A capability the machine does not have must not read as a fault.
+    ///
+    /// `cpu_l3` on a CPU with no L3 cache domain reported `failed`, which is
+    /// wrong twice over: it sends an operator looking for a break that does not
+    /// exist, and because a failed sampler exits non-zero it fails a readiness
+    /// probe on a machine working exactly as it can.
+    #[test]
+    fn an_unsupported_sampler_is_not_a_failure_and_does_not_set_exit_status() {
+        let (text, problem) = render_samplers(&[
+            sampler("cpu_usage", SamplerState::Active, Some(SamplerHealth::Healthy)),
+            sampler(
+                "cpu_l3",
+                SamplerState::Unsupported {
+                    reason: "no L3 cache domains found".into(),
+                },
+                Some(SamplerHealth::Unsupported),
+            ),
+        ]);
+
+        assert!(
+            !problem,
+            "an unsupported sampler must not make `rezolus status` exit non-zero:\n{text}"
+        );
+        assert!(text.contains("unsupported"), "{text}");
+        assert!(text.contains("no L3 cache domains found"), "{text}");
+        assert!(text.contains("1 unsupported"), "counted in the tally:\n{text}");
+        assert!(text.contains("0 failed"), "and not in the failed tally:\n{text}");
+        // The sampler's own line, not the tally line, is what must not say
+        // "failed" — the tally always carries the word.
+        let line = text
+            .lines()
+            .find(|l| l.contains("cpu_l3"))
+            .expect("cpu_l3 is listed");
+        assert!(!line.contains("failed"), "{line}");
+    }
+
+    /// The distinction the fix turns on: a real failure still is one.
+    #[test]
+    fn a_failed_sampler_still_sets_the_exit_status() {
+        let (text, problem) = render_samplers(&[sampler(
+            "cpu_l3",
+            SamplerState::Failed {
+                error: "failed to create L3 cache perf counters".into(),
+            },
+            Some(SamplerHealth::Failed),
+        )]);
+        assert!(problem, "a genuine failure must still exit non-zero:\n{text}");
+        assert!(text.contains("failed"), "{text}");
+    }
+
     /// The short forms people type, and the one case that must NOT be
     /// treated as a port: a bare IPv6 literal is all colons.
     #[test]


### PR DESCRIPTION
## Summary

Reported from the field — `rezolus status` on a host whose CPU has no L3 cache domain:

```
26 healthy, 0 unsupported, 0 degraded, 1 failed
  cpu_l3   failed   no L3 cache domains found
```

Nothing failed. The machine doesn't have the hardware, which is what `unsupported` exists to say. It goes wrong twice: an operator goes looking for a break that isn't there, and since `status` exits non-zero on a failed sampler, **a working host fails a readiness probe over the CPU it happens to have**.

## Cause

Every `Err` out of a sampler's `init` became `set_failed` (`src/agent/mod.rs:147`). A sampler had no way to distinguish "this machine cannot" from "this broke".

Adds `SamplerState::Unsupported { reason }` plus an `Unsupported` marker error that `init` can return; `run()` downcasts and records it. The reasoning is the one already written down for `PmuStarved` — not `Failed` because nothing broke, not `Disabled` because nobody turned it off.

Adding the variant made both classification sites non-exhaustive, so the compiler pointed at each rather than either being missed.

## A second instance of the same bug

While verifying on Linux I hit `gpu_nvidia` doing exactly this on a host with no NVIDIA driver. `#1081` fixed the phantom all-null GPU tables that this same early return caused, but never touched the status classification — confirmed by building unmodified current main:

```
Rezolus 5.18.1-alpha.0
24 healthy, 2 unsupported, 0 degraded, 1 failed
  gpu_nvidia   failed   a libloading error occurred: libnvidia-ml.so.1: cannot open shared object file
```

Only the driver-absence variants (`LibloadingError`, `DriverNotLoaded`, `LibraryNotFound`) map to unsupported; any other `NvmlError` is still a failure. Likewise `cpu_l3`'s other error — counters that can't be created when domains *do* exist — stays a failure.

## Verified on real hardware

32-core Debian 13, no NVIDIA driver, same host and config before and after:

| | before (main) | after |
| --- | --- | --- |
| tally | `1 failed` | `0 failed`, `3 unsupported` |
| gpu_nvidia | `failed  a libloading error occurred…` | `unsupported  no NVIDIA driver on this host (…)` |
| `status` exit | non-zero | **0** |

**None of this compiles on macOS** — `samplers/cpu/linux/` and the GPU samplers are cfg'd out — so a local `cargo check` passed clean over a genuine type error in my first draft. Everything here was built and run on Linux.

## Test plan

- [x] Linux: `cargo test` — 743 + 2 + 7 + 4 passing, 0 failures
- [x] Linux: agent built and run, `status` output captured before/after (table above)
- [x] macOS: `cargo test` 702 + 2 + 7 + 4, `clippy --all-targets -- -D warnings` exit 0, `fmt --check` clean
- [x] New unit tests: an unsupported sampler is counted as unsupported, renders its reason, and does **not** set the exit status; a genuinely failed sampler still does

## Not addressed here

Two things found along the way, both pre-existing and separable:

1. `gpu_amd`, `network/ethtool` and `drivehealth` return `Ok(None)` for the same hardware-absent condition, so they report as **disabled** — conflating "the operator turned this off" with "this machine can't". No false alarm and no exit-1, so lower severity, but it's why a host can show `0 unsupported` when things genuinely aren't supported.
2. `cargo clippy --all-targets -- -D warnings` **fails on Linux on main today** — two lints in `crates/systeminfo/src/summary/linux.rs`, a Linux-only file. The v5.18.0 release gate passed because it ran on macOS, where that file isn't compiled. CI doesn't gate on clippy either (`continue-on-error: true`), which is how it accumulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)