### PR TITLE
fix(gpu): don't derive PCIe metrics a Tegra iGPU has no link for

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.18.1-alpha.4"
+version = "5.18.1-alpha.5"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.18.1-alpha.4"
+version = "5.18.1-alpha.5"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -433,6 +433,35 @@ recording (single iGPU, 55 min at 1 s).
   library call, not an mmap read: the effort must carry a *measured* per-refresh
   overhead number and a cadence decision. And per #1108's own lesson, verify on
   Tegra whether these return real values or placeholders before trusting them.
+- **NVML utilization support is Tegra-generation-dependent** — Open, and the
+  reason the gating in #1108 is deliberately narrow. NVIDIA's stated position is
+  that NVML is not supported on Jetson (users are pointed at `tegrastats`), and
+  there are Orin reports of NVML utilization not working; JetPack 7 / Thor
+  release notes, by contrast, advertise newly-added NVML GPU monitoring. The
+  measured recording behind #1108 shows `utilization_rates().gpu` working, so at
+  least one generation populates it — but that is one host, and `utilization_rates`
+  is documented only for "fully supported devices", a list Tegra iGPUs are not on.
+  Consequence: on a generation where NVML does not populate it, the agent records
+  a constant `0`, indistinguishable from a genuinely idle GPU. Note this is
+  *main's existing behaviour*, not a regression from #1108 — that PR declined to
+  gate `.gpu` rather than introducing the exposure. *Fix:* prefer the nvgpu
+  driver's own load node (`/sys/devices/.../<addr>.gpu/load`, permille — the
+  source `tegrastats` GR3D reads) as the `gpu_utilization` source when
+  `is_tegra_soc()`, which works on every Tegra generation; it is one small sysfs
+  read per tick, so per principles 13/16/17 it needs a *measured* per-refresh
+  number. Failing that, stamp the SoC `compatible` string into snapshot metadata
+  so a consumer can at least tell which generation produced a zero.
+- **`GPU_ENERGY_CONSUMPTION` can publish a fabricated zero** — Open,
+  pre-existing, adjacent to #1108 and the same bug class. It is a `CounterGroup`
+  (`stats.rs`), and metriken's `CounterGroup::value()` has **no** sentinel: it
+  returns `Some(0)` for an unwritten slot as soon as *any* index in that group
+  has been written. So on a mixed multi-GPU host where `total_energy_consumption()`
+  succeeds for device 0 and fails for device 1, device 1 publishes a constant-zero
+  energy counter that reads as a real measurement. Cannot fire on a single-GPU
+  host (the group stays uninitialised and reads `None`), which is why #1108's
+  Tegra target does not hit it. Contrast `GaugeGroup`, which uses an `i64::MIN`
+  sentinel and correctly yields `None`. *Fix:* track written membership
+  explicitly, or move the metric to a gauge-like sentinel representation.
 - **Per-device Tegra discrimination** — Open. `is_tegra_soc()` reads
   `/proc/device-tree/compatible`, a *host* property, but "no real PCIe link / no
   utilization counters" is a *device* property. A Tegra board carrying a discrete

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -410,6 +410,53 @@ Page 0x02 (`nvme.rs`) — no kernel module.
 - **Hotplug discovery** — Open. Phase 1 discovers drives once at startup; drives
   added later are missed. *Reopen:* if hotplug matters.
 
