### PR TITLE
release: prepare v5.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 ## [Unreleased]
 
+## [5.19.0] - 2026-08-31
+
+### Changed
+
+- Agent: a sampler for a capability the machine lacks now reports `unsupported`
+  rather than `failed`, and `rezolus status` no longer exits non-zero because of
+  it. A host whose CPU has no L3 cache domain, or which has no ROCm library or
+  ethtool support, used to fail a readiness check over hardware it was never
+  going to have. Monitoring that alerts on the status exit code will stop firing
+  on such hosts; a genuine initialization failure still exits non-zero, and
+  `disabled`, `unsupported` and `failed` are now three answers rather than two.
+  (#1102, #1103)
+- GPU: a Tegra SoC's integrated GPU no longer records utilization or PCIe link
+  metrics. NVML answers both queries there and answers wrongly — a hard-coded
+  0% utilization indistinguishable from a genuinely idle GPU once it is a row in
+  an archive, and a placeholder generation and width for a link an iGPU does not
+  have. `gpu_sm_utilization`, `gpu_dram_bandwidth_utilization` and the PCIe
+  series are absent on those parts now rather than present and wrong. (#1108)
+- Viewer/MCP: a query against a `.rez` archive is 12.8x faster. A query opens
+  only the tables it touches, where before it materialized the whole archive and
+  spent 91% of its wall time opening tables it never read. `.rez` is now at or
+  ahead of a single parquet holding the same window. No format change — existing
+  archives get this on read. (#1107)
+
+### Added
+
+- Recorder: several endpoints record into one `.rez`. `rezolus record --endpoint
+  http://web-01:4241 --endpoint http://web-02:4241 -o fleet.rez` writes one
+  archive holding a recording per host, where before more than one endpoint
+  silently demoted the output to parquet. Both arms of an A/B can now be
+  captured concurrently rather than in sequence, so they share their background
+  load instead of differing in it as well as in the experiment. (#1109)
+- Packaging: `.rpm` packages for Enterprise Linux 10, and the install script now
+  accepts Rocky Linux, AlmaLinux, RHEL, CentOS Stream and Oracle Linux at major
+  9 or 10. `curl -fsSL https://install.rezolus.com | sudo bash` failed outright
+  on EL10 before. (#1113)
+
+### Fixed
+
+- Recording: reading a `.rez` while it is being written no longer panics when
+  retention evicts a table mid-query. A quiet sampler's only rows could be
+  dropped between the probe that named its table and the query that opened it,
+  crashing the viewer or MCP against a hindsight rolling buffer — which is the
+  one thing that buffer exists to be read as. A table that has gone is reported
+  absent, the same as one that was never there. (#1112)
+- Recording: a Prometheus source that emits timestamps no longer writes
+  acquisition windows anchored decades before the rows holding them. The
+  optional trailing timestamp in the exposition format is a federation staleness
+  marker, not a claim about when we read; taking it at face value gave a row
+  recorded in 2026 a window one second after the Unix epoch — a ~56-year error
+  in the operand `rate()` prices its uncertainty from, nonsense rather than
+  conservative. The window is our fetch. Any pushgateway or federation exporter
+  produced this, on the parquet path as well as `.rez`. (#1111)
+
 ## [5.18.0] - 2026-08-26
 
 ### Changed
@@ -1092,7 +1146,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.18.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.19.0...HEAD
+[5.19.0]: https://github.com/iopsystems/rezolus/compare/v5.18.0...v5.19.0
 [5.18.0]: https://github.com/iopsystems/rezolus/compare/v5.17.0...v5.18.0
 [5.17.0]: https://github.com/iopsystems/rezolus/compare/v5.16.2...v5.17.0
 [5.16.2]: https://github.com/iopsystems/rezolus/compare/v5.16.1...v5.16.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.18.1-alpha.6"
+version = "5.19.0"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.18.1-alpha.6"
+version = "5.19.0"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Release v5.19.0

Bumps `5.18.1-alpha.6` → `5.19.0` and writes the changelog for the 10 commits since v5.18.0 (2026-08-26).

**Minor, not patch**: #1109 added user-facing recorder capability (multi-endpoint `.rez`), so the alpha line's patch intent no longer fits.

### Highlights

- **Changed** — a capability the machine lacks now reports `unsupported` rather than `failed`, so `rezolus status` stops exiting non-zero over absent hardware (#1102, #1103); Tegra iGPU utilization and PCIe series are absent rather than present-and-wrong (#1108); `.rez` queries are 12.8× faster with no format change (#1107)
- **Added** — several endpoints record into one multi-recording `.rez` (#1109); `.rpm` packages for Enterprise Linux 10, with the installer widened to Rocky/Alma/RHEL/CentOS Stream/Oracle at major 9 or 10 (#1113)
- **Fixed** — reading a `.rez` while it is written no longer panics when retention evicts a table mid-query, which is exactly what a hindsight rolling buffer does (#1112); a Prometheus source emitting timestamps no longer writes windows anchored to 1970 on 2026 rows (#1111)

`#1104` (clippy gating) and `#1106` (journal entry) are internal and have no changelog entry.

### Compatibility

No on-disk format change: `SCHEMA_VERSION = 3` and `REZ_SCHEMA_VERSION = 2` are both unchanged since v5.18.0.

Two behavior changes worth calling out to operators, both noted in the changelog:
- `rezolus status` exit code flips 1 → 0 on hosts lacking L3 / ROCm / ethtool support — readiness checks that fail there today will start passing
- Tegra hosts lose `gpu_sm_utilization`, `gpu_dram_bandwidth_utilization` and the PCIe series entirely

### Verification

- `cargo clippy --all-targets -- -D warnings` → exit 0, zero warnings
- `cargo test` → exit 0, 752 passed / 0 failed (macOS; Linux/eBPF paths covered by CI)

### Watch after merge

This is the first release to build `rockylinux/rockylinux:10` RPMs, and that container build has never run — notably the clang/BPF compile. `build-rpm` uses `fail-fast: false`, so a failure there won't stop the other five RPM jobs but will leave the release without el10 packages. The `rocky10` Artifact Registry repo is created and world-readable, awaiting its first upload.

### After merge

1. `tag-release.yml` tags `v5.19.0` and bumps main to the next dev version
2. `release.yml` builds and publishes deb/rpm/Homebrew/crates.io artifacts

---
See CHANGELOG.md for the full entries.