### PR TITLE
feat(mcp): list and select a recording in a multi-recording .rez

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,12 @@ target/release/rezolus mcp query file.parquet "sum(rate(cpu_cycles[1m]))"     # 
 # bands by interval arithmetic; non-rate/non-histogram queries have no band to show)
 target/release/rezolus mcp analyze-correlation file.parquet "metric1" "metric2"
 target/release/rezolus mcp extract-features file.parquet             # structured feature record (JSON)
+target/release/rezolus mcp describe-recording multi.rez              # lists the recordings + their selectors, not an error
+target/release/rezolus mcp query multi.rez "sum(rate(cpu_cycles[1m]))" --recording source=redis  # pick one recording
+# --recording key=value (repeatable, ANDed) is on all six subcommands, and the stdio server's six
+#   tools take an optional recording object, e.g. {"source": "redis"}, same semantics;
+# it must name exactly one recording: none or several is an error listing the candidates, never a
+#   first match.
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -408,6 +408,36 @@ rankings, and subsystem coverage. Requires a recording of at least 10 seconds:
 rezolus mcp extract-features rezolus.parquet   # parquet or .rez recordings
 ```
 
+#### Multi-recording archives
+
+A `.rez` built from several endpoints (see "Several endpoints in one `.rez`"
+above) holds one *recording* per endpoint. Every MCP tool reads one recording
+at a time, so run `describe-recording` with no selector to see what the
+archive holds and the flag that picks each one:
+
+```
+$ rezolus mcp describe-recording ab.rez
+ab.rez holds 2 recordings with data (a multi-host or A/B archive):
+  - host=web-01, source=redis
+    select with: --recording source=redis
+  - host=web-01, source=valkey
+    select with: --recording source=valkey
+
+Run any tool with one of the selectors above to analyze that recording.
+```
+
+Then pass `--recording key=value` (repeatable, ANDed) to any of the six
+subcommands to analyze that one recording:
+
+```bash
+rezolus mcp query ab.rez "sum(rate(cpu_cycles[1m]))" --recording source=valkey
+```
+
+A selector must name exactly one recording: matching none or several is an
+error that lists the candidates, never a guess at which one you meant. The
+stdio server's six tools take the same selector as an optional `recording`
+object instead of repeated flags, e.g. `{"source": "valkey"}`.
+
 ---
 
 ## Use Cases

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -722,3 +722,19 @@ effort); promote one to a journal entry when it's picked up.
   failure path, and have `discard` remove the sidecars alongside the main file.
   *Why:* the failure mode is "the retry says the file already exists", which
   reads as a bug in the retry rather than fallout from the original error.
+- **Selector output is not shell-escaped, and the cache identity can alias** —
+  Open, found reviewing MCP recording selection (#1117). Two narrow holes, both
+  needing an operator-chosen label value with an unusual character. (a)
+  `flag_form` joins raw label values with `" --recording "` and presents the
+  result as something to paste, so a value containing a space —
+  `select with: --recording note=first run` — splits in the shell into a flag
+  plus a stray positional, which for `detect-anomalies` lands in the optional
+  `QUERY` slot. A value containing the literal `" --recording "` parses back as
+  a duplicate key. (b) The stdio server's post-open identity dedup uses
+  `recording_stagger_key`, a `\u{1}`-separated `k=v` join, so `{a: "\u{1}b=c"}`
+  and `{a: "", b: "c"}` render one identity and the second lookup would return
+  the first's reader. *Fix:* single-quote any value containing whitespace or a
+  quote in `flag_form`; dedup on the `BTreeMap` itself rather than a flattened
+  string. *Why:* both are the same species as the defects that arc kept
+  finding — a wrong answer that looks like a right one — just behind inputs
+  nobody types by accident.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -666,19 +666,21 @@ effort); promote one to a journal entry when it's picked up.
   a `TickBegin`/`TickEnd` bracket. The fan-out point already exists in
   `RezStream::ingest`. *Why:* the format's claim is bounded, predictable write
   cost; per-tick fsyncs scaling with endpoint count quietly erodes it.
-- **A `--recording` selector for the MCP tools** — Open, the real fix behind the
-  refusal added in #1109. `RezReader::open_with_pool` flattens every recording
-  into one view, so a multi-recording archive gives each sampler two owners and
-  `route()` refuses every query as cross-recording. `mcp open_source` now
-  refuses such an archive up front with a message, because the analysis tools
-  fold a per-metric query error into `NoData` and would otherwise report
-  "analyzed N metrics, found anomalies in 0" — a clean-looking wrong answer.
-  That is honest but not useful: `record --endpoint a --endpoint b -o out.rez`
-  is now a documented, ordinary capture, and no MCP tool can read one. *Fix:*
-  a `--recording <label-selector>` on the mcp subcommands, backed by
-  `RezReader::open_recordings`, which already returns one reader per recording
-  with its labels. *Why:* multi-host and A/B captures are exactly the ones worth
-  analyzing, and the agent-facing tools are where that analysis happens.
+- **A `--recording` selector for the MCP tools** — **DONE** (this PR), the real
+  fix behind the refusal added in #1109. `RezReader::open_with_pool` flattens
+  every recording into one view, so a multi-recording archive gives each
+  sampler two owners and `route()` refuses every query as cross-recording.
+  `mcp open_source` now refuses such an archive up front with a message,
+  because the analysis tools fold a per-metric query error into `NoData` and
+  would otherwise report "analyzed N metrics, found anomalies in 0" — a
+  clean-looking wrong answer. That is honest but not useful:
+  `record --endpoint a --endpoint b -o out.rez` is now a documented, ordinary
+  capture, and no MCP tool can read one. Shipped: `--recording key=value`
+  (repeatable, ANDed) on all six `mcp` subcommands, and an equivalent optional
+  `recording` object on the stdio server's six tools, resolved by
+  `RecordingSelector` against `RezReader::open_recordings`; it must name
+  exactly one recording, and matching none or several is an error listing the
+  candidates.
 - **The seal stagger still aliases on bit 5 (ASCII case)** — Open, found in the
   second review pass on #1109. The first pass closed bits 6-7 of every absorbed
   byte, but the same algebra survives one bit lower: `x ^ 0x20` is

--- a/src/analysis/extract/golden.rs
+++ b/src/analysis/extract/golden.rs
@@ -14,6 +14,7 @@ use std::time::SystemTime;
 use metriken::Window;
 use metriken_exposition::{Counter, Gauge, Snapshot, SnapshotV2};
 
+use crate::analysis::extract::Provenance;
 use crate::recorder::rez::RezRecorder;
 
 const NS: u64 = 1_000_000_000;
@@ -161,16 +162,104 @@ fn build_fixture_with_histogram() -> (tempfile::TempDir, std::path::PathBuf) {
     (dir, path)
 }
 
+/// A recording whose `source` is the endpoint name the USER chose, holding
+/// metrics that carry no `sampler` label — the shape `record --endpoint
+/// url,source=redis` produces for an agent older than 5.17.1, or any agent
+/// metric that ships unlabeled.
+///
+/// Sampler attribution then has only the metric NAME to go on, which is
+/// exactly the inference `Provenance` decides whether to trust.
+fn build_unlabeled_fixture(source: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let mut recorder = RezRecorder::new(
+        [
+            ("source".to_string(), source.to_string()),
+            ("sampling_interval_ms".to_string(), "1000".to_string()),
+        ]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>(),
+        [("source".to_string(), source.to_string())]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>(),
+        source.to_string(),
+    );
+    for i in 0..121u64 {
+        let ts = NS * (i + 1);
+        let window = Some(Window::new(ts - 50_000_000, ts));
+        recorder.ingest(
+            &snap(
+                ts,
+                vec![Counter::new(
+                    "cpu_cycles".to_string(),
+                    i * 1_000_000,
+                    [("metric".to_string(), "cpu_cycles".to_string())]
+                        .into_iter()
+                        .collect::<HashMap<_, _>>(),
+                )
+                .with_window(window)],
+                vec![],
+            ),
+            ts,
+        );
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("unlabeled.rez");
+    recorder.finalize(&path).expect("finalize");
+    (dir, path)
+}
+
 fn extract_fixture() -> crate::analysis::record::OverviewRecord {
     let (_dir, path) = build_fixture();
     let reader = crate::mcp::open_source(&path).expect("open");
-    crate::analysis::extract::extract(reader.as_ref()).expect("extract")
+    crate::analysis::extract::extract(reader.as_ref(), Provenance::FromMetadata).expect("extract")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::analysis::record::{AnalysisStatus, DetailTier, RECORD_SCHEMA_VERSION};
+
+    /// A `.rez` arm named by the user must still get sampler inference.
+    ///
+    /// `extract` decided whether to trust metric names by reading the
+    /// recording's `source` metadata, but for a recording inside a `.rez`
+    /// that field is the endpoint name the CALLER chose (`--endpoint
+    /// url,source=redis`), not a statement about who produced the data — a
+    /// `.rez` can only be written from a rezolus/msgpack endpoint. So
+    /// selecting such an arm silently attributed every unlabeled metric to
+    /// `unattributed`, degrading a path that used to be refused outright.
+    #[test]
+    fn a_rez_arm_named_by_the_user_still_infers_samplers() {
+        let (_dir, path) = build_unlabeled_fixture("redis");
+        let reader = crate::mcp::open_source(&path).expect("open");
+
+        let native = crate::analysis::extract::extract(
+            reader.as_ref(),
+            crate::analysis::extract::Provenance::RezolusAgent,
+        )
+        .expect("extract");
+        assert_eq!(
+            native.metrics[0].labels.get("sampler").map(String::as_str),
+            Some("cpu_perf"),
+            "a .rez is a rezolus recording whatever the arm is called"
+        );
+
+        // And the metadata-derived rule really does say otherwise here, so
+        // the assertion above is testing the provenance and not the name
+        // table: a foreign `source` still blocks inference for a file whose
+        // provenance is unknown.
+        let by_metadata = crate::analysis::extract::extract(
+            reader.as_ref(),
+            crate::analysis::extract::Provenance::FromMetadata,
+        )
+        .expect("extract");
+        assert_eq!(
+            by_metadata.metrics[0]
+                .labels
+                .get("sampler")
+                .map(String::as_str),
+            Some("unattributed")
+        );
+    }
 
     #[test]
     fn extraction_invariants_hold() {
@@ -251,11 +340,13 @@ mod tests {
         let (_dir, path) = build_fixture();
         let reader = crate::mcp::open_source(&path).expect("open");
         let a = serde_json::to_string(
-            &crate::analysis::extract::extract(reader.as_ref()).expect("run a"),
+            &crate::analysis::extract::extract(reader.as_ref(), Provenance::FromMetadata)
+                .expect("run a"),
         )
         .expect("ser a");
         let b = serde_json::to_string(
-            &crate::analysis::extract::extract(reader.as_ref()).expect("run b"),
+            &crate::analysis::extract::extract(reader.as_ref(), Provenance::FromMetadata)
+                .expect("run b"),
         )
         .expect("ser b");
         assert_eq!(a, b, "same reader, two runs, byte-identical");
@@ -267,7 +358,8 @@ mod tests {
             .expect("pool1")
             .install(|| {
                 serde_json::to_string(
-                    &crate::analysis::extract::extract(reader.as_ref()).expect("run 1t"),
+                    &crate::analysis::extract::extract(reader.as_ref(), Provenance::FromMetadata)
+                        .expect("run 1t"),
                 )
                 .expect("ser 1t")
             });
@@ -277,7 +369,8 @@ mod tests {
             .expect("pool4")
             .install(|| {
                 serde_json::to_string(
-                    &crate::analysis::extract::extract(reader.as_ref()).expect("run 4t"),
+                    &crate::analysis::extract::extract(reader.as_ref(), Provenance::FromMetadata)
+                        .expect("run 4t"),
                 )
                 .expect("ser 4t")
             });
@@ -292,7 +385,8 @@ mod tests {
     fn histogram_metric_yields_three_quantile_entries() {
         let (_dir, path) = build_fixture_with_histogram();
         let reader = crate::mcp::open_source(&path).expect("open");
-        let record = crate::analysis::extract::extract(reader.as_ref()).expect("extract");
+        let record = crate::analysis::extract::extract(reader.as_ref(), Provenance::FromMetadata)
+            .expect("extract");
         for suffix in [":p50", ":p90", ":p99"] {
             let name = format!("test_latency{suffix}");
             let m = record

--- a/src/analysis/extract/mod.rs
+++ b/src/analysis/extract/mod.rs
@@ -360,12 +360,37 @@ fn analyze_entry(
     analysis
 }
 
+/// Where a recording came from, for the sole purpose of deciding whether its
+/// metric NAMES may be trusted to name rezolus samplers.
+///
+/// Not the same question as `MetricsSource::source()`, which is a label. A
+/// recording inside a `.rez` carries the endpoint name its caller chose
+/// (`record --endpoint url,source=redis`) as its `source`, while the
+/// container itself can only be written from a rezolus/msgpack endpoint — so
+/// the label says "redis" about data that is unambiguously the agent's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provenance {
+    /// The reader is known to be over a rezolus recording, whatever its
+    /// `source` metadata says. Every recording in a `.rez` container.
+    RezolusAgent,
+    /// Provenance unknown: fall back to the `source` file metadata, where
+    /// `"rezolus"` — and nothing else — means the names are the agent's own.
+    FromMetadata,
+}
+
 /// Extract a deterministic overview record from a recording.
 ///
 /// Errors only on structural problems (no time range, sub-10s recording —
 /// the anomaly engine's floor — or the finite-float backstop tripping).
 /// Per-metric analysis failures degrade to quiet entries instead.
-pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::error::Error>> {
+///
+/// `provenance` is a REQUIRED argument rather than a default so that every
+/// caller has to answer it: the wrong answer is silent (metrics attributed
+/// to `unattributed`, coverage hollowed out), never an error.
+pub fn extract(
+    data: &dyn MetricsSource,
+    provenance: Provenance,
+) -> Result<OverviewRecord, Box<dyn std::error::Error>> {
     let (start, end) = data
         .time_range()
         .ok_or("recording has no time range (empty?)")?;
@@ -382,8 +407,18 @@ pub fn extract(data: &dyn MetricsSource) -> Result<OverviewRecord, Box<dyn std::
     // Prometheus-scraped or otherwise foreign recording proves nothing. A
     // missing/empty source is treated as unknown, i.e. conservative (no
     // inference). See the module doc in context.rs.
+    //
+    // Which recording is "genuine" comes from the caller's `provenance`, NOT
+    // from the `source` metadata alone: a recording selected out of a `.rez`
+    // reports the endpoint name its caller chose (`--endpoint
+    // url,source=redis`), so reading that field would refuse inference for
+    // data that is unambiguously the agent's own -- and silently, as
+    // `unattributed` everywhere.
     let source = data.source();
-    let infer = source == "rezolus";
+    let infer = match provenance {
+        Provenance::RezolusAgent => true,
+        Provenance::FromMetadata => source == "rezolus",
+    };
 
     // --- enumerate entries (exhaustive: every metric appears) ---
     let mut entries: Vec<(String, &'static str, String, String, bool)> = Vec::new();

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -38,4 +38,4 @@ pub use record::{
 // `crate::analysis::extract::extract` directly rather than through this
 // re-export, so the alias itself is still unused.
 #[allow(unused_imports)]
-pub use extract::extract;
+pub use extract::{extract, Provenance};

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,18 @@ fn main() {
             hindsight::run(config)
         }
         Some(("mcp", args)) => {
-            let config = mcp::Config::try_from(args.clone()).expect("failed to configure");
+            // Same as `record` below: a malformed `--recording` is the
+            // caller's typo, and `expect` reported it as a panic whose
+            // backtrace buried the one line saying what to fix. That matters
+            // more here than for a human — an agent reading a page of unwind
+            // frames has to guess whether it hit a bug or mistyped a flag.
+            let config = match mcp::Config::try_from(args.clone()) {
+                Ok(config) => config,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(2);
+                }
+            };
 
             mcp::run(config)
         }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -642,7 +642,9 @@ fn listing(
     let body = describe_candidates(recordings, &[], syntax);
     match close {
         Some(close) => format!("{lead}\n{body}\n{close}"),
-        None => format!("{lead}\n{body}"),
+        // `body` ends in a newline (one entry per line), so trim rather than
+        // close with a dangling blank line.
+        None => format!("{lead}\n{}", body.trim_end()),
     }
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -16,11 +16,65 @@ mod server;
 use chrono::{DateTime, Utc};
 use metriken_query::{MetricsSource, QueryResult};
 
-/// The chosen recording's own labels, paired with a reader over it.
-type LabeledSource = (
-    std::collections::BTreeMap<String, String>,
-    std::sync::Arc<dyn metriken_query::MetricsSource>,
-);
+/// One opened recording, plus what the opener learned about the archive it
+/// came out of.
+///
+/// More than a reader because two callers need more than a reader and cannot
+/// get it back cheaply: the stdio server keys its reader cache on WHICH
+/// recording a selector resolved to, and `describe-recording` has to describe
+/// the archive rather than the arm when no arm holds data. Both facts are
+/// known during the open; re-deriving either meant opening the archive a
+/// second time.
+pub(crate) struct Opened {
+    /// The chosen recording's own labels (empty for a plain parquet file).
+    pub labels: std::collections::BTreeMap<String, String>,
+    pub reader: std::sync::Arc<dyn metriken_query::MetricsSource>,
+    /// Every recording in the archive, populated ONLY when the reader is the
+    /// first arm handed back by default because the archive holds more than
+    /// one recording, all of them rowless, and no selector was given.
+    ///
+    /// That is the one `Ok` case where the reader misrepresents the file:
+    /// `describe-recording` would otherwise print arm 0's metadata as though
+    /// the archive held a single recording, saying nothing about the other
+    /// arms or about the fact that nothing was captured at all.
+    pub all_empty_recordings: Vec<std::collections::BTreeMap<String, String>>,
+}
+
+/// Why opening a recording did not yield exactly one reader.
+///
+/// A typed error rather than a string because `describe-recording` renders
+/// the "several recordings, pick one" case as its ANSWER, in its own words,
+/// while every analysis tool renders it as a failure. Both need the candidate
+/// list, and it exists only inside the open.
+#[derive(Debug)]
+pub(crate) enum OpenError {
+    /// A multi-recording archive with no selector: the caller must choose.
+    /// Carries the message the analysis tools print AND the candidates, so a
+    /// caller wanting to say something else about them need not reopen the
+    /// archive to find out what they are.
+    NeedsSelection {
+        message: String,
+        candidates: Vec<std::collections::BTreeMap<String, String>>,
+    },
+    Other(Box<dyn std::error::Error>),
+}
+
+impl OpenError {
+    fn other(message: String) -> Self {
+        OpenError::Other(message.into())
+    }
+}
+
+impl std::fmt::Display for OpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OpenError::NeedsSelection { message, .. } => write!(f, "{message}"),
+            OpenError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for OpenError {}
 
 /// Open a recording as a query source, selecting ONE recording out of a
 /// multi-recording `.rez` archive.
@@ -46,24 +100,26 @@ pub(crate) fn open_source_with_pool(
     selector: &RecordingSelector,
     syntax: SelectorSyntax,
 ) -> Result<std::sync::Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
-    open_source_with_pool_labeled(file, pool, selector, syntax).map(|(_, reader)| reader)
+    open_source_with_pool_labeled(file, pool, selector, syntax)
+        .map(|opened| opened.reader)
+        .map_err(Into::into)
 }
 
-/// As `open_source_with_pool`, but also reporting WHICH recording was chosen,
-/// as that recording's own label set (empty for a plain parquet file).
+/// As `open_source_with_pool`, but reporting everything the open learned —
+/// see [`Opened`] and [`OpenError`].
 ///
 /// The stdio server caches readers, and a cache keyed by the selector text
 /// would hold a second copy of the archive for every selector spelling that
 /// names the same arm (`source=redis` and `host=web-01 source=redis` are the
 /// same recording). Only the resolver knows which recording a selector landed
-/// on, so it is the only place that can say — hence the extra return value
+/// on, so it is the only place that can say — hence the richer return value
 /// rather than a second, guessing, resolution at the call site.
 pub(crate) fn open_source_with_pool_labeled(
     file: &std::path::Path,
     pool: std::sync::Arc<metriken_query::BufferPool>,
     selector: &RecordingSelector,
     syntax: SelectorSyntax,
-) -> Result<LabeledSource, Box<dyn std::error::Error>> {
+) -> Result<Opened, OpenError> {
     use crate::recorder::rez::RezFormat;
 
     // Ahead of the open, and HERE rather than in each front end, so a typo'd
@@ -73,7 +129,10 @@ pub(crate) fn open_source_with_pool_labeled(
     // "Failed to load recording: No such file or directory (os error 2)" to a
     // shell caller.
     if !file.exists() {
-        return Err(format!("Recording file not found: {}", file.display()).into());
+        return Err(OpenError::other(format!(
+            "Recording file not found: {}",
+            file.display()
+        )));
     }
 
     if crate::recorder::rez::detect_rez_format(file).unwrap_or(RezFormat::NotRez)
@@ -88,19 +147,21 @@ pub(crate) fn open_source_with_pool_labeled(
         // a guess. The advice is phrased without naming a flag because the
         // stdio server reaches this with a JSON object, not `--recording`.
         if !selector.is_empty() {
-            return Err(format!(
+            return Err(OpenError::other(format!(
                 "{} is not a .rez archive and holds no recordings to select between; \
                  a recording selector applies only to a multi-recording .rez",
                 file.display()
-            )
-            .into());
+            )));
         }
         // No labels: a bare parquet file is one recording with no label set
         // of its own, which is a stable identity for exactly one path.
-        return Ok((
-            std::collections::BTreeMap::new(),
-            std::sync::Arc::new(metriken_query::ParquetReader::open_with_pool(file, pool)?),
-        ));
+        let reader =
+            metriken_query::ParquetReader::open_with_pool(file, pool).map_err(OpenError::Other)?;
+        return Ok(Opened {
+            labels: std::collections::BTreeMap::new(),
+            reader: std::sync::Arc::new(reader),
+            all_empty_recordings: Vec::new(),
+        });
     }
 
     // Open the recordings ONCE and build the reader from the one that was
@@ -121,9 +182,13 @@ pub(crate) fn open_source_with_pool_labeled(
     // tar reads the whole archive into memory). Consuming the recordings we
     // already have avoids that. The only field this loses versus
     // `open_with_pool` is `filename`, which nothing under `src/mcp/` reads.
-    let mut recordings = crate::rez_reader::RezReader::open_recordings(file, pool)?;
+    let mut recordings =
+        crate::rez_reader::RezReader::open_recordings(file, pool).map_err(OpenError::Other)?;
     if recordings.is_empty() {
-        return Err(format!("{} holds no recordings", file.display()).into());
+        return Err(OpenError::other(format!(
+            "{} holds no recordings",
+            file.display()
+        )));
     }
 
     // Only recordings that hold tables are candidates. An arm that produced no
@@ -159,8 +224,22 @@ pub(crate) fn open_source_with_pool_labeled(
         // Every arm is empty and the caller named none of them. Opening the
         // first reports an empty recording, which is a truer answer than an
         // error about choosing between recordings that all hold nothing.
+        //
+        // The other arms' labels ride along (only when there ARE others) so a
+        // caller describing the FILE can say the archive holds several
+        // recordings and none of them captured anything, rather than
+        // reporting arm 0 as if it were the whole recording.
+        let all_empty_recordings = if recordings.len() > 1 {
+            recordings.iter().map(|(l, _)| l.clone()).collect()
+        } else {
+            Vec::new()
+        };
         let (labels, reader) = recordings.swap_remove(0);
-        return Ok((labels, std::sync::Arc::new(reader)));
+        return Ok(Opened {
+            labels,
+            reader: std::sync::Arc::new(reader),
+            all_empty_recordings,
+        });
     }
 
     // With every arm empty there is nothing to prefer, so the selector is
@@ -218,11 +297,10 @@ pub(crate) fn open_source_with_pool_labeled(
                     file.display()
                 )
             };
-            return Err(format!(
+            return Err(OpenError::other(format!(
                 "{lead}. {listing_lead}\n{}",
                 describe_candidates(&universe, &[], syntax)
-            )
-            .into());
+            )));
         }
         Err(SelectError::Ambiguous(hits)) => {
             // `hits` are HIGHLIGHTED, not passed as the candidate list:
@@ -248,14 +326,29 @@ pub(crate) fn open_source_with_pool_labeled(
                     file.display()
                 )
             };
-            return Err(
-                format!("{lead}\n{}", describe_candidates(&universe, &hits, syntax)).into(),
-            );
+            let message = format!("{lead}\n{}", describe_candidates(&universe, &hits, syntax));
+            // Only the NO-SELECTOR case is `NeedsSelection`: it is the one a
+            // caller may legitimately render as something other than a
+            // failure (`describe-recording` answers with the listing). A
+            // selector that was given and still matched several is a failed
+            // request, and every caller reports it as one.
+            return Err(if selector.is_empty() {
+                OpenError::NeedsSelection {
+                    message,
+                    candidates: universe,
+                }
+            } else {
+                OpenError::other(message)
+            });
         }
     };
 
     let (labels, reader) = recordings.swap_remove(chosen);
-    Ok((labels, std::sync::Arc::new(reader)))
+    Ok(Opened {
+        labels,
+        reader: std::sync::Arc::new(reader),
+        all_empty_recordings: Vec::new(),
+    })
 }
 
 /// Open with a selector and a fresh pool — the one-shot CLI path, so every
@@ -269,6 +362,21 @@ pub(crate) fn open_source_selected(
         metriken_query::BufferPool::new(256 * 1024 * 1024),
         selector,
         SelectorSyntax::Flags,
+    )
+}
+
+/// As `open_source_selected`, but keeping everything the open learned — for
+/// the callers that describe the archive rather than just query the reader.
+pub(crate) fn open_selected_labeled(
+    file: &std::path::Path,
+    selector: &RecordingSelector,
+    syntax: SelectorSyntax,
+) -> Result<Opened, OpenError> {
+    open_source_with_pool_labeled(
+        file,
+        metriken_query::BufferPool::new(256 * 1024 * 1024),
+        selector,
+        syntax,
     )
 }
 
@@ -422,47 +530,96 @@ pub(crate) fn describe_recording_output(
     selector: &RecordingSelector,
     syntax: SelectorSyntax,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    use crate::recorder::rez::RezFormat;
-
-    // With no selector, a multi-recording archive is LISTED rather than
-    // refused. `describe-recording` is documented as the place to start, so
-    // making the first tool an agent calls the one that explains what to call
-    // next is the whole point.
-    if selector.is_empty()
-        && crate::recorder::rez::detect_rez_format(file).unwrap_or(RezFormat::NotRez)
-            != RezFormat::NotRez
-    {
-        let pool = metriken_query::BufferPool::new(256 * 1024 * 1024);
-        let recordings = crate::rez_reader::RezReader::open_recordings(file, pool)?;
-        let candidates: Vec<std::collections::BTreeMap<String, String>> = recordings
-            .iter()
-            .filter(|(_, r)| !r.is_empty())
-            .map(|(l, _)| l.clone())
-            .collect();
-        if candidates.len() > 1 {
+    // ONE open, and every branch below is decided from what it returned.
+    //
+    // This used to open the archive twice — `detect_rez_format` +
+    // `open_recordings` to decide whether to list, both discarded, then
+    // `open_source_selected` doing the same work again. That cost a measured
+    // ~20% on a 13-table archive and scales with table count (neither
+    // container's probe is catalog-only), the same 2x the opener itself was
+    // written to avoid. Worse, it was a TOCTOU: a `.rez` is readable while a
+    // writer appends to it, so a rowless arm sealing its first segment
+    // between the two opens flipped the candidate count and turned this
+    // summary into a "Pick one" error about an archive the first open had
+    // already resolved.
+    match open_selected_labeled(file, selector, syntax) {
+        Ok(opened) => {
+            // Every arm is empty: report the ARCHIVE. `format_recording_info`
+            // would otherwise print arm 0's metadata as though the file held
+            // one recording, saying nothing about the others or about the
+            // fact that nothing was captured at all.
+            if !opened.all_empty_recordings.is_empty() {
+                return Ok(listing(
+                    format!(
+                        "{} holds {} recordings, none of which produced any rows — nothing was \
+                         captured to analyze. It holds:",
+                        file.display(),
+                        opened.all_empty_recordings.len()
+                    ),
+                    &opened.all_empty_recordings,
+                    syntax,
+                    // No invitation to analyze one: there is nothing in any
+                    // of them to analyze. The selectors are still printed —
+                    // naming an arm is how a caller confirms WHICH endpoint
+                    // reported nothing — but promising an analysis would be
+                    // the same empty promise this listing exists to avoid.
+                    None,
+                ));
+            }
+            Ok(format_recording_info(
+                file.to_str().unwrap_or("<unknown>"),
+                opened.reader.as_ref(),
+            ))
+        }
+        // With no selector, a multi-recording archive is LISTED rather than
+        // refused. `describe-recording` is documented as the place to start,
+        // so making the first tool an agent calls the one that explains what
+        // to call next is the whole point — the analysis tools render this
+        // same case as the failure it is for them.
+        Err(OpenError::NeedsSelection { candidates, .. }) => Ok(listing(
             // "recordings WITH DATA", not bare "recordings". `candidates`
             // already excludes arms that produced no rows, and
             // `open_source_with_pool`'s own NoMatch message names a dead arm
             // as "recorded but produced no rows" rather than pretending it
             // isn't there. Saying bare "N recordings" here would give a count
             // an agent can't reconcile with that later message the moment an
-            // archive has a dead arm — this is the same inconsistency Task 3
-            // settled for the error path, carried over to the listing.
-            return Ok(format!(
-                "{} holds {} recordings with data (a multi-host or A/B archive):\n{}\nRun any \
-                 tool with one of the selectors above to analyze that recording.",
+            // archive has a dead arm.
+            format!(
+                "{} holds {} recordings with data (a multi-host or A/B archive):",
                 file.display(),
-                candidates.len(),
-                describe_candidates(&candidates, &[], syntax)
-            ));
-        }
+                candidates.len()
+            ),
+            &candidates,
+            syntax,
+            Some("Run any tool with one of the selectors above to analyze that recording."),
+        )),
+        Err(e) => Err(e.into()),
     }
+}
 
-    let reader = open_source_selected(file, selector)?;
-    Ok(format_recording_info(
-        file.to_str().unwrap_or("<unknown>"),
-        reader.as_ref(),
-    ))
+/// A lead line, the recordings under it, and the closing line that fits.
+///
+/// The closing line is conditional because `describe_candidates` renders no
+/// selector for a recording no selector can name (identical or subsumed label
+/// sets). An archive where that is true of EVERY recording printed a listing
+/// with zero selectors in it followed by "Run any tool with one of the
+/// selectors above" — pointing at nothing, and exiting 0 while doing it.
+fn listing(
+    lead: String,
+    recordings: &[std::collections::BTreeMap<String, String>],
+    syntax: SelectorSyntax,
+    invite: Option<&str>,
+) -> String {
+    let close = if recording_selector::any_selectable(recordings) {
+        invite
+    } else {
+        Some("No recording in this archive can be selected by labels.")
+    };
+    let body = describe_candidates(recordings, &[], syntax);
+    match close {
+        Some(close) => format!("{lead}\n{body}\n{close}"),
+        None => format!("{lead}\n{body}"),
+    }
 }
 
 fn run_describe_recording(file: PathBuf, selector: &RecordingSelector) {
@@ -1926,6 +2083,75 @@ mod tests {
         assert!(
             !out.contains("Pick one") && !out.contains("recordings with data"),
             "must not present a choice when there is only one to make: {out}"
+        );
+    }
+
+    /// An archive of several recordings NONE of which produced rows must be
+    /// described as what it is, not as its first arm.
+    ///
+    /// The listing branch only ran when there was more than one candidate,
+    /// and candidates exclude rowless arms — so an all-empty archive fell
+    /// through and printed arm 0's `source`/`version` under
+    /// "Recording Information", with nothing saying the file holds N
+    /// recordings and no data at all. An agent reading that concludes it has
+    /// one (mysteriously empty) recording rather than a capture where every
+    /// endpoint reported nothing.
+    #[test]
+    fn describe_recording_reports_an_archive_whose_arms_are_all_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("both-empty.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[false, false]);
+
+        let out =
+            describe_recording_output(&path, &RecordingSelector::default(), SelectorSyntax::Flags)
+                .expect("describing is not an error — the file is readable");
+        assert!(
+            !out.contains("Recording Information"),
+            "must not describe arm 0 as though it were the whole file: {out}"
+        );
+        assert!(out.contains("2 recordings"), "{out}");
+        assert!(
+            out.contains("produced any rows"),
+            "must say why there is nothing to analyze: {out}"
+        );
+        assert!(
+            !out.contains("to analyze that recording"),
+            "and must not invite an analysis of a recording that holds nothing: {out}"
+        );
+        assert!(
+            out.contains("source=redis") && out.contains("source=valkey"),
+            "and name them: {out}"
+        );
+    }
+
+    /// A listing with no selectors in it must not close by telling the caller
+    /// to use one.
+    ///
+    /// Two recordings carrying identical labels are both unselectable, so
+    /// `describe_candidates` emits no "select with:" line at all — and the
+    /// closing sentence ("Run any tool with one of the selectors above")
+    /// then points at nothing. This got MORE reachable once a subset label
+    /// set became unselectable too.
+    #[test]
+    fn a_listing_with_no_selectors_does_not_promise_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dup.rez");
+        multi_recording_rez(&path, &["redis", "redis"], &[true, true]);
+
+        let out =
+            describe_recording_output(&path, &RecordingSelector::default(), SelectorSyntax::Flags)
+                .expect("a listing, not an error");
+        assert!(
+            !out.contains("select with:"),
+            "identical labels leave nothing to offer: {out}"
+        );
+        assert!(
+            !out.contains("selectors above"),
+            "so it must not tell the caller to use one: {out}"
+        );
+        assert!(
+            out.contains("cannot be selected by labels"),
+            "it must say so plainly instead: {out}"
         );
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -65,6 +65,17 @@ pub(crate) fn open_source_with_pool_labeled(
     syntax: SelectorSyntax,
 ) -> Result<LabeledSource, Box<dyn std::error::Error>> {
     use crate::recorder::rez::RezFormat;
+
+    // Ahead of the open, and HERE rather than in each front end, so a typo'd
+    // path is diagnosed the same way wherever it was typed. The stdio server
+    // used to carry this check itself while the CLI had none, so the same
+    // mistake read as "Recording file not found: x.rez" to an agent and as
+    // "Failed to load recording: No such file or directory (os error 2)" to a
+    // shell caller.
+    if !file.exists() {
+        return Err(format!("Recording file not found: {}", file.display()).into());
+    }
+
     if crate::recorder::rez::detect_rez_format(file).unwrap_or(RezFormat::NotRez)
         == RezFormat::NotRez
     {
@@ -917,9 +928,18 @@ impl TryFrom<ArgMatches> for Config {
         // subcommand, so the top-level matches never carry it. `None` is
         // server mode, which has no selector to read (see `Config.recording`).
         let recording = match args.subcommand() {
+            // `try_get_many`, not `get_many`: the latter PANICS on an arg id
+            // the matched subcommand never declared, and this lookup runs for
+            // whichever subcommand matched. The first analysis subcommand
+            // added without `recording_arg()` would abort inside clap rather
+            // than run; absent means "no selector", like every other
+            // subcommand that omits the flag.
             Some((_, sub)) => RecordingSelector::parse(
-                sub.get_many::<String>("RECORDING")
-                    .unwrap_or_default()
+                sub.try_get_many::<String>("RECORDING")
+                    .ok()
+                    .flatten()
+                    .into_iter()
+                    .flatten()
                     .cloned(),
             )?,
             None => RecordingSelector::default(),
@@ -1937,6 +1957,50 @@ mod tests {
                 "for {sub}"
             );
         }
+    }
+
+    /// Reading the selector must not panic for a subcommand that never
+    /// declared it.
+    ///
+    /// `get_many` panics on an unknown arg id, and the lookup runs for
+    /// whatever subcommand matched — so the first analysis subcommand added
+    /// without `recording_arg()` would abort the process inside clap instead
+    /// of running, or erroring, like every other bad invocation.
+    #[test]
+    fn a_subcommand_without_the_flag_does_not_panic() {
+        // The real command plus one subcommand whose author forgot
+        // `recording_arg()` — the mistake this guards against.
+        let m = command()
+            .subcommand(clap::Command::new("future-tool"))
+            .try_get_matches_from(["mcp", "future-tool"])
+            .unwrap();
+        let cfg = Config::try_from(m).expect("an unknown subcommand is not a parse failure");
+        assert!(
+            cfg.recording.is_empty(),
+            "no --recording declared means no selector"
+        );
+    }
+
+    /// A missing file reads the same from both front ends.
+    ///
+    /// The server pre-checked `exists()` and said "Recording file not found";
+    /// the CLI had no such check and surfaced whatever the parquet decoder
+    /// made of it ("No such file or directory (os error 2)"). One check, in
+    /// the shared opener, so a typo'd path is diagnosed the same way
+    /// wherever it is typed.
+    #[test]
+    fn a_missing_file_says_so_rather_than_failing_in_the_decoder() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.rez");
+        let msg = match open_source_selected(&missing, &RecordingSelector::default()) {
+            Ok(_) => panic!("a missing file cannot open"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("Recording file not found"),
+            "must name the real problem, not the decoder's view of it: {msg}"
+        );
+        assert!(msg.contains("nope.rez"), "and the path: {msg}");
     }
 
     #[test]

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -286,7 +286,11 @@ pub fn run(config: Config) {
             query1,
             query2,
         } => run_analyze_correlation(file, query1, query2),
-        Mode::DescribeRecording { file } => run_describe_recording(file),
+        // Task 5 wires the real `--recording` selector through to this call
+        // site; until then every CLI invocation behaves as it always has.
+        Mode::DescribeRecording { file } => {
+            run_describe_recording(file, &RecordingSelector::default())
+        }
         Mode::DescribeMetrics { file } => run_describe_metrics(file),
         Mode::DetectAnomalies { file, query } => run_detect_anomalies(file, query),
         Mode::Query { file, query } => run_query(file, query),
@@ -337,17 +341,66 @@ fn run_analyze_correlation(file: PathBuf, query1: String, query2: String) {
     }
 }
 
-fn run_describe_recording(file: PathBuf) {
-    let reader = match open_source(&file) {
-        Ok(r) => r,
+/// The text `describe-recording` prints.
+///
+/// Split from `run_describe_recording` so the behavior is testable without a
+/// process exit: this is the tool an agent reaches for first, and it is the
+/// one that used to fail on a multi-recording archive.
+pub(crate) fn describe_recording_output(
+    file: &std::path::Path,
+    selector: &RecordingSelector,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use crate::recorder::rez::RezFormat;
+
+    // With no selector, a multi-recording archive is LISTED rather than
+    // refused. `describe-recording` is documented as the place to start, so
+    // making the first tool an agent calls the one that explains what to call
+    // next is the whole point.
+    if selector.is_empty()
+        && crate::recorder::rez::detect_rez_format(file).unwrap_or(RezFormat::NotRez)
+            != RezFormat::NotRez
+    {
+        let pool = metriken_query::BufferPool::new(256 * 1024 * 1024);
+        let recordings = crate::rez_reader::RezReader::open_recordings(file, pool)?;
+        let candidates: Vec<std::collections::BTreeMap<String, String>> = recordings
+            .iter()
+            .filter(|(_, r)| !r.is_empty())
+            .map(|(l, _)| l.clone())
+            .collect();
+        if candidates.len() > 1 {
+            // "recordings WITH DATA", not bare "recordings". `candidates`
+            // already excludes arms that produced no rows, and
+            // `open_source_with_pool`'s own NoMatch message names a dead arm
+            // as "recorded but produced no rows" rather than pretending it
+            // isn't there. Saying bare "N recordings" here would give a count
+            // an agent can't reconcile with that later message the moment an
+            // archive has a dead arm — this is the same inconsistency Task 3
+            // settled for the error path, carried over to the listing.
+            return Ok(format!(
+                "{} holds {} recordings with data (a multi-host or A/B archive):\n{}\nRun any \
+                 tool with one of the selectors above to analyze that recording.",
+                file.display(),
+                candidates.len(),
+                describe_candidates(&candidates, &[])
+            ));
+        }
+    }
+
+    let reader = open_source_selected(file, selector)?;
+    Ok(format_recording_info(
+        file.to_str().unwrap_or("<unknown>"),
+        reader.as_ref(),
+    ))
+}
+
+fn run_describe_recording(file: PathBuf, selector: &RecordingSelector) {
+    match describe_recording_output(&file, selector) {
+        Ok(out) => println!("{out}"),
         Err(e) => {
-            eprintln!("Failed to load parquet file: {e}");
+            eprintln!("Failed to load recording: {e}");
             std::process::exit(1);
         }
-    };
-
-    let output = format_recording_info(file.to_str().unwrap_or("<unknown>"), reader.as_ref());
-    println!("{output}");
+    }
 }
 
 fn run_describe_metrics(file: PathBuf) {
@@ -1601,6 +1654,99 @@ mod tests {
             src.counter_names(),
             vec!["cpu_cycles".to_string()],
             "the arm with rows must be the one opened"
+        );
+    }
+
+    #[test]
+    fn describe_recording_lists_the_arms_instead_of_erroring() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let out = describe_recording_output(&path, &RecordingSelector::default())
+            .expect("listing is not an error — it is the answer");
+        assert!(out.contains("2 recordings"), "{out}");
+        assert!(out.contains("source=redis"), "{out}");
+        assert!(out.contains("source=valkey"), "{out}");
+        assert!(
+            out.contains("--recording"),
+            "the listing must hand back the selector to use next: {out}"
+        );
+    }
+
+    #[test]
+    fn describe_recording_with_a_selector_describes_that_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let sel = RecordingSelector::parse(["source=redis".to_string()]).unwrap();
+        let out = describe_recording_output(&path, &sel).unwrap();
+        assert!(
+            out.contains("Recording Information"),
+            "a selected recording gets the ordinary single-recording format: {out}"
+        );
+    }
+
+    /// A dead arm must not be folded into the count the listing advertises.
+    ///
+    /// Three recordings, one of them empty: the listing must say "2
+    /// recordings" (with data), never "3 recordings" — the archive's own
+    /// `describe_candidates` universe only ever includes recordings that hold
+    /// rows, so claiming 3 would promise a selector listing that isn't there.
+    /// And it must not claim just "2 recordings" as if that were the whole
+    /// archive either, since a caller who later names the dead arm gets
+    /// `open_source_with_pool`'s "recorded but produced no rows" message for
+    /// it — the two messages have to be reconcilable, not contradictory.
+    #[test]
+    fn describe_recording_does_not_count_a_dead_arm_as_a_recording() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("triple.rez");
+        multi_recording_rez(
+            &path,
+            &["redis", "valkey", "memcached"],
+            &[true, true, false],
+        );
+
+        let out = describe_recording_output(&path, &RecordingSelector::default())
+            .expect("two live arms still means \"pick one\", not an error");
+        assert!(
+            out.contains("2 recordings with data"),
+            "must count only the arms that hold rows, and say so: {out}"
+        );
+        assert!(
+            !out.contains("3 recordings"),
+            "must not report the dead arm as though it were selectable: {out}"
+        );
+        assert!(out.contains("source=redis"), "{out}");
+        assert!(out.contains("source=valkey"), "{out}");
+        assert!(
+            !out.contains("source=memcached"),
+            "the dead arm has no selector to offer, so it must not appear as a candidate: {out}"
+        );
+    }
+
+    /// Exactly one arm has data: `describe-recording` must describe it
+    /// directly rather than presenting a one-choice "pick one" listing —
+    /// this mirrors `open_source`'s own behavior (see
+    /// `an_empty_arm_with_the_same_labels_does_not_shadow_the_one_with_data`),
+    /// so a run where only one endpoint ever reported does not suddenly
+    /// require a selector just because the archive has more than one arm.
+    #[test]
+    fn describe_recording_with_a_single_live_arm_describes_it_directly() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("one-live.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, false]);
+
+        let out = describe_recording_output(&path, &RecordingSelector::default())
+            .expect("a single live arm resolves without a selector");
+        assert!(
+            out.contains("Recording Information"),
+            "the ordinary single-recording format, not a listing: {out}"
+        );
+        assert!(
+            !out.contains("Pick one") && !out.contains("recordings with data"),
+            "must not present a choice when there is only one to make: {out}"
         );
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,10 +4,10 @@ use clap::{ArgMatches, Command};
 use std::path::PathBuf;
 
 mod recording_selector;
-// RecordingSelector and SelectError are both unused until `resolve` lands and
-// the MCP CLI/server actually pass a selector through to the reader.
+// RecordingSelector, SelectError, and describe_candidates are all unused
+// until the MCP CLI/server actually pass a selector through to the reader.
 #[allow(unused_imports)]
-pub(crate) use recording_selector::{RecordingSelector, SelectError};
+pub(crate) use recording_selector::{describe_candidates, RecordingSelector, SelectError};
 
 pub mod anomaly_detection;
 pub mod correlation;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -16,6 +16,12 @@ mod server;
 use chrono::{DateTime, Utc};
 use metriken_query::{MetricsSource, QueryResult};
 
+/// The chosen recording's own labels, paired with a reader over it.
+type LabeledSource = (
+    std::collections::BTreeMap<String, String>,
+    std::sync::Arc<dyn metriken_query::MetricsSource>,
+);
+
 /// Open a recording as a query source, selecting ONE recording out of a
 /// multi-recording `.rez` archive.
 ///
@@ -35,6 +41,23 @@ pub(crate) fn open_source_with_pool(
     pool: std::sync::Arc<metriken_query::BufferPool>,
     selector: &RecordingSelector,
 ) -> Result<std::sync::Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
+    open_source_with_pool_labeled(file, pool, selector).map(|(_, reader)| reader)
+}
+
+/// As `open_source_with_pool`, but also reporting WHICH recording was chosen,
+/// as that recording's own label set (empty for a plain parquet file).
+///
+/// The stdio server caches readers, and a cache keyed by the selector text
+/// would hold a second copy of the archive for every selector spelling that
+/// names the same arm (`source=redis` and `host=web-01 source=redis` are the
+/// same recording). Only the resolver knows which recording a selector landed
+/// on, so it is the only place that can say — hence the extra return value
+/// rather than a second, guessing, resolution at the call site.
+pub(crate) fn open_source_with_pool_labeled(
+    file: &std::path::Path,
+    pool: std::sync::Arc<metriken_query::BufferPool>,
+    selector: &RecordingSelector,
+) -> Result<LabeledSource, Box<dyn std::error::Error>> {
     use crate::recorder::rez::RezFormat;
     if crate::recorder::rez::detect_rez_format(file).unwrap_or(RezFormat::NotRez)
         == RezFormat::NotRez
@@ -55,8 +78,11 @@ pub(crate) fn open_source_with_pool(
             )
             .into());
         }
-        return Ok(std::sync::Arc::new(
-            metriken_query::ParquetReader::open_with_pool(file, pool)?,
+        // No labels: a bare parquet file is one recording with no label set
+        // of its own, which is a stable identity for exactly one path.
+        return Ok((
+            std::collections::BTreeMap::new(),
+            std::sync::Arc::new(metriken_query::ParquetReader::open_with_pool(file, pool)?),
         ));
     }
 
@@ -116,8 +142,8 @@ pub(crate) fn open_source_with_pool(
         // Every arm is empty and the caller named none of them. Opening the
         // first reports an empty recording, which is a truer answer than an
         // error about choosing between recordings that all hold nothing.
-        let (_, reader) = recordings.swap_remove(0);
-        return Ok(std::sync::Arc::new(reader));
+        let (labels, reader) = recordings.swap_remove(0);
+        return Ok((labels, std::sync::Arc::new(reader)));
     }
 
     // With every arm empty there is nothing to prefer, so the selector is
@@ -209,8 +235,8 @@ pub(crate) fn open_source_with_pool(
         }
     };
 
-    let (_, reader) = recordings.swap_remove(chosen);
-    Ok(std::sync::Arc::new(reader))
+    let (labels, reader) = recordings.swap_remove(chosen);
+    Ok((labels, std::sync::Arc::new(reader)))
 }
 
 /// Open with a selector and a fresh pool — the one-shot CLI path.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,7 +4,8 @@ use clap::{ArgMatches, Command};
 use std::path::PathBuf;
 
 mod recording_selector;
-// SelectError is unused until Task 2 (`RecordingSelector::resolve`) consumes it.
+// RecordingSelector and SelectError are both unused until `resolve` lands and
+// the MCP CLI/server actually pass a selector through to the reader.
 #[allow(unused_imports)]
 pub(crate) use recording_selector::{RecordingSelector, SelectError};
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -225,6 +225,16 @@ pub(crate) fn open_source_selected(
     )
 }
 
+/// Open with no selector at all — test fixtures and `analysis::extract`'s
+/// golden fixtures, which build single-recording archives.
+///
+/// `#[cfg(test)]` on purpose, now that every CLI path passes the caller's
+/// `--recording` through: production code opening a `.rez` has to say what it
+/// did with the selector, and this signature has nowhere to say it. Reaching
+/// for it from a real code path would silently reintroduce exactly the
+/// "answered from an arm nobody chose" failure the selector exists to
+/// prevent, so the compiler refuses instead.
+#[cfg(test)]
 pub(crate) fn open_source(
     file: &std::path::Path,
 ) -> Result<std::sync::Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
@@ -279,27 +289,30 @@ pub fn format_recording_info(file_path: &str, data: &dyn MetricsSource) -> Strin
 
 /// Run the MCP server or execute MCP commands
 pub fn run(config: Config) {
-    match config.mode {
-        Mode::Server => run_server(config),
+    // Destructured rather than passed whole: `run_server` takes only what it
+    // uses, so no path hands the server a selector it will never consult.
+    let Config {
+        verbose,
+        recording,
+        mode,
+    } = config;
+    match mode {
+        Mode::Server => run_server(verbose),
         Mode::AnalyzeCorrelation {
             file,
             query1,
             query2,
-        } => run_analyze_correlation(file, query1, query2),
-        // Task 5 wires the real `--recording` selector through to this call
-        // site; until then every CLI invocation behaves as it always has.
-        Mode::DescribeRecording { file } => {
-            run_describe_recording(file, &RecordingSelector::default())
-        }
-        Mode::DescribeMetrics { file } => run_describe_metrics(file),
-        Mode::DetectAnomalies { file, query } => run_detect_anomalies(file, query),
-        Mode::Query { file, query } => run_query(file, query),
-        Mode::ExtractFeatures { file } => run_extract_features(file),
+        } => run_analyze_correlation(file, query1, query2, &recording),
+        Mode::DescribeRecording { file } => run_describe_recording(file, &recording),
+        Mode::DescribeMetrics { file } => run_describe_metrics(file, &recording),
+        Mode::DetectAnomalies { file, query } => run_detect_anomalies(file, query, &recording),
+        Mode::Query { file, query } => run_query(file, query, &recording),
+        Mode::ExtractFeatures { file } => run_extract_features(file, &recording),
     }
 }
 
-fn run_server(config: Config) {
-    let _log_drain = configure_logging(verbosity_to_level(config.verbose));
+fn run_server(verbose: u8) {
+    let _log_drain = configure_logging(verbosity_to_level(verbose));
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -321,11 +334,22 @@ fn run_server(config: Config) {
     });
 }
 
-fn run_analyze_correlation(file: PathBuf, query1: String, query2: String) {
-    let reader = match open_source(&file) {
+fn run_analyze_correlation(
+    file: PathBuf,
+    query1: String,
+    query2: String,
+    selector: &RecordingSelector,
+) {
+    // Both queries are evaluated against the SAME recording: a correlation is
+    // only meaningful within one, so one selector for the pair is the whole
+    // story here — this is not a cross-recording comparison.
+    let reader = match open_source_selected(&file, selector) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Failed to load parquet file: {e}");
+            // Not "parquet file": the input may well be a .rez archive, and
+            // the errors this prints are mostly ABOUT that archive's
+            // recordings.
+            eprintln!("Failed to load recording: {e}");
             std::process::exit(1);
         }
     };
@@ -403,11 +427,11 @@ fn run_describe_recording(file: PathBuf, selector: &RecordingSelector) {
     }
 }
 
-fn run_describe_metrics(file: PathBuf) {
-    let reader = match open_source(&file) {
+fn run_describe_metrics(file: PathBuf, selector: &RecordingSelector) {
+    let reader = match open_source_selected(&file, selector) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Failed to load parquet file: {e}");
+            eprintln!("Failed to load recording: {e}");
             std::process::exit(1);
         }
     };
@@ -416,11 +440,11 @@ fn run_describe_metrics(file: PathBuf) {
     println!("{output}");
 }
 
-fn run_detect_anomalies(file: PathBuf, query: Option<String>) {
-    let reader = match open_source(&file) {
+fn run_detect_anomalies(file: PathBuf, query: Option<String>, selector: &RecordingSelector) {
+    let reader = match open_source_selected(&file, selector) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Failed to load parquet file: {e}");
+            eprintln!("Failed to load recording: {e}");
             std::process::exit(1);
         }
     };
@@ -634,11 +658,11 @@ fn run_exhaustive_detection(reader: Arc<dyn MetricsSource>) {
     }
 }
 
-fn run_query(file: PathBuf, query: String) {
-    let reader = match open_source(&file) {
+fn run_query(file: PathBuf, query: String, selector: &RecordingSelector) {
+    let reader = match open_source_selected(&file, selector) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Failed to load parquet file: {e}");
+            eprintln!("Failed to load recording: {e}");
             std::process::exit(1);
         }
     };
@@ -657,11 +681,11 @@ fn run_query(file: PathBuf, query: String) {
     }
 }
 
-fn run_extract_features(file: PathBuf) {
-    let reader = match open_source(&file) {
+fn run_extract_features(file: PathBuf, selector: &RecordingSelector) {
+    let reader = match open_source_selected(&file, selector) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("Failed to open recording: {e}");
+            eprintln!("Failed to load recording: {e}");
             std::process::exit(1);
         }
     };
@@ -832,6 +856,17 @@ pub enum Mode {
 /// MCP server configuration
 pub struct Config {
     pub verbose: u8,
+    /// Which recording of a multi-recording `.rez` to read.
+    ///
+    /// On `Config` rather than on each `Mode` variant because it applies to
+    /// every subcommand alike — the same reason `verbose` lives here.
+    ///
+    /// Always empty for `Mode::Server`: the stdio server takes a selector per
+    /// tool call, so `--recording` is declared on the six analysis
+    /// subcommands only and clap refuses it on the bare `rezolus mcp`. That
+    /// refusal is the point — a process-wide selector the server never
+    /// consulted would be accepted and silently do nothing.
+    pub recording: RecordingSelector,
     pub mode: Mode,
 }
 
@@ -840,6 +875,18 @@ impl TryFrom<ArgMatches> for Config {
 
     fn try_from(args: ArgMatches) -> Result<Self, String> {
         let verbose = args.get_count("VERBOSE");
+
+        // Read from the SUBCOMMAND's matches: `--recording` is declared per
+        // subcommand, so the top-level matches never carry it. `None` is
+        // server mode, which has no selector to read (see `Config.recording`).
+        let recording = match args.subcommand() {
+            Some((_, sub)) => RecordingSelector::parse(
+                sub.get_many::<String>("RECORDING")
+                    .unwrap_or_default()
+                    .cloned(),
+            )?,
+            None => RecordingSelector::default(),
+        };
 
         let mode = match args.subcommand() {
             Some(("analyze-correlation", sub_args)) => {
@@ -905,8 +952,42 @@ impl TryFrom<ArgMatches> for Config {
             _ => Mode::Server,
         };
 
-        Ok(Config { verbose, mode })
+        Ok(Config {
+            verbose,
+            recording,
+            mode,
+        })
     }
+}
+
+/// The `--recording` selector, declared identically on every analysis
+/// subcommand.
+///
+/// One definition rather than six copies: this is the flag an agent reads
+/// out of `--help` and types back, so the six must not drift into six
+/// slightly different explanations of the same thing.
+///
+/// Deliberately NOT declared on the top-level `mcp` command. The stdio
+/// server resolves a selector per tool call, so a process-wide one would
+/// apply to nothing; leaving it off makes `rezolus mcp --recording ...` a
+/// clap error instead of an accepted flag that silently does nothing.
+fn recording_arg() -> clap::Arg {
+    clap::Arg::new("RECORDING")
+        .long("recording")
+        .value_name("KEY=VALUE")
+        // Hard-wrapped, and with a self-contained first line: clap is built
+        // here without `wrap_help`, so it prints this verbatim (one endless
+        // line otherwise) and `-h` leads with that first line.
+        .help(
+            "Which recording of a multi-recording .rez to read, as key=value (e.g. --recording source=redis)\n\
+             Repeatable: the pairs are ANDed and must together name exactly one\n\
+             recording. Matching none or several is an error, never a guess.\n\
+             Run `rezolus mcp describe-recording FILE` with no --recording to list\n\
+             an archive's recordings and the selector that picks each one.\n\
+             Not accepted for a .parquet file, which holds one recording and so has\n\
+             nothing to select between.",
+        )
+        .action(clap::ArgAction::Append)
 }
 
 /// Create the MCP subcommand
@@ -973,7 +1054,8 @@ pub fn command() -> Command {
                         .help("Second PromQL query (e.g., 'cgroup_memory_used')")
                         .required(true)
                         .index(3),
-                ),
+                )
+                .arg(recording_arg()),
         )
         .subcommand(
             Command::new("describe-recording")
@@ -991,7 +1073,8 @@ pub fn command() -> Command {
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
-                ),
+                )
+                .arg(recording_arg()),
         )
         .subcommand(
             Command::new("describe-metrics")
@@ -1010,7 +1093,8 @@ pub fn command() -> Command {
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
-                ),
+                )
+                .arg(recording_arg()),
         )
         .subcommand(
             Command::new("detect-anomalies")
@@ -1040,7 +1124,8 @@ pub fn command() -> Command {
                         )
                         .required(false)
                         .index(2),
-                ),
+                )
+                .arg(recording_arg()),
         )
         .subcommand(
             Command::new("query")
@@ -1074,7 +1159,8 @@ pub fn command() -> Command {
                         .help("PromQL query (e.g., 'sum(rate(cpu_cycles[1m]))')")
                         .required(true)
                         .index(2),
-                ),
+                )
+                .arg(recording_arg()),
         )
         .subcommand(
             Command::new("extract-features")
@@ -1098,7 +1184,8 @@ pub fn command() -> Command {
                         .value_parser(clap::value_parser!(PathBuf))
                         .required(true)
                         .index(1),
-                ),
+                )
+                .arg(recording_arg()),
         )
 }
 
@@ -1748,5 +1835,84 @@ mod tests {
             !out.contains("Pick one") && !out.contains("recordings with data"),
             "must not present a choice when there is only one to make: {out}"
         );
+    }
+
+    #[test]
+    fn the_recording_flag_parses_on_every_subcommand() {
+        // Every tool must accept it. The one that does not is the one an
+        // agent will reach for on the archive it cannot read.
+        for (sub, extra) in [
+            ("describe-recording", vec![]),
+            ("describe-metrics", vec![]),
+            ("detect-anomalies", vec![]),
+            ("extract-features", vec![]),
+            ("query", vec!["cpu_cycles"]),
+            ("analyze-correlation", vec!["a", "b"]),
+        ] {
+            let mut argv = vec!["mcp", sub, "f.rez", "--recording", "source=redis"];
+            argv.extend(extra);
+            let m = command()
+                .try_get_matches_from(&argv)
+                .unwrap_or_else(|e| panic!("{sub} must accept --recording: {e}"));
+            let cfg = Config::try_from(m).unwrap();
+            // Compared against the parsed selector rather than rendered text:
+            // `Display` is deliberately not the pasteable form (see
+            // `as_flags`), so asserting on `to_string()` would quietly make a
+            // rendering choice part of this test's contract.
+            assert_eq!(
+                cfg.recording,
+                RecordingSelector::parse(["source=redis".to_string()]).unwrap(),
+                "for {sub}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_recording_flag_without_an_equals_is_rejected() {
+        let m = command()
+            .try_get_matches_from(["mcp", "describe-recording", "f.rez", "--recording", "redis"])
+            .unwrap();
+        assert!(Config::try_from(m).is_err());
+    }
+
+    /// Repeating the flag ANDs the pairs; it does not overwrite.
+    ///
+    /// `parse` refuses a repeated KEY, so an `ArgAction::Set` here would not
+    /// merely lose a pair — it would silently narrow a two-label selector to
+    /// its last label, which can then resolve to a recording the caller never
+    /// named.
+    #[test]
+    fn the_recording_flag_accumulates_when_repeated() {
+        let m = command()
+            .try_get_matches_from([
+                "mcp",
+                "describe-recording",
+                "f.rez",
+                "--recording",
+                "host=web-01",
+                "--recording",
+                "source=redis",
+            ])
+            .unwrap();
+        let cfg = Config::try_from(m).unwrap();
+        assert_eq!(
+            cfg.recording,
+            RecordingSelector::parse(["host=web-01".to_string(), "source=redis".to_string()])
+                .unwrap()
+        );
+    }
+
+    /// Server mode must REJECT the flag, not accept and ignore it.
+    ///
+    /// The stdio server takes a selector per tool call, so a process-wide
+    /// `--recording` would apply to nothing. Clap rejects it today only
+    /// because the flag is declared per subcommand; pinned here so nobody
+    /// hoists it to the top level, where it would parse cleanly and then be
+    /// consulted by no one.
+    #[test]
+    fn the_recording_flag_is_not_accepted_without_a_subcommand() {
+        assert!(command()
+            .try_get_matches_from(["mcp", "--recording", "source=redis"])
+            .is_err());
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,7 +4,9 @@ use clap::{ArgMatches, Command};
 use std::path::PathBuf;
 
 mod recording_selector;
-pub(crate) use recording_selector::{describe_candidates, RecordingSelector, SelectError};
+pub(crate) use recording_selector::{
+    describe_candidates, render_labels, RecordingSelector, SelectError,
+};
 
 pub mod anomaly_detection;
 pub mod correlation;
@@ -39,9 +41,16 @@ pub(crate) fn open_source_with_pool(
     {
         // Silently ignoring the selector here would be its own wrong answer:
         // the caller believes it narrowed the data and it did not.
+        //
+        // "not a .rez archive" rather than "is a parquet file": this branch
+        // takes everything `detect_rez_format` calls `NotRez`, which includes
+        // a text file or a truncated download, and asserting parquet would be
+        // a guess. The advice is phrased without naming a flag because the
+        // stdio server reaches this with a JSON object, not `--recording`.
         if !selector.is_empty() {
             return Err(format!(
-                "{} is a parquet file and has no recordings to select; drop --recording",
+                "{} is not a .rez archive and holds no recordings to select between; \
+                 a recording selector applies only to a multi-recording .rez",
                 file.display()
             )
             .into());
@@ -102,45 +111,101 @@ pub(crate) fn open_source_with_pool(
         .iter()
         .map(|&i| recordings[i].0.clone())
         .collect();
-    if candidates.is_empty() {
-        // Every arm is empty. Opening the first reports an empty recording,
-        // which is a truer answer than an error about selecting between
-        // recordings that all hold nothing.
+    let all_empty = candidates.is_empty();
+    if all_empty && selector.is_empty() {
+        // Every arm is empty and the caller named none of them. Opening the
+        // first reports an empty recording, which is a truer answer than an
+        // error about choosing between recordings that all hold nothing.
         let (_, reader) = recordings.swap_remove(0);
         return Ok(std::sync::Arc::new(reader));
     }
 
-    let chosen = match selector.resolve(&candidates) {
-        Ok(i) => candidate_idx[i],
+    // With every arm empty there is nothing to prefer, so the selector is
+    // resolved against ALL of them: a caller that named `source=valkey` gets
+    // the valkey reader — empty, but the one it asked about — instead of the
+    // first arm wearing valkey's name in every downstream report, since
+    // `RezReader` carries the recording's own metadata into
+    // `describe-recording` and `extract-features`. Falling through to
+    // `swap_remove(0)` here would be exactly the "returned a recording the
+    // selector did not name" failure this function refuses everywhere else.
+    let (universe_idx, universe) = if all_empty {
+        (
+            (0..recordings.len()).collect::<Vec<usize>>(),
+            recordings
+                .iter()
+                .map(|(l, _)| l.clone())
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        (candidate_idx, candidates)
+    };
+    // What the listing under an error is a listing OF. Only says "with data"
+    // when that is what was filtered on.
+    let listing_lead = if all_empty {
+        "It holds:"
+    } else {
+        "Recordings with data:"
+    };
+
+    let chosen = match selector.resolve(&universe) {
+        Ok(i) => universe_idx[i],
         Err(SelectError::NoMatch) => {
+            // The named recording may exist and have been excluded for holding
+            // no rows. "No recording matches" would then be false in the way
+            // that matters: an agent reports the endpoint was never captured,
+            // when it was captured and produced nothing — itself the finding.
+            let named_but_empty: Vec<String> = recordings
+                .iter()
+                .enumerate()
+                .filter(|(i, (l, _))| !universe_idx.contains(i) && selector.matches(l))
+                .map(|(_, (l, _))| render_labels(l))
+                .collect();
+            let lead = if named_but_empty.is_empty() {
+                format!(
+                    "no recording in {} matches {}",
+                    file.display(),
+                    selector.as_flags()
+                )
+            } else {
+                format!(
+                    "{} names {} in {}, which was recorded but produced no rows, so it \
+                     holds nothing to analyze",
+                    selector.as_flags(),
+                    named_but_empty.join("; "),
+                    file.display()
+                )
+            };
             return Err(format!(
-                "no recording in {} matches --recording {selector}. It holds:\n{}",
-                file.display(),
-                describe_candidates(&candidates, &[])
+                "{lead}. {listing_lead}\n{}",
+                describe_candidates(&universe, &[])
             )
-            .into())
+            .into());
         }
         Err(SelectError::Ambiguous(hits)) => {
             // `hits` are HIGHLIGHTED, not passed as the candidate list:
-            // uniqueness must be computed against every recording, or the
-            // listing advertises selectors that are unique within the subset
-            // and ambiguous in the archive.
+            // uniqueness must be computed against every candidate, not just
+            // the matched subset, or the listing advertises selectors that are
+            // unique among the ones being shown and ambiguous against the rest.
             let lead = if selector.is_empty() {
+                // Only reachable when some arm has data, so `hits` counts the
+                // recordings WITH DATA — which is not the same as how many the
+                // archive holds, and saying "holds 3 recordings" of a 3-arm
+                // file with one dead arm would be wrong.
                 format!(
-                    "{} holds {} recordings (a multi-host or A/B archive), and the \
-                     analysis tools read one at a time. Pick one:",
+                    "{} holds {} recordings with data (a multi-host or A/B archive), and \
+                     the analysis tools read one at a time. Pick one:",
                     file.display(),
                     hits.len()
                 )
             } else {
                 format!(
-                    "--recording {selector} matches {} recordings in {}; add labels \
-                     until it names one:",
+                    "{} matches {} recordings in {}; add labels until it names one:",
+                    selector.as_flags(),
                     hits.len(),
                     file.display()
                 )
             };
-            return Err(format!("{lead}\n{}", describe_candidates(&candidates, &hits)).into());
+            return Err(format!("{lead}\n{}", describe_candidates(&universe, &hits)).into());
         }
     };
 
@@ -1093,10 +1158,36 @@ mod tests {
         sources: &[&str],
         with_rows: &[bool],
     ) {
+        multi_recording_rez_with_arms(path, sources, &vec![None; sources.len()], with_rows)
+    }
+
+    /// As `multi_recording_rez`, plus an optional `arm` label per recording.
+    ///
+    /// `source` is unique per recording and `host` is shared by all of them,
+    /// so with those two alone every selector either names one recording or
+    /// names them all. An `arm` shared by SOME of the recordings is what makes
+    /// a partial match possible, which is the only way to tell a listing that
+    /// renders the recordings a selector matched from one that renders every
+    /// recording it could have matched.
+    pub(crate) fn multi_recording_rez_with_arms(
+        path: &std::path::Path,
+        sources: &[&str],
+        arms: &[Option<&str>],
+        with_rows: &[bool],
+    ) {
         use crate::recorder::rez_v3_writer::{ManifestSeed, RezArchive, StreamRecorderV3};
         let mut archive = RezArchive::create(path).unwrap();
         let mut recs: Vec<StreamRecorderV3> = Vec::new();
-        for source in sources {
+        for (i, source) in sources.iter().enumerate() {
+            let mut labels: std::collections::BTreeMap<String, String> = [
+                ("source".to_string(), source.to_string()),
+                ("host".to_string(), "web-01".to_string()),
+            ]
+            .into_iter()
+            .collect();
+            if let Some(arm) = arms.get(i).copied().flatten() {
+                labels.insert("arm".to_string(), arm.to_string());
+            }
             let seed = ManifestSeed {
                 // `host` is shared across the arms on purpose: with `source`
                 // as the only label, no selector could ever match two
@@ -1104,12 +1195,7 @@ mod tests {
                 // silently fall through to the first arm — would be
                 // untestable through this helper. A real multi-endpoint
                 // capture of one host's two services looks exactly like this.
-                labels: [
-                    ("source".to_string(), source.to_string()),
-                    ("host".to_string(), "web-01".to_string()),
-                ]
-                .into_iter()
-                .collect(),
+                labels,
                 // Mirrors `recorder::build_rez_metadata`, which puts the same
                 // `source` in the per-recording metadata as in the labels.
                 // Tests identify which arm came back by reading it, so a
@@ -1166,8 +1252,10 @@ mod tests {
             Err(e) => e.to_string(),
         };
         assert!(
-            msg.contains("2 recordings"),
-            "the message must say how many recordings carry data: {msg}"
+            msg.contains("2 recordings with data"),
+            "the message must say how many recordings carry DATA — the count is of \
+             candidates, not of what the archive holds, and the two differ whenever \
+             an arm produced no rows: {msg}"
         );
         // No longer asserts that the message points at `rezolus view`, and
         // deliberately so: the fix on offer is now `--recording`, which reads
@@ -1314,12 +1402,21 @@ mod tests {
             Err(e) => e.to_string(),
         };
         assert!(msg.contains("no recordings"), "{msg}");
-        // Distinguishes this from the `.rez` path's own "holds no recordings":
-        // without it the test would still pass if a parquet file were somehow
-        // routed into the archive branch and rejected there for another reason.
+        // Says what the file is NOT, rather than asserting it is parquet:
+        // this branch also takes a text file or a truncated download, so
+        // naming the format would be a guess. The check also distinguishes
+        // this from the `.rez` path's own "holds no recordings", which the
+        // test would otherwise accept if a parquet file were somehow routed
+        // into the archive branch and rejected there for another reason.
         assert!(
-            msg.contains("parquet file") && msg.contains("--recording"),
-            "must say why and what to drop: {msg}"
+            msg.contains("not a .rez archive"),
+            "must say why there is nothing to select: {msg}"
+        );
+        // Phrased for both front ends: the stdio server passes a JSON object,
+        // so advice spelled as a CLI flag would be wrong there.
+        assert!(
+            !msg.contains("--recording"),
+            "must not name a CLI flag the server caller never typed: {msg}"
         );
     }
 
@@ -1341,6 +1438,158 @@ mod tests {
     /// reader with nothing in it — an analysis run reporting "no data" over
     /// an archive that holds data. Carrying the recording index through the
     /// selection instead is what prevents it.
+    /// Every arm empty and a selector given: the caller gets the arm it
+    /// named, not the first one.
+    ///
+    /// The reader carries its recording's own metadata into
+    /// `describe-recording` and `extract-features`, so first-matching here
+    /// would not merely return "an empty recording" — it would attribute the
+    /// empty result to the WRONG endpoint, which is the same wrong-arm
+    /// failure the selector exists to prevent, just with no rows to hide it.
+    #[test]
+    fn an_all_empty_archive_still_honors_the_selector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("both-empty.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[false, false]);
+
+        let sel = RecordingSelector::parse(["source=valkey".to_string()]).unwrap();
+        let src = open_source_selected(&path, &sel).expect("the named arm still opens");
+        assert!(src.counter_names().is_empty(), "it really is empty");
+        assert_eq!(
+            src.metadata_get("source").as_deref(),
+            Some("valkey"),
+            "and it must be the arm that was named, not the first one"
+        );
+    }
+
+    /// ...but with NO selector, an all-empty archive still opens rather than
+    /// erroring: reporting one empty recording beats an error about choosing
+    /// between recordings that all hold nothing.
+    #[test]
+    fn an_all_empty_archive_opens_without_a_selector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("both-empty.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[false, false]);
+
+        let src = open_source(&path).expect("an all-empty archive must still open");
+        assert!(src.counter_names().is_empty());
+    }
+
+    #[test]
+    fn a_selector_matching_nothing_in_an_all_empty_archive_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("both-empty.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[false, false]);
+
+        let sel = RecordingSelector::parse(["source=nope".to_string()]).unwrap();
+        let msg = match open_source_selected(&path, &sel) {
+            Ok(_) => panic!("must not fall back to an arm the selector did not name"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("source=redis"),
+            "it lists what is there: {msg}"
+        );
+        assert!(
+            !msg.contains("with data"),
+            "and must not claim these recordings hold data: {msg}"
+        );
+    }
+
+    /// Naming a recording that exists but produced no rows must say so, not
+    /// "no recording matches".
+    ///
+    /// The distinction is the whole finding: "that endpoint was never
+    /// captured" and "that endpoint was captured and reported nothing" lead
+    /// an agent to opposite conclusions, and only the second is true here.
+    #[test]
+    fn naming_an_empty_recording_says_it_produced_no_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("one-empty.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, false]);
+
+        let sel = RecordingSelector::parse(["source=valkey".to_string()]).unwrap();
+        let msg = match open_source_selected(&path, &sel) {
+            Ok(_) => panic!("an empty arm holds nothing to analyze"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("produced no rows"),
+            "must not report a recorded-but-silent endpoint as absent: {msg}"
+        );
+        assert!(
+            msg.contains("source=valkey"),
+            "and must name the recording it found: {msg}"
+        );
+        assert!(
+            msg.contains("source=redis"),
+            "then list what can be analyzed: {msg}"
+        );
+    }
+
+    /// A selector echoed back in an error must be pasteable.
+    ///
+    /// `Display` joins pairs with a comma, but `parse` splits each argument
+    /// on its first `=`, so `--recording host=web-01,source=nope` comes back
+    /// as the single label `host="web-01,source=nope"` and fails as a
+    /// no-match for an invisible reason. An agent told to adjust and retry
+    /// does exactly this paste.
+    #[test]
+    fn an_echoed_selector_is_in_the_repeatable_flag_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let sel = RecordingSelector::parse(["host=web-01".to_string(), "source=nope".to_string()])
+            .unwrap();
+        let msg = match open_source_selected(&path, &sel) {
+            Ok(_) => panic!("no arm matches source=nope"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("--recording host=web-01 --recording source=nope"),
+            "the echo must be the form that round-trips through parse: {msg}"
+        );
+        assert!(
+            !msg.contains("host=web-01,source=nope"),
+            "the comma-joined Display form is not pasteable: {msg}"
+        );
+    }
+
+    /// An ambiguity listing renders the recordings the selector MATCHED, not
+    /// every candidate.
+    ///
+    /// Needs three arms where a selector matches exactly two: with only two
+    /// recordings, every ambiguous selector matches both and a listing that
+    /// ignored `hits` would look identical.
+    #[test]
+    fn an_ambiguity_listing_renders_only_the_matched_recordings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("three.rez");
+        multi_recording_rez_with_arms(
+            &path,
+            &["redis", "valkey", "memcached"],
+            &[Some("a"), Some("a"), Some("b")],
+            &[true, true, true],
+        );
+
+        let sel = RecordingSelector::parse(["arm=a".to_string()]).unwrap();
+        let msg = match open_source_selected(&path, &sel) {
+            Ok(_) => panic!("arm=a matches two recordings"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("matches 2 recordings"), "{msg}");
+        assert!(
+            msg.contains("source=redis") && msg.contains("source=valkey"),
+            "{msg}"
+        );
+        assert!(
+            !msg.contains("memcached"),
+            "arm=b was never matched, so listing it would send the caller to a \
+             recording their selector excluded: {msg}"
+        );
+    }
+
     #[test]
     fn an_empty_arm_with_the_same_labels_does_not_shadow_the_one_with_data() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -4,9 +4,6 @@ use clap::{ArgMatches, Command};
 use std::path::PathBuf;
 
 mod recording_selector;
-// RecordingSelector, SelectError, and describe_candidates are all unused
-// until the MCP CLI/server actually pass a selector through to the reader.
-#[allow(unused_imports)]
 pub(crate) use recording_selector::{describe_candidates, RecordingSelector, SelectError};
 
 pub mod anomaly_detection;
@@ -17,79 +14,156 @@ mod server;
 use chrono::{DateTime, Utc};
 use metriken_query::{MetricsSource, QueryResult};
 
-/// Open a recording as a `MetricsSource`, dispatching `.rez` archives to
-/// `RezReader` and everything else to `ParquetReader` (by content, not extension).
-/// Dispatch covers both `.rez` containers (v2 tar and v3 SQLite) — `RezReader`
-/// itself dispatches on the container internally.
-/// Open a recording as a query source, refusing what the analysis tools cannot
-/// read.
+/// Open a recording as a query source, selecting ONE recording out of a
+/// multi-recording `.rez` archive.
+///
+/// Dispatch is by content, not extension: a `.rez` container (v2 tar or v3
+/// SQLite — `RezReader` sorts out which internally) goes to `RezReader`,
+/// anything else to `ParquetReader`.
+///
+/// `selector` must name exactly one recording. None or several is an error,
+/// never a first match and never a default: the analysis tools read one
+/// recording at a time, and quietly answering from one arm of an A/B while
+/// presenting it as the archive's answer is the failure this exists to
+/// prevent.
 ///
 /// `pool` is shared so the stdio server and the one-shot CLI use one budget.
 pub(crate) fn open_source_with_pool(
     file: &std::path::Path,
     pool: std::sync::Arc<metriken_query::BufferPool>,
+    selector: &RecordingSelector,
 ) -> Result<std::sync::Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
     use crate::recorder::rez::RezFormat;
     if crate::recorder::rez::detect_rez_format(file).unwrap_or(RezFormat::NotRez)
         == RezFormat::NotRez
     {
+        // Silently ignoring the selector here would be its own wrong answer:
+        // the caller believes it narrowed the data and it did not.
+        if !selector.is_empty() {
+            return Err(format!(
+                "{} is a parquet file and has no recordings to select; drop --recording",
+                file.display()
+            )
+            .into());
+        }
         return Ok(std::sync::Arc::new(
             metriken_query::ParquetReader::open_with_pool(file, pool)?,
         ));
     }
 
-    // Open the recordings ONCE and build the reader from what comes back.
+    // Open the recordings ONCE and build the reader from the one that was
+    // selected.
     //
-    // `open_with_pool` would flatten them into one view, and two recordings of
-    // the same agent then give every sampler two owners, so the reader refuses
-    // each query as cross-recording — deliberately, since silently answering
-    // from one arm of an A/B is the worse failure. But the analysis tools fold
-    // a per-metric query error into `NoData`, so that refusal surfaces as
-    // "analyzed 41 metrics, found anomalies in 0": a clean-looking wrong
-    // answer, on the shape `record --endpoint a --endpoint b -o out.rez` now
-    // produces by default. So refuse here, where the message reaches the
-    // caller.
+    // `open_with_pool` would flatten them into one view instead, and two
+    // recordings of the same agent then give every sampler two owners, so the
+    // reader refuses each query as cross-recording — deliberately, since
+    // silently answering from one arm is the worse failure. But the analysis
+    // tools fold a per-metric query error into `NoData`, so that refusal
+    // surfaces as "analyzed 41 metrics, found anomalies in 0": a clean-looking
+    // wrong answer, on the shape `record --endpoint a --endpoint b -o out.rez`
+    // now produces by default. So the choice is made here, where both the
+    // selection and any failure to select reach the caller.
     //
-    // Counting via a second open cost a measured 2x on every invocation —
+    // Selecting via a second open cost a measured 2x on every invocation —
     // neither container's probe is catalog-only (v3 reads a segment per table,
     // tar reads the whole archive into memory). Consuming the recordings we
     // already have avoids that. The only field this loses versus
     // `open_with_pool` is `filename`, which nothing under `src/mcp/` reads.
     let mut recordings = crate::rez_reader::RezReader::open_recordings(file, pool)?;
-
-    // Count only recordings that actually hold tables. An arm that produced no
-    // rows cannot collide with anything, and the flattened reader answers such
-    // an archive correctly — refusing it would reject exactly the run this
-    // branch's own endpoint-activation fix is about.
-    let with_tables = recordings.iter().filter(|(_, r)| !r.is_empty()).count();
-    if with_tables > 1 {
-        return Err(format!(
-            "{} holds {with_tables} recordings with data (a multi-host or A/B archive), \
-             and the analysis tools read one recording at a time. Re-record the endpoint \
-             you want on its own (`record --endpoint <one> -o one.rez`), or open it in \
-             `rezolus view`, which reads two recordings as a comparison",
-            file.display()
-        )
-        .into());
-    }
-
-    // The one with data, else the first — an all-empty archive still opens, and
-    // reports an empty recording rather than erroring.
-    let idx = recordings
-        .iter()
-        .position(|(_, r)| !r.is_empty())
-        .unwrap_or(0);
-    if idx >= recordings.len() {
+    if recordings.is_empty() {
         return Err(format!("{} holds no recordings", file.display()).into());
     }
-    let (_, reader) = recordings.swap_remove(idx);
+
+    // Only recordings that hold tables are candidates. An arm that produced no
+    // rows cannot be what the caller meant, and excluding it keeps a run where
+    // one endpoint never reported from needing a selector at all.
+    //
+    // The candidate's index into `recordings` is carried alongside its labels
+    // rather than recovered afterwards by matching labels: two recordings may
+    // legitimately share a label set (the recorder warns but permits it), and
+    // if the duplicate is an EMPTY arm it is not a candidate at all, so a
+    // label lookup over the full list could land on it and hand back a reader
+    // with no data. Nothing here removes from `recordings` before the index is
+    // used, so the indices stay valid.
+    //
+    // `candidates` is then BOTH the set `resolve` chooses from and the `all`
+    // that `describe_candidates` computes uniqueness against. That has to stay
+    // one set: a listing built over a wider universe would qualify selectors
+    // against recordings this call would never pick, and one built over a
+    // narrower universe would advertise a selector that resolves as ambiguous
+    // when it is pasted back.
+    let candidate_idx: Vec<usize> = recordings
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, r))| !r.is_empty())
+        .map(|(i, _)| i)
+        .collect();
+    let candidates: Vec<std::collections::BTreeMap<String, String>> = candidate_idx
+        .iter()
+        .map(|&i| recordings[i].0.clone())
+        .collect();
+    if candidates.is_empty() {
+        // Every arm is empty. Opening the first reports an empty recording,
+        // which is a truer answer than an error about selecting between
+        // recordings that all hold nothing.
+        let (_, reader) = recordings.swap_remove(0);
+        return Ok(std::sync::Arc::new(reader));
+    }
+
+    let chosen = match selector.resolve(&candidates) {
+        Ok(i) => candidate_idx[i],
+        Err(SelectError::NoMatch) => {
+            return Err(format!(
+                "no recording in {} matches --recording {selector}. It holds:\n{}",
+                file.display(),
+                describe_candidates(&candidates, &[])
+            )
+            .into())
+        }
+        Err(SelectError::Ambiguous(hits)) => {
+            // `hits` are HIGHLIGHTED, not passed as the candidate list:
+            // uniqueness must be computed against every recording, or the
+            // listing advertises selectors that are unique within the subset
+            // and ambiguous in the archive.
+            let lead = if selector.is_empty() {
+                format!(
+                    "{} holds {} recordings (a multi-host or A/B archive), and the \
+                     analysis tools read one at a time. Pick one:",
+                    file.display(),
+                    hits.len()
+                )
+            } else {
+                format!(
+                    "--recording {selector} matches {} recordings in {}; add labels \
+                     until it names one:",
+                    hits.len(),
+                    file.display()
+                )
+            };
+            return Err(format!("{lead}\n{}", describe_candidates(&candidates, &hits)).into());
+        }
+    };
+
+    let (_, reader) = recordings.swap_remove(chosen);
     Ok(std::sync::Arc::new(reader))
+}
+
+/// Open with a selector and a fresh pool — the one-shot CLI path.
+pub(crate) fn open_source_selected(
+    file: &std::path::Path,
+    selector: &RecordingSelector,
+) -> Result<std::sync::Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
+    open_source_with_pool(
+        file,
+        metriken_query::BufferPool::new(256 * 1024 * 1024),
+        selector,
+    )
 }
 
 pub(crate) fn open_source(
     file: &std::path::Path,
 ) -> Result<std::sync::Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
-    open_source_with_pool(file, metriken_query::BufferPool::new(256 * 1024 * 1024))
+    open_source_selected(file, &RecordingSelector::default())
 }
 
 /// Format recording information for display
@@ -1024,10 +1098,25 @@ mod tests {
         let mut recs: Vec<StreamRecorderV3> = Vec::new();
         for source in sources {
             let seed = ManifestSeed {
-                labels: [("source".to_string(), source.to_string())]
+                // `host` is shared across the arms on purpose: with `source`
+                // as the only label, no selector could ever match two
+                // recordings, and the ambiguous path — the one that must not
+                // silently fall through to the first arm — would be
+                // untestable through this helper. A real multi-endpoint
+                // capture of one host's two services looks exactly like this.
+                labels: [
+                    ("source".to_string(), source.to_string()),
+                    ("host".to_string(), "web-01".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+                // Mirrors `recorder::build_rez_metadata`, which puts the same
+                // `source` in the per-recording metadata as in the labels.
+                // Tests identify which arm came back by reading it, so a
+                // helper that left it empty would make that check vacuous.
+                metadata: [("source".to_string(), source.to_string())]
                     .into_iter()
                     .collect(),
-                metadata: Default::default(),
                 clock_anchor_wall_ns: 1_000_000_000,
             };
             recs.push(StreamRecorderV3::new(archive.add_recording(seed).unwrap()));
@@ -1062,6 +1151,10 @@ mod tests {
     /// right call, but `extract-features` and `detect-anomalies` fold a
     /// per-metric query error into `NoData`, so the run would report
     /// "analyzed N metrics, found anomalies in 0" and look clean.
+    ///
+    /// Companion to `no_selector_on_a_multi_recording_archive_lists_them`,
+    /// which pins the listing itself; this one pins the count and the
+    /// suggestions the message must not make.
     #[test]
     fn open_source_refuses_a_multi_recording_archive_with_a_message() {
         let dir = tempfile::tempdir().unwrap();
@@ -1076,13 +1169,17 @@ mod tests {
             msg.contains("2 recordings"),
             "the message must say how many recordings carry data: {msg}"
         );
-        assert!(
-            msg.contains("rezolus view"),
-            "and must point at something that CAN read it: {msg}"
-        );
+        // No longer asserts that the message points at `rezolus view`, and
+        // deliberately so: the fix on offer is now `--recording`, which reads
+        // the arm the caller asked about in the tool they are already in.
+        // Sending them to another tool would be worse advice than the listing.
         assert!(
             !msg.contains("recording filter"),
             "must not suggest `filter`, which cannot split by recording: {msg}"
+        );
+        assert!(
+            !msg.contains("Re-record"),
+            "must not tell the caller to re-record what they can now select: {msg}"
         );
     }
 
@@ -1127,6 +1224,134 @@ mod tests {
             source.is_ok(),
             "open_source must accept a v3 .rez: {:?}",
             source.err()
+        );
+    }
+
+    #[test]
+    fn a_selector_picks_the_named_recording() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let sel = RecordingSelector::parse(["source=valkey".to_string()]).unwrap();
+        let src = open_source_selected(&path, &sel).expect("the selector names one recording");
+        // Asserted by VALUE, not merely "some series came back": both arms
+        // hold `cpu_cycles`, so an assertion that data exists would pass even
+        // if the wrong arm were opened.
+        assert_eq!(src.counter_names(), vec!["cpu_cycles".to_string()]);
+        assert_eq!(
+            src.metadata_get("source").as_deref(),
+            Some("valkey"),
+            "the reader must be the valkey arm, not the first one"
+        );
+    }
+
+    /// With no selector, a multi-recording archive is still refused — but now
+    /// the message lists the recordings and the flag that picks each one,
+    /// rather than telling the caller to re-record.
+    #[test]
+    fn no_selector_on_a_multi_recording_archive_lists_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let msg = match open_source(&path) {
+            Ok(_) => panic!("must not silently pick an arm"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("source=redis"), "{msg}");
+        assert!(msg.contains("source=valkey"), "{msg}");
+        assert!(msg.contains("--recording"), "{msg}");
+    }
+
+    #[test]
+    fn a_selector_matching_nothing_lists_the_candidates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let sel = RecordingSelector::parse(["source=nope".to_string()]).unwrap();
+        let msg = match open_source_selected(&path, &sel) {
+            Ok(_) => panic!("must not fall back to any recording"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("source=nope"),
+            "the error names the selector: {msg}"
+        );
+        assert!(msg.contains("source=redis"), "and lists candidates: {msg}");
+    }
+
+    #[test]
+    fn an_ambiguous_selector_lists_the_ones_it_matched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        // Both arms carry host=web-01, so selecting on it matches two. This
+        // must NOT fall through to the first.
+        let sel = RecordingSelector::parse(["host=web-01".to_string()]).unwrap();
+        let msg = match open_source_selected(&path, &sel) {
+            Ok(_) => panic!("an ambiguous selector must not pick an arm"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("matches 2 recordings"), "{msg}");
+        assert!(msg.contains("source=redis"), "{msg}");
+        assert!(msg.contains("source=valkey"), "{msg}");
+    }
+
+    #[test]
+    fn a_selector_against_a_parquet_file_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let parquet_path = dir.path().join("rec.parquet");
+        let tables = build_recorder().finalize_tables();
+        let bytes = crate::recorder::rez::write_table_parquet(&tables[0]).unwrap();
+        std::fs::write(&parquet_path, bytes).unwrap();
+
+        let sel = RecordingSelector::parse(["source=redis".to_string()]).unwrap();
+        let msg = match open_source_selected(&parquet_path, &sel) {
+            Ok(_) => panic!("a parquet file has no recordings to select"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("no recordings"), "{msg}");
+        // Distinguishes this from the `.rez` path's own "holds no recordings":
+        // without it the test would still pass if a parquet file were somehow
+        // routed into the archive branch and rejected there for another reason.
+        assert!(
+            msg.contains("parquet file") && msg.contains("--recording"),
+            "must say why and what to drop: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_single_recording_archive_is_unaffected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("one.rez");
+        build_recorder().finalize(&path).unwrap();
+        assert!(open_source(&path).is_ok(), "no selector needed");
+    }
+
+    /// An empty arm must not shadow the arm that has data, even when the two
+    /// carry IDENTICAL labels.
+    ///
+    /// The recorder only warns about duplicate label sets, so this shape is
+    /// reachable. Selecting among *candidates* (recordings with tables) and
+    /// then locating the chosen one by matching its labels against the FULL
+    /// recording list would find the empty duplicate first and hand back a
+    /// reader with nothing in it — an analysis run reporting "no data" over
+    /// an archive that holds data. Carrying the recording index through the
+    /// selection instead is what prevents it.
+    #[test]
+    fn an_empty_arm_with_the_same_labels_does_not_shadow_the_one_with_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dup.rez");
+        multi_recording_rez(&path, &["redis", "redis"], &[false, true]);
+
+        let src = open_source(&path).expect("only one arm has data, so no selector is needed");
+        assert_eq!(
+            src.counter_names(),
+            vec!["cpu_cycles".to_string()],
+            "the arm with rows must be the one opened"
         );
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -3,6 +3,11 @@ use crate::*;
 use clap::{ArgMatches, Command};
 use std::path::PathBuf;
 
+mod recording_selector;
+// SelectError is unused until Task 2 (`RecordingSelector::resolve`) consumes it.
+#[allow(unused_imports)]
+pub(crate) use recording_selector::{RecordingSelector, SelectError};
+
 pub mod anomaly_detection;
 pub mod correlation;
 mod describe_metrics;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -38,6 +38,24 @@ pub(crate) struct Opened {
     /// the archive held a single recording, saying nothing about the other
     /// arms or about the fact that nothing was captured at all.
     pub all_empty_recordings: Vec<std::collections::BTreeMap<String, String>>,
+    /// Whether the reader is known to be over a rezolus recording — true for
+    /// every recording in a `.rez`, which can only be written from a
+    /// rezolus/msgpack endpoint. Recorded HERE, where the container was just
+    /// identified, because the recording's own `source` metadata cannot
+    /// answer it: that is the endpoint name the caller chose.
+    pub rezolus_native: bool,
+}
+
+impl Opened {
+    /// What the analysis layer should trust this recording's metric names to
+    /// mean. See `analysis::extract::Provenance`.
+    pub(crate) fn provenance(&self) -> crate::analysis::extract::Provenance {
+        if self.rezolus_native {
+            crate::analysis::extract::Provenance::RezolusAgent
+        } else {
+            crate::analysis::extract::Provenance::FromMetadata
+        }
+    }
 }
 
 /// Why opening a recording did not yield exactly one reader.
@@ -161,6 +179,10 @@ pub(crate) fn open_source_with_pool_labeled(
             labels: std::collections::BTreeMap::new(),
             reader: std::sync::Arc::new(reader),
             all_empty_recordings: Vec::new(),
+            // Not a `.rez`: whether this is a rezolus recording is the
+            // `source` metadata's question again, as it has always been for a
+            // plain parquet file.
+            rezolus_native: false,
         });
     }
 
@@ -239,6 +261,7 @@ pub(crate) fn open_source_with_pool_labeled(
             labels,
             reader: std::sync::Arc::new(reader),
             all_empty_recordings,
+            rezolus_native: true,
         });
     }
 
@@ -348,6 +371,7 @@ pub(crate) fn open_source_with_pool_labeled(
         labels,
         reader: std::sync::Arc::new(reader),
         all_empty_recordings: Vec::new(),
+        rezolus_native: true,
     })
 }
 
@@ -887,15 +911,22 @@ fn run_query(file: PathBuf, query: String, selector: &RecordingSelector) {
 }
 
 fn run_extract_features(file: PathBuf, selector: &RecordingSelector) {
-    let reader = match open_source_selected(&file, selector) {
-        Ok(r) => r,
+    // The labeled open, for its `rezolus_native`: a recording selected out of
+    // a `.rez` reports the endpoint name the caller chose as its `source`, so
+    // deciding sampler inference from that field alone would leave every
+    // unlabeled metric `unattributed` on exactly the archives this selector
+    // exists to read.
+    let opened = match open_selected_labeled(&file, selector, SelectorSyntax::Flags) {
+        Ok(o) => o,
         Err(e) => {
             eprintln!("Failed to load recording: {e}");
             std::process::exit(1);
         }
     };
+    let provenance = opened.provenance();
+    let reader = opened.reader;
 
-    match crate::analysis::extract::extract(reader.as_ref()) {
+    match crate::analysis::extract::extract(reader.as_ref(), provenance) {
         Ok(record) => match serde_json::to_string_pretty(&record) {
             Ok(json) => println!("{json}"),
             Err(e) => {
@@ -2152,6 +2183,57 @@ mod tests {
         assert!(
             out.contains("cannot be selected by labels"),
             "it must say so plainly instead: {out}"
+        );
+    }
+
+    /// A `.rez` is a rezolus recording whatever an arm is CALLED.
+    ///
+    /// `record --endpoint url,source=redis` puts `source=redis` in the
+    /// recording's metadata, so an analysis that decided "is this rezolus
+    /// data?" from that field alone answered no for a selected arm and
+    /// dropped sampler inference — silently, as `unattributed`. The container
+    /// answers the question: a `.rez` can only be written from a
+    /// rezolus/msgpack endpoint.
+    #[test]
+    fn a_selected_rez_arm_is_known_rezolus_native_whatever_its_source_says() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let sel = RecordingSelector::parse(["source=redis".to_string()]).unwrap();
+        let opened = open_selected_labeled(&path, &sel, SelectorSyntax::Flags).unwrap();
+        assert_eq!(
+            opened.reader.source(),
+            "redis",
+            "fixture sanity: the arm really does report a non-rezolus source"
+        );
+        assert!(opened.rezolus_native);
+        assert_eq!(
+            opened.provenance(),
+            crate::analysis::extract::Provenance::RezolusAgent
+        );
+    }
+
+    /// ...and a plain parquet file is unchanged: its `source` metadata is
+    /// still the only thing that can answer, exactly as before.
+    #[test]
+    fn a_parquet_file_still_decides_provenance_from_its_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let parquet_path = dir.path().join("rec.parquet");
+        let tables = build_recorder().finalize_tables();
+        let bytes = crate::recorder::rez::write_table_parquet(&tables[0]).unwrap();
+        std::fs::write(&parquet_path, bytes).unwrap();
+
+        let opened = open_selected_labeled(
+            &parquet_path,
+            &RecordingSelector::default(),
+            SelectorSyntax::Flags,
+        )
+        .unwrap();
+        assert!(!opened.rezolus_native);
+        assert_eq!(
+            opened.provenance(),
+            crate::analysis::extract::Provenance::FromMetadata
         );
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 mod recording_selector;
 pub(crate) use recording_selector::{
-    describe_candidates, render_labels, RecordingSelector, SelectError,
+    describe_candidates, render_labels, RecordingSelector, SelectError, SelectorSyntax,
 };
 
 pub mod anomaly_detection;
@@ -36,12 +36,17 @@ type LabeledSource = (
 /// prevent.
 ///
 /// `pool` is shared so the stdio server and the one-shot CLI use one budget.
+///
+/// `syntax` is the front end this call's messages will be read by: the same
+/// selector is `--recording k=v` to the CLI and a `recording` JSON object to
+/// an MCP client, and a message that offers the wrong one cannot be acted on.
 pub(crate) fn open_source_with_pool(
     file: &std::path::Path,
     pool: std::sync::Arc<metriken_query::BufferPool>,
     selector: &RecordingSelector,
+    syntax: SelectorSyntax,
 ) -> Result<std::sync::Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
-    open_source_with_pool_labeled(file, pool, selector).map(|(_, reader)| reader)
+    open_source_with_pool_labeled(file, pool, selector, syntax).map(|(_, reader)| reader)
 }
 
 /// As `open_source_with_pool`, but also reporting WHICH recording was chosen,
@@ -57,6 +62,7 @@ pub(crate) fn open_source_with_pool_labeled(
     file: &std::path::Path,
     pool: std::sync::Arc<metriken_query::BufferPool>,
     selector: &RecordingSelector,
+    syntax: SelectorSyntax,
 ) -> Result<LabeledSource, Box<dyn std::error::Error>> {
     use crate::recorder::rez::RezFormat;
     if crate::recorder::rez::detect_rez_format(file).unwrap_or(RezFormat::NotRez)
@@ -190,20 +196,20 @@ pub(crate) fn open_source_with_pool_labeled(
                 format!(
                     "no recording in {} matches {}",
                     file.display(),
-                    selector.as_flags()
+                    selector.render(syntax)
                 )
             } else {
                 format!(
                     "{} names {} in {}, which was recorded but produced no rows, so it \
                      holds nothing to analyze",
-                    selector.as_flags(),
+                    selector.render(syntax),
                     named_but_empty.join("; "),
                     file.display()
                 )
             };
             return Err(format!(
                 "{lead}. {listing_lead}\n{}",
-                describe_candidates(&universe, &[])
+                describe_candidates(&universe, &[], syntax)
             )
             .into());
         }
@@ -226,12 +232,14 @@ pub(crate) fn open_source_with_pool_labeled(
             } else {
                 format!(
                     "{} matches {} recordings in {}; add labels until it names one:",
-                    selector.as_flags(),
+                    selector.render(syntax),
                     hits.len(),
                     file.display()
                 )
             };
-            return Err(format!("{lead}\n{}", describe_candidates(&universe, &hits)).into());
+            return Err(
+                format!("{lead}\n{}", describe_candidates(&universe, &hits, syntax)).into(),
+            );
         }
     };
 
@@ -239,7 +247,8 @@ pub(crate) fn open_source_with_pool_labeled(
     Ok((labels, std::sync::Arc::new(reader)))
 }
 
-/// Open with a selector and a fresh pool — the one-shot CLI path.
+/// Open with a selector and a fresh pool — the one-shot CLI path, so every
+/// message it produces is spelled as the `--recording` flag the caller typed.
 pub(crate) fn open_source_selected(
     file: &std::path::Path,
     selector: &RecordingSelector,
@@ -248,6 +257,7 @@ pub(crate) fn open_source_selected(
         file,
         metriken_query::BufferPool::new(256 * 1024 * 1024),
         selector,
+        SelectorSyntax::Flags,
     )
 }
 
@@ -399,6 +409,7 @@ fn run_analyze_correlation(
 pub(crate) fn describe_recording_output(
     file: &std::path::Path,
     selector: &RecordingSelector,
+    syntax: SelectorSyntax,
 ) -> Result<String, Box<dyn std::error::Error>> {
     use crate::recorder::rez::RezFormat;
 
@@ -431,7 +442,7 @@ pub(crate) fn describe_recording_output(
                  tool with one of the selectors above to analyze that recording.",
                 file.display(),
                 candidates.len(),
-                describe_candidates(&candidates, &[])
+                describe_candidates(&candidates, &[], syntax)
             ));
         }
     }
@@ -444,7 +455,7 @@ pub(crate) fn describe_recording_output(
 }
 
 fn run_describe_recording(file: PathBuf, selector: &RecordingSelector) {
-    match describe_recording_output(&file, selector) {
+    match describe_recording_output(&file, selector, SelectorSyntax::Flags) {
         Ok(out) => println!("{out}"),
         Err(e) => {
             eprintln!("Failed to load recording: {e}");
@@ -1776,8 +1787,9 @@ mod tests {
         let path = dir.path().join("ab.rez");
         multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
 
-        let out = describe_recording_output(&path, &RecordingSelector::default())
-            .expect("listing is not an error — it is the answer");
+        let out =
+            describe_recording_output(&path, &RecordingSelector::default(), SelectorSyntax::Flags)
+                .expect("listing is not an error — it is the answer");
         assert!(out.contains("2 recordings"), "{out}");
         assert!(out.contains("source=redis"), "{out}");
         assert!(out.contains("source=valkey"), "{out}");
@@ -1787,6 +1799,38 @@ mod tests {
         );
     }
 
+    /// The CLI's own listing stays in flag syntax — the front-end split has
+    /// to cut both ways, or "render for the caller" degrades into "render
+    /// JSON everywhere" and the CLI user is handed a tool-call object.
+    /// Companion to `server_listings_render_the_json_selector_not_the_cli_flag`.
+    #[test]
+    fn cli_listings_render_the_flag_selector_not_the_json_object() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let out =
+            describe_recording_output(&path, &RecordingSelector::default(), SelectorSyntax::Flags)
+                .expect("listing is the answer");
+        assert!(
+            out.contains("select with: --recording source=redis"),
+            "{out}"
+        );
+        assert!(
+            !out.contains(r#"recording {"#),
+            "a shell caller cannot type a JSON tool argument: {out}"
+        );
+
+        // And the error leads, not just the listing.
+        let sel = RecordingSelector::parse(["source=nope".to_string()]).unwrap();
+        let msg = match open_source_selected(&path, &sel) {
+            Ok(_) => panic!("source=nope names no arm"),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("--recording source=nope"), "{msg}");
+        assert!(!msg.contains(r#"recording {"#), "{msg}");
+    }
+
     #[test]
     fn describe_recording_with_a_selector_describes_that_one() {
         let dir = tempfile::tempdir().unwrap();
@@ -1794,7 +1838,7 @@ mod tests {
         multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
 
         let sel = RecordingSelector::parse(["source=redis".to_string()]).unwrap();
-        let out = describe_recording_output(&path, &sel).unwrap();
+        let out = describe_recording_output(&path, &sel, SelectorSyntax::Flags).unwrap();
         assert!(
             out.contains("Recording Information"),
             "a selected recording gets the ordinary single-recording format: {out}"
@@ -1821,8 +1865,9 @@ mod tests {
             &[true, true, false],
         );
 
-        let out = describe_recording_output(&path, &RecordingSelector::default())
-            .expect("two live arms still means \"pick one\", not an error");
+        let out =
+            describe_recording_output(&path, &RecordingSelector::default(), SelectorSyntax::Flags)
+                .expect("two live arms still means \"pick one\", not an error");
         assert!(
             out.contains("2 recordings with data"),
             "must count only the arms that hold rows, and say so: {out}"
@@ -1851,8 +1896,9 @@ mod tests {
         let path = dir.path().join("one-live.rez");
         multi_recording_rez(&path, &["redis", "valkey"], &[true, false]);
 
-        let out = describe_recording_output(&path, &RecordingSelector::default())
-            .expect("a single live arm resolves without a selector");
+        let out =
+            describe_recording_output(&path, &RecordingSelector::default(), SelectorSyntax::Flags)
+                .expect("a single live arm resolves without a selector");
         assert!(
             out.contains("Recording Information"),
             "the ordinary single-recording format, not a listing: {out}"

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -254,13 +254,21 @@ pub(crate) fn describe_candidates(
         let rendered = render_labels(labels);
 
         let Some(pairs) = picker_pairs(all, i) else {
+            // Wrapped by hand, with the indent interpolated: this lands in
+            // terminal output and in an MCP tool result, neither of which
+            // re-wraps, and one 300-column line is what an agent then quotes
+            // back at a user.
+            const IND: &str = "    ";
             out.push_str(&format!(
-                "  - {rendered}\n    cannot be selected by labels — no combination of its \
-                 labels picks it out from every other recording in the archive; give the \
-                 recordings distinct labels before analyzing: re-capture giving each \
-                 --endpoint its own source=NAME, or (for an archive assembled by `rezolus \
-                 recording combine`) re-record its inputs with `record --label \
-                 arm=NAME`\n"
+                "  - {rendered}\n\
+                 {IND}cannot be selected by labels — every selector that names it also \
+                 names another\n\
+                 {IND}recording in this archive. To tell them apart, give them distinct \
+                 labels: re-capture\n\
+                 {IND}giving each --endpoint its own source=NAME, or — for an archive \
+                 built by `rezolus\n\
+                 {IND}recording combine` — re-record its inputs with `record --label \
+                 arm=NAME`.\n"
             ));
             continue;
         };

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -5,10 +5,9 @@
 //! because `mod.rs` is already large.
 //!
 //! `resolve`, `matches`, `is_empty`, `Display` and `describe_candidates` are
-//! all driven from `mcp::open_source_with_pool`, and `parse` from the
-//! `--recording` CLI flag. `from_json` is not driven yet — it lands with the
-//! stdio server's tool schemas — so it carries its own targeted `dead_code`
-//! allow until then rather than the module-wide one this file used to have.
+//! all driven from `mcp::open_source_with_pool`, `parse` from the
+//! `--recording` CLI flag, and `from_json` from the stdio server's `recording`
+//! tool argument.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -19,7 +18,13 @@ use std::fmt;
 /// but the recording may carry more. Recordings auto-carry `source` and
 /// `host` plus any `record --label`, so requiring the full set would make
 /// selectors long and brittle.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+// `Hash` so a selector can be half of a cache key as a TYPED pair. The stdio
+// server caches one reader per (path, selector); formatting the selector into
+// a string key instead would let two different selectors collide, since label
+// values are free text and `{"a": "b,c=d"}` renders the same `Display` text as
+// `{"a": "b", "c": "d"}` — and a collided key hands back a reader for the
+// wrong arm, silently.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub(crate) struct RecordingSelector {
     // `BTreeMap`, not `HashMap`: `Display` renders selector text into error
     // messages, so iteration order has to be deterministic (pinned by
@@ -68,9 +73,6 @@ impl RecordingSelector {
     }
 
     /// Parse a JSON object of label key to value (the stdio-server shape).
-    // Same as `parse`: this is the stdio server's entry point and lands
-    // with the tool schemas that carry a `recording` argument.
-    #[allow(dead_code)]
     pub(crate) fn from_json(v: &serde_json::Value) -> Result<Self, String> {
         let obj = v
             .as_object()

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -93,6 +93,19 @@ impl RecordingSelector {
         self.labels.is_empty()
     }
 
+    /// The selector as the flags a caller would actually type.
+    ///
+    /// NOT `Display`, and the difference matters. `Display` joins with `,`
+    /// because it renders a selector as one readable token, but `parse` splits
+    /// each argument on its FIRST `=` only, so pasting `--recording
+    /// host=b,source=a` back parses as the single label `host` =
+    /// `"b,source=a"`, matches nothing, and fails as `NoMatch` with no hint
+    /// why. Error text that invites the reader to adjust and retry a selector
+    /// must therefore print this form, which round-trips through `parse`.
+    pub(crate) fn as_flags(&self) -> String {
+        flag_form(self.labels.iter().map(|(k, v)| format!("{k}={v}")))
+    }
+
     /// Whether `labels` carries every pair in this selector.
     pub(crate) fn matches(&self, labels: &BTreeMap<String, String>) -> bool {
         self.labels
@@ -135,6 +148,29 @@ impl fmt::Display for RecordingSelector {
     }
 }
 
+/// Render `k=v` pairs as the repeatable flag a caller types.
+///
+/// One spelling for both the listing's "select with" lines and the error
+/// leads that echo a selector back, because the two must agree: the flag is
+/// repeatable and ANDs its pairs, and any other joining (notably `Display`'s
+/// comma) does not survive a round trip through `parse`.
+fn flag_form(pairs: impl IntoIterator<Item = String>) -> String {
+    let pairs: Vec<String> = pairs.into_iter().collect();
+    format!("--recording {}", pairs.join(" --recording "))
+}
+
+/// Render a recording's labels for display: `k=v, k=v` in key order.
+///
+/// Not the flag form — this is prose, naming a recording inside a sentence,
+/// so it must not look like something to paste.
+pub(crate) fn render_labels(labels: &BTreeMap<String, String>) -> String {
+    labels
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Render specific recordings from an archive, each with the flag that picks
 /// it.
 ///
@@ -164,7 +200,7 @@ pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &
     let mut out = String::new();
     for i in indices {
         let labels = &all[i];
-        let rendered: Vec<String> = labels.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        let rendered = render_labels(labels);
 
         // Two recordings sharing every label are indistinguishable to any
         // selector, and a recording with no labels at all sitting among
@@ -176,10 +212,9 @@ pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &
             labels.is_empty() || all.iter().enumerate().any(|(j, c)| j != i && c == labels);
         if unselectable {
             out.push_str(&format!(
-                "  - {}\n    cannot be selected by labels — no combination of its labels picks \
-                 it out from every other recording in the archive; re-capture giving each \
-                 --endpoint its own source=NAME\n",
-                rendered.join(", ")
+                "  - {rendered}\n    cannot be selected by labels — no combination of its \
+                 labels picks it out from every other recording in the archive; re-capture \
+                 giving each --endpoint its own source=NAME\n"
             ));
             continue;
         }
@@ -197,14 +232,15 @@ pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &
                     .count()
                     == 1
             })
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(k, v)| vec![format!("{k}={v}")])
             .next();
-        let picker = unique.unwrap_or_else(|| rendered.join(" --recording "));
+        // No single label is unique: fall back to the whole set, which the
+        // repeatable flag ANDs together.
+        let picker = flag_form(
+            unique.unwrap_or_else(|| labels.iter().map(|(k, v)| format!("{k}={v}")).collect()),
+        );
 
-        out.push_str(&format!(
-            "  - {}\n    select with: --recording {picker}\n",
-            rendered.join(", ")
-        ));
+        out.push_str(&format!("  - {rendered}\n    select with: {picker}\n"));
     }
     out
 }
@@ -327,6 +363,31 @@ mod tests {
         // messages that need to be reproducible.
         let s = RecordingSelector::parse(["host=b".to_string(), "source=a".to_string()]).unwrap();
         assert_eq!(s.to_string(), "host=b,source=a");
+    }
+
+    #[test]
+    fn the_flag_form_round_trips_where_display_does_not() {
+        let s = RecordingSelector::parse(["host=b".to_string(), "source=a".to_string()]).unwrap();
+        assert_eq!(s.as_flags(), "--recording host=b --recording source=a");
+
+        // The reason `as_flags` exists rather than reusing `Display`: the
+        // comma join reads well but does NOT survive `parse`, which splits on
+        // the first `=` only, so it comes back as one label
+        // `host="b,source=a"` that matches nothing. Error text tells the
+        // caller to adjust and retry a selector, so it must print the form
+        // that round-trips.
+        let pasted = RecordingSelector::parse([s.to_string()]).unwrap();
+        assert_ne!(pasted, s, "Display must not be mistaken for pasteable");
+
+        let round = RecordingSelector::parse(
+            s.as_flags()
+                .strip_prefix("--recording ")
+                .unwrap()
+                .split(" --recording ")
+                .map(str::to_string),
+        )
+        .unwrap();
+        assert_eq!(round, s, "the flag form must round-trip through parse");
     }
 
     #[test]

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -200,47 +200,82 @@ pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &
         let labels = &all[i];
         let rendered = render_labels(labels);
 
-        // Two recordings sharing every label are indistinguishable to any
-        // selector, and a recording with no labels at all sitting among
-        // labeled peers is unselectable for the same reason (no combination
-        // of its labels — there are none — can single it out). Echoes the
-        // recorder's own `warn_if_indistinguishable`, so both messages point
-        // at the same fix.
-        let unselectable =
-            labels.is_empty() || all.iter().enumerate().any(|(j, c)| j != i && c == labels);
-        if unselectable {
+        let Some(pairs) = picker_pairs(all, i) else {
             out.push_str(&format!(
                 "  - {rendered}\n    cannot be selected by labels — no combination of its \
-                 labels picks it out from every other recording in the archive; re-capture \
-                 giving each --endpoint its own source=NAME\n"
+                 labels picks it out from every other recording in the archive; give the \
+                 recordings distinct labels before analyzing: re-capture giving each \
+                 --endpoint its own source=NAME, or (for an archive assembled by `rezolus \
+                 recording combine`) re-record its inputs with `record --label \
+                 arm=NAME`\n"
             ));
             continue;
-        }
+        };
 
-        // Any single label unique to this recording (checked against `all`,
-        // not just `highlight`) selects it on its own; take the first in key
-        // order so the listing is byte-stable across runs. If none exists,
-        // fall back to the whole set, one pair per `--recording` flag (the
-        // flag is repeatable and ANDs its pairs together).
-        let unique = labels
-            .iter()
-            .filter(|(k, v)| {
-                all.iter()
-                    .filter(|c| c.get(*k).is_some_and(|got| got == *v))
-                    .count()
-                    == 1
-            })
-            .map(|(k, v)| vec![format!("{k}={v}")])
-            .next();
-        // No single label is unique: fall back to the whole set, which the
-        // repeatable flag ANDs together.
-        let picker = flag_form(
-            unique.unwrap_or_else(|| labels.iter().map(|(k, v)| format!("{k}={v}")).collect()),
-        );
-
-        out.push_str(&format!("  - {rendered}\n    select with: {picker}\n"));
+        out.push_str(&format!(
+            "  - {rendered}\n    select with: {}\n",
+            flag_form(pairs)
+        ));
     }
     out
+}
+
+/// The `k=v` pairs that pick recording `i` out of `all`, or `None` when no
+/// selector can.
+///
+/// The one place the "is this recording selectable at all" rule lives, so a
+/// listing and any caller asking whether a listing will contain selectors
+/// cannot disagree.
+fn picker_pairs(all: &[BTreeMap<String, String>], i: usize) -> Option<Vec<String>> {
+    let labels = &all[i];
+
+    // A recording is unselectable when some OTHER recording's labels are a
+    // SUPERSET of its own, because `matches` is subset semantics: every
+    // selector that matches `L` also matches `L ∪ {extra}`, so nothing
+    // singles out the smaller set. Testing plain equality here (the original
+    // rule) covered only the identical-labels case and let the superset case
+    // fall through to the whole-label-set fallback below, which then printed
+    // a selector resolving to `Ambiguous` — a closed loop, since the caller
+    // is told to add labels and has none left to add. Reached by the
+    // documented A/B workflow (`--label arm=baseline` on one capture, none on
+    // the other, then `recording combine`) and by a single multi-endpoint run
+    // where one endpoint's `/systeminfo` fetch fails, dropping `host` from
+    // that arm alone. Equality is a special case of superset, so this
+    // subsumes the original rule.
+    //
+    // The `is_empty` term is not subsumed: it is the only cover for a LONE
+    // unlabeled recording, where no other recording exists to be a superset
+    // and the fallback would emit a bare `--recording` with no pair at all.
+    // Echoes the recorder's own `warn_if_indistinguishable`, so both messages
+    // point at the same fix.
+    if labels.is_empty()
+        || all.iter().enumerate().any(|(j, c)| {
+            j != i
+                && labels
+                    .iter()
+                    .all(|(k, v)| c.get(k).is_some_and(|got| got == v))
+        })
+    {
+        return None;
+    }
+
+    // Any single label unique to this recording (checked against `all`, not
+    // just `highlight`) selects it on its own; take the first in key order so
+    // the listing is byte-stable across runs. If none exists, fall back to
+    // the whole set, one pair per `--recording` flag (the flag is repeatable
+    // and ANDs its pairs together) — sound here precisely because no other
+    // recording is a superset.
+    let unique = labels
+        .iter()
+        .filter(|(k, v)| {
+            all.iter()
+                .filter(|c| c.get(*k).is_some_and(|got| got == *v))
+                .count()
+                == 1
+        })
+        .map(|(k, v)| vec![format!("{k}={v}")])
+        .next();
+    Some(unique.unwrap_or_else(|| labels.iter().map(|(k, v)| format!("{k}={v}")).collect()))
 }
 
 #[cfg(test)]
@@ -579,5 +614,53 @@ mod tests {
             out.contains("re-capture") && out.contains("source=NAME"),
             "must explain why, echoing the recorder's own warning: {out}"
         );
+        // An archive assembled by `recording combine` holds recordings that
+        // were never `--endpoint`s of one run, so "give each --endpoint its
+        // own source=NAME" is advice its owner cannot act on. The label they
+        // can set is `record --label` on the inputs, before combining.
+        assert!(
+            out.contains("--label") && out.contains("combine"),
+            "must also give the fix for a combined archive, whose recordings \
+             were never endpoints of one run: {out}"
+        );
+    }
+
+    /// A recording whose labels are a SUBSET of another's is just as
+    /// unselectable as one that duplicates them, and this is the shape the
+    /// documented A/B workflow produces: `record --label arm=baseline` on one
+    /// capture and no `--label` on the other, then `recording combine`. The
+    /// arms come out as `{arm, host, source}` and `{host, source}`.
+    ///
+    /// Every selector that matches the smaller set also matches the larger
+    /// one, so `--recording host=H --recording source=rezolus` — the whole-set
+    /// fallback — resolves to `Ambiguous`. Offering it is a closed loop: the
+    /// caller is told to "add labels until it names one" and has no labels
+    /// left to add. Reachable from a single `record --endpoint a --endpoint b`
+    /// run too, when one endpoint's `/systeminfo` fetch fails and only that
+    /// arm loses `host`.
+    #[test]
+    fn a_recording_whose_labels_are_a_subset_of_anothers_is_unselectable() {
+        let all = vec![
+            labels(&[("arm", "baseline"), ("host", "h"), ("source", "rezolus")]),
+            labels(&[("host", "h"), ("source", "rezolus")]),
+        ];
+        let out = describe_candidates(&all, &[]);
+        // Only recording 0 gets a selector (`arm=baseline`); recording 1 gets
+        // the unselectable note. The round trip is what proves it: before the
+        // fix, recording 1 was offered `--recording host=h --recording
+        // source=rezolus`, which resolves to `Ambiguous([0, 1])`.
+        assert_listing_round_trips(&all, &out, &[0]);
+        assert!(
+            out.contains("cannot be selected by labels"),
+            "the subset arm must be reported as unselectable: {out}"
+        );
+    }
+
+    /// The same failure in its smallest form: `{a:1}` against `{a:1, b:2}`.
+    #[test]
+    fn a_superset_recording_makes_its_subset_peer_unselectable() {
+        let all = vec![labels(&[("a", "1")]), labels(&[("a", "1"), ("b", "2")])];
+        let out = describe_candidates(&all, &[]);
+        assert_listing_round_trips(&all, &out, &[1]);
     }
 }

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -4,9 +4,10 @@
 //! `mcp/mod.rs` because this is the part most worth testing directly, and
 //! because `mod.rs` is already large.
 //!
-//! Nothing here is called from production code yet — only the tests below —
-//! so `dead_code` is silenced module-wide until Task 2 wires `resolve` into
-//! the CLI and stdio server.
+//! Nothing here is called from production code yet, only the tests below, so
+//! `dead_code` is silenced module-wide. Both allows (here and on the
+//! `mod.rs` re-export) come off once `resolve` lands and the MCP CLI/server
+//! actually pass a selector through to the reader.
 #![allow(dead_code)]
 
 use std::collections::BTreeMap;
@@ -20,6 +21,11 @@ use std::fmt;
 /// selectors long and brittle.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct RecordingSelector {
+    // `BTreeMap`, not `HashMap`: `Display` renders selector text into error
+    // messages, so iteration order has to be deterministic (pinned by
+    // `display_orders_pairs_deterministically` below); a `BTreeMap` also
+    // matches `rez_sqlite::RecordingMeta.labels`, so a manifest's labels can
+    // be consumed with no conversion.
     labels: BTreeMap<String, String>,
 }
 
@@ -34,13 +40,29 @@ pub(crate) enum SelectError {
 
 impl RecordingSelector {
     /// Parse repeated `k=v` arguments (the CLI shape).
+    ///
+    /// A key must be non-empty and appear at most once: this is the one
+    /// module whose entire job is refusing to resolve ambiguity silently, so
+    /// letting `--recording host=a --recording host=b` collapse to `host=b`
+    /// via last-write-wins would be that same failure creeping in one layer
+    /// earlier. A value may itself contain `=` (`split_once` splits on the
+    /// first one only), which is deliberate: label values are free text.
     pub(crate) fn parse(pairs: impl IntoIterator<Item = String>) -> Result<Self, String> {
         let mut labels = BTreeMap::new();
         for p in pairs {
             let (k, v) = p
                 .split_once('=')
                 .ok_or_else(|| format!("--recording expects key=value, got {p:?} with no '='"))?;
-            labels.insert(k.to_string(), v.to_string());
+            if k.is_empty() {
+                return Err(format!(
+                    "--recording expects key=value, got {p:?} with an empty key"
+                ));
+            }
+            if let Some(prev) = labels.insert(k.to_string(), v.to_string()) {
+                return Err(format!(
+                    "--recording {k}= specified more than once ({prev:?} and {v:?})"
+                ));
+            }
         }
         Ok(Self { labels })
     }
@@ -115,7 +137,51 @@ mod tests {
     }
 
     #[test]
-    fn an_empty_selector_selects_nothing_in_particular() {
+    fn an_empty_key_is_an_error() {
+        // `--recording =redis` is a typo (probably for `source=redis`), not
+        // a label named "". Left unchecked it would silently match no
+        // recording ever, since `matches` looks the empty key up on real
+        // label maps and never finds it, so the failure would surface as
+        // "no recording matches" instead of "that isn't a key=value".
+        let err = RecordingSelector::parse(["=redis".to_string()]).unwrap_err();
+        assert!(
+            err.contains("=redis"),
+            "the error must quote the input: {err}"
+        );
+        assert!(err.contains("empty key"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_value_is_fine() {
+        // Unlike an empty key, an empty value is a legitimate label value,
+        // not a typo, so it must not be rejected the same way.
+        let s = RecordingSelector::parse(["source=".to_string()]).unwrap();
+        assert!(s.matches(&labels(&[("source", "")])));
+    }
+
+    #[test]
+    fn a_repeated_key_is_an_error() {
+        // Silently taking the last value would be the exact ambiguity this
+        // module exists to refuse, just resolved one step before `resolve`
+        // ever runs.
+        let err =
+            RecordingSelector::parse(["host=a".to_string(), "host=b".to_string()]).unwrap_err();
+        assert!(err.contains("host"), "{err}");
+        assert!(err.contains('a') && err.contains('b'), "{err}");
+    }
+
+    #[test]
+    fn a_value_may_itself_contain_an_equals_sign() {
+        // `split_once` (not `split('=')`) is deliberate: a label value is
+        // free text and may legitimately contain '='. Pinned here so a
+        // future "simplify this" pass doesn't swap it and silently truncate
+        // values like this one.
+        let s = RecordingSelector::parse(["label=a=b".to_string()]).unwrap();
+        assert!(s.matches(&labels(&[("label", "a=b")])));
+    }
+
+    #[test]
+    fn an_empty_selector_matches_everything() {
         let s = RecordingSelector::default();
         assert!(s.is_empty());
         // An empty selector matches everything, which is what makes
@@ -151,18 +217,33 @@ mod tests {
     }
 
     #[test]
+    fn display_orders_pairs_deterministically() {
+        // Not just "some order" — swapping the backing map for a `HashMap`
+        // must not pass this test, since `Display` output lands in error
+        // messages that need to be reproducible.
+        let s = RecordingSelector::parse(["host=b".to_string(), "source=a".to_string()]).unwrap();
+        assert_eq!(s.to_string(), "host=b,source=a");
+    }
+
+    #[test]
     fn parses_a_json_object() {
         let v = serde_json::json!({"source": "redis"});
         let s = RecordingSelector::from_json(&v).unwrap();
-        assert_eq!(
-            s,
-            RecordingSelector::parse(["source=redis".to_string()]).unwrap()
-        );
+        assert_eq!(s.to_string(), "source=redis");
     }
 
     #[test]
     fn a_non_object_json_selector_is_an_error() {
         let err = RecordingSelector::from_json(&serde_json::json!("redis")).unwrap_err();
         assert!(err.contains("object"), "{err}");
+    }
+
+    #[test]
+    fn a_non_string_json_value_is_an_error() {
+        // An LLM-driven MCP client emitting a bare number for a
+        // numeric-looking label (`{"arm": 1}`) is realistic; the error it
+        // sees needs to name the offending key.
+        let err = RecordingSelector::from_json(&serde_json::json!({"arm": 1})).unwrap_err();
+        assert!(err.contains("arm"), "{err}");
     }
 }

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -128,36 +128,72 @@ impl fmt::Display for RecordingSelector {
     }
 }
 
-/// Render the recordings an archive holds, each with the flag that picks it.
+/// Render specific recordings from an archive, each with the flag that picks
+/// it.
+///
+/// `all` is every recording's labels; `highlight` is which indices of `all`
+/// to render (an empty slice means "render all of them"). Uniqueness is
+/// always computed against `all`, never against `highlight` — that split is
+/// deliberate and prevents a real bug: describing only a matched subset
+/// (e.g. the indices `resolve` returned inside `Ambiguous`) using that
+/// subset as the uniqueness universe would call a label unique because it
+/// only looks that way among the couple of recordings being described, then
+/// hand back a `--recording` that still collides with a THIRD recording
+/// sitting elsewhere in the archive. Taking `all` separately from
+/// `highlight` makes that mistake impossible to write.
 ///
 /// Printing the selector rather than only the labels is the point: the
 /// caller's next command is a copy of a line it was just given.
 ///
 /// Deliberately unnumbered — an index would invite `--recording 1`, which is
 /// not a supported selector.
-pub(crate) fn describe_candidates(candidates: &[BTreeMap<String, String>]) -> String {
+pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &[usize]) -> String {
+    let indices: Vec<usize> = if highlight.is_empty() {
+        (0..all.len()).collect()
+    } else {
+        highlight.to_vec()
+    };
+
     let mut out = String::new();
-    for labels in candidates {
+    for i in indices {
+        let labels = &all[i];
         let rendered: Vec<String> = labels.iter().map(|(k, v)| format!("{k}={v}")).collect();
-        // The most specific single label that would pick this one, if any
-        // exists; otherwise the whole set (each pair its own `--recording`,
-        // since that flag is repeatable and ANDs its pairs together).
-        let unique: Vec<String> = labels
+
+        // Two recordings sharing every label are indistinguishable to any
+        // selector, and a recording with no labels at all sitting among
+        // labeled peers is unselectable for the same reason (no combination
+        // of its labels — there are none — can single it out). Echoes the
+        // recorder's own `warn_if_indistinguishable`, so both messages point
+        // at the same fix.
+        let unselectable =
+            labels.is_empty() || all.iter().enumerate().any(|(j, c)| j != i && c == labels);
+        if unselectable {
+            out.push_str(&format!(
+                "  - {}\n    cannot be selected by labels — no combination of its labels picks \
+                 it out from every other recording in the archive; re-capture giving each \
+                 --endpoint its own source=NAME\n",
+                rendered.join(", ")
+            ));
+            continue;
+        }
+
+        // Any single label unique to this recording (checked against `all`,
+        // not just `highlight`) selects it on its own; take the first in key
+        // order so the listing is byte-stable across runs. If none exists,
+        // fall back to the whole set, one pair per `--recording` flag (the
+        // flag is repeatable and ANDs its pairs together).
+        let unique = labels
             .iter()
             .filter(|(k, v)| {
-                candidates
-                    .iter()
+                all.iter()
                     .filter(|c| c.get(*k).is_some_and(|got| got == *v))
                     .count()
                     == 1
             })
             .map(|(k, v)| format!("{k}={v}"))
-            .collect();
-        let picker = if unique.is_empty() {
-            rendered.join(" --recording ")
-        } else {
-            unique[0].clone()
-        };
+            .next();
+        let picker = unique.unwrap_or_else(|| rendered.join(" --recording "));
+
         out.push_str(&format!(
             "  - {}\n    select with: --recording {picker}\n",
             rendered.join(", ")
@@ -328,6 +364,15 @@ mod tests {
     }
 
     #[test]
+    fn resolve_against_no_candidates_is_no_match() {
+        // Not a panic, not "vacuously ambiguous" — an archive that somehow
+        // holds no recordings is just as much "no match" as one that holds
+        // several none of which fit.
+        let s = RecordingSelector::default();
+        assert_eq!(s.resolve(&[]), Err(SelectError::NoMatch));
+    }
+
+    #[test]
     fn several_matches_is_an_error_not_the_first() {
         // Both arms share host=web-01. Picking the first would silently
         // analyze one arm of an A/B and present it as the answer.
@@ -335,6 +380,27 @@ mod tests {
         assert_eq!(
             s.resolve(&two_arms()),
             Err(SelectError::Ambiguous(vec![0, 1]))
+        );
+    }
+
+    #[test]
+    fn ambiguous_reports_only_the_indices_that_matched() {
+        // Three recordings, exactly two ("arm=a") match, and they are not
+        // contiguous from zero. `two_arms` alone can't catch a `resolve`
+        // that returns `(0..candidates.len())` instead of the real hits,
+        // since there every candidate matches every ambiguous test selector.
+        // The caller uses these indices to list which recordings the
+        // selector matched, so a wrong payload here would show the user
+        // recordings their selector never named.
+        let candidates = vec![
+            labels(&[("arm", "a"), ("host", "1")]),
+            labels(&[("arm", "b"), ("host", "2")]),
+            labels(&[("arm", "a"), ("host", "3")]),
+        ];
+        let s = RecordingSelector::parse(["arm=a".to_string()]).unwrap();
+        assert_eq!(
+            s.resolve(&candidates),
+            Err(SelectError::Ambiguous(vec![0, 2]))
         );
     }
 
@@ -355,18 +421,97 @@ mod tests {
         assert_eq!(s.resolve(&two_arms()[..1]), Ok(0));
     }
 
+    /// Parse the `--recording ...` lines a listing prints and confirm each
+    /// one, fed straight back through `parse` and `resolve`, actually names
+    /// the recording it was printed under.
+    ///
+    /// A round trip is the only check strong enough for this job: a `picker`
+    /// that is always the first label in key order (for `two_arms`, that's
+    /// `host=web-01` for BOTH recordings, since "host" sorts before
+    /// "source") would still pass plain substring assertions — `out` would
+    /// contain "source=redis", "source=valkey", and "--recording" no matter
+    /// what `picker` actually was. Feeding it back through `resolve` is what
+    /// catches a selector that looks plausible but doesn't work.
+    fn assert_listing_round_trips(all: &[BTreeMap<String, String>], out: &str, expect: &[usize]) {
+        let pickers: Vec<&str> = out
+            .lines()
+            .filter_map(|l| l.trim_start().strip_prefix("select with: --recording "))
+            .collect();
+        assert_eq!(
+            pickers.len(),
+            expect.len(),
+            "one selector line per rendered recording: {out}"
+        );
+        for (picker, &i) in pickers.iter().zip(expect) {
+            let pairs: Vec<String> = picker.split(" --recording ").map(str::to_string).collect();
+            let s = RecordingSelector::parse(pairs).unwrap_or_else(|e| {
+                panic!("emitted an unparseable selector for recording {i}: {e} ({picker:?})")
+            });
+            assert_eq!(
+                s.resolve(all),
+                Ok(i),
+                "the selector printed for recording {i} must resolve back to it: {picker:?}\n{out}"
+            );
+        }
+    }
+
     #[test]
     fn the_candidate_listing_names_every_recording_and_its_selector() {
-        let out = describe_candidates(&two_arms());
+        let all = two_arms();
+        let out = describe_candidates(&all, &[]);
         assert!(out.contains("source=redis"), "{out}");
         assert!(out.contains("source=valkey"), "{out}");
+        assert_listing_round_trips(&all, &out, &[0, 1]);
+        // No indices: they invite `--recording 1`, which is not a selector.
+        // Checked against a few plausible numbering styles, not just one.
+        for pat in ["[1]", "[2]", "(1)", "(2)", "1.", "2.", "#1", "#2"] {
+            assert!(!out.contains(pat), "found index-like text {pat:?}: {out}");
+        }
+    }
+
+    #[test]
+    fn describe_candidates_computes_uniqueness_against_the_full_archive_not_the_highlighted_subset()
+    {
+        // `arm=a` matches recordings 0 and 1 (Ambiguous([0, 1])). Recording 2
+        // is not in the highlighted set, but it still carries `host=1`, the
+        // same as recording 0 — so `host=1` must NOT be offered as recording
+        // 0's selector, even though within {0, 1} alone it would look
+        // unique.
+        let all = vec![
+            labels(&[("arm", "a"), ("host", "1")]),
+            labels(&[("arm", "a"), ("host", "2")]),
+            labels(&[("arm", "b"), ("host", "1")]),
+        ];
+        assert_eq!(
+            RecordingSelector::parse(["arm=a".to_string()])
+                .unwrap()
+                .resolve(&all),
+            Err(SelectError::Ambiguous(vec![0, 1]))
+        );
+
+        let out = describe_candidates(&all, &[0, 1]);
+        assert_listing_round_trips(&all, &out, &[0, 1]);
+    }
+
+    #[test]
+    fn identical_labels_are_reported_as_unselectable_not_a_dead_end_selector() {
+        // Two recordings that carry exactly the same labels: the recorder
+        // permits this (warning only) and the reader treats it as legal, so
+        // this is reachable, not hypothetical. Offering a `--recording` for
+        // either one would be a dead end — pasting it resolves to
+        // `Ambiguous` again, forever.
+        let dup = vec![
+            labels(&[("host", "web-01"), ("source", "redis")]),
+            labels(&[("host", "web-01"), ("source", "redis")]),
+        ];
+        let out = describe_candidates(&dup, &[]);
         assert!(
-            out.contains("--recording"),
-            "the listing must show the flag that picks one: {out}"
+            !out.contains("select with: --recording"),
+            "no selector can pick between identical label sets, so none should be offered: {out}"
         );
         assert!(
-            !out.contains("[1]"),
-            "no indices — they invite `--recording 1`, which is not a selector: {out}"
+            out.contains("re-capture") && out.contains("source=NAME"),
+            "must explain why, echoing the recorder's own warning: {out}"
         );
     }
 }

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -4,11 +4,12 @@
 //! `mcp/mod.rs` because this is the part most worth testing directly, and
 //! because `mod.rs` is already large.
 //!
-//! Nothing here is called from production code yet, only the tests below, so
-//! `dead_code` is silenced module-wide. Both allows (here and on the
-//! `mod.rs` re-export) come off once the MCP CLI/server actually pass a
-//! selector through to the reader.
-#![allow(dead_code)]
+//! `resolve`, `matches`, `is_empty`, `Display` and `describe_candidates` are
+//! all driven from `mcp::open_source_with_pool`. The two constructors are
+//! not, yet: `parse` lands with the `--recording` CLI flag and `from_json`
+//! with the stdio server's tool schemas, so each carries its own targeted
+//! `dead_code` allow until then rather than the module-wide one this file
+//! used to have.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -47,6 +48,9 @@ impl RecordingSelector {
     /// via last-write-wins would be that same failure creeping in one layer
     /// earlier. A value may itself contain `=` (`split_once` splits on the
     /// first one only), which is deliberate: label values are free text.
+    // Called from the tests below and, once it exists, the `--recording`
+    // CLI flag; not yet from production code.
+    #[allow(dead_code)]
     pub(crate) fn parse(pairs: impl IntoIterator<Item = String>) -> Result<Self, String> {
         let mut labels = BTreeMap::new();
         for p in pairs {
@@ -68,6 +72,9 @@ impl RecordingSelector {
     }
 
     /// Parse a JSON object of label key to value (the stdio-server shape).
+    // Same as `parse`: this is the stdio server's entry point and lands
+    // with the tool schemas that carry a `recording` argument.
+    #[allow(dead_code)]
     pub(crate) fn from_json(v: &serde_json::Value) -> Result<Self, String> {
         let obj = v
             .as_object()

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -273,6 +273,17 @@ pub(crate) fn describe_candidates(
     out
 }
 
+/// Whether any recording in `all` can be named by a selector at all.
+///
+/// Asked by a caller that is about to print a listing and needs to know
+/// whether it will contain any "select with:" lines — text inviting the
+/// reader to use one is a lie when every recording is indistinguishable from
+/// a peer. Shares `picker_pairs` with the listing itself rather than
+/// re-deriving the rule, so the two cannot disagree.
+pub(crate) fn any_selectable(all: &[BTreeMap<String, String>]) -> bool {
+    (0..all.len()).any(|i| picker_pairs(all, i).is_some())
+}
+
 /// The `k=v` pairs that pick recording `i` out of `all`, or `None` when no
 /// selector can.
 ///

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -5,11 +5,10 @@
 //! because `mod.rs` is already large.
 //!
 //! `resolve`, `matches`, `is_empty`, `Display` and `describe_candidates` are
-//! all driven from `mcp::open_source_with_pool`. The two constructors are
-//! not, yet: `parse` lands with the `--recording` CLI flag and `from_json`
-//! with the stdio server's tool schemas, so each carries its own targeted
-//! `dead_code` allow until then rather than the module-wide one this file
-//! used to have.
+//! all driven from `mcp::open_source_with_pool`, and `parse` from the
+//! `--recording` CLI flag. `from_json` is not driven yet — it lands with the
+//! stdio server's tool schemas — so it carries its own targeted `dead_code`
+//! allow until then rather than the module-wide one this file used to have.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -48,9 +47,6 @@ impl RecordingSelector {
     /// via last-write-wins would be that same failure creeping in one layer
     /// earlier. A value may itself contain `=` (`split_once` splits on the
     /// first one only), which is deliberate: label values are free text.
-    // Called from the tests below and, once it exists, the `--recording`
-    // CLI flag; not yet from production code.
-    #[allow(dead_code)]
     pub(crate) fn parse(pairs: impl IntoIterator<Item = String>) -> Result<Self, String> {
         let mut labels = BTreeMap::new();
         for p in pairs {

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -6,8 +6,8 @@
 //!
 //! Nothing here is called from production code yet, only the tests below, so
 //! `dead_code` is silenced module-wide. Both allows (here and on the
-//! `mod.rs` re-export) come off once `resolve` lands and the MCP CLI/server
-//! actually pass a selector through to the reader.
+//! `mod.rs` re-export) come off once the MCP CLI/server actually pass a
+//! selector through to the reader.
 #![allow(dead_code)]
 
 use std::collections::BTreeMap;
@@ -92,6 +92,29 @@ impl RecordingSelector {
             .iter()
             .all(|(k, v)| labels.get(k).is_some_and(|got| got == v))
     }
+
+    /// The index of the single recording this selector names.
+    ///
+    /// An EMPTY selector matches every candidate, so with several recordings
+    /// it resolves to `Ambiguous` — "no selector given" and "an ambiguous
+    /// selector" reach the caller through one path, and there is a single
+    /// place that decides what to say.
+    pub(crate) fn resolve(
+        &self,
+        candidates: &[BTreeMap<String, String>],
+    ) -> Result<usize, SelectError> {
+        let hits: Vec<usize> = candidates
+            .iter()
+            .enumerate()
+            .filter(|(_, l)| self.matches(l))
+            .map(|(i, _)| i)
+            .collect();
+        match hits.as_slice() {
+            [] => Err(SelectError::NoMatch),
+            [one] => Ok(*one),
+            _ => Err(SelectError::Ambiguous(hits)),
+        }
+    }
 }
 
 impl fmt::Display for RecordingSelector {
@@ -103,6 +126,44 @@ impl fmt::Display for RecordingSelector {
             .collect();
         write!(f, "{}", rendered.join(","))
     }
+}
+
+/// Render the recordings an archive holds, each with the flag that picks it.
+///
+/// Printing the selector rather than only the labels is the point: the
+/// caller's next command is a copy of a line it was just given.
+///
+/// Deliberately unnumbered — an index would invite `--recording 1`, which is
+/// not a supported selector.
+pub(crate) fn describe_candidates(candidates: &[BTreeMap<String, String>]) -> String {
+    let mut out = String::new();
+    for labels in candidates {
+        let rendered: Vec<String> = labels.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        // The most specific single label that would pick this one, if any
+        // exists; otherwise the whole set (each pair its own `--recording`,
+        // since that flag is repeatable and ANDs its pairs together).
+        let unique: Vec<String> = labels
+            .iter()
+            .filter(|(k, v)| {
+                candidates
+                    .iter()
+                    .filter(|c| c.get(*k).is_some_and(|got| got == *v))
+                    .count()
+                    == 1
+            })
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        let picker = if unique.is_empty() {
+            rendered.join(" --recording ")
+        } else {
+            unique[0].clone()
+        };
+        out.push_str(&format!(
+            "  - {}\n    select with: --recording {picker}\n",
+            rendered.join(", ")
+        ));
+    }
+    out
 }
 
 #[cfg(test)]
@@ -245,5 +306,67 @@ mod tests {
         // sees needs to name the offending key.
         let err = RecordingSelector::from_json(&serde_json::json!({"arm": 1})).unwrap_err();
         assert!(err.contains("arm"), "{err}");
+    }
+
+    fn two_arms() -> Vec<BTreeMap<String, String>> {
+        vec![
+            labels(&[("source", "redis"), ("host", "web-01")]),
+            labels(&[("source", "valkey"), ("host", "web-01")]),
+        ]
+    }
+
+    #[test]
+    fn resolves_to_the_one_matching_recording() {
+        let s = RecordingSelector::parse(["source=valkey".to_string()]).unwrap();
+        assert_eq!(s.resolve(&two_arms()), Ok(1));
+    }
+
+    #[test]
+    fn no_match_is_an_error_not_a_default() {
+        let s = RecordingSelector::parse(["source=nope".to_string()]).unwrap();
+        assert_eq!(s.resolve(&two_arms()), Err(SelectError::NoMatch));
+    }
+
+    #[test]
+    fn several_matches_is_an_error_not_the_first() {
+        // Both arms share host=web-01. Picking the first would silently
+        // analyze one arm of an A/B and present it as the answer.
+        let s = RecordingSelector::parse(["host=web-01".to_string()]).unwrap();
+        assert_eq!(
+            s.resolve(&two_arms()),
+            Err(SelectError::Ambiguous(vec![0, 1]))
+        );
+    }
+
+    #[test]
+    fn an_empty_selector_over_several_recordings_is_ambiguous() {
+        // "No selector given" reaches the caller as ambiguity over all of
+        // them, so there is one code path for "you must choose".
+        let s = RecordingSelector::default();
+        assert_eq!(
+            s.resolve(&two_arms()),
+            Err(SelectError::Ambiguous(vec![0, 1]))
+        );
+    }
+
+    #[test]
+    fn an_empty_selector_over_one_recording_resolves() {
+        let s = RecordingSelector::default();
+        assert_eq!(s.resolve(&two_arms()[..1]), Ok(0));
+    }
+
+    #[test]
+    fn the_candidate_listing_names_every_recording_and_its_selector() {
+        let out = describe_candidates(&two_arms());
+        assert!(out.contains("source=redis"), "{out}");
+        assert!(out.contains("source=valkey"), "{out}");
+        assert!(
+            out.contains("--recording"),
+            "the listing must show the flag that picks one: {out}"
+        );
+        assert!(
+            !out.contains("[1]"),
+            "no indices — they invite `--recording 1`, which is not a selector: {out}"
+        );
     }
 }

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -1,0 +1,168 @@
+//! Selecting one recording out of a multi-recording `.rez` archive.
+//!
+//! Pure logic over label sets: no file access, no reader. Kept separate from
+//! `mcp/mod.rs` because this is the part most worth testing directly, and
+//! because `mod.rs` is already large.
+//!
+//! Nothing here is called from production code yet — only the tests below —
+//! so `dead_code` is silenced module-wide until Task 2 wires `resolve` into
+//! the CLI and stdio server.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Labels a recording must carry to be selected.
+///
+/// Subset semantics: every `k=v` here must appear in the recording's labels,
+/// but the recording may carry more. Recordings auto-carry `source` and
+/// `host` plus any `record --label`, so requiring the full set would make
+/// selectors long and brittle.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RecordingSelector {
+    labels: BTreeMap<String, String>,
+}
+
+/// Why a selector did not name exactly one recording.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SelectError {
+    /// No recording carries every label in the selector.
+    NoMatch,
+    /// Several do; the indices of those that matched.
+    Ambiguous(Vec<usize>),
+}
+
+impl RecordingSelector {
+    /// Parse repeated `k=v` arguments (the CLI shape).
+    pub(crate) fn parse(pairs: impl IntoIterator<Item = String>) -> Result<Self, String> {
+        let mut labels = BTreeMap::new();
+        for p in pairs {
+            let (k, v) = p
+                .split_once('=')
+                .ok_or_else(|| format!("--recording expects key=value, got {p:?} with no '='"))?;
+            labels.insert(k.to_string(), v.to_string());
+        }
+        Ok(Self { labels })
+    }
+
+    /// Parse a JSON object of label key to value (the stdio-server shape).
+    pub(crate) fn from_json(v: &serde_json::Value) -> Result<Self, String> {
+        let obj = v
+            .as_object()
+            .ok_or_else(|| "recording must be an object of label key to value".to_string())?;
+        let mut labels = BTreeMap::new();
+        for (k, val) in obj {
+            let s = val
+                .as_str()
+                .ok_or_else(|| format!("recording label {k:?} must be a string"))?;
+            labels.insert(k.clone(), s.to_string());
+        }
+        Ok(Self { labels })
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.labels.is_empty()
+    }
+
+    /// Whether `labels` carries every pair in this selector.
+    pub(crate) fn matches(&self, labels: &BTreeMap<String, String>) -> bool {
+        self.labels
+            .iter()
+            .all(|(k, v)| labels.get(k).is_some_and(|got| got == v))
+    }
+}
+
+impl fmt::Display for RecordingSelector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let rendered: Vec<String> = self
+            .labels
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        write!(f, "{}", rendered.join(","))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parses_key_value_pairs() {
+        let s = RecordingSelector::parse(["source=redis".to_string()]).unwrap();
+        assert!(!s.is_empty());
+        assert_eq!(s.to_string(), "source=redis");
+    }
+
+    #[test]
+    fn a_value_without_an_equals_is_an_error() {
+        // Not silently ignored: `--recording redis` is a plausible typo for
+        // `--recording source=redis`, and dropping it would run against the
+        // wrong recording rather than say so.
+        let err = RecordingSelector::parse(["redis".to_string()]).unwrap_err();
+        assert!(
+            err.contains("redis"),
+            "the error must quote the input: {err}"
+        );
+        assert!(err.contains('='), "and say what was expected: {err}");
+    }
+
+    #[test]
+    fn an_empty_selector_selects_nothing_in_particular() {
+        let s = RecordingSelector::default();
+        assert!(s.is_empty());
+        // An empty selector matches everything, which is what makes
+        // "no selector given" fall through to the caller's own policy
+        // rather than being a special case inside the matcher.
+        assert!(s.matches(&labels(&[("source", "redis")])));
+    }
+
+    #[test]
+    fn matching_is_a_subset_not_an_equality() {
+        let s = RecordingSelector::parse(["source=redis".to_string()]).unwrap();
+        assert!(s.matches(&labels(&[("source", "redis"), ("host", "web-01")])));
+    }
+
+    #[test]
+    fn a_differing_value_does_not_match() {
+        let s = RecordingSelector::parse(["source=redis".to_string()]).unwrap();
+        assert!(!s.matches(&labels(&[("source", "valkey")])));
+    }
+
+    #[test]
+    fn a_missing_key_does_not_match() {
+        let s = RecordingSelector::parse(["arm=a".to_string()]).unwrap();
+        assert!(!s.matches(&labels(&[("source", "redis")])));
+    }
+
+    #[test]
+    fn several_pairs_are_anded() {
+        let s = RecordingSelector::parse(["source=redis".to_string(), "host=web-01".to_string()])
+            .unwrap();
+        assert!(s.matches(&labels(&[("source", "redis"), ("host", "web-01")])));
+        assert!(!s.matches(&labels(&[("source", "redis"), ("host", "web-02")])));
+    }
+
+    #[test]
+    fn parses_a_json_object() {
+        let v = serde_json::json!({"source": "redis"});
+        let s = RecordingSelector::from_json(&v).unwrap();
+        assert_eq!(
+            s,
+            RecordingSelector::parse(["source=redis".to_string()]).unwrap()
+        );
+    }
+
+    #[test]
+    fn a_non_object_json_selector_is_an_error() {
+        let err = RecordingSelector::from_json(&serde_json::json!("redis")).unwrap_err();
+        assert!(err.contains("object"), "{err}");
+    }
+}

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -91,7 +91,7 @@ impl RecordingSelector {
         self.labels.is_empty()
     }
 
-    /// The selector as the flags a caller would actually type.
+    /// The selector as the CALLER would actually spell it, in `syntax`.
     ///
     /// NOT `Display`, and the difference matters. `Display` joins with `,`
     /// because it renders a selector as one readable token, but `parse` splits
@@ -99,9 +99,13 @@ impl RecordingSelector {
     /// host=b,source=a` back parses as the single label `host` =
     /// `"b,source=a"`, matches nothing, and fails as `NoMatch` with no hint
     /// why. Error text that invites the reader to adjust and retry a selector
-    /// must therefore print this form, which round-trips through `parse`.
-    pub(crate) fn as_flags(&self) -> String {
-        flag_form(self.labels.iter().map(|(k, v)| format!("{k}={v}")))
+    /// must therefore print a form that round-trips through the front end it
+    /// is being shown to.
+    pub(crate) fn render(&self, syntax: SelectorSyntax) -> String {
+        picker_form(
+            self.labels.iter().map(|(k, v)| (k.clone(), v.clone())),
+            syntax,
+        )
     }
 
     /// Whether `labels` carries every pair in this selector.
@@ -146,15 +150,60 @@ impl fmt::Display for RecordingSelector {
     }
 }
 
-/// Render `k=v` pairs as the repeatable flag a caller types.
+/// How the caller being spoken to spells a recording selector.
+///
+/// The two front ends do not share a syntax: the one-shot CLI takes a
+/// repeatable `--recording k=v` flag, while an MCP client has no flags at all
+/// and sends a `recording` object in the tool call's arguments. Every message
+/// that tells a caller how to name an arm has to be rendered for the front
+/// end that will read it — a listing that hands an agent `--recording
+/// source=redis` is an instruction it cannot follow, and `describe_recording`
+/// (whose schema nominates it as the discovery step) is exactly where that
+/// dead end lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SelectorSyntax {
+    /// `--recording k=v --recording k=v` — the one-shot CLI subcommands.
+    Flags,
+    /// `recording {"k": "v"}` — the stdio server's tool argument.
+    Json,
+}
+
+/// Render `k=v` pairs as the selector a caller of `syntax` would type.
 ///
 /// One spelling for both the listing's "select with" lines and the error
-/// leads that echo a selector back, because the two must agree: the flag is
-/// repeatable and ANDs its pairs, and any other joining (notably `Display`'s
-/// comma) does not survive a round trip through `parse`.
-fn flag_form(pairs: impl IntoIterator<Item = String>) -> String {
-    let pairs: Vec<String> = pairs.into_iter().collect();
-    format!("--recording {}", pairs.join(" --recording "))
+/// leads that echo a selector back, because the two must agree. The flag form
+/// repeats the flag rather than joining with `Display`'s comma, which does
+/// not survive a round trip through `parse`; the JSON form is built through
+/// `serde_json` so a label value containing a quote or a backslash still
+/// pastes back as valid JSON.
+fn picker_form(
+    pairs: impl IntoIterator<Item = (String, String)>,
+    syntax: SelectorSyntax,
+) -> String {
+    let pairs: Vec<(String, String)> = pairs.into_iter().collect();
+    match syntax {
+        SelectorSyntax::Flags => format!(
+            "--recording {}",
+            pairs
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(" --recording ")
+        ),
+        SelectorSyntax::Json => format!(
+            "recording {{{}}}",
+            pairs
+                .iter()
+                .map(|(k, v)| format!("{}: {}", json_str(k), json_str(v)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+/// One JSON string literal, escaped.
+fn json_str(s: &str) -> String {
+    serde_json::Value::String(s.to_string()).to_string()
 }
 
 /// Render a recording's labels for display: `k=v, k=v` in key order.
@@ -169,8 +218,8 @@ pub(crate) fn render_labels(labels: &BTreeMap<String, String>) -> String {
         .join(", ")
 }
 
-/// Render specific recordings from an archive, each with the flag that picks
-/// it.
+/// Render specific recordings from an archive, each with the selector that
+/// picks it, spelled in `syntax`.
 ///
 /// `all` is every recording's labels; `highlight` is which indices of `all`
 /// to render (an empty slice means "render all of them"). Uniqueness is
@@ -179,7 +228,7 @@ pub(crate) fn render_labels(labels: &BTreeMap<String, String>) -> String {
 /// (e.g. the indices `resolve` returned inside `Ambiguous`) using that
 /// subset as the uniqueness universe would call a label unique because it
 /// only looks that way among the couple of recordings being described, then
-/// hand back a `--recording` that still collides with a THIRD recording
+/// hand back a selector that still collides with a THIRD recording
 /// sitting elsewhere in the archive. Taking `all` separately from
 /// `highlight` makes that mistake impossible to write.
 ///
@@ -188,7 +237,11 @@ pub(crate) fn render_labels(labels: &BTreeMap<String, String>) -> String {
 ///
 /// Deliberately unnumbered — an index would invite `--recording 1`, which is
 /// not a supported selector.
-pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &[usize]) -> String {
+pub(crate) fn describe_candidates(
+    all: &[BTreeMap<String, String>],
+    highlight: &[usize],
+    syntax: SelectorSyntax,
+) -> String {
     let indices: Vec<usize> = if highlight.is_empty() {
         (0..all.len()).collect()
     } else {
@@ -214,7 +267,7 @@ pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &
 
         out.push_str(&format!(
             "  - {rendered}\n    select with: {}\n",
-            flag_form(pairs)
+            picker_form(pairs, syntax)
         ));
     }
     out
@@ -226,7 +279,7 @@ pub(crate) fn describe_candidates(all: &[BTreeMap<String, String>], highlight: &
 /// The one place the "is this recording selectable at all" rule lives, so a
 /// listing and any caller asking whether a listing will contain selectors
 /// cannot disagree.
-fn picker_pairs(all: &[BTreeMap<String, String>], i: usize) -> Option<Vec<String>> {
+fn picker_pairs(all: &[BTreeMap<String, String>], i: usize) -> Option<Vec<(String, String)>> {
     let labels = &all[i];
 
     // A recording is unselectable when some OTHER recording's labels are a
@@ -262,8 +315,8 @@ fn picker_pairs(all: &[BTreeMap<String, String>], i: usize) -> Option<Vec<String
     // Any single label unique to this recording (checked against `all`, not
     // just `highlight`) selects it on its own; take the first in key order so
     // the listing is byte-stable across runs. If none exists, fall back to
-    // the whole set, one pair per `--recording` flag (the flag is repeatable
-    // and ANDs its pairs together) — sound here precisely because no other
+    // the whole set, whose pairs the selector ANDs together — sound here
+    // precisely because no other
     // recording is a superset.
     let unique = labels
         .iter()
@@ -273,9 +326,9 @@ fn picker_pairs(all: &[BTreeMap<String, String>], i: usize) -> Option<Vec<String
                 .count()
                 == 1
         })
-        .map(|(k, v)| vec![format!("{k}={v}")])
+        .map(|(k, v)| vec![(k.clone(), v.clone())])
         .next();
-    Some(unique.unwrap_or_else(|| labels.iter().map(|(k, v)| format!("{k}={v}")).collect()))
+    Some(unique.unwrap_or_else(|| labels.iter().map(|(k, v)| (k.clone(), v.clone())).collect()))
 }
 
 #[cfg(test)]
@@ -398,12 +451,43 @@ mod tests {
         assert_eq!(s.to_string(), "host=b,source=a");
     }
 
+    /// Read a rendered selector back the way its front end would.
+    ///
+    /// The flag form goes through `parse` (what clap hands over); the JSON
+    /// form through `serde_json` + `from_json` (what an MCP client sends).
+    /// Anything a message prints has to survive this, or the caller is being
+    /// told to type something that does not work.
+    fn reparse(rendered: &str, syntax: SelectorSyntax) -> RecordingSelector {
+        match syntax {
+            SelectorSyntax::Flags => RecordingSelector::parse(
+                rendered
+                    .strip_prefix("--recording ")
+                    .unwrap_or_else(|| panic!("not a flag-form selector: {rendered:?}"))
+                    .split(" --recording ")
+                    .map(str::to_string),
+            )
+            .unwrap_or_else(|e| panic!("unparseable flag selector {rendered:?}: {e}")),
+            SelectorSyntax::Json => {
+                let body = rendered
+                    .strip_prefix("recording ")
+                    .unwrap_or_else(|| panic!("not a JSON-form selector: {rendered:?}"));
+                let v: serde_json::Value = serde_json::from_str(body)
+                    .unwrap_or_else(|e| panic!("invalid JSON selector {body:?}: {e}"));
+                RecordingSelector::from_json(&v)
+                    .unwrap_or_else(|e| panic!("unusable JSON selector {body:?}: {e}"))
+            }
+        }
+    }
+
     #[test]
     fn the_flag_form_round_trips_where_display_does_not() {
         let s = RecordingSelector::parse(["host=b".to_string(), "source=a".to_string()]).unwrap();
-        assert_eq!(s.as_flags(), "--recording host=b --recording source=a");
+        assert_eq!(
+            s.render(SelectorSyntax::Flags),
+            "--recording host=b --recording source=a"
+        );
 
-        // The reason `as_flags` exists rather than reusing `Display`: the
+        // The reason `render` exists rather than reusing `Display`: the
         // comma join reads well but does NOT survive `parse`, which splits on
         // the first `=` only, so it comes back as one label
         // `host="b,source=a"` that matches nothing. Error text tells the
@@ -412,15 +496,37 @@ mod tests {
         let pasted = RecordingSelector::parse([s.to_string()]).unwrap();
         assert_ne!(pasted, s, "Display must not be mistaken for pasteable");
 
-        let round = RecordingSelector::parse(
-            s.as_flags()
-                .strip_prefix("--recording ")
-                .unwrap()
-                .split(" --recording ")
-                .map(str::to_string),
-        )
-        .unwrap();
-        assert_eq!(round, s, "the flag form must round-trip through parse");
+        assert_eq!(
+            reparse(&s.render(SelectorSyntax::Flags), SelectorSyntax::Flags),
+            s,
+            "the flag form must round-trip through parse"
+        );
+    }
+
+    /// The stdio server's caller has no flags to type: it sends a `recording`
+    /// object in the tool call. A message rendered for it must therefore be
+    /// JSON that survives `from_json`, not CLI syntax.
+    #[test]
+    fn the_json_form_round_trips_through_the_server_parser() {
+        let s = RecordingSelector::parse(["host=b".to_string(), "source=a".to_string()]).unwrap();
+        let rendered = s.render(SelectorSyntax::Json);
+        assert_eq!(rendered, r#"recording {"host": "b", "source": "a"}"#);
+        assert!(
+            !rendered.contains("--recording"),
+            "an MCP client has no flag to type: {rendered}"
+        );
+        assert_eq!(reparse(&rendered, SelectorSyntax::Json), s);
+    }
+
+    /// A label value carrying a quote or a backslash must still paste back as
+    /// valid JSON — hence rendering through `serde_json` rather than
+    /// `format!`. Label values are free text (a container name, a git
+    /// revision, a command line), so this is not hypothetical.
+    #[test]
+    fn the_json_form_escapes_label_values() {
+        let s = RecordingSelector::parse([r#"cmd=say "hi"\now"#.to_string()]).unwrap();
+        let rendered = s.render(SelectorSyntax::Json);
+        assert_eq!(reparse(&rendered, SelectorSyntax::Json), s);
     }
 
     #[test]
@@ -533,10 +639,15 @@ mod tests {
     /// contain "source=redis", "source=valkey", and "--recording" no matter
     /// what `picker` actually was. Feeding it back through `resolve` is what
     /// catches a selector that looks plausible but doesn't work.
-    fn assert_listing_round_trips(all: &[BTreeMap<String, String>], out: &str, expect: &[usize]) {
+    fn assert_listing_round_trips(
+        all: &[BTreeMap<String, String>],
+        out: &str,
+        expect: &[usize],
+        syntax: SelectorSyntax,
+    ) {
         let pickers: Vec<&str> = out
             .lines()
-            .filter_map(|l| l.trim_start().strip_prefix("select with: --recording "))
+            .filter_map(|l| l.trim_start().strip_prefix("select with: "))
             .collect();
         assert_eq!(
             pickers.len(),
@@ -544,10 +655,7 @@ mod tests {
             "one selector line per rendered recording: {out}"
         );
         for (picker, &i) in pickers.iter().zip(expect) {
-            let pairs: Vec<String> = picker.split(" --recording ").map(str::to_string).collect();
-            let s = RecordingSelector::parse(pairs).unwrap_or_else(|e| {
-                panic!("emitted an unparseable selector for recording {i}: {e} ({picker:?})")
-            });
+            let s = reparse(picker, syntax);
             assert_eq!(
                 s.resolve(all),
                 Ok(i),
@@ -556,13 +664,26 @@ mod tests {
         }
     }
 
+    /// Both front ends' listings must round-trip, not just the CLI's.
+    fn assert_listing_round_trips_both(
+        all: &[BTreeMap<String, String>],
+        highlight: &[usize],
+        expect: &[usize],
+    ) {
+        for syntax in [SelectorSyntax::Flags, SelectorSyntax::Json] {
+            let out = describe_candidates(all, highlight, syntax);
+            assert_listing_round_trips(all, &out, expect, syntax);
+        }
+    }
+
     #[test]
     fn the_candidate_listing_names_every_recording_and_its_selector() {
         let all = two_arms();
-        let out = describe_candidates(&all, &[]);
+        let out = describe_candidates(&all, &[], SelectorSyntax::Flags);
         assert!(out.contains("source=redis"), "{out}");
         assert!(out.contains("source=valkey"), "{out}");
-        assert_listing_round_trips(&all, &out, &[0, 1]);
+        assert_listing_round_trips(&all, &out, &[0, 1], SelectorSyntax::Flags);
+        assert_listing_round_trips_both(&all, &[], &[0, 1]);
         // No indices: they invite `--recording 1`, which is not a selector.
         // Checked against a few plausible numbering styles, not just one.
         for pat in ["[1]", "[2]", "(1)", "(2)", "1.", "2.", "#1", "#2"] {
@@ -590,8 +711,7 @@ mod tests {
             Err(SelectError::Ambiguous(vec![0, 1]))
         );
 
-        let out = describe_candidates(&all, &[0, 1]);
-        assert_listing_round_trips(&all, &out, &[0, 1]);
+        assert_listing_round_trips_both(&all, &[0, 1], &[0, 1]);
     }
 
     #[test]
@@ -605,9 +725,9 @@ mod tests {
             labels(&[("host", "web-01"), ("source", "redis")]),
             labels(&[("host", "web-01"), ("source", "redis")]),
         ];
-        let out = describe_candidates(&dup, &[]);
+        let out = describe_candidates(&dup, &[], SelectorSyntax::Flags);
         assert!(
-            !out.contains("select with: --recording"),
+            !out.contains("select with:"),
             "no selector can pick between identical label sets, so none should be offered: {out}"
         );
         assert!(
@@ -644,12 +764,13 @@ mod tests {
             labels(&[("arm", "baseline"), ("host", "h"), ("source", "rezolus")]),
             labels(&[("host", "h"), ("source", "rezolus")]),
         ];
-        let out = describe_candidates(&all, &[]);
+        let out = describe_candidates(&all, &[], SelectorSyntax::Flags);
         // Only recording 0 gets a selector (`arm=baseline`); recording 1 gets
         // the unselectable note. The round trip is what proves it: before the
         // fix, recording 1 was offered `--recording host=h --recording
         // source=rezolus`, which resolves to `Ambiguous([0, 1])`.
-        assert_listing_round_trips(&all, &out, &[0]);
+        assert_listing_round_trips(&all, &out, &[0], SelectorSyntax::Flags);
+        assert_listing_round_trips_both(&all, &[], &[0]);
         assert!(
             out.contains("cannot be selected by labels"),
             "the subset arm must be reported as unselectable: {out}"
@@ -660,7 +781,6 @@ mod tests {
     #[test]
     fn a_superset_recording_makes_its_subset_peer_unselectable() {
         let all = vec![labels(&[("a", "1")]), labels(&[("a", "1"), ("b", "2")])];
-        let out = describe_candidates(&all, &[]);
-        assert_listing_round_trips(&all, &out, &[1]);
+        assert_listing_round_trips_both(&all, &[], &[1]);
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -596,7 +596,16 @@ impl Server {
         // shared pool (`describe_recording_output` opens with a pool of its
         // own). It is a metadata read called once or twice a session, so the
         // duplicated open is worth strict parity with the CLI.
-        let output = crate::mcp::describe_recording_output(path, &selector)?;
+        // `Json`: every selector this renders is going back to an MCP client,
+        // which has no `--recording` flag to type — it sends a `recording`
+        // object in the tool call. This tool's schema is what points an agent
+        // here to discover the arms, so CLI syntax would end the discovery
+        // path in an instruction the client cannot follow.
+        let output = crate::mcp::describe_recording_output(
+            path,
+            &selector,
+            crate::mcp::SelectorSyntax::Json,
+        )?;
         Ok(output)
     }
 
@@ -643,8 +652,12 @@ impl Server {
         // 2-recording archive. `open_source_with_pool_labeled` also does the
         // `.rez`-vs-parquet dispatch by content, so it replaces the whole
         // branch.
-        let (labels, reader) =
-            crate::mcp::open_source_with_pool_labeled(path, Arc::clone(&self.pool), selector)?;
+        let (labels, reader) = crate::mcp::open_source_with_pool_labeled(
+            path,
+            Arc::clone(&self.pool),
+            selector,
+            crate::mcp::SelectorSyntax::Json,
+        )?;
         let identity = crate::recorder::seal_policy::recording_stagger_key(&labels);
 
         let mut cache = self.reader_cache.write().unwrap();
@@ -1041,6 +1054,78 @@ mod tests {
         assert!(
             Arc::ptr_eq(&narrow, &wide),
             "two selectors naming one recording must not retain two readers"
+        );
+    }
+
+    /// Every selector the SERVER renders must be in the syntax an MCP client
+    /// can actually send.
+    ///
+    /// The client has no `--recording` flag — its interface is
+    /// `{"recording": {"source": "redis"}}` — so a listing that says
+    /// `select with: --recording source=redis` hands an agent an instruction
+    /// it cannot follow. `describe_recording` is where the schema explicitly
+    /// sends an agent to discover the arms ("Call describe_recording without
+    /// it first to list them"), so that path ending in unusable syntax is a
+    /// dead end from "I can't read this archive" onward.
+    #[tokio::test]
+    async fn server_listings_render_the_json_selector_not_the_cli_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        crate::mcp::tests::multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+        let args = json!({"parquet_file": path.to_str().unwrap()});
+
+        let server = Server::new();
+        let listing = server
+            .describe_recording(&args)
+            .await
+            .expect("no selector lists the arms");
+        assert!(
+            !listing.contains("--recording"),
+            "the MCP client has no flags to type: {listing}"
+        );
+        assert!(
+            listing.contains(r#"recording {"source": "redis"}"#),
+            "it must render the tool argument the client can send: {listing}"
+        );
+    }
+
+    /// ...and so must every error the server returns, not just the listing.
+    #[tokio::test]
+    async fn server_errors_render_the_json_selector_not_the_cli_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        crate::mcp::tests::multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+        let p = path.to_str().unwrap();
+        let server = Server::new();
+
+        // No selector: ambiguous over both arms.
+        let ambiguous = server
+            .get_reader_selected(p, &crate::mcp::RecordingSelector::default())
+            .await
+            .err()
+            .expect("a 2-recording archive must be refused")
+            .to_string();
+        assert!(!ambiguous.contains("--recording"), "{ambiguous}");
+        assert!(
+            ambiguous.contains(r#"recording {"source": "redis"}"#),
+            "{ambiguous}"
+        );
+
+        // A selector that names nothing: the echo of the selector itself must
+        // be in the client's syntax too.
+        let no_match = server
+            .get_reader_selected(
+                p,
+                &crate::mcp::RecordingSelector::parse(["source=nope".to_string()]).unwrap(),
+            )
+            .await
+            .err()
+            .expect("source=nope names no arm")
+            .to_string();
+        assert!(!no_match.contains("--recording"), "{no_match}");
+        assert!(
+            no_match.contains(r#"recording {"source": "nope"}"#),
+            "the echoed selector must be pasteable as a tool argument: {no_match}"
         );
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -562,7 +562,13 @@ impl Server {
         // half of the two to leave unfixed. `open_source_with_pool` also does
         // the `.rez`-vs-parquet dispatch by content, so it replaces the whole
         // branch.
-        let reader = crate::mcp::open_source_with_pool(path, Arc::clone(&self.pool))?;
+        // No selector yet: the tool schemas do not carry one, so a
+        // multi-recording archive still comes back as the listing error.
+        let reader = crate::mcp::open_source_with_pool(
+            path,
+            Arc::clone(&self.pool),
+            &crate::mcp::RecordingSelector::default(),
+        )?;
 
         {
             let mut cache = self.reader_cache.write().unwrap();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -591,8 +591,10 @@ impl Server {
         //
         // The cost is that this one tool bypasses the reader cache and the
         // shared pool (`describe_recording_output` opens with a pool of its
-        // own). It is a metadata read called once or twice a session, so the
-        // duplicated open is worth strict parity with the CLI.
+        // own). It is a metadata read called once or twice a session, so a
+        // separate open is worth strict parity with the CLI — and it is one
+        // open, not two: the listing decision and the reader now come out of
+        // the same call.
         // `Json`: every selector this renders is going back to an MCP client,
         // which has no `--recording` flag to type — it sends a `recording`
         // object in the tool call. This tool's schema is what points an agent
@@ -654,13 +656,14 @@ impl Server {
         // 2-recording archive. `open_source_with_pool_labeled` also does the
         // `.rez`-vs-parquet dispatch by content, so it replaces the whole
         // branch.
-        let (labels, reader) = crate::mcp::open_source_with_pool_labeled(
+        let opened = crate::mcp::open_source_with_pool_labeled(
             path,
             Arc::clone(&self.pool),
             selector,
             crate::mcp::SelectorSyntax::Json,
         )?;
-        let identity = crate::recorder::seal_policy::recording_stagger_key(&labels);
+        let reader = opened.reader;
+        let identity = crate::recorder::seal_policy::recording_stagger_key(&opened.labels);
 
         let mut cache = self.reader_cache.write().unwrap();
         // Distinct selectors can name the SAME recording (`source=redis` and

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -76,6 +76,13 @@ struct CachedReader {
     /// retaining their own copy of the archive.
     identity: String,
     source: Arc<dyn metriken_query::MetricsSource>,
+    /// What the analysis layer may trust this recording's metric names to
+    /// mean, as the OPEN determined it. Cached alongside the reader because
+    /// the reader cannot be asked afterwards: a recording selected out of a
+    /// `.rez` reports the endpoint name the caller chose as its `source`, so
+    /// re-deriving provenance from the reader would answer "foreign" for data
+    /// that is unambiguously the agent's.
+    provenance: crate::analysis::extract::Provenance,
 }
 
 /// MCP server state
@@ -635,11 +642,30 @@ impl Server {
         parquet_file: &str,
         selector: &crate::mcp::RecordingSelector,
     ) -> Result<Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
+        self.get_reader_with_provenance(parquet_file, selector)
+            .await
+            .map(|(reader, _)| reader)
+    }
+
+    /// As `get_reader_selected`, also reporting what the open determined
+    /// about the recording's provenance — needed only by `extract_features`,
+    /// whose sampler attribution depends on it.
+    async fn get_reader_with_provenance(
+        &self,
+        parquet_file: &str,
+        selector: &crate::mcp::RecordingSelector,
+    ) -> Result<
+        (
+            Arc<dyn metriken_query::MetricsSource>,
+            crate::analysis::extract::Provenance,
+        ),
+        Box<dyn std::error::Error>,
+    > {
         let key = (parquet_file.to_string(), selector.clone());
         {
             let cache = self.reader_cache.read().unwrap();
             if let Some(hit) = cache.get(&key) {
-                return Ok(Arc::clone(&hit.source));
+                return Ok((Arc::clone(&hit.source), hit.provenance));
             }
         }
 
@@ -662,6 +688,7 @@ impl Server {
             selector,
             crate::mcp::SelectorSyntax::Json,
         )?;
+        let provenance = opened.provenance();
         let reader = opened.reader;
         let identity = crate::recorder::seal_policy::recording_stagger_key(&opened.labels);
 
@@ -682,10 +709,11 @@ impl Server {
             CachedReader {
                 identity,
                 source: Arc::clone(&source),
+                provenance,
             },
         );
 
-        Ok(source)
+        Ok((source, provenance))
     }
 
     /// Analyze correlation between two metrics
@@ -793,8 +821,10 @@ impl Server {
             .ok_or("Missing parquet_file")?;
 
         let selector = Self::selector_of(arguments)?;
-        let reader = self.get_reader_selected(parquet_file, &selector).await?;
-        let record = crate::analysis::extract::extract(reader.as_ref())?;
+        let (reader, provenance) = self
+            .get_reader_with_provenance(parquet_file, &selector)
+            .await?;
+        let record = crate::analysis::extract::extract(reader.as_ref(), provenance)?;
         Ok(serde_json::to_string_pretty(&record)?)
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -68,9 +68,27 @@ impl From<&str> for McpTool {
 /// next tool call against the same file.
 const MCP_CACHE_SIZE_BYTES: usize = 500 * 1024 * 1024;
 
+/// A cached reader, tagged with the recording it was opened from.
+struct CachedReader {
+    /// The chosen recording's label set, canonically rendered by
+    /// `recording_stagger_key`. Two selectors that name the same recording of
+    /// the same file share the reader under this identity rather than each
+    /// retaining their own copy of the archive.
+    identity: String,
+    source: Arc<dyn metriken_query::MetricsSource>,
+}
+
 /// MCP server state
 pub struct Server {
-    reader_cache: Arc<RwLock<HashMap<String, Arc<dyn metriken_query::MetricsSource>>>>,
+    /// Keyed by (path, selector) — a TYPED pair, never a formatted string.
+    ///
+    /// A multi-recording `.rez` yields a DIFFERENT reader per recording from
+    /// ONE path, so keying on the path alone serves the second request the
+    /// first's reader and answers about the wrong arm, silently. Keying on
+    /// `format!("{path}\u{{1}}{selector}")` has a narrower version of the same
+    /// bug: label values are free text, so two different selectors can render
+    /// identical key bytes. The tuple cannot alias.
+    reader_cache: Arc<RwLock<HashMap<(String, crate::mcp::RecordingSelector), CachedReader>>>,
     /// Shared LRU row-group cache for all readers opened by this server.
     pool: Arc<BufferPool>,
 }
@@ -181,6 +199,11 @@ impl Server {
                                         "parquet_file": {
                                             "type": "string",
                                             "description": "Path to the parquet file"
+                                        },
+                                        "recording": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "string"},
+                                            "description": "Which recording to read from a multi-recording .rez, as label key/value pairs (e.g. {\"source\": \"redis\"}). Must name exactly one. Call describe_recording without it first to list them."
                                         }
                                     },
                                     "required": ["parquet_file"]
@@ -195,6 +218,11 @@ impl Server {
                                         "parquet_file": {
                                             "type": "string",
                                             "description": "Path to the parquet file"
+                                        },
+                                        "recording": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "string"},
+                                            "description": "Which recording to read from a multi-recording .rez, as label key/value pairs (e.g. {\"source\": \"redis\"}). Must name exactly one. Call describe_recording without it first to list them."
                                         },
                                         "metric1": {
                                             "type": "string",
@@ -217,6 +245,11 @@ impl Server {
                                         "parquet_file": {
                                             "type": "string",
                                             "description": "Path to the parquet file"
+                                        },
+                                        "recording": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "string"},
+                                            "description": "Which recording to read from a multi-recording .rez, as label key/value pairs (e.g. {\"source\": \"redis\"}). Must name exactly one. Call describe_recording without it first to list them."
                                         }
                                     },
                                     "required": ["parquet_file"]
@@ -231,6 +264,11 @@ impl Server {
                                         "parquet_file": {
                                             "type": "string",
                                             "description": "Path to the parquet file"
+                                        },
+                                        "recording": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "string"},
+                                            "description": "Which recording to read from a multi-recording .rez, as label key/value pairs (e.g. {\"source\": \"redis\"}). Must name exactly one. Call describe_recording without it first to list them."
                                         },
                                         "query": {
                                             "type": "string",
@@ -250,6 +288,11 @@ impl Server {
                                             "type": "string",
                                             "description": "Path to the parquet file"
                                         },
+                                        "recording": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "string"},
+                                            "description": "Which recording to read from a multi-recording .rez, as label key/value pairs (e.g. {\"source\": \"redis\"}). Must name exactly one. Call describe_recording without it first to list them."
+                                        },
                                         "query": {
                                             "type": "string",
                                             "description": "PromQL query expression. For COUNTERS use rate(metric[1m]), for GAUGES query directly, for HISTOGRAMS use histogram_quantile(0.99, metric). Use sum(), avg(), etc. to aggregate multiple series."
@@ -267,6 +310,11 @@ impl Server {
                                         "parquet_file": {
                                             "type": "string",
                                             "description": "Path to the recording (parquet or .rez)"
+                                        },
+                                        "recording": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "string"},
+                                            "description": "Which recording to read from a multi-recording .rez, as label key/value pairs (e.g. {\"source\": \"redis\"}). Must name exactly one. Call describe_recording without it first to list them."
                                         }
                                     },
                                     "required": ["parquet_file"]
@@ -528,54 +576,98 @@ impl Server {
             .and_then(|f| f.as_str())
             .ok_or("Missing parquet_file")?;
 
+        // Kept ahead of the open so a typo'd path says so plainly; without
+        // it the failure arrives as whatever the parquet decoder makes of a
+        // missing file.
         let path = Path::new(parquet_file);
         if !path.exists() {
-            return Err(format!("Parquet file not found: {parquet_file}").into());
+            return Err(format!("Recording file not found: {parquet_file}").into());
         }
 
-        let reader = self.get_reader(parquet_file).await?;
-        let output = super::format_recording_info(parquet_file, reader.as_ref());
+        let selector = Self::selector_of(arguments)?;
+        // The CLI's own text, not `get_reader_selected` + `format_recording_info`.
+        // With no selector a multi-recording archive is LISTED here rather
+        // than refused, and `describe_recording` is where an agent starts, so
+        // the server answering "pick one, here they are" is the behavior that
+        // has to match. Reproducing that branch here instead is how the two
+        // paths diverged the first time.
+        //
+        // The cost is that this one tool bypasses the reader cache and the
+        // shared pool (`describe_recording_output` opens with a pool of its
+        // own). It is a metadata read called once or twice a session, so the
+        // duplicated open is worth strict parity with the CLI.
+        let output = crate::mcp::describe_recording_output(path, &selector)?;
         Ok(output)
     }
 
-    /// Load or get cached ParquetReader
-    async fn get_reader(
+    /// Read the optional `recording` object from a tool call's arguments.
+    ///
+    /// Absent means "no selector", which is not the same as "any recording":
+    /// over a multi-recording archive it resolves as ambiguous and the caller
+    /// is told to choose. That is the point — the alternative is answering
+    /// from an arm nobody named.
+    fn selector_of(
+        arguments: &Value,
+    ) -> Result<crate::mcp::RecordingSelector, Box<dyn std::error::Error>> {
+        match arguments.get("recording") {
+            Some(v) => Ok(crate::mcp::RecordingSelector::from_json(v)?),
+            None => Ok(crate::mcp::RecordingSelector::default()),
+        }
+    }
+
+    /// Load or get a cached reader for `parquet_file`, honoring `selector`.
+    async fn get_reader_selected(
         &self,
         parquet_file: &str,
+        selector: &crate::mcp::RecordingSelector,
     ) -> Result<Arc<dyn metriken_query::MetricsSource>, Box<dyn std::error::Error>> {
+        let key = (parquet_file.to_string(), selector.clone());
         {
             let cache = self.reader_cache.read().unwrap();
-            if let Some(reader) = cache.get(parquet_file) {
-                return Ok(Arc::clone(reader));
+            if let Some(hit) = cache.get(&key) {
+                return Ok(Arc::clone(&hit.source));
             }
         }
 
         let path = Path::new(parquet_file);
         if !path.exists() {
-            return Err(format!("Parquet file not found: {parquet_file}").into());
+            return Err(format!("Recording file not found: {parquet_file}").into());
         }
 
-        // The same open the one-shot CLI uses — including the refusal of a
-        // multi-recording archive. Server mode is what an AI agent actually
-        // drives, so having the CLI refuse and the server quietly answer
-        // "94 metrics, all NoData" over a 2-recording archive was the worse
-        // half of the two to leave unfixed. `open_source_with_pool` also does
-        // the `.rez`-vs-parquet dispatch by content, so it replaces the whole
+        // The same open the one-shot CLI uses — including the selector, and
+        // the refusal of a multi-recording archive that names none. Server
+        // mode is what an AI agent actually drives, so any behavior added on
+        // only one of the two paths diverges exactly as the first
+        // multi-recording refusal did: the CLI refused while the server
+        // answered `extract_features` with every metric `NoData` over a
+        // 2-recording archive. `open_source_with_pool_labeled` also does the
+        // `.rez`-vs-parquet dispatch by content, so it replaces the whole
         // branch.
-        // No selector yet: the tool schemas do not carry one, so a
-        // multi-recording archive still comes back as the listing error.
-        let reader = crate::mcp::open_source_with_pool(
-            path,
-            Arc::clone(&self.pool),
-            &crate::mcp::RecordingSelector::default(),
-        )?;
+        let (labels, reader) =
+            crate::mcp::open_source_with_pool_labeled(path, Arc::clone(&self.pool), selector)?;
+        let identity = crate::recorder::seal_policy::recording_stagger_key(&labels);
 
-        {
-            let mut cache = self.reader_cache.write().unwrap();
-            cache.insert(parquet_file.to_string(), Arc::clone(&reader));
-        }
+        let mut cache = self.reader_cache.write().unwrap();
+        // Distinct selectors can name the SAME recording (`source=redis` and
+        // `host=web-01 source=redis`), and an LLM client will emit both across
+        // a session. Collapse them onto one reader by the recording's own
+        // identity so the archive is not retained once per spelling. Matching
+        // on the path too: an identity is only meaningful within one file, and
+        // an archive with no labels at all renders the empty identity.
+        let source = cache
+            .iter()
+            .find(|((p, _), c)| p == parquet_file && c.identity == identity)
+            .map(|(_, c)| Arc::clone(&c.source))
+            .unwrap_or(reader);
+        cache.insert(
+            key,
+            CachedReader {
+                identity,
+                source: Arc::clone(&source),
+            },
+        );
 
-        Ok(reader)
+        Ok(source)
     }
 
     /// Analyze correlation between two metrics
@@ -598,7 +690,8 @@ impl Server {
             .and_then(|m| m.as_str())
             .ok_or("Missing metric2")?;
 
-        let reader = self.get_reader(parquet_file).await?;
+        let selector = Self::selector_of(arguments)?;
+        let reader = self.get_reader_selected(parquet_file, &selector).await?;
 
         use crate::mcp::correlation::{calculate_correlation, format_correlation_result};
 
@@ -616,7 +709,8 @@ impl Server {
             .and_then(|f| f.as_str())
             .ok_or("Missing parquet_file")?;
 
-        let reader = self.get_reader(parquet_file).await?;
+        let selector = Self::selector_of(arguments)?;
+        let reader = self.get_reader_selected(parquet_file, &selector).await?;
 
         use crate::mcp::describe_metrics::format_metrics_description;
         Ok(format_metrics_description(reader.as_ref()))
@@ -637,7 +731,8 @@ impl Server {
             .and_then(|q| q.as_str())
             .ok_or("Missing query")?;
 
-        let reader = self.get_reader(parquet_file).await?;
+        let selector = Self::selector_of(arguments)?;
+        let reader = self.get_reader_selected(parquet_file, &selector).await?;
 
         use crate::mcp::anomaly_detection::{detect_anomalies, format_anomaly_detection_result};
 
@@ -657,7 +752,8 @@ impl Server {
             .and_then(|q| q.as_str())
             .ok_or("Missing query")?;
 
-        let reader = self.get_reader(parquet_file).await?;
+        let selector = Self::selector_of(arguments)?;
+        let reader = self.get_reader_selected(parquet_file, &selector).await?;
 
         let (start_time, end_time) = reader.time_range().unwrap_or((0.0, 0.0));
         let step = 1.0;
@@ -678,7 +774,8 @@ impl Server {
             .and_then(|f| f.as_str())
             .ok_or("Missing parquet_file")?;
 
-        let reader = self.get_reader(parquet_file).await?;
+        let selector = Self::selector_of(arguments)?;
+        let reader = self.get_reader_selected(parquet_file, &selector).await?;
         let record = crate::analysis::extract::extract(reader.as_ref())?;
         Ok(serde_json::to_string_pretty(&record)?)
     }
@@ -742,13 +839,13 @@ mod tests {
     /// Server mode must refuse a multi-recording archive exactly as the
     /// one-shot CLI does.
     ///
-    /// This is the half that was missed the first time. `get_reader` had its
+    /// This is the half that was missed the first time. The server had its
     /// own `detect_rez_format` + `open_with_pool` branch, so the CLI refused
     /// while the stdio server — the mode an AI agent actually drives —
     /// answered `extract_features` over a 2-recording archive with every
     /// metric `NoData`, empty correlations, and a `duration_s` that was the
     /// union of two unrelated timelines. Both paths now share
-    /// `mcp::open_source_with_pool`.
+    /// `mcp::open_source_with_pool_labeled`.
     #[tokio::test]
     async fn get_reader_refuses_a_multi_recording_archive() {
         let dir = tempfile::tempdir().unwrap();
@@ -757,7 +854,10 @@ mod tests {
 
         let server = Server::new();
         let err = server
-            .get_reader(path.to_str().unwrap())
+            .get_reader_selected(
+                path.to_str().unwrap(),
+                &crate::mcp::RecordingSelector::default(),
+            )
             .await
             .err()
             .expect("server mode must refuse it, not answer NoData for every metric")
@@ -768,7 +868,7 @@ mod tests {
         );
     }
 
-    /// `get_reader` must dispatch a v3 (SQLite) `.rez` to `RezReader`, not
+    /// The server's open must dispatch a v3 (SQLite) `.rez` to `RezReader`, not
     /// `ParquetReader::open_with_pool`. Mutation check: reverting the
     /// `detect_rez_format` check to `is_rez_path` makes this fail — a v3 file
     /// then falls through to `ParquetReader`, which errors on the SQLite
@@ -785,10 +885,15 @@ mod tests {
         );
 
         let server = Server::new();
-        let result = server.get_reader(rez_path.to_str().unwrap()).await;
+        let result = server
+            .get_reader_selected(
+                rez_path.to_str().unwrap(),
+                &crate::mcp::RecordingSelector::default(),
+            )
+            .await;
         assert!(
             result.is_ok(),
-            "get_reader must accept a v3 .rez: {:?}",
+            "the server must accept a v3 .rez: {:?}",
             result.err().map(|e| e.to_string())
         );
     }
@@ -840,5 +945,191 @@ mod tests {
         assert!(json.contains("\"result\""));
         assert!(json.contains("\"metric\""));
         assert!(json.contains("\"values\""));
+    }
+
+    #[tokio::test]
+    async fn the_server_honors_a_recording_selector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        crate::mcp::tests::multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+
+        let server = Server::new();
+        let args = serde_json::json!({
+            "parquet_file": path.to_str().unwrap(),
+            "recording": {"source": "valkey"}
+        });
+        let out = server
+            .describe_recording(&args)
+            .await
+            .expect("a selector must work in server mode too");
+        assert!(out.contains("Recording Information"), "{out}");
+        // Not just "it opened something": the report must be ABOUT the arm
+        // that was named. A handler that resolved the selector and then read
+        // the other recording would still print a well-formed report.
+        assert!(
+            out.contains("valkey") && !out.contains("redis"),
+            "the report must describe the named arm: {out}"
+        );
+    }
+
+    /// The cache is keyed by path; two recordings from one archive must not
+    /// collide. Without the recording in the key, the second request returns
+    /// the first's reader and answers about the wrong arm.
+    #[tokio::test]
+    async fn two_recordings_of_one_archive_do_not_share_a_cache_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        crate::mcp::tests::multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+        let p = path.to_str().unwrap();
+
+        let server = Server::new();
+        let redis = server
+            .get_reader_selected(
+                p,
+                &crate::mcp::RecordingSelector::parse(["source=redis".to_string()]).unwrap(),
+            )
+            .await
+            .unwrap();
+        let valkey = server
+            .get_reader_selected(
+                p,
+                &crate::mcp::RecordingSelector::parse(["source=valkey".to_string()]).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(redis.metadata_get("source").as_deref(), Some("redis"));
+        assert_eq!(
+            valkey.metadata_get("source").as_deref(),
+            Some("valkey"),
+            "the second request must not be served the first's cached reader"
+        );
+    }
+
+    /// Two selectors that name the SAME recording share one reader.
+    ///
+    /// The cache is keyed by the resolved recording's identity, not by the
+    /// selector text, so `source=valkey` and `host=web-01 source=valkey` —
+    /// which an LLM client will realistically emit for the same arm across
+    /// two calls — do not each retain their own copy of the archive.
+    #[tokio::test]
+    async fn equivalent_selectors_share_one_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        crate::mcp::tests::multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+        let p = path.to_str().unwrap();
+
+        let server = Server::new();
+        let narrow = server
+            .get_reader_selected(
+                p,
+                &crate::mcp::RecordingSelector::parse(["source=valkey".to_string()]).unwrap(),
+            )
+            .await
+            .unwrap();
+        let wide = server
+            .get_reader_selected(
+                p,
+                &crate::mcp::RecordingSelector::parse([
+                    "source=valkey".to_string(),
+                    "host=web-01".to_string(),
+                ])
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            Arc::ptr_eq(&narrow, &wide),
+            "two selectors naming one recording must not retain two readers"
+        );
+    }
+
+    /// A handler that honors `recording` is invisible if the schema never
+    /// advertises it: an MCP client sends only what the schema declares, so a
+    /// tool missing the property would leave an agent unable to name an arm
+    /// and told only that the archive holds two.
+    #[tokio::test]
+    async fn every_tool_schema_advertises_the_recording_argument() {
+        let mut server = Server::new();
+        let listing = server
+            .handle_message(json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
+            .await
+            .unwrap()
+            .expect("tools/list must answer");
+        let tools = listing["result"]["tools"].as_array().unwrap().clone();
+        assert_eq!(tools.len(), 6, "all six tools must be listed");
+        for tool in tools {
+            let name = tool["name"].as_str().unwrap();
+            let props = &tool["inputSchema"]["properties"];
+            assert!(
+                props.get("recording").is_some(),
+                "{name} does not advertise a recording selector"
+            );
+            // Optional on purpose: a single-recording archive — the common
+            // case — must stay callable without one.
+            let required = tool["inputSchema"]["required"].as_array().unwrap();
+            assert!(
+                !required.iter().any(|r| r == "recording"),
+                "{name} must not require a selector"
+            );
+        }
+    }
+
+    /// Trap 1, mechanized: EVERY handler that opens a reader has to pass the
+    /// selector down. One that quietly dropped it would fall back to "no
+    /// selector", which over a 2-recording archive is the ambiguity error —
+    /// and that error is exactly what an agent would see instead of an answer.
+    ///
+    /// Asserting "not the ambiguity error" rather than "Ok" on purpose: some
+    /// of these tools legitimately fail on a 3-row fixture (extract_features
+    /// wants 10s of data), and that failure is not the one under test.
+    #[tokio::test]
+    async fn every_handler_honors_the_recording_selector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ab.rez");
+        crate::mcp::tests::multi_recording_rez(&path, &["redis", "valkey"], &[true, true]);
+        let p = path.to_str().unwrap();
+
+        let server = Server::new();
+        let args = json!({
+            "parquet_file": p,
+            "recording": {"source": "valkey"},
+            "query": "cpu_cycles",
+            "metric1": "cpu_cycles",
+            "metric2": "cpu_cycles",
+        });
+
+        type Outcome = Result<String, Box<dyn std::error::Error>>;
+        let outcomes: Vec<(&str, Outcome)> = vec![
+            ("describe_recording", server.describe_recording(&args).await),
+            (
+                "analyze_correlation",
+                server.analyze_correlation(&args).await,
+            ),
+            ("describe_metrics", server.describe_metrics(&args).await),
+            ("detect_anomalies", server.detect_anomalies(&args).await),
+            ("query", server.execute_query(&args).await),
+            (
+                "extract_features",
+                server.execute_extract_features(&args).await,
+            ),
+        ];
+        // Collected, not asserted in the loop: a handler-by-handler report is
+        // what makes this useful when one of the six is missed, and asserting
+        // eagerly would hide the other five behind the first.
+        let dropped: Vec<&str> = outcomes
+            .into_iter()
+            .filter(|(_, outcome)| {
+                outcome
+                    .as_ref()
+                    .err()
+                    .is_some_and(|e| e.to_string().contains("recordings with data"))
+            })
+            .map(|(name, _)| name)
+            .collect();
+        assert!(
+            dropped.is_empty(),
+            "these handlers dropped the recording selector: {dropped:?}"
+        );
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -576,14 +576,11 @@ impl Server {
             .and_then(|f| f.as_str())
             .ok_or("Missing parquet_file")?;
 
-        // Kept ahead of the open so a typo'd path says so plainly; without
-        // it the failure arrives as whatever the parquet decoder makes of a
-        // missing file.
+        // No `exists()` check here: `open_source_with_pool_labeled` makes it,
+        // so both front ends report a missing file with one message instead
+        // of the server saying "Recording file not found" and the CLI
+        // surfacing the decoder's "No such file or directory (os error 2)".
         let path = Path::new(parquet_file);
-        if !path.exists() {
-            return Err(format!("Recording file not found: {parquet_file}").into());
-        }
-
         let selector = Self::selector_of(arguments)?;
         // The CLI's own text, not `get_reader_selected` + `format_recording_info`.
         // With no selector a multi-recording archive is LISTED here rather
@@ -619,8 +616,14 @@ impl Server {
         arguments: &Value,
     ) -> Result<crate::mcp::RecordingSelector, Box<dyn std::error::Error>> {
         match arguments.get("recording") {
+            // An explicit `null` is an ABSENT selector, not a malformed one.
+            // Many MCP clients and LLM tool-call serializers spell an omitted
+            // optional property as `"recording": null`, and `get` hands that
+            // back as `Some(Value::Null)`; passing it to `from_json` would
+            // fail a valid single-recording call with "recording must be an
+            // object of label key to value".
+            None | Some(serde_json::Value::Null) => Ok(crate::mcp::RecordingSelector::default()),
             Some(v) => Ok(crate::mcp::RecordingSelector::from_json(v)?),
-            None => Ok(crate::mcp::RecordingSelector::default()),
         }
     }
 
@@ -638,10 +641,9 @@ impl Server {
             }
         }
 
+        // A missing file is reported by the opener (one message for both
+        // front ends), not pre-checked here.
         let path = Path::new(parquet_file);
-        if !path.exists() {
-            return Err(format!("Recording file not found: {parquet_file}").into());
-        }
 
         // The same open the one-shot CLI uses — including the selector, and
         // the refusal of a multi-recording archive that names none. Server
@@ -1127,6 +1129,45 @@ mod tests {
             no_match.contains(r#"recording {"source": "nope"}"#),
             "the echoed selector must be pasteable as a tool argument: {no_match}"
         );
+    }
+
+    /// An explicit `"recording": null` means "no selector", not an error.
+    ///
+    /// Many MCP clients and LLM tool-call serializers emit an explicit null
+    /// for an omitted optional property. `arguments.get("recording")` returns
+    /// `Some(Value::Null)` for that, which `from_json` rejects as "must be an
+    /// object" — turning a perfectly valid single-recording call into a hard
+    /// failure for a client that did nothing wrong.
+    #[tokio::test]
+    async fn an_explicit_null_recording_means_no_selector() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("one.rez");
+        crate::mcp::tests::multi_recording_rez(&path, &["redis"], &[true]);
+
+        let server = Server::new();
+        let args = json!({"parquet_file": path.to_str().unwrap(), "recording": null});
+        let out = server
+            .describe_recording(&args)
+            .await
+            .expect("an explicit null is an omitted selector, not a bad one");
+        assert!(out.contains("Recording Information"), "{out}");
+    }
+
+    /// The missing-file message is the opener's, so it is the same one the
+    /// CLI prints (see `a_missing_file_says_so_rather_than_failing_in_the_decoder`).
+    #[tokio::test]
+    async fn a_missing_file_reports_the_same_way_as_the_cli() {
+        let server = Server::new();
+        let err = server
+            .get_reader_selected(
+                "/nonexistent/does-not-exist.rez",
+                &crate::mcp::RecordingSelector::default(),
+            )
+            .await
+            .err()
+            .expect("a missing file cannot open")
+            .to_string();
+        assert!(err.contains("Recording file not found"), "{err}");
     }
 
     /// A handler that honors `recording` is invisible if the schema never


### PR DESCRIPTION
## Summary

`record --endpoint a --endpoint b -o out.rez` (#1109) made multi-recording archives an ordinary capture. No MCP tool could read one — #1112's follow-up made them refuse such archives up front, which was honest but not useful: multi-host and A/B captures are exactly the recordings worth analyzing, and the agent-facing tools are where that analysis happens.

Now `describe-recording` lists what an archive holds, each recording with the selector that picks it:

```
$ rezolus mcp describe-recording ab.rez
ab.rez holds 2 recordings with data (a multi-host or A/B archive):
  - host=web-01, source=redis
    select with: --recording source=redis
  - host=web-01, source=valkey
    select with: --recording source=valkey

Run any tool with one of the selectors above to analyze that recording.
```

and every tool takes that selector — `--recording key=value` on the six CLI subcommands (repeatable, ANDed), an optional `recording` object on the six stdio tools.

A selector must name **exactly one** recording. None or several is an error listing the candidates, never a first-match: silently analyzing one arm of an A/B and presenting it as the archive's answer is the failure this design exists to prevent.

## Design

`RecordingSelector` is pure logic in its own module — parse, subset-match, resolve to one index or a typed refusal. Selection resolves in the single `open_source_with_pool_labeled` that the CLI and stdio server share. **That sharing is load-bearing**: the last time this behavior lived in two places, the CLI refused multi-recording archives while the server answered `extract_features` with all 94 metrics `NoData` and a `duration_s` that was the union of two unrelated timelines. `open_source` is now `#[cfg(test)]`, so no production path can re-introduce a selector-less open.

Matching is a **subset** test — `--recording source=redis` selects a recording labelled `{source: redis, host: web-01}` without naming every label. Recordings auto-carry `source` and `host`, so requiring the full set would make selectors long and brittle.

The reader cache is keyed `(path, selector)` with a post-open dedup on the resolved recording's identity, so two spellings that name the same arm share one reader rather than opening the archive twice. Keyed on the path alone — as it was — the second request for a different recording would have been served the first's reader.

## What the reviews found

A quality review ran after each of seven tasks, then two adversarial reviewers went at the whole branch. They found **nine defects, all the same species**: something silently resolving an ambiguity instead of refusing, or reporting a state that was not the true one. Every one was in the plan's code rather than the implementation of it.

The one worth reading, found independently by both adversarial reviewers and reproduced with shipped commands:

**A recording whose labels are a strict subset of another's was advertised a selector that cannot select it.** The unselectable guard tested exact label equality, but matching is subset semantics — so every selector matching `L` also matches `L ∪ {extra}`, and the fallback printed exactly that selector. Pasting it returned "matches 2 recordings; add labels until it names one", which then re-offered the same selector. A closed loop: there are no more labels to add, that recording is genuinely unselectable, and the code had a message for that case which it never reached.

Reachable through the **documented A/B workflow** — `record --label arm=baseline`, `record` without, `recording combine` — and through a single multi-endpoint run where one endpoint's `/systeminfo` fetch fails, dropping `host` from that arm alone.

Also fixed: the stdio server rendered every selector as a `--recording` flag its clients cannot send (the schema nominates `describe_recording` as the discovery step, so the designated path from "I can't read this" to "here's how" ended in an unusable instruction — now rendered as `recording {"source": "redis"}` for JSON callers); `"recording": null` was a hard error where many clients emit explicit null for an absent optional; a selected arm silently lost sampler inference in `extract-features` because `infer` keyed on the arm's user-chosen `source` label; an all-empty archive was described as though it were one recording; and `describe-recording` opened the archive twice, which also carried a TOCTOU on a live buffer.

Earlier tasks fixed: duplicate `k=v` keys silently last-won; an empty arm sharing duplicate labels shadowed the arm holding data; an all-empty archive ignored the selector entirely; `NoMatch` claimed a recording did not exist when it existed and was empty; a listing counted "N recordings" while counting only arms with data; and error text echoed selectors in a comma form that does not parse back.

## Verified safe

All twelve entry points (six CLI subcommands, six stdio tools) checked empirically across four scenarios each — driving the real server over JSON-RPC and the real CLI, hashing per-arm output to confirm the arms genuinely differ. No handler drops the selector; CLI and server outputs are byte-identical. Cache keys cannot alias (typed tuple, `Hash`/`Eq` over a `BTreeMap`); the identity dedup is computed from the resolved recording's own labels, so it cannot return a different recording than the key names. `rezolus mcp server --recording ...` is a clap error, not an accepted-and-ignored flag.

## Test plan

- [x] 820 tests (up from 804 on main), `cargo clippy --all-targets` clean, `cargo fmt --check` clean
- [x] Every fix mutation-checked — reverted, confirmed the matching test fails, restored
- [x] The critical fix reproduced end to end before and after, with shipped commands against a real combined archive
- [x] README listing output is real binary output, not an invented format

## Follow-ups filed rather than grown into this PR

Flag output is not shell-escaped (a label value containing a space splits wrong), and the cache identity can alias if a label value contains `\u{1}`. Both need an operator-chosen label with an unusual character.