+## Agent — NVIDIA GPU sampler
+
+Source: PR #1108 (Tegra placeholder gating), grounded in a measured Tegra
+recording (single iGPU, 55 min at 1 s).
+
+- **Video engine (NVENC/NVDEC) utilization** — Open, and the highest-value gap.
+  NVML's `utilization_rates().gpu` covers only the SM/graphics engine; NVENC and
+  NVDEC are separate fixed-function blocks it does not count. On a transcode-heavy
+  workload the video engines can be saturated while `gpu_utilization` reads ~0, so
+  the recording cannot explain what the GPU is doing. The measured Tegra recording
+  shows exactly this shape: ~18.6 W drawn and a 49.6 °C → 61.5 °C thermal ramp
+  while `gpu_utilization` is 0, with power *lowest* during the 91% SM plateau. We
+  already record `gpu_clock{clock="video"}` — the engine's clock — but never its
+  utilization. *Add:* `encoder_utilization()` / `decoder_utilization()`
+  (`UtilizationInfo{utilization, sampling_period}`), and probably `encoder_stats()`
+  (`session_count`, `average_fps`, `average_latency`). *Avoid:* `encoder_sessions()`
+  — a per-session `Vec`, unbounded cardinality, wrong for an always-on fleetwide
+  sampler. *Note:* `nvml-wrapper` 0.12.1 has no bindings for
+  `nvmlDeviceGetJpgUtilization`/`GetOfaUtilization`, so NVJPEG and the optical-flow
+  engine need raw FFI or a crate bump. Per principles 13/16/17 this is an NVML
+  library call, not an mmap read: the effort must carry a *measured* per-refresh
+  overhead number and a cadence decision. And per #1108's own lesson, verify on
+  Tegra whether these return real values or placeholders before trusting them.
+- **Per-device Tegra discrimination** — Open. `is_tegra_soc()` reads
+  `/proc/device-tree/compatible`, a *host* property, but "no real PCIe link / no
+  utilization counters" is a *device* property. A Tegra board carrying a discrete
+  PCIe GPU (NVIDIA IGX Orin is `nvidia,tegra234`) would have that card's genuine
+  `gpu_pcie_bandwidth` and `gpu_memory_utilization` suppressed. *Fix:* AND the
+  host probe with a per-device discriminator (`Device::bus_type()` or
+  `pci_info()`), stored as a `Vec<bool>` beside `gpm_supported`. *Gated on* access
+  to a Tegra host with a discrete GPU — the discriminator's behaviour on a Tegra
+  iGPU is unverified, and guessing risks breaking the fix on its target platform.
+- **Tegra probe is invisible in containers** — Open. `/sys/firmware` is in runc's
+  default masked-paths list, so a non-privileged container reads the device tree as
+  absent and a genuine Tegra host is treated as not-Tegra (back to recording the
+  placeholders). The documented deployments use `--privileged`, which disables
+  masking, so the shipped path works; a Kubernetes pod granted only
+  `CAP_BPF`/`CAP_PERFMON` does not. Nothing in the recording distinguishes
+  "not Tegra" from "couldn't tell". *Fix:* subsumed by per-device discrimination
+  above; failing that, make the probe three-valued and surface it in snapshot
+  metadata (per the project's surface-errors-not-journald preference).
+- **Gating is invisible to operators** — Open. On a Jetson an operator sees empty
+  `gpu_pcie_bandwidth` / `gpu_memory_utilization` charts and cannot tell
+  "deliberately not read" from "the sampler broke". `SamplerState::Unsupported`
+  (`src/agent/sampler_status.rs`) is whole-sampler only; there is no per-metric
+  equivalent today. *Reopen:* if per-metric status machinery lands.
+
 ## metriken — measurement uncertainty (arc)
 
 Source: [measurement uncertainty](journal/2026-07-08-measurement-uncertainty.md).

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -170,35 +170,39 @@ impl NvidiaInner {
                  * pcie link
                  */
 
-                if let Ok(v) = device
-                    .pcie_throughput(PcieUtilCounter::Receive)
-                    .map(|v| v as i64 * KB)
-                {
-                    GPU_PCIE_THROUGHPUT_RX.set(id, v);
-                }
-
-                if let Ok(v) = device
-                    .pcie_throughput(PcieUtilCounter::Send)
-                    .map(|v| v as i64 * KB)
-                {
-                    GPU_PCIE_THROUGHPUT_TX.set(id, v);
-                }
-
-                // A Tegra SoC's integrated GPU sits on the memory fabric, not
-                // a PCIe link to the host. NVML still answers the link
-                // queries, with a placeholder gen/width whose product is a
-                // bandwidth the part does not have, so don't derive one. A
-                // measured Tegra recording reports gen 1 x1 for the whole run
-                // — a rate no real NVIDIA GPU runs at — which the table below
-                // turns into a constant, fabricated 250 MiB/s.
+                // A Tegra SoC's integrated GPU sits on the memory fabric,
+                // not a PCIe link to the host, so nothing derived from such a
+                // link is recorded there. That is a fact about the hardware,
+                // not about any particular NVML build: the whole block is
+                // gated on it rather than on which of these calls happens to
+                // fail today.
                 //
-                // `pcie_throughput()` above is deliberately left ungated: it
-                // sits on the same absent link, but NVML returns an error for
-                // it on Tegra rather than a placeholder, so `if let Ok(..)`
-                // already drops it. The same measured recording carries no
-                // `gpu_pcie_throughput` series at all, confirming the call
-                // failed on every one of its samples.
+                // It matters because the failure modes differ and are not
+                // stable. On a measured Tegra recording `pcie_throughput()`
+                // returned an error every sample — no `gpu_pcie_throughput`
+                // appears in any of its 3290 snapshots — so `if let Ok(..)`
+                // alone would have sufficed. But the link queries below
+                // *succeeded* on that same host, reporting gen 1 x1, a rate
+                // no real NVIDIA GPU runs at, which the table turns into a
+                // constant, fabricated 250 MiB/s. Relying on an error that
+                // NVML is not contractually obliged to keep returning would
+                // leave the first JetPack that answers `Ok(0)` silently
+                // recording throughput for a link that does not exist.
                 if !self.tegra_soc {
+                    if let Ok(v) = device
+                        .pcie_throughput(PcieUtilCounter::Receive)
+                        .map(|v| v as i64 * KB)
+                    {
+                        GPU_PCIE_THROUGHPUT_RX.set(id, v);
+                    }
+
+                    if let Ok(v) = device
+                        .pcie_throughput(PcieUtilCounter::Send)
+                        .map(|v| v as i64 * KB)
+                    {
+                        GPU_PCIE_THROUGHPUT_TX.set(id, v);
+                    }
+
                     if let Ok(link_width) = device.current_pcie_link_width() {
                         if let Ok(link_gen) = device.current_pcie_link_gen() {
                             let v = match link_gen {
@@ -253,25 +257,26 @@ impl NvidiaInner {
                  * utilization
                  */
 
-                // `utilization_rates()` returns both fields from one call,
-                // but on a Tegra SoC only one of them is real. A measured
-                // Tegra recording (single iGPU, 55 min at 1s) shows `.gpu`
-                // tracking a workload cleanly — idle, ramp, a ~91% plateau,
-                // decay, idle, peaking at 97 — while `.memory` reads 0 for
-                // every one of the 3290 samples, including throughout that
-                // plateau. A memory-utilization of exactly zero under a
-                // sustained 91% load is not a credible reading; it is an
-                // unpopulated field, and a successful zero is
-                // indistinguishable from a genuinely idle GPU once it is in a
-                // recording. So record `.gpu`, which works, and skip
-                // `.memory`, which does not. Missing beats wrong
-                // (`docs/principles.md`).
+                // Both fields are recorded on every host, Tegra included. A
+                // measured Tegra recording shows `.gpu` tracking a workload
+                // cleanly — idle, ramp, a ~91% plateau, decay, idle, peaking
+                // at 97 — so the reading is real there, not a placeholder.
+                //
+                // `.memory` read 0 for that whole run and is deliberately
+                // *not* gated on the strength of it. NVML defines both fields
+                // as duty cycles of *time*, not intensity: `.gpu` is the
+                // percent of time at least one kernel was resident, `.memory`
+                // the percent of time global memory was being read or
+                // written. A compute-bound kernel whose working set stays in
+                // cache or registers pins `.gpu` high while `.memory` rounds
+                // to zero. The same recording bears that out — the GPU drew
+                // *less* power during the 91% plateau (17.3 W) than while
+                // idle (19.0 W), so the plateau was its lightest phase, and a
+                // zero global-memory duty cycle there is the expected reading
+                // rather than a broken counter.
                 if let Ok(utilization) = device.utilization_rates() {
                     GPU_UTILIZATION.set(id, utilization.gpu as i64);
-
-                    if !self.tegra_soc {
-                        GPU_MEMORY_UTILIZATION.set(id, utilization.memory as i64);
-                    }
+                    GPU_MEMORY_UTILIZATION.set(id, utilization.memory as i64);
                 }
 
                 /*

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -187,7 +187,17 @@ impl NvidiaInner {
                 // A Tegra SoC's integrated GPU sits on the memory fabric, not
                 // a PCIe link to the host. NVML still answers the link
                 // queries, with a placeholder gen/width whose product is a
-                // bandwidth the part does not have, so don't derive one.
+                // bandwidth the part does not have, so don't derive one. A
+                // measured Tegra recording reports gen 1 x1 for the whole run
+                // — a rate no real NVIDIA GPU runs at — which the table below
+                // turns into a constant, fabricated 250 MiB/s.
+                //
+                // `pcie_throughput()` above is deliberately left ungated: it
+                // sits on the same absent link, but NVML returns an error for
+                // it on Tegra rather than a placeholder, so `if let Ok(..)`
+                // already drops it. The same measured recording carries no
+                // `gpu_pcie_throughput` series at all, confirming the call
+                // failed on every one of its samples.
                 if !self.tegra_soc {
                     if let Ok(link_width) = device.current_pcie_link_width() {
                         if let Ok(link_gen) = device.current_pcie_link_gen() {
@@ -243,18 +253,23 @@ impl NvidiaInner {
                  * utilization
                  */
 
-                // On a Tegra SoC this call *succeeds* and reports 0/0
-                // unconditionally: the integrated GPU exposes no utilization
-                // counters to NVML, and GPM — which would otherwise supply
-                // `gpu_sm_utilization`/`gpu_dram_bandwidth_utilization` below
-                // — reports itself unsupported there as well. Unlike a failed
-                // read, a successful zero is indistinguishable from a
-                // genuinely idle GPU once it is in a recording, so skip the
-                // read rather than record one. Missing beats wrong
+                // `utilization_rates()` returns both fields from one call,
+                // but on a Tegra SoC only one of them is real. A measured
+                // Tegra recording (single iGPU, 55 min at 1s) shows `.gpu`
+                // tracking a workload cleanly — idle, ramp, a ~91% plateau,
+                // decay, idle, peaking at 97 — while `.memory` reads 0 for
+                // every one of the 3290 samples, including throughout that
+                // plateau. A memory-utilization of exactly zero under a
+                // sustained 91% load is not a credible reading; it is an
+                // unpopulated field, and a successful zero is
+                // indistinguishable from a genuinely idle GPU once it is in a
+                // recording. So record `.gpu`, which works, and skip
+                // `.memory`, which does not. Missing beats wrong
                 // (`docs/principles.md`).
-                if !self.tegra_soc {
-                    if let Ok(utilization) = device.utilization_rates() {
-                        GPU_UTILIZATION.set(id, utilization.gpu as i64);
+                if let Ok(utilization) = device.utilization_rates() {
+                    GPU_UTILIZATION.set(id, utilization.gpu as i64);
+
+                    if !self.tegra_soc {
                         GPU_MEMORY_UTILIZATION.set(id, utilization.memory as i64);
                     }
                 }

--- a/src/agent/samplers/gpu/linux/nvidia/mod.rs
+++ b/src/agent/samplers/gpu/linux/nvidia/mod.rs
@@ -81,6 +81,10 @@ struct NvidiaInner {
     nvml: Nvml,
     devices: usize,
     gpm_supported: Vec<bool>,
+    /// Whether this host is a Tegra SoC, whose integrated GPU NVML enumerates
+    /// but only partly describes. Probed once at init — the device tree is
+    /// fixed for the life of the process.
+    tegra_soc: bool,
 }
 
 impl NvidiaInner {
@@ -108,11 +112,14 @@ impl NvidiaInner {
 
         let gpm_samples = (0..devices).map(|_| None).collect();
 
+        let tegra_soc = crate::common::is_tegra_soc();
+
         Ok(Self {
             gpm_samples,
             nvml,
             devices,
             gpm_supported,
+            tegra_soc,
         })
     }
 
@@ -177,22 +184,28 @@ impl NvidiaInner {
                     GPU_PCIE_THROUGHPUT_TX.set(id, v);
                 }
 
-                if let Ok(link_width) = device.current_pcie_link_width() {
-                    if let Ok(link_gen) = device.current_pcie_link_gen() {
-                        let v = match link_gen {
-                            1 => 250 * MB,
-                            2 => 500 * MB,
-                            3 => 984 * MB,
-                            4 => 1970 * MB,
-                            5 => 3940 * MB,
-                            6 => 7560 * MB,
-                            7 => 15130 * MB,
-                            _ => 0,
-                        };
+                // A Tegra SoC's integrated GPU sits on the memory fabric, not
+                // a PCIe link to the host. NVML still answers the link
+                // queries, with a placeholder gen/width whose product is a
+                // bandwidth the part does not have, so don't derive one.
+                if !self.tegra_soc {
+                    if let Ok(link_width) = device.current_pcie_link_width() {
+                        if let Ok(link_gen) = device.current_pcie_link_gen() {
+                            let v = match link_gen {
+                                1 => 250 * MB,
+                                2 => 500 * MB,
+                                3 => 984 * MB,
+                                4 => 1970 * MB,
+                                5 => 3940 * MB,
+                                6 => 7560 * MB,
+                                7 => 15130 * MB,
+                                _ => 0,
+                            };
 
-                        if v > 0 {
-                            let v = v * link_width as i64;
-                            GPU_PCIE_BANDWIDTH.set(id, v as _);
+                            if v > 0 {
+                                let v = v * link_width as i64;
+                                GPU_PCIE_BANDWIDTH.set(id, v as _);
+                            }
                         }
                     }
                 }
@@ -230,9 +243,20 @@ impl NvidiaInner {
                  * utilization
                  */
 
-                if let Ok(utilization) = device.utilization_rates() {
-                    GPU_UTILIZATION.set(id, utilization.gpu as i64);
-                    GPU_MEMORY_UTILIZATION.set(id, utilization.memory as i64);
+                // On a Tegra SoC this call *succeeds* and reports 0/0
+                // unconditionally: the integrated GPU exposes no utilization
+                // counters to NVML, and GPM — which would otherwise supply
+                // `gpu_sm_utilization`/`gpu_dram_bandwidth_utilization` below
+                // — reports itself unsupported there as well. Unlike a failed
+                // read, a successful zero is indistinguishable from a
+                // genuinely idle GPU once it is in a recording, so skip the
+                // read rather than record one. Missing beats wrong
+                // (`docs/principles.md`).
+                if !self.tegra_soc {
+                    if let Ok(utilization) = device.utilization_rates() {
+                        GPU_UTILIZATION.set(id, utilization.gpu as i64);
+                        GPU_MEMORY_UTILIZATION.set(id, utilization.memory as i64);
+                    }
                 }
 
                 /*

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,7 @@
 mod logging;
+mod soc;
 pub use logging::{configure_logging, verbosity_to_level, Level, LogConfig, LogDrain};
+pub use soc::is_tegra_soc;
 
 pub static HISTOGRAM_GROUPING_POWER: u8 = 3;
 

--- a/src/common/soc.rs
+++ b/src/common/soc.rs
@@ -55,20 +55,31 @@ fn is_tegra_soc_at(path: impl AsRef<std::path::Path>) -> bool {
 mod tests {
     use super::*;
 
-    fn write_temp(name: &str, contents: &[u8]) -> std::path::PathBuf {
-        let path = std::env::temp_dir().join(name);
+    /// A `compatible` file in a private temp dir.
+    ///
+    /// Deliberately not a fixed path under `temp_dir()`: two concurrent test
+    /// runs on one machine (a CI matrix on a shared runner, or a second user)
+    /// would race on the same name, and a failing assert would leak the file
+    /// into later runs.
+    fn write_temp(contents: &[u8]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("compatible");
         std::fs::write(&path, contents).expect("write temp compatible");
-        path
+        (dir, path)
     }
 
     #[test]
     fn reads_tegra_soc_from_device_tree_property() {
-        let path = write_temp(
-            "rezolus-soc-tegra-compatible",
-            b"nvidia,p3971-0089\0nvidia,tegra264\0",
-        );
+        let (_dir, path) = write_temp(b"nvidia,p3971-0089\0nvidia,tegra264\0");
         assert!(is_tegra_soc_at(&path));
-        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn reads_a_non_tegra_device_tree_property_as_false() {
+        // Pins that the wrapper actually *parses* what it reads. Without this
+        // case, replacing the whole body with `path.exists()` passes.
+        let (_dir, path) = write_temp(b"raspberrypi,4-model-b\0brcm,bcm2711\0");
+        assert!(!is_tegra_soc_at(&path));
     }
 
     #[test]
@@ -88,6 +99,13 @@ mod tests {
     }
 
     #[test]
+    fn matches_a_single_entry_with_no_trailing_nul() {
+        // What a truncated read, or a property written without its terminator,
+        // looks like. `split` still yields the entry intact.
+        assert!(compatible_is_tegra(b"nvidia,tegra234"));
+    }
+
+    #[test]
     fn rejects_non_tegra_boards() {
         assert!(!compatible_is_tegra(
             b"raspberrypi,4-model-b\0brcm,bcm2711\0"
@@ -96,10 +114,27 @@ mod tests {
     }
 
     #[test]
+    fn rejects_other_nvidia_parts() {
+        // The `tegra` half of the token is load-bearing: an NVIDIA-vendored
+        // entry that does not name the SoC family is not a Tegra SoC. Without
+        // this case, matching on `b"nvidia,"` alone passes.
+        assert!(!compatible_is_tegra(b"nvidia,p3971-0089\0"));
+        assert!(!compatible_is_tegra(b"nvidia,holoscan\0"));
+    }
+
+    #[test]
     fn requires_nvidia_tegra_at_an_entry_boundary() {
         // A vendor string that merely *contains* the token is a different
         // part; entries are matched from their start, not searched.
         assert!(!compatible_is_tegra(b"acme,not-nvidia,tegra264\0"));
+    }
+
+    #[test]
+    fn matches_case_sensitively() {
+        // Device tree vendor prefixes are lowercase by schema; an uppercase
+        // value is not a device tree we recognise. Recorded as a decision
+        // rather than left to chance.
+        assert!(!compatible_is_tegra(b"NVIDIA,TEGRA234\0"));
     }
 
     #[test]

--- a/src/common/soc.rs
+++ b/src/common/soc.rs
@@ -1,0 +1,109 @@
+//! SoC identification from the flattened device tree.
+//!
+//! Some NVIDIA parts are integrated GPUs on a Tegra SoC rather than discrete
+//! boards. NVML enumerates them, but most of its discrete-GPU query surface
+//! either returns `NOT_SUPPORTED` or — worse — succeeds while reporting a
+//! value the hardware cannot actually measure. The GPU samplers use this to
+//! decide which NVML readings are meaningful on the running host.
+//!
+//! The check reads the device tree's root `compatible` property, a
+//! NUL-separated list of `vendor,model` strings ordered most-specific first.
+//! On a Jetson-class board that looks like:
+//!
+//! ```text
+//! nvidia,p3971-0089\0nvidia,tegra264\0
+//! ```
+//!
+//! where the trailing entry names the SoC. Every Tegra generation uses the
+//! `nvidia,tegra<n>` form, so matching that prefix identifies the family
+//! without enumerating individual SoCs.
+
+/// The device tree's root `compatible` property.
+///
+/// Absent on x86 hosts and on ARM systems that boot via ACPI rather than a
+/// flattened device tree; callers treat "cannot read" as "not a Tegra SoC".
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub const DEVICE_TREE_COMPATIBLE: &str = "/proc/device-tree/compatible";
+
+/// Whether a device tree `compatible` property identifies an NVIDIA Tegra SoC.
+///
+/// Takes the raw property bytes so the parse is testable without a device
+/// tree present; see [`is_tegra_soc`] for the reading wrapper.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn compatible_is_tegra(compatible: &[u8]) -> bool {
+    compatible
+        .split(|b| *b == 0)
+        .any(|entry| entry.starts_with(b"nvidia,tegra"))
+}
+
+/// Whether the running host is an NVIDIA Tegra SoC.
+///
+/// A host with no device tree — every x86 machine, and ARM systems that boot
+/// via ACPI — is not a Tegra part, so an unreadable property reads as `false`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn is_tegra_soc() -> bool {
+    is_tegra_soc_at(DEVICE_TREE_COMPATIBLE)
+}
+
+fn is_tegra_soc_at(path: impl AsRef<std::path::Path>) -> bool {
+    std::fs::read(path)
+        .map(|compatible| compatible_is_tegra(&compatible))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp(name: &str, contents: &[u8]) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, contents).expect("write temp compatible");
+        path
+    }
+
+    #[test]
+    fn reads_tegra_soc_from_device_tree_property() {
+        let path = write_temp(
+            "rezolus-soc-tegra-compatible",
+            b"nvidia,p3971-0089\0nvidia,tegra264\0",
+        );
+        assert!(is_tegra_soc_at(&path));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn identifies_tegra_soc_from_compatible() {
+        assert!(compatible_is_tegra(b"nvidia,p3971-0089\0nvidia,tegra264\0"));
+    }
+
+    #[test]
+    fn matches_every_tegra_generation() {
+        for compatible in [
+            &b"nvidia,p3701-0000+p3737-0000\0nvidia,tegra234\0"[..],
+            &b"nvidia,tegra194\0"[..],
+            &b"nvidia,tegra186\0"[..],
+        ] {
+            assert!(compatible_is_tegra(compatible), "{compatible:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_tegra_boards() {
+        assert!(!compatible_is_tegra(
+            b"raspberrypi,4-model-b\0brcm,bcm2711\0"
+        ));
+        assert!(!compatible_is_tegra(b""));
+    }
+
+    #[test]
+    fn requires_nvidia_tegra_at_an_entry_boundary() {
+        // A vendor string that merely *contains* the token is a different
+        // part; entries are matched from their start, not searched.
+        assert!(!compatible_is_tegra(b"acme,not-nvidia,tegra264\0"));
+    }
+
+    #[test]
+    fn absent_device_tree_is_not_a_tegra_soc() {
+        assert!(!is_tegra_soc_at("/nonexistent/device-tree/compatible"));
+    }
+}

--- a/src/recorder/rez_v3_writer.rs
+++ b/src/recorder/rez_v3_writer.rs
@@ -2663,6 +2663,31 @@ mod tests {
             }
         }
 
+        fn gauge_group_schema(members: &[&str]) -> GroupSchema {
+            GroupSchema {
+                counters: Vec::new(),
+                gauges: members.iter().map(|n| desc(n)).collect(),
+                histograms: Vec::new(),
+            }
+        }
+
+        fn gauge_group_snapshot(
+            name: &str,
+            schema: &GroupSchema,
+            gauges: Vec<Option<i64>>,
+            window: Option<Window>,
+        ) -> GroupSnapshot {
+            GroupSnapshot {
+                name: name.to_string(),
+                schema_hash: schema.hash(),
+                schema: Some(Arc::new(schema.clone())),
+                window,
+                counters: Vec::new(),
+                gauges,
+                histograms: Vec::new(),
+            }
+        }
+
         fn group_snapshot(
             name: &str,
             schema: &GroupSchema,
@@ -2697,6 +2722,92 @@ mod tests {
         /// bucket (integer division).
         fn seals_immediately() -> SealPolicy {
             policy(1)
+        }
+
+        /// A declared group member that is never written must reach the
+        /// segment as a present, all-null nullable column — never as a
+        /// fabricated `0`, and never silently dropped.
+        ///
+        /// The NVIDIA sampler manufactures exactly this on a Tegra SoC: the
+        /// PCIe-derived gauges are deliberately not `set()`, while their
+        /// siblings in the same acquisition group are. Before this, every V3
+        /// writer test was counter-only (`group_schema` hardcodes
+        /// `gauges: Vec::new()`), so the `Vec<Option<i64>>` -> `Int64Array`
+        /// path was untested despite being on that sampler's live path.
+        #[test]
+        fn v3_group_gauge_member_that_is_never_written_stays_null() {
+            use arrow::array::Array as _;
+
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("out.rez");
+            let (mut rec, rid) = recorder(&path, seals_immediately());
+
+            let sch = gauge_group_schema(&["written", "never_written"]);
+            let ts = 1_000_000_000u64;
+            let window = Some(Window::new(ts - 50_000_000, ts));
+            let g = gauge_group_snapshot(
+                "gpu_nvidia/gpu_nvidia_devices",
+                &sch,
+                vec![Some(97), None],
+                window,
+            );
+            rec.ingest(&v3_snap(ts, vec![g]), ts, 7).unwrap();
+            rec.maybe_seal().unwrap();
+            rec.sync().unwrap();
+
+            let db = RezDb::open(&path).unwrap();
+            let segs = db
+                .read_segments(rid, "gpu_nvidia/gpu_nvidia_devices")
+                .unwrap();
+            assert_eq!(segs.len(), 1, "the single tick must have sealed");
+
+            let mut reader =
+                parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(
+                    bytes::Bytes::from(segs[0].bytes.clone()),
+                )
+                .unwrap()
+                .build()
+                .unwrap();
+            let batch = reader.next().unwrap().unwrap();
+
+            // Both members are present as columns; membership comes from
+            // registration, so gating a `set()` must not drop the column.
+            let names: Vec<String> = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect();
+            assert!(
+                names.iter().any(|n| n == "never_written"),
+                "unwritten member must still get a column, got {names:?}"
+            );
+
+            let idx = batch.schema().index_of("never_written").unwrap();
+            let field = batch.schema().field(idx).clone();
+            assert_eq!(field.data_type(), &arrow::datatypes::DataType::Int64);
+            assert!(field.is_nullable(), "the column must be nullable");
+
+            let col = batch
+                .column(idx)
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .expect("Int64 column");
+            assert_eq!(col.len(), 1);
+            assert!(
+                col.is_null(0),
+                "an unwritten gauge member must be null, not a fabricated 0"
+            );
+
+            // ...while its written sibling in the same group is unaffected.
+            let widx = batch.schema().index_of("written").unwrap();
+            let wcol = batch
+                .column(widx)
+                .as_any()
+                .downcast_ref::<arrow::array::Int64Array>()
+                .expect("Int64 column");
+            assert!(!wcol.is_null(0));
+            assert_eq!(wcol.value(0), 97);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

On a Tegra SoC, NVML answers the PCIe link queries for an integrated GPU that has
no host PCIe link, returning a placeholder rather than an error. The derived
bandwidth lands in a recording looking like a measurement. This suppresses the
PCIe-derived metrics on Tegra and **nothing else**.

The branch reached that scope by being wrong twice and measuring its way out. Both
reversals are recorded below, because the pattern is the point: every gate here now
rests on a hardware fact or a measurement, and the two that rested on inference were
removed.

## What a real Tegra recording shows

Single iGPU, 55 min at 1 s (3290 snapshots). The host is confirmed Tegra by its own
signature: `current_pcie_link_gen`/`width` report **gen 1 ×1** for the entire run —
a rate no real NVIDIA GPU runs at.

| NVML call | result on Tegra | gated? |
|---|---|---|
| `current_pcie_link_gen`/`width` | gen 1 ×1 placeholder → constant, fabricated 250 MiB/s | ✅ yes |
| `pcie_throughput(Rx/Tx)` | returned `Err` every sample — 0 occurrences in the raw stream | ✅ yes, for the same physical reason |
| `utilization_rates().gpu` | **idle → ramp → ~91% plateau → decay → idle, peak 97** | ❌ no — it works |
| `utilization_rates().memory` | 0 all run — but see below | ❌ no |
| `power_usage` / `temperature` | 4.3–20.9 W / 43–62 °C, varying | no |
| `gpu_clock` | only `video` + `graphics` resolve; `compute`/`memory` error | no |

## Two things this branch got wrong

**1. It originally gated `gpu_utilization`.** The premise was that
`utilization_rates()` "succeeds and reports 0/0 unconditionally" on Tegra — one
engineer's observation. The recording falsifies it: `.gpu` tracks a workload cleanly.
Gating it would have deleted the most useful GPU metric the platform has.

**2. It then gated `utilization_rates().memory`,** on the grounds that "zero memory
utilization under a sustained 91% load is not credible" — i.e. it repeated the same
mistake, smaller. Refuted by the same recording. NVML defines both fields as duty
cycles of *time*, not intensity, so a compute-bound kernel with a cache-resident
working set pins `.gpu` high while `.memory` rounds to zero. And the plateau was not
a sustained load: the GPU drew **17.3 W across it versus 19.0 W while idle** — its
lightest phase. Zero global-memory duty cycle there is the *expected* reading.

## Adversarial review

Two passes, four independent reviewers.

**Fixed**

- **`gpu_utilization` gated in error** → ungated. (pass 1)
- **`utilization_rates().memory` gated on inference** → ungated. (pass 2)
- **`pcie_throughput` left outside the gate** → moved inside. Flagged independently by
  both pass-2 reviewers. It errors on the measured host, but that is not a contract
  NVML owes us; each JetPack adds NVML surface, and the first that answers `Ok(0)`
  would record throughput for a link that does not exist — *harder* to spot than the
  250 MiB/s placeholder, because 0 B/s on an idle link looks plausible. The gate now
  rests on the hardware fact, not on which call happens to fail.
- **Tests didn't pin the parser** → three mutations (match `nvidia,` alone, substring
  vs prefix, `path.exists()` for the read) all passed the old suite; each now fails it.
- **All-null gauge column untested** → every V3 writer test was counter-only, so the
  path this sampler manufactures was untested on its own critical path. Added a test
  asserting an unwritten declared member reaches the segment as a present, nullable,
  all-null `Int64` column while its written sibling is unaffected; verified to fail
  when the value is coerced to `0`.
- **Shared fixed temp path in tests** → now a private `tempfile::tempdir()`.

**Verified safe** (traced, not assumed)

- **No fabricated zeros.** All gated metrics are `GaugeGroup`s, which map an `i64::MIN`
  sentinel to `None`; `Some(i64::MIN)` is unrepresentable, and a repo-wide sweep found
  no `.unwrap_or(0)` on a snapshot gauge value. Confirmed end-to-end: msgpack `nil`,
  Prometheus omits the series, viewer TSDB skips it with no zero backfill, `.rez` writes
  a nullable all-null column, `.parquet` omits the column.
- **Acquisition-group integrity** (principle 18). Partially populating a group is not a
  new archetype — the seven GPM metrics in this same group are already permanently
  unwritten on every pre-Hopper host. Membership comes from registration, `acquire()`/
  `finish()` are untouched, and skipping a read makes the actual span *shorter* than the
  published window, the safe direction.
- **`schema_hash` stability.** `tegra_soc` is probed once at init and the statics are
  declared unconditionally, so Tegra and non-Tegra hosts emit the *same* schema hash and
  their recordings combine cleanly.
- **Query behaviour.** A gated metric returns an empty series — not an error, not zeros.
- **Strict no-op off Tegra.** Whitespace/comment-normalised diff of `refresh_nvml` against
  main is four lines: two guards and two braces. No reordering, no changed values. The new
  field is appended last, so the `gpm_samples`-before-`nvml` drop-order invariant holds.

**Known limitations — recorded in `docs/backlog.md`, deliberately not fixed here**

- **NVML utilization support is Tegra-generation-dependent.** NVIDIA's stated position is
  that NVML is unsupported on Jetson; JetPack 7 / Thor advertises newly-added NVML GPU
  monitoring. So on a generation where `.gpu` is *not* populated, the agent records a
  constant 0 indistinguishable from an idle GPU. **This is main's existing behaviour** —
  this PR declines to gate `.gpu` rather than introducing the exposure. The real fix is to
  prefer the nvgpu driver's own load node (what `tegrastats` reads), which works on every
  generation; that needs a measured per-refresh cost per principles 13/16/17.
- **The probe is host-wide, the property is per-device.** A Tegra board with a discrete PCIe
  GPU (IGX Orin) would have that card's real PCIe metrics suppressed. The per-device
  discriminator can't be verified without such a host.
- **`GPU_ENERGY_CONSUMPTION` can publish a fabricated zero** — pre-existing, same bug class.
  It's a `CounterGroup`, which has no sentinel and returns `Some(0)` for an unwritten slot
  once any index is written. Cannot fire on a single-GPU host.
- **Container false negative** — runc masks `/sys/firmware`, so an unprivileged container
  reads a genuine Tegra as not-Tegra.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean on Linux (rustc 1.98, CI's toolchain)
- [x] 755 tests pass on Linux; 714 on macOS (sampler is cfg'd out there)
- [x] Three parser mutations + one fabricated-zero mutation each verified to fail the suite
- [x] Claims re-checked against the raw msgpack stream, not just the converted parquet
- [ ] Not run on Tegra hardware from my side — behavioural claims rest on the recording above

## Follow-up

The same recording shows ~18.6 W drawn and a 49.6 → 61.5 °C ramp while `gpu_utilization`
reads 0, with power *lowest* during the SM plateau. NVML's `.gpu` covers only the
SM/graphics engine — NVENC/NVDEC are separate blocks it doesn't count. We record
`gpu_clock{clock="video"}` but never the video engine's utilization. Filed as the
highest-value gap in `docs/backlog.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)