### PR TITLE
feat(packaging): build and install Rezolus on Enterprise Linux 10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,21 +66,29 @@ jobs:
     if: github.repository == 'iopsystems/rezolus'
     name: "rpm ${{ matrix.distro }}:${{ matrix.version }} (${{ matrix.arch }})"
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
-    container: "${{ matrix.distro }}:${{ matrix.version }}"
+    # `image` is explicit because Docker Hub's `library/rockylinux` was
+    # deprecated after Rocky 9 -- Rocky 10 is only published under the
+    # `rockylinux/rockylinux` org repo. `distro`/`version` still name the
+    # artifact and pick the target yum repo (rockylinux 10 -> rocky10).
+    container: "${{ matrix.image }}"
     strategy:
       matrix:
         include:
-          - { distro: rockylinux, version: 9, arch: x86_64 }
-          - { distro: rockylinux, version: 9, arch: arm64 }
-          - { distro: amazonlinux, version: 2023, arch: x86_64 }
-          - { distro: amazonlinux, version: 2023, arch: arm64 }
+          - { distro: rockylinux, version: 9, arch: x86_64, image: "rockylinux:9" }
+          - { distro: rockylinux, version: 9, arch: arm64, image: "rockylinux:9" }
+          - { distro: rockylinux, version: 10, arch: x86_64, image: "rockylinux/rockylinux:10" }
+          - { distro: rockylinux, version: 10, arch: arm64, image: "rockylinux/rockylinux:10" }
+          - { distro: amazonlinux, version: 2023, arch: x86_64, image: "amazonlinux:2023" }
+          - { distro: amazonlinux, version: 2023, arch: arm64, image: "amazonlinux:2023" }
       fail-fast: false
     steps:
+      # `dnf` rather than `yum` throughout: every image in the matrix has it,
+      # while el10 no longer guarantees the legacy `yum` entry point.
       - name: install basic dependencies
         if: matrix.distro == 'amazonlinux'
         shell: bash
         run: |
-          yum install -y tar gzip
+          dnf install -y tar gzip
 
       - uses: actions/checkout@v5
 
@@ -92,7 +100,7 @@ jobs:
       - name: install build dependencies
         shell: bash
         run: |
-          yum install -y gcc elfutils-devel clang openssl-devel
+          dnf install -y gcc elfutils-devel clang openssl-devel
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -133,7 +141,7 @@ jobs:
           echo "Building rpm: Version=$RPM_VERSION Release=$RPM_RELEASE Arch=$RPM_ARCH"
 
           # rpm-build provides rpmbuild (not in the minimal container image).
-          yum install -y rpm-build
+          dnf install -y rpm-build
 
           mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS} target/generate-rpm
 
@@ -167,7 +175,7 @@ jobs:
             exit 0
           fi
           # Install GPG agent and pinentry (not present in minimal container images)
-          yum install -y --allowerasing gnupg2 pinentry
+          dnf install -y --allowerasing gnupg2 pinentry
 
           # Import the GPG signing key
           echo "$GPG_SIGNING_KEY" | base64 -d | gpg --batch --import
@@ -183,7 +191,7 @@ jobs:
           MACROS
 
           # Install rpm-sign (provides rpmsign binary needed by rpm --addsign)
