### PR TITLE
test(hindsight): draw again when a dump lands on the seal boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.19.1-alpha.1"
+version = "5.19.1-alpha.2"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.19.1-alpha.1"
+version = "5.19.1-alpha.2"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true

--- a/tests/hindsight_dump.rs
+++ b/tests/hindsight_dump.rs
@@ -901,48 +901,83 @@ fn sealing_continues_through(
 ///
 /// Timed off the buffer's own reported WAL depth rather than off the clock: the
 /// dump is taken when `/status` says 1–2 rows are live, which puts the next
-/// seal several ticks away and makes "the tail is a partial segment" a fact
-/// about observed state rather than a hope about scheduling.
+/// seal several ticks away. That read happens *before* the dump though, and the
+/// buffer keeps ingesting in between, so the phase it establishes can be lost —
+/// whether the tail really is partial is therefore checked against the dump
+/// itself, and a dump that missed is redrawn rather than failed.
 #[test]
 fn a_dump_cuts_the_timeline_at_its_snapshot_and_seals_the_live_tail() {
     // Eight-row segments at 10 Hz: a seal every ~800 ms, so catching the buffer
     // with 1-2 live WAL rows leaves ~600 ms before the next one.
     const SEGMENT_ROWS: u64 = 8;
+    // How many dumps to take before giving up on catching a partial tail.
+    //
+    // The WAL depth cycles 0 -> SEGMENT_ROWS every ~800 ms, and `/status` is
+    // read *before* the dump, so a stall between the two requests loses the
+    // phase that read established. Land in the tick where the buffer has just
+    // sealed and the dump's last segment is a full one with nothing live
+    // behind it — roughly one tick in eight, which is what a loaded CI runner
+    // hit. Each dump is an independent draw of that phase and costs
+    // single-digit milliseconds against this one-counter buffer, so redraw
+    // rather than fail the run: the same reasoning as `Hindsight::start`
+    // retrying the lost-port race.
+    const DUMP_ATTEMPTS: usize = 5;
+
     let h = Hindsight::start(SEGMENT_ROWS as usize, 1);
     let dir = tempfile::tempdir().unwrap();
     let dest = dir.path().join("dump.rez");
 
-    // Wait for a buffer that has sealed AND is part-way into its next segment.
-    let at_dump = h.wait_until("a partly-filled WAL over sealed segments", |s| {
-        s.segments("fake") >= 2 && (1..=2).contains(&s.table("fake").live_wal_rows)
-    });
-    let live_before = at_dump.table("fake").live_wal_rows;
-    h.dump_to(&dest);
-    // Read /status again AFTER the dump so the live-row count at the moment
-    // the snapshot was taken is BRACKETED rather than guessed. The buffer is
-    // still ingesting at 10 Hz, so any fixed tolerance on `live_before` is a
-    // bet on how long the dump takes — and on a loaded CI runner that bet
-    // loses (observed: 1 row before, a 7-row tail).
-    let live_after = h.status().table("fake").live_wal_rows;
+    let mut missed = Vec::new();
+    let (dumped, live_before, live_after) = loop {
+        // Wait for a buffer that has sealed AND is part-way into its next
+        // segment.
+        let at_dump = h.wait_until("a partly-filled WAL over sealed segments", |s| {
+            s.segments("fake") >= 2 && (1..=2).contains(&s.table("fake").live_wal_rows)
+        });
+        let live_before = at_dump.table("fake").live_wal_rows;
+        h.dump_to(&dest);
+        // Read /status again AFTER the dump so the live-row count at the moment
+        // the snapshot was taken is BRACKETED rather than guessed. The buffer is
+        // still ingesting at 10 Hz, so any fixed tolerance on `live_before` is a
+        // bet on how long the dump takes — and on a loaded CI runner that bet
+        // loses (observed: 1 row before, a 7-row tail).
+        let live_after = h.status().table("fake").live_wal_rows;
 
-    let dumped = read_rez(&dest, "fake");
-    assert!(
-        dumped.wal.is_empty(),
-        "a ranged dump copies no WAL rows — the tail is materialized into a \
-         segment instead, so that its metrics keep their labels: {:?}",
-        dumped.wal
-    );
+        let dumped = read_rez(&dest, "fake");
+        // True of every dump taken here, not only the one that is kept.
+        assert!(
+            dumped.wal.is_empty(),
+            "a ranged dump copies no WAL rows — the tail is materialized into a \
+             segment instead, so that its metrics keep their labels: {:?}",
+            dumped.wal
+        );
+        let tail_rows = dumped
+            .segments
+            .last()
+            .expect("the dump must hold at least the tail")
+            .rows;
+        // Asked of the dump in hand rather than of the `/status` read that
+        // preceded it. A full last segment means the snapshot landed on a seal
+        // boundary with no live tail to carry, and every claim below would hold
+        // vacuously — so that dump is discarded and the phase drawn again.
+        if tail_rows < SEGMENT_ROWS {
+            break (dumped, live_before, live_after);
+        }
+        missed.push(tail_rows);
+        assert!(
+            missed.len() < DUMP_ATTEMPTS,
+            "fixture: {DUMP_ATTEMPTS} dumps in a row landed on a seal boundary \
+             with no live tail to carry — last segments held {missed:?} rows, a \
+             full {SEGMENT_ROWS} every time. One is the phase race; this many \
+             means the buffer is sealing between the /status read and every \
+             snapshot the test takes"
+        );
+    };
+
     let tail = dumped
         .segments
         .last()
         .expect("the dump must hold at least the tail");
-    assert!(
-        tail.rows < SEGMENT_ROWS,
-        "fixture: the dump's last segment holds {} rows, a full segment — the \
-         dump landed exactly on a seal boundary and there was no live tail to \
-         carry",
-        tail.rows
-    );
     // `live_after` can be lower than `live_before` if a seal landed between
     // the two reads, which resets the WAL — in that case the tail is bounded
     // by a full segment instead, which the assertion above already covers.


### PR DESCRIPTION
## Summary

`a_dump_cuts_the_timeline_at_its_snapshot_and_seals_the_live_tail` failed on ubuntu-22.04 and ubuntu-24.04 during #1113 — a change containing no Rust at all:

```
fixture: the dump's last segment holds 8 rows, a full segment — the dump
landed exactly on a seal boundary and there was no live tail to carry
```

**Root cause.** The fixture needs the snapshot taken while the WAL holds a partial tail, and establishes that by reading `/status` until 1–2 rows are live. That read happens *before* the dump and the buffer keeps ingesting in between, so the phase the read establishes is not necessarily the phase the snapshot lands in. The test's doc comment claimed the opposite — "a fact about observed state rather than a hope about scheduling" — which is precisely what made this failure look impossible. Corrected here.

**The failing phase is narrower than "a slow runner."** A flat 900 ms stall between the read and the dump does **not** reproduce it — the WAL cycles 0 → 8 every 800 ms, so an arbitrary delay usually lands mid-cycle on a partial tail and the test passes. The miss requires landing in the tick where the buffer has just sealed, leaving `segments.last()` a full segment with nothing live behind it: about one tick in eight. Stalling by `(SEGMENT_ROWS - live_before)` ticks reproduces the CI failure exactly — same assertion, same 8 rows.

**The fix.** The fixture question is asked of the dump in hand rather than the `/status` read that preceded it; a dump that missed is discarded and the phase drawn again, up to 5 times. Each dump is an independent draw costing single-digit milliseconds on a one-counter buffer, taking the odds from ~1 in 8 per stall to ~1 in 32,000. Same reasoning as `Hindsight::start` retrying the lost-port race (#1087). Exhausting all 5 still fails, with a message separating the phase race from a buffer that seals before every snapshot.

`dumped.wal.is_empty()` moved inside the loop on the way past — it's a claim about every ranged dump, not just the one the test keeps, so this is slightly more coverage than before.

Deliberately **not** done: freezing ingestion during the dump would make it fully deterministic, but this file exists to test that a dump runs while the buffer keeps recording ("two connections running at once"), so freezing would remove the concurrency under test. Bigger segments or a slower interval only widen the window at 4–6× the wall clock without closing it.

## Test plan

| Run | Injection | Result |
|---|---|---|
| baseline | none | pass — test works normally |
| repro A | flat 900 ms stall | **pass** — disproved "any long stall does it"; corrected the model to phase alignment |
| repro B | stall targeted at the seal phase | **fail** — exact CI failure, same line and message |
| verify | repro B's stall on attempt 1 only | pass — retry recovers from the precise failure |

- [x] All 7 tests in `tests/hindsight_dump.rs` pass (14.61 s)
- [x] `cargo clippy --all-targets -- -D warnings` exit 0, zero warnings
- [x] `cargo fmt --all --check` clean
- [x] No `REPRO`/`VERIFY` scaffolding left in the file (grep count 0)

Note: the reproduction was driven on macOS; the original failure was on Linux CI runners. The mechanism is scheduling phase, not platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)