### PR TITLE
refactor: extract the .rez format into its own crate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,10 +180,10 @@ File-level metadata keys are defined in `src/parquet_metadata.rs`:
 
 ### `.rez` Archive Format
 
-The `.rez` format (`src/recorder/rez.rs`, `src/rez_reader.rs`) is a container holding many parquet tables plus a `manifest.json`, rather than a single parquet file. Two container shapes exist and both are readable:
+The `.rez` format (`crates/rez/`: `src/rez.rs`, `src/reader.rs`) is a container holding many parquet tables plus a `manifest.json`, rather than a single parquet file. Two container shapes exist and both are readable:
 
 - **v2 (tar)** — a tar archive with `manifest.json` and one table per sampler (`<recording>/<sampler>.parquet`).
-- **v3 (SQLite)** — a SQLite container (`src/recorder/rez_sqlite.rs`, `src/recorder/rez_v3_writer.rs`) with a real WAL: rows land in the WAL and are periodically sealed into parquet segments. This is what `hindsight` maintains as its rolling buffer, and it is readable live while a writer is still appending.
+- **v3 (SQLite)** — a SQLite container (`crates/rez/src/rez_sqlite.rs`, `crates/rez/src/rez_v3_writer.rs`) with a real WAL: rows land in the WAL and are periodically sealed into parquet segments. This is what `hindsight` maintains as its rolling buffer, and it is readable live while a writer is still appending.
 
 Each sampler records at its own cadence. Table granularity depends on the snapshot format the agent produced:
 
@@ -195,6 +195,25 @@ Either way the query engine consumes the window columns to compute `rate()`/`ira
 Because each sampler records at its own cadence, a query spanning *two samplers of materially different cadence* (measured row spacing differing by at least 2x, with the slower coarser than the step) is evaluated at the **slow sampler's own row timestamps** rather than on the uniform `start + k·step` grid — otherwise nearly every point lands where the slow sampler never read and its value is merely held forward. `RezReader::cross_cadence_eval_timestamps` picks those timestamps and passes them as `QueryOptions::eval_timestamps`; cadence is measured from the rows (never `interval()`, which reports one nominal value for the whole archive) and per *sampler*, since a group that skips ticks is sparse within its sampler's cadence rather than a second cadence. Single-sampler queries and `RateMode::Raw` are untouched.
 
 A `.rez` requires every endpoint to be rezolus/msgpack to produce (not Prometheus), but any number of them. The manifest carries per-recording label sets (`source`/`host` auto-populated, plus any `record --label k=v`, which applies to every recording in the run); a multi-recording `.rez` — built live by `record --endpoint a --endpoint b -o out.rez`, or offline by `parquet combine` — drives the viewer's A/B comparison, aliasing baseline/experiment from each recording's `arm`/`host` labels. The seal stagger keys on sampler + the recording's canonical label set (`seal_policy::recording_stagger_key`), so two recordings of the same agent do not seal in lockstep; identical label sets warn at startup.
+
+### `.rez` lives in its own crate
+
+`crates/rez` holds the whole format — container (v2 tar, v3 SQLite), writers,
+and the `RezReader` that presents an archive as a `metriken_query::MetricsSource`.
+It is a workspace crate rather than a module of the binary because `rezolus` is
+**binary-only** (no `lib` target), so nothing can depend on it: a reader living
+there was reachable by the server viewer and by nothing else, which is why the
+static-site WASM viewer has never opened a `.rez`.
+
+The binary re-exports the modules under the paths call sites already use
+(`crate::recorder::rez`, `crate::rez_reader`, …), so `.rez` code reads the same
+from inside `rezolus`.
+
+Fixture builders (`rez::rez::recorder_tests_support`, and the tar writer
+`rez_stream`) sit behind the crate's `test-support` feature rather than
+`#[cfg(test)]` — a `#[cfg(test)]` module in `rez` is invisible to the binary
+crate's tests, which build most `.rez` fixtures in this repo. The binary enables
+that feature as a dev-dependency.
 
 ### Service Extensions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,6 +2956,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rez"