-          yum install -y rpm-sign
+          dnf install -y rpm-sign
 
           # Sign each RPM
           for rpm in target/generate-rpm/*.rpm; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.18.1-alpha.5"
+version = "5.18.1-alpha.6"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.18.1-alpha.5"
+version = "5.18.1-alpha.6"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/README.md
+++ b/README.md
@@ -465,7 +465,8 @@ curl -fsSL https://install.rezolus.com | bash
 The quick install script works on both Linux and macOS. On macOS it uses
 Homebrew if available, or falls back to Cargo. It adds the package repo,
 installs Rezolus, and starts the agent and exporter as systemd services.
-Supported distributions include Debian, Ubuntu, Rocky Linux, and Amazon Linux.
+Supported distributions include Debian, Ubuntu, Enterprise Linux 9 and 10
+(Rocky Linux, AlmaLinux, RHEL, CentOS Stream, Oracle Linux), and Amazon Linux.
 
 By default, the `rezolus` (agent) and `rezolus-exporter` services run after
 install, so Prometheus exposition is available immediately. The config assumes

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ package manager.
 **Supported distributions:**
 - Debian: 13 (trixie/stable), 12 (bookworm/oldstable), 11 (bullseye/oldoldstable)
 - Ubuntu: 20.04 (focal), 22.04 (jammy), 24.04 (noble)
-- Rocky Linux: 9
+- Enterprise Linux 9 and 10 (Rocky Linux, AlmaLinux, RHEL, CentOS Stream, Oracle Linux)
 - Amazon Linux: 2023
 
 ```bash
@@ -51,13 +51,14 @@ echo "deb [arch=${ARCH}] https://us-apt.pkg.dev/projects/rezolus ${DISTRO}-${COD
 sudo apt update && sudo apt install rezolus
 ```
 
-### AmazonLinux/RockyLinux
+### Enterprise Linux / Amazon Linux
 
 ```bash
 # Add repository and install
 source /etc/os-release
 case "$ID" in
-    rocky) REPO_NAME="rocky9" ;;
+    # One repo per Enterprise Linux major version, shared by all derivatives.
+    rocky|almalinux|rhel|centos|ol) REPO_NAME="rocky${VERSION_ID%%.*}" ;;
     amzn) REPO_NAME="al2023" ;;
 esac
 sudo tee /etc/yum.repos.d/rezolus.repo <<EOF
@@ -84,7 +85,7 @@ symbols.
 # Debian/Ubuntu
 sudo dpkg -i rezolus_*.deb
 
-# Rocky/Amazon Linux  
+# Enterprise/Amazon Linux  
 sudo rpm -i rezolus-*.rpm
 ```
 
@@ -160,7 +161,7 @@ ls -la ../*.deb
 
 ### Building RPM Packages
 
-On a Rocky Linux or Amazon Linux system, you can build `.rpm` packages:
+On an Enterprise Linux (Rocky, Alma, RHEL, ...) or Amazon Linux system, you can build `.rpm` packages:
 
 ```bash
 # Clone the repository

--- a/install.sh
+++ b/install.sh
@@ -179,15 +179,21 @@ elif command -v dnf &> /dev/null || command -v yum &> /dev/null; then
     fi
 
     case "$DISTRO" in
-        rocky)
+        rocky|almalinux|rhel|centos|ol)
+            # Rezolus publishes one RPM repo per Enterprise Linux major
+            # version (named for the distro it is built on), and every el9 /
+            # el10 derivative installs the same package from it.
             MAJOR_VERSION="${VERSION_ID%%.*}"
-            if [[ "$MAJOR_VERSION" == "9" ]]; then
-                REPO_NAME="rocky9"
-            else
-                echo "Error: Unsupported Rocky Linux version: $VERSION_ID" >&2
-                echo "Supported versions: 9" >&2
-                exit 1
-            fi
+            case "$MAJOR_VERSION" in
+                9|10)
+                    REPO_NAME="rocky${MAJOR_VERSION}"
+                    ;;
+                *)
+                    echo "Error: Unsupported ${NAME:-$DISTRO} version: $VERSION_ID" >&2
+                    echo "Supported Enterprise Linux versions: 9, 10" >&2
+                    exit 1
+                    ;;
+            esac
             ;;
         amzn)
             if [[ "$VERSION_ID" == "2023" ]]; then
@@ -200,13 +206,14 @@ elif command -v dnf &> /dev/null || command -v yum &> /dev/null; then
             ;;
         *)
             echo "Error: Unsupported RPM-based distribution: $DISTRO" >&2
-            echo "Supported distributions: Rocky Linux, Amazon Linux" >&2
+            echo "Supported distributions: Rocky Linux, AlmaLinux, RHEL," >&2
+            echo "CentOS Stream, Oracle Linux (9 and 10), and Amazon Linux 2023" >&2
             exit 1
             ;;
     esac
 else
     echo "Error: No supported package manager found" >&2
-    echo "This installer requires apt (Debian/Ubuntu) or dnf/yum (Rocky Linux/Amazon Linux)" >&2
+    echo "This installer requires apt (Debian/Ubuntu) or dnf/yum (Enterprise Linux/Amazon Linux)" >&2
     echo "" >&2
     echo "To install Rezolus without a package manager, use:" >&2
     echo "  cargo install rezolus" >&2

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -128,7 +128,7 @@
 </div>
 <div class="p-5 rounded-xl border border-slate-200 dark:border-slate-800">
 <h3 class="text-sm font-bold mb-2">RHEL / Amazon Linux</h3>
-<p class="text-sm text-slate-500">Rocky Linux 9 &middot; Amazon Linux 2023</p>
+<p class="text-sm text-slate-500">Enterprise Linux 9 &amp; 10 &middot; Amazon Linux 2023</p>
 </div>
 </div>
 </section>


### PR DESCRIPTION
## Summary

- `curl -fsSL https://install.rezolus.com | sudo bash` fails on Rocky Linux 10.2 with `Unsupported Rocky Linux version: 10.2`. The installer only accepted major 9, and the release RPM matrix only built `rockylinux:9` / `amazonlinux:2023`, so there was no el10 package to point at either.
- **Build el10 RPMs**: adds `rockylinux 10` (x86_64 + arm64) to the release matrix. Each entry now names its container `image` explicitly — Docker Hub's `library/rockylinux` was deprecated after 9 (newest tag `9.3.20231119`, no 10), so the old `"${{ matrix.distro }}:${{ matrix.version }}"` expression would have failed to pull; Rocky 10 exists only under `rockylinux/rockylinux`. `distro`/`version` still drive artifact naming and the existing `rocky${version}` upload mapping, so these land in `rocky10` with no change to the upload step.
- The job's `yum install` calls become `dnf`: all four images have dnf, el10 no longer guarantees the legacy `yum` entry point, and this job only runs on release tags where a wrong guess surfaces late.
- **Broaden the installer**: one RPM repo per EL major version is shared by all derivatives, so `rocky` at major 9 becomes `rocky|almalinux|rhel|centos|ol` at major 9 or 10 → `rocky${MAJOR}`. el8 still gets a clean `supported versions: 9, 10` message rather than a dnf failure.
- Docs updated (`README.md`, `docs/installation.md`, `site/docs/installation.html`) to say Enterprise Linux 9 and 10.

## Infrastructure (already done)

The `rocky10` Artifact Registry repo has been created in project `rezolus`, matching `rocky9` exactly: YUM, `STANDARD_REPOSITORY`, Google-managed encryption, single `allUsers → roles/artifactregistry.reader` binding. Unauthenticated `GET .../projects/rezolus/rocky10/repodata/repomd.xml` returns 200. Uploads need nothing further — `rezolus-github-package-publish@` holds project-level `artifactregistry.writer`.

## Test plan

- [x] Installer distro detection exercised against faked `os-release` values: `rocky 10.2`→`rocky10`, `almalinux 10.0`→`rocky10`, `centos 10`→`rocky10`, `rocky 9.6`/`rhel 9.4`/`ol 9.5`→`rocky9`, `rocky 8.10`→clean unsupported-version error, `amzn 2023`→`al2023`, `fedora 42`→clean unsupported-distro error
- [x] `bash -n install.sh` clean; `release.yml` parses and yields the expected 6 RPM builds
- [x] `rocky10` repo reachable unauthenticated (HTTP 200), currently 0 packages
- [ ] **Not yet verified**: an actual el10 RPM build. The `rockylinux/rockylinux:10` container build — notably the clang/BPF compile — has not been exercised; it runs first on the next release tag
- [ ] **Known window**: until a stable release populates `rocky10`, a Rocky 10 host running this installer fetches repo metadata successfully and then gets `No match for argument: rezolus` from dnf. Shipping now so it works on the next release, per intent

Note: no Rust changed, so `cargo test`/`clippy`/`fmt` were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)