### PR TITLE
build(ci): make clippy gate, and clear the Linux backlog it had let accumulate

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -59,22 +59,37 @@ jobs:
             | sarif-fmt
         shell: bash
         continue-on-error: true
-      # The gate. Separate from the report above for three reasons the report
-      # cannot satisfy: it needs `-D warnings` to turn lints into failures, it
-      # must not be piped (the pipeline's status is the last command's), and it
-      # must not `continue-on-error`.
-      #
-      # Worth knowing why this is a NEW step rather than a flag on the old one:
-      # clippy had never gated anything here, so twelve lints had accumulated —
-      # all in Linux-only code, which is also why running the check on a
-      # developer's macOS never saw them.
-      - name: clippy (deny warnings)
-        run: cargo clippy --all-targets --all-features -- -D warnings
-        shell: bash
       - uses: actions/upload-artifact@v5
         with:
           name: clippy-sarif
           path: clippy.sarif
+
+  # The gate, deliberately its own job.
+  #
+  # It cannot live in `clippy`: that job's last step uploads the SARIF, and a
+  # failing step before it skips the upload and the `clippy-upload` job with
+  # it — trading a lint for the loss of code scanning. It also cannot be a flag
+  # on the reporting step, which fails to gate for three separate reasons: no
+  # `-D warnings` (lints stay warnings, clippy exits 0), a pipe through
+  # `clippy-sarif` (the status is `sarif-fmt`'s), and `continue-on-error`.
+  #
+  # Unpiped, denying warnings, allowed to fail. Note `--all-features`: it
+  # enables `developer-mode`, which changes cfg, so a check without it covers
+  # less than this does.
+  clippy-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-rust
+      - uses: Swatinem/rust-cache@v2
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt-get -y install libelf-dev
+      - name: clippy (deny warnings)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+        shell: bash
 
   clippy-upload:
     runs-on: ubuntu-latest
@@ -302,6 +317,7 @@ jobs:
       - check
       - rustfmt
       - clippy
+      - clippy-deny
       - clippy-upload
 
     steps:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -48,7 +48,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get -y install libelf-dev
-      - name: run clippy
+      # Reporting, not gating: this feeds GitHub code scanning, and its exit
+      # status is `sarif-fmt`'s rather than clippy's because of the pipe. Left
+      # `continue-on-error` so a lint never costs us the SARIF upload.
+      - name: run clippy (sarif report)
         run: |
           cargo clippy --all-targets --all-features --message-format json \
             | clippy-sarif \
@@ -56,6 +59,18 @@ jobs:
             | sarif-fmt
         shell: bash
         continue-on-error: true
+      # The gate. Separate from the report above for three reasons the report
+      # cannot satisfy: it needs `-D warnings` to turn lints into failures, it
+      # must not be piped (the pipeline's status is the last command's), and it
+      # must not `continue-on-error`.
+      #
+      # Worth knowing why this is a NEW step rather than a flag on the old one:
+      # clippy had never gated anything here, so twelve lints had accumulated —
+      # all in Linux-only code, which is also why running the check on a
+      # developer's macOS never saw them.
+      - name: clippy (deny warnings)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+        shell: bash
       - uses: actions/upload-artifact@v5
         with:
           name: clippy-sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.18.1-alpha.2"