+version = "0.1.0"
+dependencies = [
+ "arrow",
+ "bytes",
+ "histogram",
+ "metriken",
+ "metriken-exposition",
+ "metriken-query",
+ "parquet",
+ "rmp-serde",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "rezolus"
 version = "5.19.1-alpha.2"
 dependencies = [
@@ -3006,6 +3026,7 @@ dependencies = [
  "regex",
  "report-save",
  "reqwest",
+ "rez",
  "rmp-serde",
  "rusqlite",
  "rustfft",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/dashboard", "crates/report-save", "crates/systeminfo", "crates/viewer"]
+members = [".", "crates/dashboard", "crates/report-save", "crates/rez", "crates/systeminfo", "crates/viewer"]
 exclude = ["xtask"]
 resolver = "2"
 
@@ -22,6 +22,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
 dashboard = { path = "crates/dashboard" }
+rez = { path = "crates/rez" }
 report-save = { path = "crates/report-save" }
 include_dir = "0.7.4"
 walkdir = "2.5.0"
@@ -90,6 +91,7 @@ reqwest = { version = "0.13.3", default-features = false, features = [
 ] }
 # `bundled` compiles SQLite from source: slower builds, but no runtime system
 # dependency, which is what the `.deb` in [package.metadata.deb] needs.
+rez.workspace = true
 rusqlite = { version = "0.40", features = ["bundled", "blob"] }
 rustls = { version = "0.23", default-features = false, features = [
     "logging",
@@ -139,6 +141,12 @@ report-save.workspace = true
 systeminfo = { path = "crates/systeminfo" }
 walkdir.workspace = true
 tar = { version = "0.4.45", default-features = false }
+
+[dev-dependencies]
+# The binary's own tests build `.rez` fixtures with the format crate's shared
+# builders. A `#[cfg(test)]` module over there would be invisible here, so they
+# live behind a feature that only the test build turns on.
+rez = { workspace = true, features = ["test-support"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.26.2" }

--- a/crates/rez/Cargo.toml
+++ b/crates/rez/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "rez"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
+
+[dependencies]
+arrow = "58.2.0"
+bytes = "1"
+histogram.workspace = true
+metriken.workspace = true
+metriken-exposition.workspace = true
+metriken-query = { workspace = true, features = ["ingest"] }
+parquet = { version = "58.2.0", default-features = false, features = [
+    "arrow",
+    "simdutf8",
+    "zstd",
+    # `Compression::LZ4_RAW`, the codec `.rez` segments are written with. Pulls
+    # in `lz4_flex` (pure Rust, no C). See `rez::segment_writer_props`.
+    "lz4",
+] }
+rusqlite = { version = "0.40", features = ["bundled", "blob"] }
+rmp-serde = "1.3.1"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tar = { version = "0.4.45", default-features = false }
+tempfile = "3"
+tracing = "0.1"
+
+[features]
+# Fixture builders used by the binary crate's tests. Not `#[cfg(test)]`,
+# because a `#[cfg(test)]` module in THIS crate is invisible to the crate
+# under test next door.
+test-support = []
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/rez/src/lib.rs
+++ b/crates/rez/src/lib.rs
@@ -1,0 +1,21 @@
+//! The `.rez` archive format: container, writers, and reader.
+//!
+//! Extracted from the `rezolus` binary so the WASM viewer can read the same
+//! archives the binary writes. `rezolus` is a binary-only crate with no `lib`
+//! target, so nothing could depend on it; a `.rez` reader living there was
+//! reachable by the server viewer and by nothing else, which is why the
+//! static-site viewer has never opened a `.rez` at all.
+//!
+//! Nothing here knows about samplers, endpoints, or the CLI — it speaks in
+//! recordings, tables, segments, and bytes.
+
+pub mod reader;
+pub mod rez;
+pub mod rez_sqlite;
+/// The tar (v1/v2) `.rez` writer, kept only so tests can build v1/v2 fixtures.
+/// Nothing ships that writes this container any more.
+#[cfg(any(test, feature = "test-support"))]
+pub mod rez_stream;
+pub mod rez_v3_rewrite;
+pub mod rez_v3_writer;
+pub mod seal_policy;

--- a/crates/rez/src/reader.rs
+++ b/crates/rez/src/reader.rs
@@ -51,9 +51,9 @@ use metriken_query::{
     SegmentedParquetReader, UnionChild, UnionError, UnionMetricsSource,
 };
 
-use crate::recorder::rez::{self, RecordingBytes};
-use crate::recorder::rez_sqlite::RezDb;
-use crate::recorder::rez_v3_writer::materialize_wal_tail;
+use crate::rez::{self, RecordingBytes};
+use crate::rez_sqlite::RezDb;
+use crate::rez_v3_writer::materialize_wal_tail;
 
 /// The two concrete reader shapes a `.rez` table opens as, kept concrete
 /// (not type-erased behind `Box<dyn MetricsSource>`) so a same-timeline
@@ -847,7 +847,7 @@ impl RezReader {
         step_s: f64,
         rate_mode: RateMode,
     ) -> Option<Arc<[u64]>> {
-        use crate::recorder::rez::table_sampler;
+        use crate::rez::table_sampler;
 
         if matches!(rate_mode, RateMode::Raw) {
             return None;
@@ -1142,7 +1142,7 @@ fn union_sorted(iters: impl Iterator<Item = Vec<String>>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::recorder::rez::RezRecorder;
+    use crate::rez::RezRecorder;
     use metriken::Window;
     use metriken_exposition::{Counter, Gauge, Snapshot, SnapshotV2};
     use std::time::SystemTime;
@@ -1236,8 +1236,8 @@ mod tests {
     /// Write the same `rows` through the streaming writer with a tiny row cap,
     /// so every table seals into several segments.
     fn write_streamed_rez(rows: &[(Snapshot, u64)], max_rows: usize, out: &std::path::Path) {
-        use crate::recorder::rez_stream::{ManifestSeed, RezWriterHandle, StreamRecorder};
-        use crate::recorder::seal_policy::SealPolicy;
+        use crate::rez_stream::{ManifestSeed, RezWriterHandle, StreamRecorder};
+        use crate::seal_policy::SealPolicy;
 
         let handle = RezWriterHandle::create(
             out,
@@ -1268,7 +1268,7 @@ mod tests {
 
     /// `sampler -> segment count` for a written archive.
     fn segment_counts(path: &std::path::Path) -> BTreeMap<String, usize> {
-        let (manifest, _) = crate::recorder::rez::read_archive_bytes(path).unwrap();
+        let (manifest, _) = crate::rez::read_archive_bytes(path).unwrap();
         manifest.recordings[0]
             .tables
             .iter()
@@ -1355,8 +1355,8 @@ mod tests {
     /// multi-segment and `RezReader` opens it with the segment-aware source —
     /// the reader that implements the `__run__` conflict policy.
     fn segmented_histogram_rez(n: u64, max_rows: usize, out: &std::path::Path) {
-        use crate::recorder::rez_stream::{ManifestSeed, RezWriterHandle, StreamRecorder};
-        use crate::recorder::seal_policy::SealPolicy;
+        use crate::rez_stream::{ManifestSeed, RezWriterHandle, StreamRecorder};
+        use crate::seal_policy::SealPolicy;
         use metriken_exposition::Histogram as ExpHistogram;
 
         let handle = RezWriterHandle::create(
@@ -1462,7 +1462,7 @@ mod tests {
         // Build a 2-recording .rez by reading a 1-recording fixture and writing
         // it twice under distinct dirs/arms via write_archive_bytes.
         let (_d, p) = two_sampler_rez();
-        let (m, rb) = crate::recorder::rez::read_archive_bytes(&p).unwrap();
+        let (m, rb) = crate::rez::read_archive_bytes(&p).unwrap();
         let rec0 = m.recordings.into_iter().next().unwrap();
         let bytes0: Vec<Vec<Vec<u8>>> = rb
             .into_iter()
@@ -1482,8 +1482,7 @@ mod tests {
 
         let d = tempfile::tempdir().unwrap();
         let out = d.path().join("two_rec.rez");
-        crate::recorder::rez::write_archive_bytes(&out, &[(a, bytes0.clone()), (b, bytes0)])
-            .unwrap();
+        crate::rez::write_archive_bytes(&out, &[(a, bytes0.clone()), (b, bytes0)]).unwrap();
 
         let pool = BufferPool::new(64 * 1024 * 1024);
         let readers = RezReader::open_recordings(&out, pool).unwrap();
@@ -1505,7 +1504,7 @@ mod tests {
     #[test]
     fn multi_recording_same_sampler_query_errors_instead_of_silently_dropping_one_recording() {
         let (_d, p) = two_sampler_rez();
-        let (m, rb) = crate::recorder::rez::read_archive_bytes(&p).unwrap();
+        let (m, rb) = crate::rez::read_archive_bytes(&p).unwrap();
         let rec0 = m.recordings.into_iter().next().unwrap();
         let bytes0: Vec<Vec<Vec<u8>>> = rb
             .into_iter()
@@ -1525,8 +1524,7 @@ mod tests {
 
         let d = tempfile::tempdir().unwrap();
         let out = d.path().join("two_rec.rez");
-        crate::recorder::rez::write_archive_bytes(&out, &[(a, bytes0.clone()), (b, bytes0)])
-            .unwrap();
+        crate::rez::write_archive_bytes(&out, &[(a, bytes0.clone()), (b, bytes0)]).unwrap();
 
         let pool = BufferPool::new(64 * 1024 * 1024);
         // The flattening path — NOT open_recordings.
@@ -1715,11 +1713,11 @@ mod tests {
 
     mod v3 {
         use super::*;
-        use crate::recorder::rez_sqlite::WalRow;
-        use crate::recorder::rez_v3_writer::{
+        use crate::rez_sqlite::WalRow;
+        use crate::rez_v3_writer::{
             encode_wal_row, ManifestSeed, RezArchive, StreamRecorderV3, WalCell, WalValue,
         };
-        use crate::recorder::seal_policy::SealPolicy;
+        use crate::seal_policy::SealPolicy;
         use metriken_exposition::Histogram as ExpHistogram;
 
         const ANCHOR: u64 = 1_700_000_000_000_000_000;

--- a/crates/rez/src/rez.rs
+++ b/crates/rez/src/rez.rs
@@ -121,9 +121,9 @@ use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 // Only the test-only eager reader (read_table_parquet) needs these.
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 use arrow::array::ListArray;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 /// Per-metric column values for a table (row-aligned with the table's timestamps).
@@ -370,7 +370,7 @@ fn table_to_batch(table: &RezTable) -> Result<(Arc<Schema>, RecordBatch), RezErr
 /// bound per-column-writer memory and none of them measurably does, while
 /// chunk-level statistics costs finalize latency and read pruning. The
 /// dictionary is the whole effect.
-pub(crate) fn segment_writer_props() -> WriterProperties {
+pub fn segment_writer_props() -> WriterProperties {
     WriterProperties::builder()
         .set_compression(Compression::LZ4_RAW)
         .set_dictionary_enabled(false)
@@ -387,7 +387,7 @@ pub fn write_table_parquet(table: &RezTable) -> Result<Vec<u8>, RezError> {
     Ok(buf)
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 fn u64_col(a: &ArrayRef) -> &UInt64Array {
     a.as_any()
         .downcast_ref::<UInt64Array>()
@@ -398,7 +398,7 @@ fn u64_col(a: &ArrayRef) -> &UInt64Array {
 /// path decodes tables lazily via metriken-query's `ParquetReader`
 /// (`read_archive_bytes` → `RezReader`); this eager decoder exists to verify
 /// the write path independently.
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub fn read_table_parquet(sampler: String, bytes: Vec<u8>) -> Result<RezTable, RezError> {
     let reader = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(bytes))?.build()?;
 
@@ -606,7 +606,7 @@ pub struct RezArchive {
     pub tables: Vec<Vec<RezTable>>,
 }
 
-pub(crate) fn append_tar_entry<W: std::io::Write>(
+pub fn append_tar_entry<W: std::io::Write>(
     builder: &mut tar::Builder<W>,
     name: &str,
     bytes: &[u8],
@@ -1050,28 +1050,28 @@ use metriken_exposition::{Counter, Gauge, Histogram, Snapshot};
 use tracing::warn;
 
 /// A borrowed snapshot entry, tagged by shape.
-pub(crate) enum Entry<'a> {
+pub enum Entry<'a> {
     Counter(&'a Counter),
     Gauge(&'a Gauge),
     Histogram(&'a Histogram),
 }
 
 impl Entry<'_> {
-    pub(crate) fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         match self {
             Entry::Counter(c) => &c.name,
             Entry::Gauge(g) => &g.name,
             Entry::Histogram(h) => &h.name,
         }
     }
-    pub(crate) fn metadata(&self) -> &HashMap<String, String> {
+    pub fn metadata(&self) -> &HashMap<String, String> {
         match self {
             Entry::Counter(c) => &c.metadata,
             Entry::Gauge(g) => &g.metadata,
             Entry::Histogram(h) => &h.metadata,
         }
     }
-    pub(crate) fn window(&self) -> Option<Window> {
+    pub fn window(&self) -> Option<Window> {
         match self {
             Entry::Counter(c) => c.window,
             Entry::Gauge(g) => g.window,
@@ -1125,7 +1125,7 @@ const HISTOGRAM_BUCKET_BYTES: usize = 8;
 /// A cell whose shape does not match its column's established type is skipped
 /// by `push_row` and charged nothing here, for the same reason: it is not
 /// stored.
-pub(crate) fn entries_approx_bytes(entries: &[Entry<'_>]) -> usize {
+pub fn entries_approx_bytes(entries: &[Entry<'_>]) -> usize {
     entries
         .iter()
         .map(|e| match e {
@@ -1139,7 +1139,7 @@ pub(crate) fn entries_approx_bytes(entries: &[Entry<'_>]) -> usize {
 
 /// A growing per-sampler table. Columns are sparse: shorter than the row count
 /// until padded (a metric absent in some rows gets `None` there).
-pub(crate) struct TableBuilder {
+pub struct TableBuilder {
     sampler: String,
     timestamps: Vec<u64>,
     wall_offsets: Vec<i64>,
@@ -1153,7 +1153,7 @@ pub(crate) struct TableBuilder {
 }
 
 impl TableBuilder {
-    pub(crate) fn new(sampler: String) -> Self {
+    pub fn new(sampler: String) -> Self {
         Self {
             sampler,
             timestamps: Vec::new(),
@@ -1181,7 +1181,7 @@ impl TableBuilder {
     /// so both containers reach it identically. This is what
     /// `entries_approx_bytes_matches_what_push_row_accounts` pins that against.
     #[cfg(test)]
-    pub(crate) fn approx_bytes(&self) -> usize {
+    pub fn approx_bytes(&self) -> usize {
         self.approx_bytes
     }
 
@@ -1189,11 +1189,11 @@ impl TableBuilder {
     /// "never seal an empty builder" test).
     /// Rows appended so far.
     ///
-    /// `#[cfg(test)]` because its only caller is the tar writer, which is
-    /// itself test-only now — the v3 writer rebuilds a table from the WAL at
+    /// Gated because its only caller is the tar writer, which is itself a
+    /// fixture-only path now — the v3 writer rebuilds a table from the WAL at
     /// seal time and never asks a builder how full it is.
-    #[cfg(test)]
-    pub(crate) fn rows(&self) -> usize {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn rows(&self) -> usize {
         self.timestamps.len()
     }
 
@@ -1220,12 +1220,7 @@ impl TableBuilder {
     /// `wall_offset_ns` the wall-clock observation for that tick (raw
     /// `SystemTime` reading minus `snapshot_ts`), stored once per row in the
     /// table-level `:wall_offset` sidecar.
-    pub(crate) fn push_row(
-        &mut self,
-        snapshot_ts: u64,
-        wall_offset_ns: i64,
-        entries: &[Entry<'_>],
-    ) {
+    pub fn push_row(&mut self, snapshot_ts: u64, wall_offset_ns: i64, entries: &[Entry<'_>]) {
         let row = self.timestamps.len();
         self.timestamps.push(snapshot_ts);
         self.wall_offsets.push(wall_offset_ns);
@@ -1320,7 +1315,7 @@ impl TableBuilder {
     /// This runs on the scrape thread, so its cost is bounded deliberately: one
     /// realloc-and-copy per column, and the transient double-allocation a
     /// shrink needs is one column's worth, never the whole table's.
-    pub(crate) fn finish(mut self) -> RezTable {
+    pub fn finish(mut self) -> RezTable {
         let rows = self.timestamps.len();
         let columns = self
             .order
@@ -1357,7 +1352,7 @@ impl TableBuilder {
 /// an absent (`None`) slot — "registered, no reading this tick" per
 /// `GroupSnapshot`'s doc — costs nothing, matching `entries_approx_bytes`'
 /// "only counted cells" rule.
-pub(crate) fn group_approx_bytes(g: &metriken_exposition::GroupSnapshot) -> usize {
+pub fn group_approx_bytes(g: &metriken_exposition::GroupSnapshot) -> usize {
     let mut bytes = WINDOW_SLOT_BYTES;
     bytes += g.counters.iter().filter(|v| v.is_some()).count() * VALUE_SLOT_BYTES;
     bytes += g.gauges.iter().filter(|v| v.is_some()).count() * VALUE_SLOT_BYTES;
@@ -1374,7 +1369,7 @@ pub(crate) fn group_approx_bytes(g: &metriken_exposition::GroupSnapshot) -> usiz
 /// sparse and keyed by name — a schema-hash change mid-table (a cgroup
 /// added/removed) is handled the same lazy-padding way `TableBuilder`
 /// handles a metric appearing or vanishing.
-pub(crate) struct GroupTableBuilder {
+pub struct GroupTableBuilder {
     name: String,
     timestamps: Vec<u64>,
     wall_offsets: Vec<i64>,
@@ -1388,7 +1383,7 @@ pub(crate) struct GroupTableBuilder {
 }
 
 impl GroupTableBuilder {
-    pub(crate) fn new(name: String) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
             name,
             reported_bad_histograms: HashSet::new(),
@@ -1403,7 +1398,7 @@ impl GroupTableBuilder {
     /// Rows pushed so far — lets a caller that skipped some input rows (an
     /// un-anchored WAL tail) tell "nothing pushed at all" from "pushed a
     /// partial table" without inspecting the finished `RezTable`.
-    pub(crate) fn rows(&self) -> usize {
+    pub fn rows(&self) -> usize {
         self.timestamps.len()
     }
 
@@ -1471,7 +1466,7 @@ impl GroupTableBuilder {
     /// `histogram::Histogram::from_buckets` can fail on a malformed payload.
     /// Errors rather than panics, matching the v2 writer's WAL-recovery path.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn push_row(
+    pub fn push_row(
         &mut self,
         ts: u64,
         wall_offset_ns: i64,
@@ -1566,7 +1561,7 @@ impl GroupTableBuilder {
     /// Consume the builder into the table the writer will encode. Mirrors
     /// `TableBuilder::finish`, but stamps `table_window` (`Some`) instead of
     /// leaving each column's `windows` populated.
-    pub(crate) fn finish(mut self) -> RezTable {
+    pub fn finish(mut self) -> RezTable {
         let rows = self.timestamps.len();
         let columns = self
             .order
@@ -1673,7 +1668,7 @@ mod table_sampler_tests {
 /// Partition a snapshot's metrics by their `sampler` label (`"unattributed"`
 /// when the label is absent). Shared by the in-memory `RezRecorder` and the
 /// streaming `StreamRecorder` so the two ingest paths cannot drift apart.
-pub(crate) fn group_by_sampler(snapshot: &Snapshot) -> BTreeMap<&str, Vec<Entry<'_>>> {
+pub fn group_by_sampler(snapshot: &Snapshot) -> BTreeMap<&str, Vec<Entry<'_>>> {
     let (counters, gauges, histograms) = match snapshot {
         Snapshot::V1(s) => (&s.counters, &s.gauges, &s.histograms),
         Snapshot::V2(s) => (&s.counters, &s.gauges, &s.histograms),
@@ -1731,7 +1726,7 @@ pub(crate) fn group_by_sampler(snapshot: &Snapshot) -> BTreeMap<&str, Vec<Entry<
 /// One sampler group's dedup key: the representative acquisition window (max
 /// `end_ns` among windowed metrics), or `snapshot_ts` when nothing in the group
 /// carries a window (windowless → one row per poll).
-pub(crate) fn dedup_key(entries: &[Entry<'_>], snapshot_ts: u64) -> u64 {
+pub fn dedup_key(entries: &[Entry<'_>], snapshot_ts: u64) -> u64 {
     entries
         .iter()
         .filter_map(|e| e.window())
@@ -1799,7 +1794,7 @@ impl RezRecorder {
 
     /// Test/inspection helper: the current (unpadded) table builder view.
     #[cfg(test)]
-    pub(crate) fn table(&self, sampler: &str) -> Option<&TableBuilder> {
+    pub fn table(&self, sampler: &str) -> Option<&TableBuilder> {
         self.tables.get(sampler)
     }
 
@@ -1910,12 +1905,6 @@ pub fn recording_dir_slug(labels: &BTreeMap<String, String>) -> String {
     } else {
         slug
     }
-}
-
-/// True when the recording should be written as a `.rez` archive: either the
-/// output path ends in `.rez` or `--format rez` was given.
-pub fn wants_rez(format: crate::Format) -> bool {
-    format == crate::Format::Rez
 }
 
 #[cfg(test)]
@@ -2145,15 +2134,47 @@ mod builder_tests {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod recorder_tests_support {
-    pub use super::recorder_tests::{counter, snap};
+/// Fixture builders shared by this crate's tests and the `rezolus` binary's.
+///
+/// Gated on `test-support` rather than `#[cfg(test)]`: a `#[cfg(test)]` module
+/// here is invisible to the crate next door, and the binary's viewer, MCP and
+/// `parquet` tests all build `.rez` fixtures with these.
+#[cfg(any(test, feature = "test-support"))]
+pub mod recorder_tests_support {
+    use metriken::Window;
+    use metriken_exposition::{Counter, Snapshot, SnapshotV2};
+    use std::collections::HashMap;
+    use std::time::SystemTime;
+
+    fn cmeta(metric: &str, sampler: &str) -> HashMap<String, String> {
+        [
+            ("metric".to_string(), metric.to_string()),
+            ("sampler".to_string(), sampler.to_string()),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    pub fn snap(ts: u64, counters: Vec<Counter>) -> Snapshot {
+        Snapshot::V2(SnapshotV2 {
+            systemtime: SystemTime::UNIX_EPOCH + std::time::Duration::from_nanos(ts),
+            duration: std::time::Duration::ZERO,
+            metadata: HashMap::new(),
+            counters,
+            gauges: Vec::new(),
+            histograms: Vec::new(),
+        })
+    }
+
+    pub fn counter(name: &str, sampler: &str, value: u64, window: Option<Window>) -> Counter {
+        Counter::new(name.to_string(), value, cmeta(name, sampler)).with_window(window)
+    }
 
     /// Create a minimal, valid, empty v3 `.rez` at `path` (one recording, no
     /// sampler tables yet) — the cheapest fixture for tests across the crate
     /// that just need `detect_rez_format(path)` to see `V3Sqlite`.
-    pub(crate) fn empty_v3_rez(path: &std::path::Path) {
-        use crate::recorder::rez_v3_writer::{ManifestSeed, RezArchive};
+    pub fn empty_v3_rez(path: &std::path::Path) {
+        use crate::rez_v3_writer::{ManifestSeed, RezArchive};
         let seed = ManifestSeed {
             labels: [("source".to_string(), "rezolus".to_string())]
                 .into_iter()
@@ -2173,8 +2194,8 @@ pub(crate) mod recorder_tests_support {
     /// wrong arm still returns *some* series, so a test asserting only that
     /// data came back would pass either way; distinguishable values make the
     /// wrong arm fail.
-    pub(crate) fn multi_recording_v3_rez(path: &std::path::Path, recordings: &[(&str, &str)]) {
-        use crate::recorder::rez_v3_writer::{ManifestSeed, RezArchive, StreamRecorderV3};
+    pub fn multi_recording_v3_rez(path: &std::path::Path, recordings: &[(&str, &str)]) {
+        use crate::rez_v3_writer::{ManifestSeed, RezArchive, StreamRecorderV3};
         use metriken::Window;
         const ANCHOR: u64 = 1_700_000_000_000_000_000;
 
@@ -2224,13 +2245,8 @@ pub(crate) mod recorder_tests_support {
     /// Real rows, not an empty catalog: the rewrite tools copy segments and
     /// materialize WAL tails, so a fixture with no data would exercise
     /// neither.
-    pub(crate) fn populated_v3_rez(
-        path: &std::path::Path,
-        arm: &str,
-        samplers: &[&str],
-        ticks: u64,
-    ) {
-        use crate::recorder::rez_v3_writer::{ManifestSeed, RezArchive, StreamRecorderV3};
+    pub fn populated_v3_rez(path: &std::path::Path, arm: &str, samplers: &[&str], ticks: u64) {
+        use crate::rez_v3_writer::{ManifestSeed, RezArchive, StreamRecorderV3};
         const ANCHOR: u64 = 1_700_000_000_000_000_000;
         let seed = ManifestSeed {
             labels: [
@@ -2265,33 +2281,11 @@ pub(crate) mod recorder_tests_support {
 mod recorder_tests {
     use super::*;
     use metriken::Window;
-    use metriken_exposition::{Counter, Snapshot, SnapshotV2};
+    use metriken_exposition::Snapshot;
     use std::collections::HashMap;
     use std::time::SystemTime;
 
-    fn cmeta(metric: &str, sampler: &str) -> HashMap<String, String> {
-        [
-            ("metric".to_string(), metric.to_string()),
-            ("sampler".to_string(), sampler.to_string()),
-        ]
-        .into_iter()
-        .collect()
-    }
-
-    pub fn snap(ts: u64, counters: Vec<Counter>) -> Snapshot {
-        Snapshot::V2(SnapshotV2 {
-            systemtime: SystemTime::UNIX_EPOCH + std::time::Duration::from_nanos(ts),
-            duration: std::time::Duration::ZERO,
-            metadata: HashMap::new(),
-            counters,
-            gauges: Vec::new(),
-            histograms: Vec::new(),
-        })
-    }
-
-    pub fn counter(name: &str, sampler: &str, value: u64, window: Option<Window>) -> Counter {
-        Counter::new(name.to_string(), value, cmeta(name, sampler)).with_window(window)
-    }
+    use super::recorder_tests_support::{counter, snap};
 
     // Interim behavior until native V3 ingest lands: a V3 payload here means
     // the agent was flipped ahead of this recorder build, so group_by_sampler
@@ -3027,7 +3021,7 @@ mod archive_tests {
 
         // v3: a SQLite database created by the v3 container module.
         let v3 = dir.path().join("v3.rez");
-        drop(crate::recorder::rez_sqlite::RezDb::create(&v3).unwrap());
+        drop(crate::rez_sqlite::RezDb::create(&v3).unwrap());
         assert_eq!(detect_rez_format(&v3).unwrap(), RezFormat::V3Sqlite);
 
         // v2: an actual tar archive, built the way the other tests here do.
@@ -3057,7 +3051,7 @@ mod archive_tests {
         assert!(is_rez_path(&v2).unwrap());
 
         let v3 = dir.path().join("v3.rez");
-        drop(crate::recorder::rez_sqlite::RezDb::create(&v3).unwrap());
+        drop(crate::rez_sqlite::RezDb::create(&v3).unwrap());
         // A v3 file is NOT a tar, so the legacy sniff correctly says false.
         // This is why callers must migrate to detect_rez_format rather than
         // having is_rez_path silently start returning true for SQLite files.
@@ -3517,24 +3511,6 @@ mod finalize_tests {
             other => panic!("expected gauge column, got {other:?}"),
         }
         assert_eq!(t.columns[0].windows, vec![Some(w)]);
-    }
-}
-
-#[cfg(test)]
-mod selection_tests {
-    use super::*;
-    use crate::Format;
-
-    /// The `.rez` extension is folded into the format by
-    /// `RecordingConfig::resolve_format_and_output`, so by the time the
-    /// recorder asks, the format is the only thing left to consult — an
-    /// extension that disagreed with an explicit `--format` was rejected at
-    /// parse time rather than quietly overriding it here.
-    #[test]
-    fn format_alone_selects_rez() {
-        assert!(wants_rez(Format::Rez));
-        assert!(!wants_rez(Format::Parquet));
-        assert!(!wants_rez(Format::Raw));
     }
 }
 

--- a/crates/rez/src/rez_sqlite.rs
+++ b/crates/rez/src/rez_sqlite.rs
@@ -25,7 +25,7 @@ use rusqlite::{Connection, OpenFlags};
 /// where it hurts: every tick commits a small WAL row, so write amplification
 /// scales with the page size. Optimize for the per-tick write, not the bulk
 /// read.
-pub(crate) const PAGE_SIZE: u32 = 4096;
+pub const PAGE_SIZE: u32 = 4096;
 
 /// Cap the `-wal` sidecar by BYTES, not pages. At `PAGE_SIZE` this is close to
 /// SQLite's own ~1000-page default, so it changes nothing today — it exists so
@@ -78,7 +78,7 @@ const SCHEMA_VERSION: i64 = 3;
 
 /// One recording's identity: everything known when the recording starts.
 #[derive(Clone)]
-pub(crate) struct RecordingMeta {
+pub struct RecordingMeta {
     pub labels: BTreeMap<String, String>,
     pub metadata: BTreeMap<String, String>,
     /// Wall-clock reading (ns since epoch) at recording start. Row timestamps
@@ -87,7 +87,7 @@ pub(crate) struct RecordingMeta {
 }
 
 /// A row of the `recordings` table.
-pub(crate) struct RecordingRow {
+pub struct RecordingRow {
     pub id: i64,
     pub meta: RecordingMeta,
     /// Whether the recording was cleanly finalized. This is what replaced the
@@ -99,14 +99,14 @@ pub(crate) struct RecordingRow {
 /// The catalog facts about one sealed segment. The segment's own bytes are an
 /// opaque parquet BLOB the database never looks inside — this is everything
 /// SQLite is asked to know about it.
-pub(crate) struct SegmentMeta {
+pub struct SegmentMeta {
     pub rows: u64,
     pub first_ts: u64,
     pub last_ts: u64,
 }
 
 /// A row of the `segments` table for one `(recording, sampler)`.
-pub(crate) struct SegmentRow {
+pub struct SegmentRow {
     pub seq: u64,
     pub meta: SegmentMeta,
     pub bytes: Vec<u8>,
@@ -119,7 +119,7 @@ pub(crate) struct SegmentRow {
 /// unchanged every tick, so carrying them per row costs several times the
 /// payload for nothing. They are re-anchored once per segment instead — see
 /// `WalCell`.
-pub(crate) struct WalRow {
+pub struct WalRow {
     pub sampler: String,
     pub ts: u64,
     pub wall_offset: i64,
@@ -130,7 +130,7 @@ pub(crate) struct WalRow {
 /// can tell "the window moved" from "nothing was old enough yet" — and so a
 /// test can assert the WAL rows went with their segments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub(crate) struct Evicted {
+pub struct Evicted {
     pub segments: usize,
     pub wal_rows: usize,
 }
@@ -138,7 +138,7 @@ pub(crate) struct Evicted {
 /// How many rows a table holds and what time span they cover, answered from
 /// catalog columns alone — no segment or WAL payload is read. `first_ts` and
 /// `last_ts` are `None` when `rows` is 0.
-pub(crate) struct Span {
+pub struct Span {
     pub rows: u64,
     pub first_ts: Option<u64>,
     pub last_ts: Option<u64>,
@@ -156,7 +156,7 @@ const LIVE_WAL_PREDICATE: &str = "recording_id = ?1 AND sampler = ?2 \
            0)";
 
 /// An open handle on a `.rez` v3 file.
-pub(crate) struct RezDb {
+pub struct RezDb {
     conn: Connection,
 }
 
@@ -167,7 +167,7 @@ impl RezDb {
     /// Fails if `path` already exists: a `.rez` is valid from creation, so there
     /// is no `.partial` staging file standing between a new recording and a
     /// previous one.
-    pub(crate) fn create(path: &Path) -> Result<Self, String> {
+    pub fn create(path: &Path) -> Result<Self, String> {
         Self::create_with_page_size(path, PAGE_SIZE)
     }
 
@@ -235,7 +235,7 @@ impl RezDb {
     }
 
     /// Open an existing `.rez`, reapplying the per-connection pragmas.
-    pub(crate) fn open(path: &Path) -> Result<Self, String> {
+    pub fn open(path: &Path) -> Result<Self, String> {
         // No `SQLITE_OPEN_CREATE`: opening a `.rez` that is not there is an
         // error, not an empty new recording.
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)
@@ -311,13 +311,13 @@ impl RezDb {
     }
 
     /// Start a recording, returning its id.
-    pub(crate) fn insert_recording(&self, meta: &RecordingMeta) -> Result<i64, String> {
+    pub fn insert_recording(&self, meta: &RecordingMeta) -> Result<i64, String> {
         insert_recording_sql(&self.conn, meta)
     }
 
     /// Every recording in the file, in insertion order. A `.rez` may hold
     /// several (multi-host, or an A/B pair).
-    pub(crate) fn read_recordings(&self) -> Result<Vec<RecordingRow>, String> {
+    pub fn read_recordings(&self) -> Result<Vec<RecordingRow>, String> {
         let mut stmt = self
             .conn
             .prepare(
@@ -373,7 +373,7 @@ impl RezDb {
     /// prune runs outside the seal transaction" is made unrepresentable rather
     /// than merely documented — inside it, a quiet sampler's accumulated rows
     /// make the delete long enough to threaten the tick.
-    pub(crate) fn transaction<T>(
+    pub fn transaction<T>(
         &mut self,
         f: impl FnOnce(&RezTx<'_>) -> Result<T, String>,
     ) -> Result<T, String> {
@@ -394,7 +394,7 @@ impl RezDb {
 
     /// Insert one sealed segment's bytes and catalog facts, committing on its
     /// own. Batch writers should use `transaction` instead.
-    pub(crate) fn insert_segment(
+    pub fn insert_segment(
         &self,
         recording_id: i64,
         sampler: &str,
@@ -426,7 +426,7 @@ impl RezDb {
     /// table at open (`time_range` is asked before any query runs) and the
     /// payload for almost none of them, so the two questions get separate
     /// queries.
-    pub(crate) fn read_segment_meta(
+    pub fn read_segment_meta(
         &self,
         recording_id: i64,
         sampler: &str,
@@ -456,7 +456,7 @@ impl RezDb {
 
     /// One segment's payload, by sequence number — for the reader's name probe,
     /// which needs a single segment's schema and none of the rest.
-    pub(crate) fn read_segment_bytes(
+    pub fn read_segment_bytes(
         &self,
         recording_id: i64,
         sampler: &str,
@@ -481,7 +481,7 @@ impl RezDb {
         }
     }
 
-    pub(crate) fn read_segments(
+    pub fn read_segments(
         &self,
         recording_id: i64,
         sampler: &str,
@@ -546,7 +546,7 @@ impl RezDb {
     /// selecting part of one would mean decoding and re-encoding it — the cost
     /// the container exists to avoid. A caller gets a little more than it asked
     /// for at each edge and should report the span it actually got.
-    pub(crate) fn segments_overlapping(
+    pub fn segments_overlapping(
         &self,
         recording_id: i64,
         sampler: &str,
@@ -584,7 +584,7 @@ impl RezDb {
     /// `f` gets `&Self`, so it may call any reader here; it must not write
     /// through this handle, which is why this is not exposed as a general
     /// transaction.
-    pub(crate) fn read_snapshot<T>(
+    pub fn read_snapshot<T>(
         &self,
         f: impl FnOnce(&Self) -> Result<T, String>,
     ) -> Result<T, String> {
@@ -603,7 +603,7 @@ impl RezDb {
     /// Sum of `rows` across every segment for `(recording_id, sampler)`. Does
     /// not include WAL rows — callers combining sealed and unsealed row
     /// counts must add `live_wal().len()` themselves.
-    pub(crate) fn total_rows(&self, recording_id: i64, sampler: &str) -> Result<u64, String> {
+    pub fn total_rows(&self, recording_id: i64, sampler: &str) -> Result<u64, String> {
         let total: i64 = self
             .conn
             .query_row(
@@ -619,7 +619,7 @@ impl RezDb {
     /// alphabetically. A sampler with only unsealed WAL rows and no sealed
     /// segment yet will NOT appear here — use `all_samplers` for "every
     /// sampler this recording has ever seen".
-    pub(crate) fn samplers(&self, recording_id: i64) -> Result<Vec<String>, String> {
+    pub fn samplers(&self, recording_id: i64) -> Result<Vec<String>, String> {
         let mut stmt = self
             .conn
             .prepare(
@@ -645,7 +645,7 @@ impl RezDb {
     /// this module is the only place that knows the schema well enough to
     /// look at both tables. Recovery/inventory callers should call this, not
     /// `samplers()`, when they need to know which tables exist at all.
-    pub(crate) fn all_samplers(&self, recording_id: i64) -> Result<Vec<String>, String> {
+    pub fn all_samplers(&self, recording_id: i64) -> Result<Vec<String>, String> {
         let mut stmt = self
             .conn
             .prepare(
@@ -682,18 +682,14 @@ impl RezDb {
     /// through. `&mut self` makes "don't open a nested transaction while one
     /// is outstanding" a compile error for that caller instead of a runtime
     /// one. Reads stay on `&self`.
-    pub(crate) fn insert_wal_rows(
-        &mut self,
-        recording_id: i64,
-        rows: &[WalRow],
-    ) -> Result<(), String> {
+    pub fn insert_wal_rows(&mut self, recording_id: i64, rows: &[WalRow]) -> Result<(), String> {
         self.transaction(|tx| tx.insert_wal_rows(recording_id, rows))
     }
 
     /// Every WAL row for `(recording_id, sampler)`, sealed or not, oldest
     /// first. Recovery should use `live_wal` instead — this is the raw table,
     /// kept for inspection and for the WAL tests to compare against.
-    pub(crate) fn read_wal(&self, recording_id: i64, sampler: &str) -> Result<Vec<WalRow>, String> {
+    pub fn read_wal(&self, recording_id: i64, sampler: &str) -> Result<Vec<WalRow>, String> {
         let mut stmt = self
             .conn
             .prepare(
@@ -729,7 +725,7 @@ impl RezDb {
     ///
     /// This turns the prune into a pure background optimisation with no
     /// correctness role.
-    pub(crate) fn live_wal(&self, recording_id: i64, sampler: &str) -> Result<Vec<WalRow>, String> {
+    pub fn live_wal(&self, recording_id: i64, sampler: &str) -> Result<Vec<WalRow>, String> {
         let mut stmt = self
             .conn
             .prepare(&format!(
@@ -745,7 +741,7 @@ impl RezDb {
     /// share `LIVE_WAL_PREDICATE`, so the depth cannot drift from the rows the
     /// reader replays); this is the aggregate form, for callers that want the
     /// number rather than the payload.
-    pub(crate) fn live_wal_span(&self, recording_id: i64, sampler: &str) -> Result<Span, String> {
+    pub fn live_wal_span(&self, recording_id: i64, sampler: &str) -> Result<Span, String> {
         self.query_span(
             &format!("SELECT COUNT(*), MIN(ts), MAX(ts) FROM wal WHERE {LIVE_WAL_PREDICATE}"),
             recording_id,
@@ -759,11 +755,7 @@ impl RezDb {
     /// `parquet metadata` describes a 197 MB archive from this, and pulling
     /// `bytes` back only to discard it is exactly the cost the catalog exists to
     /// avoid.
-    pub(crate) fn segment_span(
-        &self,
-        recording_id: i64,
-        sampler: &str,
-    ) -> Result<(u64, Span), String> {
+    pub fn segment_span(&self, recording_id: i64, sampler: &str) -> Result<(u64, Span), String> {
         let segments: i64 = self
             .conn
             .query_row(
@@ -837,7 +829,7 @@ impl RezDb {
     /// that is why WAL rows are per-sampler rather than whole snapshots — a
     /// slow-sealing table's prune must not touch, or be blocked by, any other
     /// sampler's tail.
-    pub(crate) fn prune_wal(
+    pub fn prune_wal(
         &self,
         recording_id: i64,
         sampler: &str,
@@ -874,11 +866,7 @@ impl RezDb {
     /// and it only stops it if the two land together: a straddling row has
     /// `ts <= last_ts < cutoff_ts`, so the WAL delete provably covers every row
     /// the segment delete un-shadows.
-    pub(crate) fn evict_before(
-        &mut self,
-        recording_id: i64,
-        cutoff_ts: u64,
-    ) -> Result<Evicted, String> {
+    pub fn evict_before(&mut self, recording_id: i64, cutoff_ts: u64) -> Result<Evicted, String> {
         self.evict(
             recording_id,
             "DELETE FROM segments WHERE recording_id = ?1 AND last_ts < ?2",
@@ -923,7 +911,7 @@ impl RezDb {
     /// `pages` says. That is not a slow reclaim, it is no reclaim at all: at
     /// one page per retention pass a hindsight buffer would never work off a
     /// spike.
-    pub(crate) fn incremental_vacuum(&self, pages: u32) -> Result<(), String> {
+    pub fn incremental_vacuum(&self, pages: u32) -> Result<(), String> {
         let fail = |e| format!("failed to reclaim {pages} pages: {e}");
         let mut stmt = self
             .conn
@@ -946,7 +934,7 @@ impl RezDb {
     /// A plain file copy is NOT an equivalent: in WAL mode the main database
     /// file lags every commit since the last checkpoint, so copying it alone
     /// silently loses the most recent ticks.
-    pub(crate) fn vacuum_into(&self, dest: &Path) -> Result<(), String> {
+    pub fn vacuum_into(&self, dest: &Path) -> Result<(), String> {
         let dest = dest
             .to_str()
             .ok_or_else(|| format!("dump destination {} is not valid UTF-8", dest.display()))?;
@@ -960,7 +948,7 @@ impl RezDb {
     /// together — from catalog columns alone. `None` when the recording holds
     /// no rows at all, which for a rolling buffer means "nothing within the
     /// lookback".
-    pub(crate) fn recording_time_span(
+    pub fn recording_time_span(
         &self,
         recording_id: i64,
     ) -> Result<(Option<u64>, Option<u64>), String> {
@@ -984,7 +972,7 @@ impl RezDb {
     /// Mark a recording cleanly finalized, outside any batch. The dump uses
     /// it: a copy taken at time T is a finished artifact even though the
     /// buffer it came from is still running.
-    pub(crate) fn mark_complete(&mut self, recording_id: i64) -> Result<(), String> {
+    pub fn mark_complete(&mut self, recording_id: i64) -> Result<(), String> {
         self.transaction(|tx| tx.mark_complete(recording_id))
     }
 
@@ -996,7 +984,7 @@ impl RezDb {
     /// table added here without being handled there would vanish silently
     /// from every rewritten archive.
     #[cfg(test)]
-    pub(crate) fn user_table_names(&self) -> Result<Vec<String>, String> {
+    pub fn user_table_names(&self) -> Result<Vec<String>, String> {
         let mut stmt = self
             .conn
             .prepare(
@@ -1016,7 +1004,7 @@ impl RezDb {
     /// column: `annotate` changes it and nothing else, and rewriting an
     /// archive's every segment BLOB to edit one JSON string would make a
     /// cheap operation cost the size of the recording.
-    pub(crate) fn update_recording_metadata(
+    pub fn update_recording_metadata(
         &self,
         recording_id: i64,
         metadata: &BTreeMap<String, String>,
@@ -1036,20 +1024,20 @@ impl RezDb {
         Ok(())
     }
 
-    pub(crate) fn pragma_u32(&self, name: &str) -> Result<u32, String> {
+    pub fn pragma_u32(&self, name: &str) -> Result<u32, String> {
         let value = self.pragma_i64(name)?;
         u32::try_from(value).map_err(|_| format!("pragma {name} is {value}, not a u32"))
     }
 
     /// Signed, because `cache_size` is negative when denominated in kibibytes.
-    pub(crate) fn pragma_i64(&self, name: &str) -> Result<i64, String> {
+    pub fn pragma_i64(&self, name: &str) -> Result<i64, String> {
         self.conn
             .pragma_query_value(None, name, |row| row.get(0))
             .map_err(|e| format!("failed to read pragma {name}: {e}"))
     }
 
     /// The recording's `(ts, offset_ns)` clock observations, oldest first.
-    pub(crate) fn read_clock_offsets(&self, recording_id: i64) -> Result<Vec<(u64, i64)>, String> {
+    pub fn read_clock_offsets(&self, recording_id: i64) -> Result<Vec<(u64, i64)>, String> {
         let mut stmt = self
             .conn
             .prepare("SELECT ts, offset_ns FROM clock_offsets WHERE recording_id = ?1 ORDER BY ts")
@@ -1067,7 +1055,7 @@ impl RezDb {
         Ok(out)
     }
 
-    pub(crate) fn pragma_string(&self, name: &str) -> Result<String, String> {
+    pub fn pragma_string(&self, name: &str) -> Result<String, String> {
         self.conn
             .pragma_query_value(None, name, |row| row.get(0))
             .map_err(|e| format!("failed to read pragma {name}: {e}"))
@@ -1081,7 +1069,7 @@ impl RezDb {
 /// and no read accessor. The prune belongs OUTSIDE the seal transaction, where
 /// its cost cannot land on a tick, and `live_wal`'s watermark filter is what
 /// makes a crash between the two harmless — see `live_wal`.
-pub(crate) struct RezTx<'a> {
+pub struct RezTx<'a> {
     tx: rusqlite::Transaction<'a>,
 }
 
@@ -1092,7 +1080,7 @@ impl RezTx<'_> {
     /// recorded: the ranged dump writes a recording row and every segment it
     /// selected, and either the whole file is that recording or there is no
     /// file at all.
-    pub(crate) fn insert_recording(&self, meta: &RecordingMeta) -> Result<i64, String> {
+    pub fn insert_recording(&self, meta: &RecordingMeta) -> Result<i64, String> {
         insert_recording_sql(&self.tx, meta)
     }
 
@@ -1102,7 +1090,7 @@ impl RezTx<'_> {
     /// (`blob_open`). At the sizes a segment reaches, `blob_open`'s two-step
     /// (reserve, then stream) is measurably slower than handing SQLite the
     /// whole buffer, so the simpler API is also the faster one here.
-    pub(crate) fn insert_segment(
+    pub fn insert_segment(
         &self,
         recording_id: i64,
         sampler: &str,
@@ -1114,7 +1102,7 @@ impl RezTx<'_> {
     }
 
     /// Insert every WAL row for one tick — one sampler each, typically.
-    pub(crate) fn insert_wal_rows(&self, recording_id: i64, rows: &[WalRow]) -> Result<(), String> {
+    pub fn insert_wal_rows(&self, recording_id: i64, rows: &[WalRow]) -> Result<(), String> {
         let mut stmt = self
             .tx
             .prepare(
@@ -1136,7 +1124,7 @@ impl RezTx<'_> {
     }
 
     /// Append one `(ts, offset_ns)` clock observation for the recording.
-    pub(crate) fn insert_clock_offset(
+    pub fn insert_clock_offset(
         &self,
         recording_id: i64,
         ts: u64,
@@ -1154,7 +1142,7 @@ impl RezTx<'_> {
     /// Mark the recording cleanly finalized. This is what replaced the
     /// `.partial` filename convention: the file is valid from creation, so
     /// "was it finished" is a queryable property instead of a name.
-    pub(crate) fn mark_complete(&self, recording_id: i64) -> Result<(), String> {
+    pub fn mark_complete(&self, recording_id: i64) -> Result<(), String> {
         self.tx
             .execute(
                 "UPDATE recordings SET complete = 1 WHERE id = ?1",

--- a/crates/rez/src/rez_stream.rs
+++ b/crates/rez/src/rez_stream.rs
@@ -39,7 +39,9 @@ use std::time::{Duration, Instant};
 use metriken_exposition::Snapshot;
 use tracing::warn;
 
-use super::seal_policy::{stagger_bucket, SINGLE_RECORDING_KEY};
+#[cfg(test)]
+use super::seal_policy::stagger_bucket;
+use super::seal_policy::SINGLE_RECORDING_KEY;
 use super::seal_policy::{SealPolicy, SegmentAccount};
 
 use super::rez::{
@@ -49,7 +51,7 @@ use super::rez::{
 };
 
 /// The fixed parts of the recording's manifest entry, known at recording start.
-pub(crate) struct ManifestSeed {
+pub struct ManifestSeed {
     /// Directory holding this recording's tables inside the tar.
     pub dir: String,
     pub labels: BTreeMap<String, String>,
@@ -61,7 +63,7 @@ pub(crate) struct ManifestSeed {
 
 /// One sealed segment handed to the writer thread. The table already carries
 /// its `wall_offsets`; everything here is owned data (`Send + 'static`).
-pub(crate) struct SealJob {
+pub struct SealJob {
     pub sampler: String,
     pub table: RezTable,
 }
@@ -132,7 +134,7 @@ impl TableState {
 
 /// Handle to the writer thread. Every fallible hand-off reports the writer's
 /// stored error, in the required order: send-failure → join → report.
-pub(crate) struct RezWriterHandle {
+pub struct RezWriterHandle {
     tx: Option<SyncSender<WriterMsg>>,
     thread: Option<JoinHandle<Result<(), String>>>,
     partial: PathBuf,
@@ -141,7 +143,7 @@ pub(crate) struct RezWriterHandle {
 impl RezWriterHandle {
     /// Create `<output>.partial`, write the initial empty checkpoint manifest,
     /// and spawn the writer thread.
-    pub(crate) fn create(output: &Path, seed: ManifestSeed) -> Result<Self, String> {
+    pub fn create(output: &Path, seed: ManifestSeed) -> Result<Self, String> {
         let partial = partial_path(output)?;
         rename_aside_if_present(&partial)?;
 
@@ -209,13 +211,13 @@ impl RezWriterHandle {
 
     /// The in-progress archive's path — the recovery artifact if this recording
     /// never finalizes.
-    pub(crate) fn partial_path(&self) -> &Path {
+    pub fn partial_path(&self) -> &Path {
         &self.partial
     }
 
     /// Hand one seal batch (= one checkpoint) to the writer. Blocks while the
     /// channel is full: that is the intended backpressure signal.
-    pub(crate) fn seal(&mut self, batch: Vec<SealJob>) -> Result<(), String> {
+    pub fn seal(&mut self, batch: Vec<SealJob>) -> Result<(), String> {
         if batch.is_empty() {
             // An empty batch is the common case — nothing is due most ticks —
             // but returning `Ok` unconditionally means writer health is only
@@ -239,11 +241,7 @@ impl RezWriterHandle {
 
     /// Seal the tails, write the final manifest and tar footer, rename the
     /// `.partial` into place.
-    pub(crate) fn finalize(
-        mut self,
-        tails: Vec<SealJob>,
-        clock_offset: (u64, i64),
-    ) -> Result<(), String> {
+    pub fn finalize(mut self, tails: Vec<SealJob>, clock_offset: (u64, i64)) -> Result<(), String> {
         self.send(WriterMsg::Finalize {
             tails,
             clock_offset,
@@ -252,7 +250,7 @@ impl RezWriterHandle {
     }
 
     /// Give up on the recording: stop the writer and unlink the `.partial`.
-    pub(crate) fn abort(mut self) {
+    pub fn abort(mut self) {
         if let Err(e) = self.join() {
             warn!("the .rez writer failed before the recording was aborted: {e}");
         }
@@ -544,13 +542,13 @@ fn writer_thread(
 /// writers differ only in what they build out of a sealed `TableBuilder`, and
 /// widening the fields to share the rest is what let the `due` predicate get
 /// copied in the first place.
-pub(crate) struct BuilderState {
+pub struct BuilderState {
     builder: TableBuilder,
     account: SegmentAccount,
 }
 
 impl BuilderState {
-    pub(crate) fn open_first(sampler: &str, policy: &SealPolicy) -> Self {
+    pub fn open_first(sampler: &str, policy: &SealPolicy) -> Self {
         Self {
             builder: TableBuilder::new(sampler.to_string()),
             // The V1/V2 writer holds exactly one recording per archive — a tar
@@ -563,7 +561,7 @@ impl BuilderState {
     }
 
     /// Append one row to the open segment, and account it.
-    pub(crate) fn push_row(&mut self, ts: u64, wall_offset_ns: i64, entries: &[Entry<'_>]) {
+    pub fn push_row(&mut self, ts: u64, wall_offset_ns: i64, entries: &[Entry<'_>]) {
         self.builder.push_row(ts, wall_offset_ns, entries);
         self.account.add_row(entries_approx_bytes(entries));
     }
@@ -581,19 +579,19 @@ impl BuilderState {
 
     /// The final partial segment, or `None` when there is nothing to seal.
     /// Consuming, because a recorder only asks this while finalizing.
-    pub(crate) fn into_tail(self) -> Option<TableBuilder> {
+    pub fn into_tail(self) -> Option<TableBuilder> {
         (self.builder.rows() > 0).then_some(self.builder)
     }
 
     /// Rows in the open segment.
     #[cfg(test)]
-    pub(crate) fn open_rows(&self) -> usize {
+    pub fn open_rows(&self) -> usize {
         self.builder.rows()
     }
 
     /// The row and age targets the *current* open segment seals at.
     #[cfg(test)]
-    pub(crate) fn targets(&self) -> (usize, Duration) {
+    pub fn targets(&self) -> (usize, Duration) {
         self.account.targets()
     }
 }
@@ -607,7 +605,7 @@ impl BuilderState {
 /// lines are all the two ingest paths do differently — everything that could
 /// drift, the `due` predicate and the `mem::replace` rotation that carries
 /// `last_key` forward by leaving it outside the builder, is shared.
-pub(crate) fn drain_due(
+pub fn drain_due(
     builders: &mut BTreeMap<String, BuilderState>,
     policy: &SealPolicy,
 ) -> Vec<(String, TableBuilder)> {
@@ -623,7 +621,7 @@ pub(crate) fn drain_due(
 }
 
 /// The scrape-side half: per-sampler open segments plus the seal decision.
-pub(crate) struct StreamRecorder {
+pub struct StreamRecorder {
     /// Open segment per sampler: builder, open instant, and current targets.
     builders: BTreeMap<String, BuilderState>,
     /// Window-advance dedup keys. Held here, not on the builder, so dedup
@@ -635,11 +633,11 @@ pub(crate) struct StreamRecorder {
 }
 
 impl StreamRecorder {
-    pub(crate) fn new(handle: RezWriterHandle) -> Self {
+    pub fn new(handle: RezWriterHandle) -> Self {
         Self::with_policy(handle, SealPolicy::default())
     }
 
-    pub(crate) fn with_policy(handle: RezWriterHandle, policy: SealPolicy) -> Self {
+    pub fn with_policy(handle: RezWriterHandle, policy: SealPolicy) -> Self {
         Self {
             builders: BTreeMap::new(),
             last_keys: BTreeMap::new(),
@@ -651,7 +649,7 @@ impl StreamRecorder {
     /// Append one scraped snapshot: partition by sampler and, for each sampler
     /// whose representative acquisition window advanced, push a row stamped
     /// `anchored_ts` with this tick's `wall_offset_ns` observation.
-    pub(crate) fn ingest(&mut self, snapshot: &Snapshot, anchored_ts: u64, wall_offset_ns: i64) {
+    pub fn ingest(&mut self, snapshot: &Snapshot, anchored_ts: u64, wall_offset_ns: i64) {
         for (sampler, entries) in group_by_sampler(snapshot) {
             let key = dedup_key(&entries, anchored_ts);
             if let Some(&last) = self.last_keys.get(sampler) {
@@ -675,7 +673,7 @@ impl StreamRecorder {
     /// Call this every loop iteration, scrape or not: an unreachable endpoint
     /// must still get its pre-outage rows sealed, or the kill-loss window is no
     /// longer bounded in time.
-    pub(crate) fn maybe_seal(&mut self) -> Result<(), String> {
+    pub fn maybe_seal(&mut self) -> Result<(), String> {
         let batch = drain_due(&mut self.builders, &self.policy)
             .into_iter()
             .map(|(sampler, builder)| SealJob {
@@ -688,7 +686,7 @@ impl StreamRecorder {
 
     /// Seal the remaining partial segments (small by construction) and finalize
     /// the archive.
-    pub(crate) fn finalize(mut self, clock_offset: (u64, i64)) -> Result<(), String> {
+    pub fn finalize(mut self, clock_offset: (u64, i64)) -> Result<(), String> {
         let tails: Vec<SealJob> = std::mem::take(&mut self.builders)
             .into_iter()
             .filter_map(|(sampler, state)| {
@@ -702,7 +700,7 @@ impl StreamRecorder {
     }
 
     /// Give up on the recording: stop the writer and unlink the `.partial`.
-    pub(crate) fn abort(self) {
+    pub fn abort(self) {
         self.handle.abort();
     }
 
@@ -731,8 +729,8 @@ impl StreamRecorder {
 /// cleanly finalized, `complete` recording), `false` drops the writer and
 /// leaves the recoverable `<out>.partial` (an incomplete recording). Returns
 /// the path that now exists.
-#[cfg(test)]
-pub(crate) fn write_segmented_rez(
+#[cfg(any(test, feature = "test-support"))]
+pub fn write_segmented_rez(
     out: &Path,
     dir: &str,
     labels: BTreeMap<String, String>,
@@ -741,7 +739,7 @@ pub(crate) fn write_segmented_rez(
     max_rows: usize,
     finalize: bool,
 ) -> PathBuf {
-    use crate::recorder::rez::recorder_tests_support::{counter, snap};
+    use crate::rez::recorder_tests_support::{counter, snap};
     use metriken::Window;
 
     let seed = ManifestSeed {
@@ -788,8 +786,8 @@ pub(crate) fn write_segmented_rez(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::recorder::rez::recorder_tests_support::{counter, snap};
-    use crate::recorder::rez::{Entry, RezManifest, TableBuilder, REZ_MANIFEST_NAME};
+    use crate::rez::recorder_tests_support::{counter, snap};
+    use crate::rez::{Entry, RezManifest, TableBuilder, REZ_MANIFEST_NAME};
     use metriken::Window;
     use std::io::Read;
 
@@ -883,9 +881,9 @@ mod tests {
         let handle = RezWriterHandle::create(&out, seed()).unwrap();
         assert!(partial.exists(), "the .partial is created up front");
         assert!(!out.exists(), "the output appears only on clean finalize");
-        assert!(crate::recorder::rez::is_rez_path(&partial).unwrap());
+        assert!(crate::rez::is_rez_path(&partial).unwrap());
 
-        let (manifest, recordings) = crate::recorder::rez::read_archive_bytes(&partial).unwrap();
+        let (manifest, recordings) = crate::rez::read_archive_bytes(&partial).unwrap();
         assert_eq!(manifest.version, 2);
         assert_eq!(manifest.recordings.len(), 1);
         let rec = &manifest.recordings[0];
@@ -942,7 +940,7 @@ mod tests {
         assert_eq!(manifests[1].recordings[0].tables[0].rows, 3);
         assert_eq!(manifests[2].recordings[0].tables[0].rows, 5);
 
-        let (manifest, recordings) = crate::recorder::rez::read_archive_bytes(&out).unwrap();
+        let (manifest, recordings) = crate::rez::read_archive_bytes(&out).unwrap();
         assert_eq!(manifest.version, 2);
         let rec = &manifest.recordings[0];
         assert!(rec.complete, "finalize marks the recording complete");
@@ -1035,7 +1033,7 @@ mod tests {
 
         // Exit-on-first-error: nothing the writer accepted after the failure
         // reached the archive, and the output was never produced.
-        let (manifest, _) = crate::recorder::rez::read_archive_bytes(&partial).unwrap();
+        let (manifest, _) = crate::rez::read_archive_bytes(&partial).unwrap();
         assert!(
             manifest.recordings[0].tables.is_empty(),
             "the writer stopped at the first error"
@@ -1141,7 +1139,7 @@ mod tests {
         let mut recovered_counts: Vec<usize> = Vec::new();
         for cut in cuts {
             std::fs::write(&cut_path, &bytes[..cut]).unwrap();
-            match crate::recorder::rez::read_archive_bytes(&cut_path) {
+            match crate::rez::read_archive_bytes(&cut_path) {
                 Ok((manifest, recordings)) => {
                     first_ok.get_or_insert(cut);
                     let rec = &manifest.recordings[0];
@@ -1187,7 +1185,7 @@ mod tests {
         );
 
         // The untruncated `.partial` still carries every sealed segment.
-        let (manifest, _) = crate::recorder::rez::read_archive_bytes(&partial).unwrap();
+        let (manifest, _) = crate::rez::read_archive_bytes(&partial).unwrap();
         let named: usize = manifest.recordings[0]
             .tables
             .iter()
@@ -1213,7 +1211,7 @@ mod tests {
         drop(handle);
 
         assert!(!out.exists(), "no output without a clean finalize");
-        let (manifest, recordings) = crate::recorder::rez::read_archive_bytes(&partial).unwrap();
+        let (manifest, recordings) = crate::rez::read_archive_bytes(&partial).unwrap();
         let rec = &manifest.recordings[0];
         assert!(!rec.complete, "recovered recordings are not complete");
         assert_eq!(rec.tables.len(), 1);
@@ -1248,7 +1246,7 @@ mod tests {
         let handle = RezWriterHandle::create(&out, seed()).unwrap();
         let aside = dir.path().join("out.rez.partial.recovered-0");
         assert_eq!(std::fs::read(&aside).unwrap(), b"old recoverable bytes");
-        assert!(crate::recorder::rez::is_rez_path(&partial).unwrap());
+        assert!(crate::rez::is_rez_path(&partial).unwrap());
         handle.abort();
 
         // A second collision picks the next free suffix.
@@ -1327,7 +1325,7 @@ mod tests {
         rec.maybe_seal().unwrap();
         rec.finalize((ts, 0)).unwrap();
 
-        let (manifest, _) = crate::recorder::rez::read_archive_bytes(&out).unwrap();
+        let (manifest, _) = crate::rez::read_archive_bytes(&out).unwrap();
         let idx = &manifest.recordings[0].tables[0];
         assert_eq!(idx.rows, 5, "5 distinct observations, the 6th deduped");
         assert_eq!(idx.files.len(), 3, "ceil(5 / 2) segments");
@@ -1369,7 +1367,7 @@ mod tests {
         rec.ingest(&s, ts, 0);
         rec.finalize((ts, 0)).unwrap();
 
-        let (manifest, _) = crate::recorder::rez::read_archive_bytes(&out).unwrap();
+        let (manifest, _) = crate::rez::read_archive_bytes(&out).unwrap();
         let idx = &manifest.recordings[0].tables[0];
         assert_eq!(idx.files.len(), 2);
         assert_eq!(idx.rows, 2);
@@ -1574,7 +1572,7 @@ mod tests {
         }
         rec.finalize((ts, 0)).unwrap();
 
-        let (manifest, _) = crate::recorder::rez::read_archive_bytes(&out).unwrap();
+        let (manifest, _) = crate::rez::read_archive_bytes(&out).unwrap();
         let idx = &manifest.recordings[0].tables[0];
         assert_eq!(idx.files.len(), 1, "empty builders never seal");
         assert_eq!(idx.rows, 1);
@@ -1588,7 +1586,7 @@ mod tests {
         let rec = StreamRecorder::new(handle);
         rec.finalize((1, 0)).unwrap();
 
-        let (manifest, recordings) = crate::recorder::rez::read_archive_bytes(&out).unwrap();
+        let (manifest, recordings) = crate::rez::read_archive_bytes(&out).unwrap();
         assert!(manifest.recordings[0].tables.is_empty());
         assert!(manifest.recordings[0].complete);
         assert!(recordings[0].tables.is_empty());

--- a/crates/rez/src/rez_v3_rewrite.rs
+++ b/crates/rez/src/rez_v3_rewrite.rs
@@ -10,11 +10,11 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
-use crate::recorder::rez::table_sampler;
-use crate::recorder::rez_sqlite::{RecordingMeta, RezDb, RezTx, SegmentMeta};
+use crate::rez::table_sampler;
+use crate::rez_sqlite::{RecordingMeta, RezDb, RezTx, SegmentMeta};
 
 /// What one copy pass carries across.
-pub(crate) struct CopySpec<'a> {
+pub struct CopySpec<'a> {
     /// Row-timestamp bound in nanoseconds. The rewrite tools copy everything;
     /// hindsight's dump narrows it to the incident window.
     pub start: u64,
@@ -33,7 +33,7 @@ pub(crate) struct CopySpec<'a> {
 
 impl CopySpec<'_> {
     /// Every recording, every table, every row, metadata untouched.
-    pub(crate) fn everything() -> Self {
+    pub fn everything() -> Self {
         CopySpec {
             start: 0,
             end: u64::MAX,
@@ -60,7 +60,7 @@ impl CopySpec<'_> {
 /// complete afterwards for a specific reason: the buffer it copied is
 /// perpetually mid-recording and would otherwise never produce a snapshot that
 /// did not warn.
-pub(crate) fn copy_recordings_into(
+pub fn copy_recordings_into(
     src: &RezDb,
     tx: &RezTx<'_>,
     spec: &CopySpec<'_>,
@@ -115,7 +115,7 @@ pub(crate) fn copy_recordings_into(
             // tail's span would claim a start the bytes do not contain.
             // `last_ts` stays the raw tail's own last row — a skip is always a
             // leading run, so that one is always right.
-            let materialized = crate::recorder::rez_v3_writer::materialize_wal_tail(&table, &tail)
+            let materialized = crate::rez_v3_writer::materialize_wal_tail(&table, &tail)
                 .map_err(|e| format!("failed to seal the {table} tail: {e}"))?;
             if let Some(materialized) = materialized {
                 let meta = SegmentMeta {
@@ -208,8 +208,8 @@ type CatalogedTable<'a> = (&'a str, Vec<(SegmentMeta, &'a Vec<u8>)>);
 /// reader materializes it that way. That is the same footprint `parquet
 /// combine` has always had on a v2 input, but it does bound the size of
 /// archive this can upgrade in one pass.
-pub(crate) fn upgrade_tar_to_v3(src: &Path, dest: &Path) -> Result<usize, String> {
-    use crate::recorder::rez;
+pub fn upgrade_tar_to_v3(src: &Path, dest: &Path) -> Result<usize, String> {
+    use crate::rez;
 
     let (manifest, recordings) = rez::read_archive_bytes(src)
         .map_err(|e| format!("failed to read {}: {e}", src.display()))?;
@@ -264,7 +264,7 @@ pub(crate) fn upgrade_tar_to_v3(src: &Path, dest: &Path) -> Result<usize, String
 
 #[cfg(test)]
 mod tests {
-    use crate::recorder::rez_sqlite::RezDb;
+    use crate::rez_sqlite::RezDb;
 
     /// Every table in the v3 schema is either copied by
     /// [`super::copy_recordings_into`] or deliberately not carried, and this
@@ -316,8 +316,8 @@ mod tests {
     /// checkpoint still reads as recovered afterwards.
     #[test]
     fn upgrading_a_tar_archive_carries_data_labels_and_completeness() {
-        use crate::recorder::rez;
-        use crate::recorder::rez_stream::write_segmented_rez;
+        use crate::rez;
+        use crate::rez_stream::write_segmented_rez;
 
         let d = tempfile::tempdir().unwrap();
         // One cleanly finalized, one recovered from a checkpoint.

--- a/crates/rez/src/rez_v3_writer.rs
+++ b/crates/rez/src/rez_v3_writer.rs
@@ -52,7 +52,7 @@ use super::seal_policy::{SealPolicy, SegmentAccount};
 /// than reintroduce the field. A/B aliasing is NOT affected: both viewer paths
 /// alias baseline/experiment on `arm`/`host` labels only, and `labels` survives
 /// verbatim in the `recordings` row.
-pub(crate) type ManifestSeed = RecordingMeta;
+pub type ManifestSeed = RecordingMeta;
 
 enum Msg {
     /// Insert a `recordings` row and hand its id back.
@@ -99,7 +99,7 @@ enum Msg {
     Shutdown,
     /// Reply once everything queued ahead of this has been committed. Carries
     /// no data and changes nothing — see [`RecordingWriter::sync`].
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     Sync(SyncSender<()>),
 }
 
@@ -130,7 +130,7 @@ const RECLAIM_FREELIST_DIVISOR: u32 = 10;
 
 /// Handle to the writer thread. Every fallible hand-off reports the writer's
 /// stored error, in the required order: send-failure → join → report.
-pub(crate) struct RezArchive {
+pub struct RezArchive {
     /// The master sender. Kept only to clone per-recording handles from, and
     /// dropped by `join` so the writer's channel can actually close.
     tx: Option<SyncSender<Msg>>,
@@ -149,7 +149,7 @@ impl RezArchive {
     /// an early-killed recording is just a recording whose `complete` is 0.
     ///
     /// The archive holds no recordings yet; add each with `add_recording`.
-    pub(crate) fn create(path: &Path) -> Result<Self, String> {
+    pub fn create(path: &Path) -> Result<Self, String> {
         let db = RezDb::create(path)?;
 
         // Bound 1, as in v2: the hand-off blocks while the writer is busy,
@@ -183,9 +183,9 @@ impl RezArchive {
     /// label-tagged `recordings` list — and they are independent: each has its
     /// own segment sequences, its own clock-offset series, and its own
     /// `complete` flag.
-    pub(crate) fn add_recording(&mut self, seed: ManifestSeed) -> Result<RecordingWriter, String> {
+    pub fn add_recording(&mut self, seed: ManifestSeed) -> Result<RecordingWriter, String> {
         // Derived before the seed is sent, since the seed moves.
-        let stagger_key = crate::recorder::seal_policy::recording_stagger_key(&seed.labels);
+        let stagger_key = crate::seal_policy::recording_stagger_key(&seed.labels);
         let Some(tx) = self.tx.as_ref() else {
             return Err("the .rez writer thread has already been joined".to_string());
         };
@@ -214,7 +214,7 @@ impl RezArchive {
     }
 
     /// The archive being written — valid and readable while it is written.
-    pub(crate) fn path(&self) -> &Path {
+    pub fn path(&self) -> &Path {
         &self.path
     }
 
@@ -228,7 +228,7 @@ impl RezArchive {
     /// distinction is load-bearing: the guarantee lives in `Msg::Shutdown`, not
     /// in the drop order, and removing it would turn every "must drop first"
     /// note in this file into a real deadlock.
-    pub(crate) fn join(&mut self) -> Result<(), String> {
+    pub fn join(&mut self) -> Result<(), String> {
         // Tell the writer to stop before releasing our own sender. A handle
         // that outlived its archive still holds a clone, so waiting for the
         // channel to close on its own could wait forever; `Shutdown` ends the
@@ -268,7 +268,7 @@ impl RezArchive {
     /// thread, so anything that reads the file straight afterwards has to join
     /// too. Mirrors `RezStream::finalize` in the recorder.
     #[cfg(test)]
-    pub(crate) fn finalize_single(
+    pub fn finalize_single(
         mut self,
         writer: RecordingWriter,
         clock_offset: (u64, i64),
@@ -280,8 +280,8 @@ impl RezArchive {
 
     /// As `finalize_single`, but for a caller holding the `StreamRecorderV3`
     /// (which owns the handle) rather than a bare `RecordingWriter`.
-    #[cfg(test)]
-    pub(crate) fn finalize_single_rec(
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn finalize_single_rec(
         mut self,
         rec: StreamRecorderV3,
         clock_offset: (u64, i64),
@@ -291,11 +291,8 @@ impl RezArchive {
         queued.and(joined)
     }
 
-    #[cfg(test)]
-    pub(crate) fn single(
-        path: &Path,
-        seed: ManifestSeed,
-    ) -> Result<(Self, RecordingWriter), String> {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn single(path: &Path, seed: ManifestSeed) -> Result<(Self, RecordingWriter), String> {
         let mut archive = Self::create(path)?;
         let writer = archive.add_recording(seed)?;
         Ok((archive, writer))
@@ -318,7 +315,7 @@ impl Drop for RezArchive {
 /// Cheap and cloneable-in-spirit: it is a sender plus an id. Dropping it
 /// releases this recording's claim on the writer; the thread exits once every
 /// handle *and* the archive's master sender are gone.
-pub(crate) struct RecordingWriter {
+pub struct RecordingWriter {
     tx: SyncSender<Msg>,
     recording_id: i64,
     /// This recording's stagger identity — its canonical label set. Held here
@@ -339,24 +336,24 @@ impl RecordingWriter {
     /// uses: the recorder asks the archive directly. Kept because a recorder
     /// naming its own output is the obvious thing to want.
     #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn path(&self) -> &Path {
+    pub fn path(&self) -> &Path {
         &self.path
     }
 
     /// The `recordings` row this handle appends to.
     #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn recording_id(&self) -> i64 {
+    pub fn recording_id(&self) -> i64 {
         self.recording_id
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
     /// This recording's stagger identity — see `stagger_bucket`.
-    pub(crate) fn stagger_key(&self) -> &str {
+    pub fn stagger_key(&self) -> &str {
         &self.stagger_key
     }
 
     /// Hand one tick's WAL rows to the writer.
-    pub(crate) fn wal(&mut self, rows: Vec<WalRow>) -> Result<(), String> {
+    pub fn wal(&mut self, rows: Vec<WalRow>) -> Result<(), String> {
         if rows.is_empty() {
             return self.check_alive();
         }
@@ -369,7 +366,7 @@ impl RecordingWriter {
     /// Hand one seal batch (= one transaction) to the writer, as the samplers
     /// to seal. Blocks while the channel is full: that is the intended
     /// backpressure signal.
-    pub(crate) fn seal(&mut self, batch: Vec<String>) -> Result<(), String> {
+    pub fn seal(&mut self, batch: Vec<String>) -> Result<(), String> {
         if batch.is_empty() {
             return self.check_alive();
         }
@@ -390,7 +387,7 @@ impl RecordingWriter {
     ///
     /// Fire-and-forget, like `wal` and `seal`: a failure surfaces on the next
     /// hand-off, which is the convention the whole writer follows.
-    pub(crate) fn evict_before(&mut self, cutoff_ts: u64) -> Result<(), String> {
+    pub fn evict_before(&mut self, cutoff_ts: u64) -> Result<(), String> {
         self.send(Msg::Evict {
             recording_id: self.recording_id,
             cutoff_ts,
@@ -422,8 +419,8 @@ impl RecordingWriter {
     /// inherent to an asynchronous writer and harmless. Tests do assert it, and
     /// without a barrier they race the writer. Give this a `cfg`-free home the
     /// moment a real caller needs to see its own last tick.
-    #[cfg(test)]
-    pub(crate) fn sync(&mut self) -> Result<(), String> {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn sync(&mut self) -> Result<(), String> {
         let (tx, rx) = sync_channel(0);
         self.send(Msg::Sync(tx))?;
         let _ = rx.recv();
@@ -435,7 +432,7 @@ impl RecordingWriter {
     /// Consumes the handle, which is what releases its sender: the writer
     /// thread ends when the last handle and the archive's master sender are
     /// gone, so a handle kept alive past its finalize would stall the join.
-    pub(crate) fn finalize(mut self, clock_offset: (u64, i64)) -> Result<(), String> {
+    pub fn finalize(mut self, clock_offset: (u64, i64)) -> Result<(), String> {
         self.send(Msg::Finalize {
             recording_id: self.recording_id,
             clock_offset,
@@ -527,7 +524,7 @@ fn writer_loop(rx: &Receiver<Msg>, db: &mut RezDb) -> Result<(), String> {
         match rx.recv() {
             // Nothing to do but answer: arriving here at all means every
             // message queued before it has already been handled.
-            #[cfg(test)]
+            #[cfg(any(test, feature = "test-support"))]
             Ok(Msg::Sync(reply)) => {
                 let _ = reply.send(());
             }
@@ -785,7 +782,7 @@ fn seal_batch(
 /// as `[index, payload]`, so these field names cost nothing on the wire and are
 /// chosen for readability.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct WalCell {
+pub struct WalCell {
     /// The snapshot entry's name — the segment's column key (`"5"`, `"5x3"`).
     /// Numeric-id strings of a few bytes, so carrying one per cell per tick is
     /// noise next to the value; dropping them and relying on positional order
@@ -839,7 +836,7 @@ pub(crate) struct WalCell {
 /// A cell's value, tagged by shape — which is also what tells a reader which
 /// `RezValues` column the cell belongs in.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) enum WalValue {
+pub enum WalValue {
     Counter(u64),
     Gauge(i64),
     /// `(grouping_power, max_value_power, buckets)`. The H2 config travels with
@@ -972,7 +969,7 @@ fn materialize_sampler_wal_tail(
 /// they read; duplicating it here would just be a second place for it to
 /// drift from the one that is actually used.
 #[derive(Debug, PartialEq)]
-pub(crate) struct MaterializedTail {
+pub struct MaterializedTail {
     pub bytes: Vec<u8>,
     pub rows: u64,
     pub first_ts: u64,
@@ -1004,7 +1001,7 @@ pub(crate) struct MaterializedTail {
 /// `no_registered_sampler_name_contains_a_slash` pinning the invariant
 /// against every registered `SAMPLERS` entry; the structural non-aliasing
 /// above is the release-build backstop if that is ever violated anyway.
-pub(crate) fn is_group_table_key(table_key: &str) -> bool {
+pub fn is_group_table_key(table_key: &str) -> bool {
     table_key.contains('/')
 }
 
@@ -1017,7 +1014,7 @@ pub(crate) fn is_group_table_key(table_key: &str) -> bool {
 /// writing) call this — neither has access to `StreamRecorderV3`'s in-memory
 /// schema cache, which is why a V3 group's WAL rows must be self-sufficient
 /// (see [`WalGroupRow`]).
-pub(crate) fn materialize_wal_tail(
+pub fn materialize_wal_tail(
     table_key: &str,
     rows: &[WalRow],
 ) -> Result<Option<MaterializedTail>, Box<dyn std::error::Error>> {
@@ -1045,7 +1042,7 @@ pub(crate) fn materialize_wal_tail(
 /// external schema cache — required because both the writer thread and a
 /// fresh reader process call it (see `materialize_wal_tail`'s doc).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct WalGroupRow {
+pub struct WalGroupRow {
     /// Which schema (by content hash) these values align with.
     pub schema_hash: (u64, u64),
     /// The schema itself, present only on the row that (re-)anchors it —
@@ -1060,12 +1057,12 @@ pub(crate) struct WalGroupRow {
     pub histograms: Vec<Option<(u8, u8, Vec<u64>)>>,
 }
 
-pub(crate) fn encode_wal_group_row(row: &WalGroupRow) -> Result<Vec<u8>, String> {
+pub fn encode_wal_group_row(row: &WalGroupRow) -> Result<Vec<u8>, String> {
     rmp_serde::to_vec(row).map_err(|e| format!("failed to encode a group WAL row: {e}"))
 }
 
 /// The inverse of [`encode_wal_group_row`].
-pub(crate) fn decode_wal_group_row(bytes: &[u8]) -> Result<WalGroupRow, String> {
+pub fn decode_wal_group_row(bytes: &[u8]) -> Result<WalGroupRow, String> {
     rmp_serde::from_slice(bytes).map_err(|e| format!("failed to decode a group WAL row: {e}"))
 }
 
@@ -1164,12 +1161,12 @@ fn materialize_group_wal_tail(
 }
 
 // Encode one sampler's cells for one tick into a `wal.row` BLOB.
-pub(crate) fn encode_wal_row(cells: &[WalCell]) -> Result<Vec<u8>, String> {
+pub fn encode_wal_row(cells: &[WalCell]) -> Result<Vec<u8>, String> {
     rmp_serde::to_vec(cells).map_err(|e| format!("failed to encode a WAL row: {e}"))
 }
 
 /// The inverse of [`encode_wal_row`] — the recovery entry point.
-pub(crate) fn decode_wal_row(bytes: &[u8]) -> Result<Vec<WalCell>, String> {
+pub fn decode_wal_row(bytes: &[u8]) -> Result<Vec<WalCell>, String> {
     rmp_serde::from_slice(bytes).map_err(|e| format!("failed to decode a WAL row: {e}"))
 }
 
@@ -1187,7 +1184,7 @@ pub(crate) fn decode_wal_row(bytes: &[u8]) -> Result<Vec<WalCell>, String> {
 /// of 26 tables recovered nothing at all because they had not sealed yet. Here
 /// every tick is committed as it arrives, for quiet tables as much as busy
 /// ones, so an unclean kill costs one tick rather than a whole open segment.
-pub(crate) struct StreamRecorderV3 {
+pub struct StreamRecorderV3 {
     /// Open segment per sampler — the seal decision's inputs, and no rows.
     ///
     /// **The rows live in the WAL and nowhere else.** v2 keeps a parallel
@@ -1253,7 +1250,7 @@ pub(crate) struct StreamRecorderV3 {
 /// or references an unknown hash with no schema attached, affects neither —
 /// it is an error, not a cache event.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct SchemaCacheStats {
+pub struct SchemaCacheStats {
     pub hits: u64,
     pub misses: u64,
 }
@@ -1271,11 +1268,11 @@ const SCHEMA_RING_LEN: usize = 3;
 type SchemaRing = std::collections::VecDeque<((u64, u64), Arc<GroupSchema>)>;
 
 impl StreamRecorderV3 {
-    pub(crate) fn new(handle: RecordingWriter) -> Self {
+    pub fn new(handle: RecordingWriter) -> Self {
         Self::with_policy(handle, SealPolicy::default())
     }
 
-    pub(crate) fn with_policy(handle: RecordingWriter, policy: SealPolicy) -> Self {
+    pub fn with_policy(handle: RecordingWriter, policy: SealPolicy) -> Self {
         Self {
             accounts: BTreeMap::new(),
             last_keys: BTreeMap::new(),
@@ -1296,13 +1293,13 @@ impl StreamRecorderV3 {
     /// archive now backs several recorders and the path is a property of the
     /// archive rather than of any one recording.
     #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) fn path(&self) -> &Path {
+    pub fn path(&self) -> &Path {
         self.handle.path()
     }
 
     /// V3 schema-hash cache hit/miss counts so far — see [`SchemaCacheStats`].
     #[cfg(test)]
-    pub(crate) fn schema_cache_stats(&self) -> SchemaCacheStats {
+    pub fn schema_cache_stats(&self) -> SchemaCacheStats {
         self.schema_stats
     }
 
@@ -1328,7 +1325,7 @@ impl StreamRecorderV3 {
     /// return `Ok` for the tick that ultimately kills the writer, and the error
     /// surfaces on a later hand-off. That is inherent to the writer thread and
     /// is why `maybe_seal` polls health even with nothing to seal.
-    pub(crate) fn ingest(
+    pub fn ingest(
         &mut self,
         snapshot: &Snapshot,
         anchored_ts: u64,
@@ -1689,7 +1686,7 @@ impl StreamRecorderV3 {
     /// message is committed before it is read, and every row after it is not
     /// yet visible to `live_wal`'s watermark. The segment therefore covers
     /// exactly the rows this decision was made about.
-    pub(crate) fn maybe_seal(&mut self) -> Result<(), String> {
+    pub fn maybe_seal(&mut self) -> Result<(), String> {
         let now = Instant::now();
         let mut batch = Vec::new();
         for (sampler, account) in self.accounts.iter_mut() {
@@ -1718,15 +1715,15 @@ impl StreamRecorderV3 {
     /// — but hindsight is the same writer with retention configured, and this
     /// is the configuration. Call it AFTER `maybe_seal`, so a segment closed
     /// this tick is catalogued before the cutoff is applied to it.
-    pub(crate) fn evict_before(&mut self, cutoff_ts: u64) -> Result<(), String> {
+    pub fn evict_before(&mut self, cutoff_ts: u64) -> Result<(), String> {
         self.handle.evict_before(cutoff_ts)
     }
 
     /// Block until the writer has committed everything handed off so far; see
     /// [`RecordingWriter::sync`]. Needed before reading the file through a second
     /// connection, which otherwise sees the state from before the last tick.
-    #[cfg(test)]
-    pub(crate) fn sync(&mut self) -> Result<(), String> {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn sync(&mut self) -> Result<(), String> {
         self.handle.sync()
     }
 
@@ -1737,7 +1734,7 @@ impl StreamRecorderV3 {
     /// reader can materialize that tail: a cleanly finished recording should be
     /// segments and nothing else, so the WAL is left empty and no consumer pays
     /// for a replay it does not need.
-    pub(crate) fn finalize(mut self, clock_offset: (u64, i64)) -> Result<(), String> {
+    pub fn finalize(mut self, clock_offset: (u64, i64)) -> Result<(), String> {
         let tails: Vec<String> = std::mem::take(&mut self.accounts)
             .into_iter()
             .filter(|(_, account)| account.rows() > 0)
@@ -1766,8 +1763,8 @@ impl StreamRecorderV3 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::recorder::rez::recorder_tests_support::counter;
-    use crate::recorder::rez::{detect_rez_format, Entry, RezFormat, TableBuilder};
+    use crate::rez::recorder_tests_support::counter;
+    use crate::rez::{detect_rez_format, Entry, RezFormat, TableBuilder};
     use metriken::Window;
 
     const ANCHOR: u64 = 1_700_000_000_000_000_000;
@@ -2382,7 +2379,7 @@ mod tests {
         // noise (steady state, where it would be pure cost), and it must be
         // BOUNDED when it does run, so a shrink cannot put a multi-second
         // reclaim on a tick.
-        use crate::recorder::rez_sqlite::RecordingMeta;
+        use crate::rez_sqlite::RecordingMeta;
 
         let dir = tempfile::tempdir().unwrap();
         let mut db = RezDb::create(&dir.path().join("t.rez")).unwrap();
@@ -2470,7 +2467,7 @@ mod tests {
     // `StreamRecorderV3` — the ingest side.
     // ---------------------------------------------------------------------
 
-    use crate::recorder::rez::recorder_tests_support::snap;
+    use crate::rez::recorder_tests_support::snap;
     use metriken_exposition::{Counter, Gauge, Histogram as ExpHistogram, Snapshot, SnapshotV2};
     use std::collections::HashMap;
     use std::time::{Duration, SystemTime};
@@ -2842,8 +2839,7 @@ mod tests {
     /// stored parquet BLOB.
     fn segment_unit(bytes: &[u8]) -> String {
         let table =
-            crate::recorder::rez::read_table_parquet("cpu_usage".to_string(), bytes.to_vec())
-                .unwrap();
+            crate::rez::read_table_parquet("cpu_usage".to_string(), bytes.to_vec()).unwrap();
         table
             .columns
             .iter()
@@ -3297,7 +3293,7 @@ mod tests {
             );
 
             // And the emitted window values decode back to the group's window.
-            let table = crate::recorder::rez::read_table_parquet(
+            let table = crate::rez::read_table_parquet(
                 "cpu_usage/percpu".to_string(),
                 segs[0].bytes.clone(),
             )
@@ -3523,7 +3519,7 @@ mod tests {
             let mut selected: Vec<&str> = all
                 .iter()
                 .map(String::as_str)
-                .filter(|t| crate::recorder::rez::table_sampler(t) == "cpu_usage")
+                .filter(|t| crate::rez::table_sampler(t) == "cpu_usage")
                 .collect();
             selected.sort();
             assert_eq!(selected, vec!["cpu_usage/aggregate", "cpu_usage/percpu"]);
@@ -3584,11 +3580,8 @@ mod tests {
                 "the catalog extent must reflect the ONE row that materialized \
                  (ts=2_000), not the raw WAL span's rows=2/first_ts=1_000"
             );
-            let table = crate::recorder::rez::read_table_parquet(
-                "cpu_usage/percpu".to_string(),
-                tail.bytes,
-            )
-            .unwrap();
+            let table =
+                crate::rez::read_table_parquet("cpu_usage/percpu".to_string(), tail.bytes).unwrap();
             assert_eq!(
                 table.timestamps,
                 vec![2_000],
@@ -3706,11 +3699,8 @@ mod tests {
                  (ts=1_200, tick 3's self-anchored row), not the raw live_wal \
                  span's rows=2/first_ts=1_100"
             );
-            let table = crate::recorder::rez::read_table_parquet(
-                "cpu_usage/percpu".to_string(),
-                tail.bytes,
-            )
-            .unwrap();
+            let table =
+                crate::rez::read_table_parquet("cpu_usage/percpu".to_string(), tail.bytes).unwrap();
             assert_eq!(
                 table.timestamps,
                 vec![1_200],

--- a/crates/rez/src/seal_policy.rs
+++ b/crates/rez/src/seal_policy.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 /// `[0, STAGGER_BUCKETS)`, i.e. somewhere in `[max_rows / 2, max_rows]`. 64
 /// buckets is ample spread for a dozen tables, and capping the reduction at
 /// 50% bounds the startup cost to one short segment per sampler.
-pub(crate) const STAGGER_BUCKETS: u64 = 64;
+pub const STAGGER_BUCKETS: u64 = 64;
 
 /// The stagger identity of a writer that can only ever hold one recording.
 ///
@@ -25,7 +25,7 @@ pub(crate) const STAGGER_BUCKETS: u64 = 64;
 /// builder for the reader and `parquet_tools` tests, and nothing in the bin's
 /// live path constructs one any more.
 #[cfg_attr(not(test), allow(dead_code))]
-pub(crate) const SINGLE_RECORDING_KEY: &str = "";
+pub const SINGLE_RECORDING_KEY: &str = "";
 
 /// When an open segment is due to be sealed. Byte-first: the byte cap is the
 /// one that bounds both the builder's memory footprint and the encoder's input,
@@ -36,7 +36,7 @@ pub(crate) const SINGLE_RECORDING_KEY: &str = "";
 /// open segment is naturally tiny — so age sealing only bounds how much data an
 /// unclean kill loses. It is also what drives segment count, so the trade (loss
 /// window vs segments and read-time merge width) is deliberate.
-pub(crate) struct SealPolicy {
+pub struct SealPolicy {
     pub max_bytes: usize,
     pub max_rows: usize,
     pub max_age: Duration,
@@ -94,7 +94,7 @@ impl Default for SealPolicy {
 /// at the same row from the same input, which they do by both deciding here —
 /// the alternative is two copies of a four-term predicate drifting apart in a
 /// way that only shows up as differently-shaped archives.
-pub(crate) struct SegmentAccount {
+pub struct SegmentAccount {
     rows: usize,
     approx_bytes: usize,
     /// Instant the current segment was opened (the age bound's origin).
@@ -125,7 +125,7 @@ impl SegmentAccount {
     /// over the tick budget. Shortening only the first segment desyncs the
     /// tables for the life of the recording while leaving steady-state segment
     /// size and count untouched — `rotate` restores the full policy.
-    pub(crate) fn open_first(sampler: &str, recording_key: &str, policy: &SealPolicy) -> Self {
+    pub fn open_first(sampler: &str, recording_key: &str, policy: &SealPolicy) -> Self {
         let bucket = stagger_bucket(sampler, recording_key);
         // Divide before multiplying: `max_rows` is `usize::MAX` in several
         // callers, and `max_rows * bucket` would overflow.
@@ -148,7 +148,7 @@ impl SegmentAccount {
 
     /// Account one appended row. `bytes` is [`entries_approx_bytes`] of that
     /// row, which is exactly what `TableBuilder::push_row` would have charged.
-    pub(crate) fn add_row(&mut self, bytes: usize) {
+    pub fn add_row(&mut self, bytes: usize) {
         self.rows += 1;
         self.approx_bytes += bytes;
     }
@@ -160,7 +160,7 @@ impl SegmentAccount {
     /// because all three are staggered on the first segment and `rotate`
     /// restores them. Reading `policy.max_bytes` here instead is what let the
     /// byte cap escape the stagger.
-    pub(crate) fn is_due(&self, now: Instant) -> bool {
+    pub fn is_due(&self, now: Instant) -> bool {
         self.rows > 0
             && (self.approx_bytes >= self.max_bytes
                 || self.rows >= self.max_rows
@@ -169,7 +169,7 @@ impl SegmentAccount {
 
     /// Reset onto a fresh segment after a seal, dropping the startup stagger:
     /// every segment after the first uses the full policy.
-    pub(crate) fn rotate(&mut self, policy: &SealPolicy, now: Instant) {
+    pub fn rotate(&mut self, policy: &SealPolicy, now: Instant) {
         self.rows = 0;
         self.approx_bytes = 0;
         self.opened_at = now;
@@ -179,19 +179,19 @@ impl SegmentAccount {
     }
 
     /// Rows in the open segment.
-    pub(crate) fn rows(&self) -> usize {
+    pub fn rows(&self) -> usize {
         self.rows
     }
 
     /// The row and age targets the *current* open segment seals at.
     #[cfg(test)]
-    pub(crate) fn targets(&self) -> (usize, Duration) {
+    pub fn targets(&self) -> (usize, Duration) {
         (self.max_rows, self.max_age)
     }
 
     /// This segment's byte cap, after the first-segment stagger.
     #[cfg(test)]
-    pub(crate) fn byte_target(&self) -> usize {
+    pub fn byte_target(&self) -> usize {
         self.max_bytes
     }
 }
@@ -226,7 +226,7 @@ impl SegmentAccount {
 /// the degenerate case — the operator gave two endpoints nothing to tell them
 /// apart — and the answer is to warn rather than to fold in the id and
 /// reintroduce order-dependence.
-pub(crate) fn stagger_bucket(sampler: &str, recording_key: &str) -> u64 {
+pub fn stagger_bucket(sampler: &str, recording_key: &str) -> u64 {
     const PRIME: u64 = 0x0000_0100_0000_01b3; // FNV-1a 64-bit prime
 
     // Absorb one byte, twice: the byte itself, then the two bits the final
@@ -279,7 +279,7 @@ pub(crate) fn stagger_bucket(sampler: &str, recording_key: &str) -> u64 {
 ///
 /// `BTreeMap` already fixes the order, so this is just a rendering — but it is
 /// done in one place so the writer and any test agree on the exact bytes.
-pub(crate) fn recording_stagger_key(labels: &std::collections::BTreeMap<String, String>) -> String {
+pub fn recording_stagger_key(labels: &std::collections::BTreeMap<String, String>) -> String {
     let mut out = String::new();
     for (k, v) in labels {
         if !out.is_empty() {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -419,7 +419,7 @@ Source: [`.rez` v3 — SQLite container with a real WAL](journal/2026-08-12-rez-
   `baseline`/`experiment` capture ids to become open-ended, which is UI work,
   not selection work.
 - **Reopening a table can panic on a live archive** — **DONE**. Was open,
-  `SamplerReader::reader` (`src/rez_reader.rs:229-233`) reopens a table's
+  `SamplerReader::reader` (`crates/rez/src/reader.rs:229-233`) reopens a table's
   segments with `.expect("segments opened at probe time cannot fail to
   reopen")`. That holds for a finished archive but not a live one: a `.rez` is
   readable while it is written, and `table_segments` returns sealed segments
@@ -466,7 +466,7 @@ Source: [`.rez` v3 — SQLite container with a real WAL](journal/2026-08-12-rez-
   *Reopen:* if restart-heavy recordings make split columns a real annoyance.
 - **Seal thresholds as compile-time constants** — Open. Byte-first seal
   thresholds (est. bytes primary, row cap, ~5 min age bound for the kill-loss
-  window) ship as constants in `src/recorder/rez.rs`. *Reopen:* if real
+  window) ship as constants in `crates/rez/src/rez.rs`. *Reopen:* if real
   workloads need tuning — promote to a `--flag` or config knob.
 - **Fast finalize for the classic parquet path** — By design. The single-file
   parquet's wide schema is only knowable once recording ends, so its finalize

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod mcp;
 mod parquet_metadata;
 mod parquet_tools;
 mod recorder;
-mod rez_reader;
+pub(crate) use ::rez::reader as rez_reader;
 mod status_cli;
 mod viewer;
 

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -4,19 +4,28 @@ mod child;
 mod config;
 mod endpoint;
 mod prometheus;
-pub(crate) mod rez;
-pub(crate) mod rez_sqlite;
+// The `.rez` format lives in its own crate so the WASM viewer can read the
+// archives this binary writes (`rezolus` is binary-only, so nothing could
+// depend on it). Re-exported under the paths call sites already use.
 /// The tar (v1/v2) `.rez` writer, kept only so tests can build v1/v2 fixtures.
 ///
 /// Nothing ships that writes this container any more: `record` writes v3, and
 /// `combine`/`filter`/`annotate`/`parquet upgrade` convert a tar archive
 /// rather than producing one. Proving that tar archives still READ, though,
-/// requires being able to construct one.
+/// requires being able to construct one — which is what the `rez` crate's
+/// `test-support` feature (a dev-dependency here) exists for.
 #[cfg(test)]
-pub(crate) mod rez_stream;
-pub(crate) mod rez_v3_rewrite;
-pub(crate) mod rez_v3_writer;
-pub(crate) mod seal_policy;
+pub(crate) use ::rez::rez_stream;
+pub(crate) use ::rez::{rez, rez_sqlite, rez_v3_rewrite, rez_v3_writer, seal_policy};
+
+/// True when the recording should be written as a `.rez` archive: either the
+/// output path ends in `.rez` or `--format rez` was given.
+///
+/// Lives here rather than in the `rez` crate because `Format` is this binary's
+/// CLI vocabulary — the archive format has no opinion about how a run chose it.
+fn wants_rez(format: crate::Format) -> bool {
+    format == crate::Format::Rez
+}
 
 use crate::parquet_metadata;
 pub use config::RecordingConfig;
@@ -1009,7 +1018,7 @@ pub fn run(mut config: RecordingConfig) {
 
     // `.rez` per-sampler archive mode. By this point the output extension has
     // already been folded into the format, so the format is the whole answer.
-    let mut rez_mode = rez::wants_rez(config.format);
+    let mut rez_mode = wants_rez(config.format);
 
     if rez_mode {
         // `.rez` ingest reads msgpack snapshots; an explicitly-prometheus


### PR DESCRIPTION
## Why

`rezolus` is a **binary-only** crate — no `lib` target — so nothing can depend on it. The `.rez` reader living inside it was therefore reachable by the server viewer and by nothing else, which is why the static-site WASM viewer (`crates/viewer`) has never opened a `.rez` at all. That is not an oversight, it is a structural gap, and this is step 1 of closing it.

`crates/rez` now holds the whole format: the container (v2 tar, v3 SQLite), the writers, the v3 rewrite tooling, the seal policy, and the `RezReader` that presents an archive as a `metriken_query::MetricsSource`. Nothing in it knows about samplers, endpoints, or the CLI.

## What to check

**This is a move, not a rewrite.** No behavior changes, no test changes. The same 823 tests pass, now split 661 in the binary and 162 in the new crate. Git detected every file as a rename, so the diff is the non-mechanical part. Three things:

- **The binary re-exports the modules under the paths call sites already use** (`crate::recorder::rez`, `crate::rez_reader`, …). `.rez` code reads the same from inside `rezolus`, and the diff stays a move instead of a thousand-line import churn.
- **`wants_rez` moved the other way**, into `src/recorder/mod.rs`. It matched on the binary's `Format` CLI enum; the archive format has no opinion about how a run chose it.
- **Fixture builders sit behind a `test-support` feature, not `#[cfg(test)]`.** A `#[cfg(test)]` module in `rez` is invisible to the crate next door, and the viewer, MCP, hindsight and `parquet` tests all build their `.rez` fixtures with `recorder_tests_support` (and the v1/v2 tar writer `rez_stream`). The binary enables the feature as a **dev**-dependency, so a normal build never compiles them. A handful of items that were `#[cfg(test)]` for the same reason are now `#[cfg(any(test, feature = "test-support"))]`.

Visibility inside the moved modules went from `pub(crate)` to `pub` wholesale — in a crate whose modules are all public, that is the same statement it was before.

## What this does not do yet

The reader half still pulls `metriken` (for `Window`) and `metriken-exposition`, and `metriken-core`'s `linkme` distributed slices have **no wasm32 implementation** — `linkme` gates on a fixed `target_os` list that `unknown` is not in. So `crates/viewer` cannot depend on this crate yet. Decoupling the container layer from the metrics registry is the next PR; reading a `.rez` in the browser is the one after.

Verified on the way: `rusqlite 0.40` with `bundled` **does** compile for `wasm32-unknown-unknown` (it routes through `sqlite-wasm-rs`), so the v3 container is reachable in the browser once the metriken dependency is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)