### PR TITLE
fix(install): build from source instead of a crates.io stuck on 5.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.19.1-alpha.0"
+version = "5.19.1-alpha.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.19.1-alpha.0"
+version = "5.19.1-alpha.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,6 +93,36 @@ sudo rpm -i rezolus-*.rpm
 
 If you need to build Rezolus from source, you can either build the binary directly or create distribution packages.
 
+### Build Prerequisites
+
+Building the eBPF programs needs a C toolchain, clang, and libelf:
+
+```bash
+# Debian/Ubuntu
+sudo apt install -y build-essential pkg-config libelf-dev clang
+
+# Enterprise Linux (Rocky, Alma, RHEL, ...) / Amazon Linux
+sudo dnf install -y gcc elfutils-devel clang
+
+# macOS (no eBPF; CPU usage only)
+xcode-select --install
+```
+
+### One-Command Install from Source
+
+To build and install the latest release without cloning:
+
+```bash
+cargo install --git https://github.com/iopsystems/rezolus --tag v5.19.0 --locked rezolus
+```
+
+Omit `--tag` to build the default branch. This installs the binary to
+`~/.cargo/bin/rezolus`; the configs and systemd units below are not installed,
+so set those up by hand if you want to run Rezolus as a service.
+
+Note that `cargo install rezolus` (from crates.io) is **not** the way to install
+current Rezolus — that registry is stuck on an old version.
+
 ### Building the Binary
 
 To build just the Rezolus binary without packaging:

--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,20 @@ if [[ "$OS_TYPE" == "Darwin" ]]; then
     elif command -v cargo &> /dev/null; then
         echo "Homebrew not found, but Cargo is available"
         echo "Installing Rezolus via Cargo..."
-        cargo install rezolus
+        # Not `cargo install rezolus`: the crates.io publish step was dropped
+        # from the release pipeline (#771) and that registry is stuck on 5.4.0,
+        # so it would quietly install a year-old build. Install from the release
+        # tag instead, falling back to the default branch if the tag lookup
+        # fails (no network for the API, rate limit, unexpected payload).
+        LATEST_TAG="$(curl -fsSL https://api.github.com/repos/iopsystems/rezolus/releases/latest 2>/dev/null \
+            | sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' | head -1)"
+        if [[ -n "$LATEST_TAG" ]]; then
+            echo "Building ${LATEST_TAG} from source (this takes a few minutes)..."
+            cargo install --git https://github.com/iopsystems/rezolus --tag "$LATEST_TAG" --locked rezolus
+        else
+            echo "Could not resolve the latest release tag; building the default branch..."
+            cargo install --git https://github.com/iopsystems/rezolus --locked rezolus
+        fi
         echo ""
         echo "Installation completed successfully"
         echo "Run 'rezolus --help' for usage information"
@@ -215,8 +228,13 @@ else
     echo "Error: No supported package manager found" >&2
     echo "This installer requires apt (Debian/Ubuntu) or dnf/yum (Enterprise Linux/Amazon Linux)" >&2
     echo "" >&2
-    echo "To install Rezolus without a package manager, use:" >&2
-    echo "  cargo install rezolus" >&2
+    echo "To install Rezolus without a package manager, build from source:" >&2
+    echo "  cargo install --git https://github.com/iopsystems/rezolus --locked rezolus" >&2
+    echo "" >&2
+    echo "Build prerequisites (a C toolchain, clang, libelf) are listed in" >&2
+    echo "  https://github.com/iopsystems/rezolus/blob/main/docs/installation.md" >&2
+    echo "Prebuilt .deb and .rpm packages are also attached to each release:" >&2
+    echo "  https://github.com/iopsystems/rezolus/releases/latest" >&2
     exit 1
 fi
 

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -63,7 +63,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -61,7 +61,7 @@
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.18.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">


### PR DESCRIPTION
## Summary

- `install.sh` fell back to `cargo install rezolus` in two places — macOS without Homebrew, and Linux with no supported package manager. Both installed **rezolus 5.4.0** (released 2025-09-30) with no indication anything was wrong.
- **Why crates.io is stale**: the publish step was deleted from `release.yml` by #771, a PR whose title ("Prepare systeminfo crate for publishing") and body describe adding a `version` to the systeminfo dep and clearing `publish = false`. It did neither — its whole diff is 15 deleted lines of `publish to crates.io` plus a one-line `tag-release.yml` change. `git log -S "publish = false" -- crates/systeminfo/Cargo.toml` returns only #68, the crate's original extraction.
- **Restoring it isn't a one-liner**: the root manifest declares `dashboard`, `report-save` and `systeminfo` as path deps with no `version` (crates.io rejects that) and all three are `publish = false`. Adding versions naively would be worse than failing — `systeminfo` (0.1.5) and `dashboard` (0.1.0) are taken on crates.io by unrelated crates, so a published rezolus would resolve to strangers' code. Whether to publish those crates at all is left open; this PR fixes what users hit today.
- Both fallbacks now build from source: macOS resolves the latest release tag from the GitHub API and installs it (falling back to the default branch if the lookup fails); Linux prints the command, the prerequisites, and the releases page.
- `docs/installation.md` gains **Build Prerequisites** — previously undocumented, so the existing clone + `cargo build --release` instructions fail on a clean machine — plus a one-command source install and an explicit warning off `cargo install rezolus`.

Prerequisites are taken from the canonical sources: `debian/control`'s `Build-Depends` (`pkg-config`, `libelf-dev`, `clang`) and the RPM job's `dnf install -y gcc elfutils-devel clang`. `openssl-devel` is omitted — there's no `openssl-sys` in `Cargo.lock`, the project is on rustls.

## Test plan

- [x] `cargo install --git https://github.com/iopsystems/rezolus --tag v5.19.0 --locked rezolus` into a scratch root: exit 0, `rezolus 5.19.0`, built from `8f1336a4` in 5m57s
- [x] Tag-resolution snippet against the live GitHub API returns `v5.19.0`
- [x] `bash -n install.sh` clean
- [ ] Not exercised: the macOS Homebrew-absent branch end to end (requires a machine without Homebrew), and the Linux no-package-manager branch

Note: `scripts/sync-docs-version.sh` moved the `site/docs/*.html` version labels from v5.18.0 to v5.19.0, per the standard PR step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)