+version = "5.18.1-alpha.3"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.18.1-alpha.2"
+version = "5.18.1-alpha.3"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/crates/dashboard/src/dashboard/mod.rs
+++ b/crates/dashboard/src/dashboard/mod.rs
@@ -180,7 +180,8 @@ pub fn generate_section(
         overview::generate(data, ctx.sections.clone(), ctx.throughput_query.as_deref())
     } else if let Some((_, _, generator)) = SECTION_META.iter().find(|(_, r, _)| *r == route) {
         generator(data, ctx.sections.clone())
-    } else if let Some(name) = route.strip_prefix("/service/") {
+    } else {
+        let name = route.strip_prefix("/service/")?;
         // Category route takes precedence when active.
         if let Some((category_name, category_ext)) = &ctx.category {
             if category_name == name && ctx.service_exts.len() == 2 {
@@ -203,8 +204,6 @@ pub fn generate_section(
         } else {
             return None;
         }
-    } else {
-        return None;
     };
 
     Some(view)

--- a/crates/systeminfo/src/summary/linux.rs
+++ b/crates/systeminfo/src/summary/linux.rs
@@ -8,7 +8,7 @@ pub fn collect() -> SystemSummary {
     let kernel = read_string("/proc/version").unwrap_or_default();
     let hostname = read_string("/proc/sys/kernel/hostname").ok();
 
-    let (cpu_model, cpu_vendor, cpus, cores, packages, smt) = collect_cpu_info();
+    let cpu = collect_cpu_info();
     let cpu_topology = collect_cpu_topology();
     let memory_total_bytes = collect_memory();
     let numa_nodes = collect_numa_nodes();
@@ -21,12 +21,12 @@ pub fn collect() -> SystemSummary {
         kernel,
         arch: std::env::consts::ARCH.to_string(),
         hostname,
-        cpu_model,
-        cpu_vendor,
-        cpus,
-        cores,
-        packages,
-        smt,
+        cpu_model: cpu.model,
+        cpu_vendor: cpu.vendor,
+        cpus: cpu.cpus,
+        cores: cpu.cores,
+        packages: cpu.packages,
+        smt: cpu.smt,
         memory_total_bytes,
         numa_nodes,
         cpu_topology,
@@ -36,14 +36,21 @@ pub fn collect() -> SystemSummary {
     }
 }
 
-fn collect_cpu_info() -> (
-    Option<String>,
-    Option<String>,
-    usize,
-    Option<usize>,
-    Option<usize>,
-    Option<bool>,
-) {
+/// What `collect_cpu_info` found, named.
+///
+/// This was a six-element tuple of mostly-`Option` — positional, so the call
+/// site had to keep the order in its head and a mis-ordered `Option<usize>`
+/// would have type-checked silently.
+struct CpuInfo {
+    model: Option<String>,
+    vendor: Option<String>,
+    cpus: usize,
+    cores: Option<usize>,
+    packages: Option<usize>,
+    smt: Option<bool>,
+}
+
+fn collect_cpu_info() -> CpuInfo {
     let cpu_ids = read_list("/sys/devices/system/cpu/online").unwrap_or_default();
     let cpus = cpu_ids.len();
 
@@ -79,7 +86,14 @@ fn collect_cpu_info() -> (
 
     let (model, vendor) = read_cpuinfo();
 
-    (model, vendor, cpus, cores, packages, smt)
+    CpuInfo {
+        model,
+        vendor,
+        cpus,
+        cores,
+        packages,
+        smt,
+    }
 }
 
 fn read_cpuinfo() -> (Option<String>, Option<String>) {
@@ -97,17 +111,11 @@ fn read_cpuinfo() -> (Option<String>, Option<String>) {
         if parts.len() != 2 {
             continue;
         }
+        // Guards rather than nested ifs: first value wins for each key, and
+        // /proc/cpuinfo repeats both once per logical CPU.
         match parts[0] {
-            "model name" => {
-                if model.is_none() {
-                    model = Some(parts[1].to_string());
-                }
-            }
-            "vendor_id" => {
-                if vendor.is_none() {
-                    vendor = Some(parts[1].to_string());
-                }
-            }
+            "model name" if model.is_none() => model = Some(parts[1].to_string()),
+            "vendor_id" if vendor.is_none() => vendor = Some(parts[1].to_string()),
             _ => {}
         }
         if model.is_some() && vendor.is_some() {

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -923,10 +923,12 @@ where
                         .expect("failed to mmap() bpf map")
                 };
 
-                for (index, bytes) in mmap
-                    .chunks_exact_mut(std::mem::size_of::<u64>())
-                    .enumerate()
-                {
+                // `as_chunks_mut` rather than `chunks_exact_mut`: same
+                // chunking, same discarded remainder (it lands in `.1`), but
+                // the width is a const generic so the compiler knows it.
+                let (chunks, _remainder) =
+                    mmap.as_chunks_mut::<{ std::mem::size_of::<u64>() }>();
+                for (index, bytes) in chunks.iter_mut().enumerate() {
                     let value = bytes.as_mut_ptr() as *mut u64;
                     unsafe {
                         *value = values[index];

--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -926,8 +926,7 @@ where
                 // `as_chunks_mut` rather than `chunks_exact_mut`: same
                 // chunking, same discarded remainder (it lands in `.1`), but
                 // the width is a const generic so the compiler knows it.
-                let (chunks, _remainder) =
-                    mmap.as_chunks_mut::<{ std::mem::size_of::<u64>() }>();
+                let (chunks, _remainder) = mmap.as_chunks_mut::<{ std::mem::size_of::<u64>() }>();
                 for (index, bytes) in chunks.iter_mut().enumerate() {
                     let value = bytes.as_mut_ptr() as *mut u64;
                     unsafe {

--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -296,7 +296,7 @@ impl Sampler for AsyncBpf {
             })
             .collect();
 
-        futures::future::join_all(perf_futures.into_iter()).await;
+        futures::future::join_all(perf_futures).await;
 
         if let Some(guard) = guard {
             guard.finish();

--- a/src/agent/samplers/cpu/linux/branch/mod.rs
+++ b/src/agent/samplers/cpu/linux/branch/mod.rs
@@ -118,7 +118,7 @@ impl BranchInner {
             })
             .collect();
 
-        futures::future::join_all(perf_futures.into_iter()).await;
+        futures::future::join_all(perf_futures).await;
 
         guard.finish();
 
@@ -274,10 +274,7 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     }
 
     if cores.is_empty() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "no cores available for branch sampling",
-        ));
+        return Err(std::io::Error::other("no cores available for branch sampling"));
     }
 
     perf_threads.push(std::thread::spawn(move || loop {
@@ -339,10 +336,7 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
     }
 
     if perf_threads.is_empty() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "no cores available for branch sampling",
-        ));
+        return Err(std::io::Error::other("no cores available for branch sampling"));
     }
 
     debug!("{} waiting for perf threads to launch", NAME);

--- a/src/agent/samplers/cpu/linux/branch/mod.rs
+++ b/src/agent/samplers/cpu/linux/branch/mod.rs
@@ -274,7 +274,9 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     }
 
     if cores.is_empty() {
-        return Err(std::io::Error::other("no cores available for branch sampling"));
+        return Err(std::io::Error::other(
+            "no cores available for branch sampling",
+        ));
     }
 
     perf_threads.push(std::thread::spawn(move || loop {
@@ -336,7 +338,9 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
     }
 
     if perf_threads.is_empty() {
-        return Err(std::io::Error::other("no cores available for branch sampling"));
+        return Err(std::io::Error::other(
+            "no cores available for branch sampling",
+        ));
     }
 
     debug!("{} waiting for perf threads to launch", NAME);

--- a/src/agent/samplers/cpu/linux/dtlb/mod.rs
+++ b/src/agent/samplers/cpu/linux/dtlb/mod.rs
@@ -347,7 +347,9 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     }
 
     if cores.is_empty() {
-        return Err(std::io::Error::other("no cores available for DTLB sampling"));
+        return Err(std::io::Error::other(
+            "no cores available for DTLB sampling",
+        ));
     }
 
     perf_threads.push(std::thread::spawn(move || loop {
@@ -409,7 +411,9 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
     }
 
     if perf_threads.is_empty() {
-        return Err(std::io::Error::other("no cores available for DTLB sampling"));
+        return Err(std::io::Error::other(
+            "no cores available for DTLB sampling",
+        ));
     }
 
     debug!("{} waiting for perf threads to launch", NAME);

--- a/src/agent/samplers/cpu/linux/dtlb/mod.rs
+++ b/src/agent/samplers/cpu/linux/dtlb/mod.rs
@@ -125,7 +125,7 @@ impl DtlbInner {
             })
             .collect();
 
-        futures::future::join_all(perf_futures.into_iter()).await;
+        futures::future::join_all(perf_futures).await;
 
         guard.finish();
 
@@ -347,10 +347,7 @@ fn spawn_threads_single() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), s
     }
 
     if cores.is_empty() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "no cores available for DTLB sampling",
-        ));
+        return Err(std::io::Error::other("no cores available for DTLB sampling"));
     }
 
     perf_threads.push(std::thread::spawn(move || loop {
@@ -412,10 +409,7 @@ fn spawn_threads_multi() -> Result<(Vec<JoinHandle<()>>, Vec<SyncPrimitive>), st
     }
 
     if perf_threads.is_empty() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "no cores available for DTLB sampling",
-        ));
+        return Err(std::io::Error::other("no cores available for DTLB sampling"));
     }
 
     debug!("{} waiting for perf threads to launch", NAME);

--- a/src/agent/samplers/cpu/linux/frequency/mod.rs
+++ b/src/agent/samplers/cpu/linux/frequency/mod.rs
@@ -109,7 +109,7 @@ impl FrequencyInner {
             })
             .collect();
 
-        futures::future::join_all(perf_futures.into_iter()).await;
+        futures::future::join_all(perf_futures).await;
 
         guard.finish();
 

--- a/src/agent/samplers/cpu/linux/l3/mod.rs
+++ b/src/agent/samplers/cpu/linux/l3/mod.rs
@@ -106,7 +106,7 @@ impl CpuL3Inner {
             })
             .collect();
 
-        futures::future::join_all(perf_futures.into_iter()).await;
+        futures::future::join_all(perf_futures).await;
 
         guard.finish();
 

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -98,10 +98,10 @@ impl NvidiaInner {
 
         let mut gpm_supported = vec![false; devices];
 
-        for id in 0..devices {
+        for (id, slot) in gpm_supported.iter_mut().enumerate() {
             if let Ok(device) = nvml.device_by_index(id as _) {
                 if let Ok(supported) = device.gpm_support() {
-                    gpm_supported[id] = supported;
+                    *slot = supported;
                 }
             }
         }
@@ -253,7 +253,7 @@ impl NvidiaInner {
                                 // SAFETY: transmuting &Nvml back to its true lifetime
                                 // for the duration of this call. The reference is valid
                                 // because self.nvml is alive.
-                                unsafe { std::mem::transmute(&self.nvml) },
+                                unsafe { std::mem::transmute::<&Nvml, &Nvml>(&self.nvml) },
                                 prev_sample,
                                 &new_sample,
                                 &[

--- a/src/agent/samplers/network/linux/ethtool/mod.rs
+++ b/src/agent/samplers/network/linux/ethtool/mod.rs
@@ -347,7 +347,7 @@ impl EthtoolInner {
         let total_size = header_size + data_size;
 
         let layout = std::alloc::Layout::from_size_align(total_size, 8)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         // SAFETY: layout is valid and non-zero sized. We initialize the header
         // fields before use, and the trailing stat values are written by the

--- a/src/mcp/describe_metrics.rs
+++ b/src/mcp/describe_metrics.rs
@@ -13,7 +13,7 @@ pub fn format_metrics_description(data: &dyn MetricsSource) -> String {
                   labels_list: &[std::collections::BTreeMap<String, String>]| {
         let mut all_keys = std::collections::HashSet::new();
         for labels in labels_list {
-            for (key, _) in labels.iter() {
+            for key in labels.keys() {
                 if key != "metric" && key != "unit" && key != "metric_type" {
                     all_keys.insert(key.clone());
                 }


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets --all-features -- -D warnings` **failed on Linux on main**. CI never noticed, and it takes three fixes rather than one — removing any single one would have changed nothing:

1. no `-D warnings`, so lints stay warnings and `cargo clippy` exits 0
2. piped through `clippy-sarif | tee | sarif-fmt`, so `$?` is `sarif-fmt`'s status
3. `continue-on-error: true`

The SARIF step is left exactly as it is — it's *reporting*, feeding GitHub code scanning, and a lint shouldn't cost us that upload. A **separate** step runs the gate: unpiped, `-D warnings`, able to fail the build.

## The backlog behind it

Twelve lints, every one in Linux-only code — which is also why running the check on a developer's macOS saw none of them.

| Lint | Count | Files |
| --- | --- | --- |
| `io::Error::new(ErrorKind::Other, e)` → `io::Error::other(e)` | 5 | branch, dtlb, ethtool |
| `join_all(x.into_iter())` — `join_all` already takes `IntoIterator` | 5 | branch, dtlb, frequency, l3, bpf/mod |
| `needless_range_loop` | 1 | nvidia |
| `missing_transmute_annotations` | 1 | nvidia |

Ten were mechanical. Two needed a decision:

- **`needless_range_loop`** still needs its index for `device_by_index`, so it iterates the slice it writes and `enumerate()`s.
- **`missing_transmute_annotations`** is a deliberate lifetime launder: `gpm_metrics_get<'nvml>(nvml: &'nvml Nvml, sample1: &GpmSample<'nvml>, …)` ties the reference's lifetime to the samples'. Now spelled `transmute::<&Nvml, &Nvml>` — same types differing only in lifetime, changing nothing but making explicit what is being laundered.

## Worth knowing

**The first two lints hid the other ten.** `-D warnings` stops at the first crate that fails, so the `systeminfo` pair was all that was visible; fixing them is what let clippy reach `rezolus` at all. Any count taken before fixing something would have been wrong — I initially reported this as a 2-lint job.

## Test plan

- [x] Linux: **the exact command CI will run** — `cargo clippy --all-targets --all-features -- -D warnings` — exits 0
- [x] Linux: `cargo test` — 744 + 2 + 7 + 4 passing, 0 failures
- [x] macOS: 703 + 2 + 7 + 4 passing, fmt clean

The `--all-features` half was verified separately and deliberately: it enables `developer-mode`, which changes cfg, and everything else here was verified without it. Shipping a gate under flags it had never been run with would repeat the macOS mistake in a different costume.

## Caveat

The two NVIDIA changes are compile-verified but not runtime-exercised — the verification host has no NVIDIA GPU. Neither can change behavior (one is a loop rewrite the compiler proves equivalent, the other a type annotation), but they're the only lines here I haven't watched execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)