### PR TITLE
feat(recorder): record a Prometheus endpoint into a .rez

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,10 @@ target/release/rezolus record --url http://host:9090/metrics -o out.parquet --me
 # Auto-detects Rezolus agent vs Prometheus endpoints. The -o extension picks the format
 # (.rez | .parquet | .raw); --format {rez|parquet|raw} is rarely needed and conflicting with
 # the extension is an error. With no -o, the output is rezolus.<ext> for the format in play.
-# .rez requires every endpoint to be rezolus/msgpack, but any number of them: several
-# endpoints become one multi-recording archive. A run that chose no format at all falls
-# back to rezolus.parquet (with a note) for a Prometheus source; endpoint count never
-# triggers that fallback.
+# .rez takes any number of endpoints, rezolus or Prometheus, each as its own recording
+# in one multi-recording archive. A Prometheus scrape becomes one acquisition group per
+# target (`prometheus/scrape`), windowed by the real HTTP round trip. Only --separate
+# demotes the format, since one archive cannot be one file per endpoint.
 # Also: --metadata key=value (repeatable), --label key=value (repeatable; tags a .rez
 # recording, source/host auto-populated), --interval, --duration.
 
@@ -195,7 +195,7 @@ Either way the query engine consumes the window columns to compute `rate()`/`ira
 
 Because each sampler records at its own cadence, a query spanning *two samplers of materially different cadence* (measured row spacing differing by at least 2x, with the slower coarser than the step) is evaluated at the **slow sampler's own row timestamps** rather than on the uniform `start + k·step` grid — otherwise nearly every point lands where the slow sampler never read and its value is merely held forward. `RezReader::cross_cadence_eval_timestamps` picks those timestamps and passes them as `QueryOptions::eval_timestamps`; cadence is measured from the rows (never `interval()`, which reports one nominal value for the whole archive) and per *sampler*, since a group that skips ticks is sparse within its sampler's cadence rather than a second cadence. Single-sampler queries and `RateMode::Raw` are untouched.
 
-A `.rez` requires every endpoint to be rezolus/msgpack to produce (not Prometheus), but any number of them. The manifest carries per-recording label sets (`source`/`host` auto-populated, plus any `record --label k=v`, which applies to every recording in the run); a multi-recording `.rez` — built live by `record --endpoint a --endpoint b -o out.rez`, or offline by `parquet combine` — drives the viewer's A/B comparison, aliasing baseline/experiment from each recording's `arm`/`host` labels. The seal stagger keys on sampler + the recording's canonical label set (`seal_policy::recording_stagger_key`), so two recordings of the same agent do not seal in lockstep; identical label sets warn at startup.
+A `.rez` takes any number of endpoints, rezolus or Prometheus. A Prometheus target is converted on the way in: one scrape is one request and one response, so it becomes a single V3 acquisition group named `prometheus/scrape`, windowed by the real HTTP round trip (`src/recorder/prometheus.rs`). That is why it is a group rather than a flat V2 snapshot — a V2 table carries `<name>:window_begin`/`<name>:window_width` per value column, which would triple the schema width of every Prometheus table. The manifest carries per-recording label sets (`source`/`host` auto-populated, plus any `record --label k=v`, which applies to every recording in the run); a multi-recording `.rez` — built live by `record --endpoint a --endpoint b -o out.rez`, or offline by `parquet combine` — drives the viewer's A/B comparison, aliasing baseline/experiment from each recording's `arm`/`host` labels. The seal stagger keys on sampler + the recording's canonical label set (`seal_policy::recording_stagger_key`), so two recordings of the same agent do not seal in lockstep; identical label sets warn at startup.
 
 ### `.rez` lives in its own crate
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -360,8 +360,33 @@ Source: [`.rez` v3 — SQLite container with a real WAL](journal/2026-08-12-rez-
   agents with identical sampler sets would seal in permanent lockstep — the key
   must widen to the sampler plus the recording's canonical label set (not the
   recording id, which would make segmentation depend on endpoint order).
-- **Prometheus sources inside `.rez`** — Open, and it would *improve*
-  measurement honesty rather than compromise it. A scrape is one acquisition —
+- **Prometheus sources inside `.rez`** — **DONE**, and it did improve
+  measurement honesty rather than compromise it. `PrometheusConverter` emits
+  `SnapshotV3` with one group per target (`prometheus/scrape` — the slash is
+  load-bearing, since `.rez` dispatches a table's WAL rows on it), windowed by
+  the real HTTP round trip now that `scrape_one` returns the request and
+  response instants. Both refusals are gone; only `--separate` still demotes
+  the format. Schema members are ordered by assigned metric id, sorted
+  numerically, so the schema changes only when the metric set does. The parquet
+  path is unchanged and a test pins that on our side of the
+  `metriken-exposition` boundary rather than trusting its contract. Fell out of
+  it: `infer_source_name` used host and port alone, so two exporters behind one
+  address (`/metrics` and `/federate`) inferred the SAME source and became
+  recordings nothing could tell apart — the path joins the name now.
+  *Considered and declined:* widening the window with the exporter's own
+  embedded timestamp to account for a caching exporter. It is on the EXPORTER's
+  clock while the window is on ours, so folding it in re-introduces the
+  two-clocks-in-one-interval mixing the embedded-timestamp entry below removed
+  — and the failure is silent and unmeasurable from here: an exporter five
+  minutes slow inflates every band by five minutes, indistinguishable from a
+  value genuinely five minutes stale. Recording the observed staleness
+  (`response_received - embedded_ts`) as a SEPARATE signal would detect caching
+  exporters without contaminating a quantity that describes our clock; judged
+  not worth the design step it needs. The round-trip window therefore stays a
+  lower bound on uncertainty — which a zero-width window also was, and far
+  worse.
+  *Original analysis, kept because it is what the work followed:* A scrape is
+  one acquisition —
   one request, one response — so it models naturally as one acquisition group
   per target with the window set to the real HTTP round-trip. Today the
   Prometheus path already emits windows (`prometheus.rs:335`) but they are

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -400,12 +400,10 @@ Source: [`.rez` v3 — SQLite container with a real WAL](journal/2026-08-12-rez-
   is stored relative to the row timestamp, so the resulting `rate()` uncertainty
   band is nonsense rather than merely wide. Fixed by deriving the window from `fetch_ns` — the recorder's own
   clock for the tick — and ignoring `sample.timestamp` entirely, which also
-  ends the two-semantics mixing. Still zero-width, which understates: the
-  honest bracket is the real round-trip `[request_sent, response_received]`,
-  and the converter is handed only parsed text and a single instant, so the
-  request instant does not reach it. That widening is tracked with the
-  Prometheus-in-`.rez` entry above — it moves this window's edges, not its
-  anchor.
+  ends the two-semantics mixing. The remaining zero width is **fixed too**:
+  `scrape_one` returns the request and response instants, so the window is now
+  the real round-trip `[request_sent, response_received]` — a widening of this
+  window rather than a change of its anchor, as predicted.
 - **Viewer shows only the first two recordings** — **PARTLY DONE**. `rezolus
   view` now takes `--baseline k=v` / `--experiment k=v` (repeatable, ANDed,
   subset match — the same selector semantics as the MCP `--recording` flag,

--- a/src/recorder/endpoint.rs
+++ b/src/recorder/endpoint.rs
@@ -89,7 +89,47 @@ impl EndpointState {
 pub fn infer_source_name(url: &Url) -> String {
     let host = url.host_str().unwrap_or("unknown");
     let port = url.port().map(|p| format!("-{p}")).unwrap_or_default();
-    format!("{host}{port}")
+    match distinguishing_path(url) {
+        Some(path) => format!("{host}{port}-{path}"),
+        None => format!("{host}{port}"),
+    }
+}
+
+/// The part of a URL's path worth putting in a source name, or `None` when it
+/// carries nothing a host and port do not already say.
+///
+/// **Host and port alone are not unique per target.** Several exporters behind
+/// one address, distinguished only by path, is an ordinary Prometheus
+/// deployment — `/metrics` and `/federate`, or a path per tenant — and it is
+/// far more common there than for a Rezolus agent, which is one per host on a
+/// fixed port. Two targets inferring the SAME source get identical label sets,
+/// and then nothing downstream can tell their recordings apart: no `--recording`
+/// selector names either, and the viewer falls back to positional aliases. The
+/// recorder warns about that, but a warning is a poor substitute for a name.
+///
+/// `/metrics` is excluded because it is the convention rather than a
+/// distinction: appending it to every inferred name would be noise on the
+/// common case and would rename every existing capture's source for nothing.
+fn distinguishing_path(url: &Url) -> Option<String> {
+    let path = url.path().trim_matches('/');
+    if path.is_empty() || path == "metrics" {
+        return None;
+    }
+    // Slashes and anything else awkward become `-`: this ends up as a label
+    // value, a `.rez` recording's directory slug and a `--separate` filename,
+    // so it has to be a plain word in all three.
+    let slug: String = path
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    // Collapse the runs the mapping above can create (`/metrics//v2/` →
+    // `metrics--v2`) and trim the edges.
+    let slug = slug
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    (!slug.is_empty()).then_some(slug)
 }
 
 #[cfg(test)]
@@ -101,6 +141,47 @@ mod tests {
         let url: Url = "http://localhost:4241/metrics".parse().unwrap();
         let name = infer_source_name(&url);
         assert_eq!(name, "localhost-4241");
+    }
+
+    /// Several exporters behind one address, distinguished only by path, is an
+    /// ordinary Prometheus deployment. Inferring the same source for both gives
+    /// them identical label sets, and then nothing downstream can tell their
+    /// recordings apart: no `--recording` selector names either, and the viewer
+    /// falls back to positional aliases. The recorder warns, but a warning is a
+    /// poor substitute for a name.
+    #[test]
+    fn two_targets_on_one_address_infer_different_sources() {
+        let a: Url = "http://svc:9090/metrics".parse().unwrap();
+        let b: Url = "http://svc:9090/federate".parse().unwrap();
+        assert_ne!(infer_source_name(&a), infer_source_name(&b));
+    }
+
+    /// `/metrics` is the convention, not a distinction: appending it to every
+    /// inferred name would be noise on the common case and would rename every
+    /// existing capture's source for nothing.
+    #[test]
+    fn the_conventional_metrics_path_is_not_part_of_the_name() {
+        for url in [
+            "http://svc:9090/metrics",
+            "http://svc:9090/metrics/",
+            "http://svc:9090/",
+            "http://svc:9090",
+        ] {
+            let url: Url = url.parse().unwrap();
+            assert_eq!(infer_source_name(&url), "svc-9090", "{url}");
+        }
+    }
+
+    /// The inferred name becomes a label value, a `.rez` recording's directory
+    /// slug and a `--separate` filename, so it has to be a plain word in all
+    /// three — no slashes, no runs of separators, no leading or trailing dash.
+    #[test]
+    fn a_nested_path_becomes_one_plain_word() {
+        let url: Url = "http://svc:9090/metrics//v2/tenant_a/".parse().unwrap();
+        let name = infer_source_name(&url);
+        assert_eq!(name, "svc-9090-metrics-v2-tenant-a");
+        assert!(!name.contains('/') && !name.contains("--"));
+        assert!(!name.starts_with('-') && !name.ends_with('-'));
     }
 
     #[test]

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -375,7 +375,31 @@ async fn sleep_until_opt(deadline: Option<Instant>) {
     }
 }
 
-async fn scrape_one(client: &Client, url: &Url) -> Result<Vec<u8>, String> {
+/// One scrape's body, bracketed by when the request went out and when the
+/// response was fully read.
+///
+/// **The bracket is the point for a Prometheus endpoint.** A scrape is one
+/// acquisition — one request, one response — and every value in it was read
+/// somewhere inside that interval. Nothing narrower is knowable from here: the
+/// exporter does not say when it sampled, only what it read. A Rezolus agent
+/// stamps each metric's own window and this bracket is ignored for it.
+struct Scraped {
+    body: Vec<u8>,
+    /// Wall-clock ns when the request was sent.
+    request_ns: u64,
+    /// Wall-clock ns when the response finished arriving.
+    response_ns: u64,
+}
+
+fn wall_now_ns() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
+}
+
+async fn scrape_one(client: &Client, url: &Url) -> Result<Scraped, String> {
+    let request_ns = wall_now_ns();
     let response = client
         .get(url.clone())
         .send()
@@ -384,11 +408,19 @@ async fn scrape_one(client: &Client, url: &Url) -> Result<Vec<u8>, String> {
     if !response.status().is_success() {
         return Err(format!("HTTP {}", response.status()));
     }
-    response
+    let body = response
         .bytes()
         .await
         .map(|b| b.to_vec())
-        .map_err(|e| format!("{e}"))
+        .map_err(|e| format!("{e}"))?;
+    Ok(Scraped {
+        body,
+        request_ns,
+        // Read AFTER the body, not after the headers: the values are in the
+        // body, so a bracket that closed at the response line would exclude
+        // part of the interval they were actually read over.
+        response_ns: wall_now_ns(),
+    })
 }
 
 fn inject_provenance(
@@ -1401,7 +1433,11 @@ pub fn run(mut config: RecordingConfig) {
 
             for (idx, result) in results {
                 match result {
-                    Ok(body) => {
+                    Ok(Scraped {
+                        body,
+                        request_ns,
+                        response_ns,
+                    }) => {
                         endpoints[idx].record_success(wall_ns);
 
                         // `.rez`: decode once and hand the snapshot straight to
@@ -1477,7 +1513,10 @@ pub fn run(mut config: RecordingConfig) {
                             let bytes = if let Some(ref mut conv) = ew.converter {
                                 // Prometheus: parse text → snapshot → msgpack
                                 let text = String::from_utf8_lossy(&body);
-                                let snapshot = conv.convert(&text, wall_ns);
+                                // The real round trip, not the tick's clock:
+                                // every value in this body was read somewhere
+                                // inside it. See `Scraped`.
+                                let snapshot = conv.convert(&text, request_ns, response_ns);
                                 match rmp_serde::encode::to_vec(&snapshot) {
                                     Ok(b) => b,
                                     Err(e) => {

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -86,11 +86,11 @@ pub fn command() -> Command {
              not .rez: it means parquet, unless --format says otherwise. A --format that\n\
              contradicts the extension (say --format parquet with -o out.rez) IS an error,\n\
              rather than a silent choice between them.\n\n\
-             When the format was not chosen at all — no --format, no -o — and any endpoint\n\
-             turns out to be Prometheus, the recording falls back to rezolus.parquet and\n\
-             says so on stderr. The endpoint COUNT never causes that fallback. Pass --format\n\
-             rez (or an -o ending in .rez) to make a .rez archive a requirement instead: then\n\
-             the same situation is an error and nothing is recorded.\n\n\
+             A Prometheus endpoint records into a .rez like any other. One scrape is one\n\
+             request and one response, so it becomes one acquisition group per target,\n\
+             windowed by the real HTTP round trip. Neither the source nor the endpoint\n\
+             count demotes the format any more; only --separate does, since one archive\n\
+             cannot be one file per endpoint.\n\n\
              OVERWRITING: a .rez output path must NOT already exist — the recorder refuses\n\
              rather than truncate, because the archive is committed as it goes and has no\n\
              staging file. A parquet or raw output IS overwritten. There is no --force; remove\n\
@@ -225,7 +225,7 @@ pub fn command() -> Command {
             clap::Arg::new("FORMAT")
                 .long("format")
                 .short('f')
-                .help("Output format: rez (per-sampler archive, the default), parquet (one columnar table), or raw (concatenated msgpack snapshots). Usually unnecessary — the -o extension picks the format, and giving both a --format and a conflicting extension is an error. rez requires every endpoint to be a rezolus/msgpack one, but any number of them")
+                .help("Output format: rez (per-sampler archive, the default), parquet (one columnar table), or raw (concatenated msgpack snapshots). Usually unnecessary — the -o extension picks the format, and giving both a --format and a conflicting extension is an error. rez takes any number of endpoints, rezolus or Prometheus, each as its own recording")
                 .action(clap::ArgAction::Set)
                 .value_parser(value_parser!(Format)),
         )
@@ -945,7 +945,6 @@ fn build_per_source_metadata(
 
 struct EndpointWriter {
     writer: std::fs::File,
-    converter: Option<prometheus::PrometheusConverter>,
 }
 
 /// Upper bound on a single scrape or endpoint probe, whatever the interval.
@@ -1053,39 +1052,27 @@ pub fn run(mut config: RecordingConfig) {
     let mut rez_mode = wants_rez(config.format);
 
     if rez_mode {
-        // `.rez` ingest reads msgpack snapshots; an explicitly-prometheus
-        // endpoint yields none, so settle it up front (before probing) rather
-        // than recording an empty archive. Auto-detected prometheus is handled
-        // right after the probe, below.
+        // Neither a Prometheus endpoint nor several endpoints is a blocker any
+        // more. Each endpoint becomes its own label-tagged recording in one
+        // archive, and a Prometheus scrape converts to a V3 acquisition group
+        // on the way in — one request and one response is exactly one
+        // acquisition, which is what the group models.
         //
-        // Several endpoints are NOT a blocker any more: each becomes its own
-        // label-tagged recording in one archive, which is what the container's
-        // `recordings` list has always modelled and what `combine` could only
-        // assemble after the fact.
-        let blocker = endpoints
-            .iter()
-            .find(|e| matches!(e.config.protocol, Some(Protocol::Prometheus)))
-            .map(|ep| {
-                format!(
-                    "{} is configured protocol=prometheus, and .rez requires a rezolus (msgpack) endpoint",
-                    ep.config.url
-                )
-            })
-            // `--separate` writes a file per endpoint, which one archive
-            // cannot do. An explicit `.rez` was already rejected at parse
-            // time; reaching here means the format was merely defaulted, so
-            // demote to the parquet-per-endpoint run the flag asked for
-            // rather than erroring on a format nobody chose.
-            .or_else(|| {
-                // Only with several endpoints: with one there is nothing to
-                // separate, and `main`'s multi-endpoint blocker never fired
-                // on a single-endpoint run either.
-                (config.separate && config.endpoints.len() > 1).then(|| {
-                    "--separate writes one file per endpoint, which a .rez cannot do (every \
+        // `--separate` is what remains: it writes a file per endpoint, which
+        // one archive cannot do. An explicit `.rez` was already rejected at
+        // parse time; reaching here means the format was merely defaulted, so
+        // demote to the parquet-per-endpoint run the flag asked for rather
+        // than erroring on a format nobody chose.
+        let blocker = None.or_else(|| {
+            // Only with several endpoints: with one there is nothing to
+            // separate, and `main`'s multi-endpoint blocker never fired
+            // on a single-endpoint run either.
+            (config.separate && config.endpoints.len() > 1).then(|| {
+                "--separate writes one file per endpoint, which a .rez cannot do (every \
                      endpoint is a recording inside the one archive)"
-                        .to_string()
-                })
-            });
+                    .to_string()
+            })
+        });
 
         if let Some(reason) = blocker {
             demote_from_rez(&mut config, &reason);
@@ -1163,31 +1150,8 @@ pub fn run(mut config: RecordingConfig) {
     // output (or, in v2, the `<output>.partial`) and spawning the writer thread
     // are both fallible.
     let mut rez_recorder: Option<RezStream> = None;
-    // Endpoints ruled out of a `.rez` run after it started — a late endpoint
-    // that turned out to be prometheus. Kept so they are not re-probed every
-    // tick for the rest of the run.
-    let mut rez_excluded: std::collections::HashSet<usize> = std::collections::HashSet::new();
     if rez_mode {
-        // An endpoint that ANSWERED as prometheus still blocks the archive, the
-        // same as a configured one: `.rez` ingest reads msgpack snapshots, and
-        // a prometheus endpoint yields none. Checked across every active
-        // endpoint now that there can be several, and reported by name so a
-        // multi-endpoint run says which one demoted it.
-        let non_msgpack = endpoints
-            .iter()
-            .filter(|ep| ep.status == EndpointStatus::Active)
-            .find(|ep| ep.protocol() != Some(&Protocol::Msgpack))
-            .map(|ep| {
-                format!(
-                    "{} answered as prometheus, and .rez requires a rezolus (msgpack) endpoint",
-                    ep.config.url
-                )
-            });
-
-        if let Some(reason) = non_msgpack {
-            demote_from_rez(&mut config, &reason);
-            rez_mode = false;
-        } else {
+        {
             // Every active endpoint becomes a recording in ONE archive. Only
             // the endpoints active at this point: a `.rez` recording is opened
             // when its writer is, and an endpoint that activates later through
@@ -1210,6 +1174,25 @@ pub fn run(mut config: RecordingConfig) {
         }
     }
 
+    // Per-endpoint Prometheus converters, kept OUTSIDE `EndpointWriter`
+    // because `.rez` mode has no writer to hang them on: it has no msgpack
+    // spool at all, snapshots go straight into the streaming writer. Both
+    // modes need the same converter — one per endpoint, because it holds the
+    // (name, labels) -> id map that keeps a column's identity stable across
+    // scrapes, and two endpoints' id spaces must not mix.
+    let mut prom_converters: Vec<Option<prometheus::PrometheusConverter>> = endpoints
+        .iter()
+        .map(|ep| {
+            (ep.status == EndpointStatus::Active && ep.protocol() == Some(&Protocol::Prometheus))
+                .then(|| {
+                    prometheus::PrometheusConverter::with_provenance(
+                        ep.config.source_label().to_string(),
+                        ep.config.url.to_string(),
+                    )
+                })
+        })
+        .collect();
+
     let mut writers: Vec<Option<EndpointWriter>> = endpoints
         .iter()
         .map(|ep| {
@@ -1224,15 +1207,7 @@ pub fn run(mut config: RecordingConfig) {
                         std::process::exit(1);
                     }
                 };
-                let converter = if ep.protocol() == Some(&Protocol::Prometheus) {
-                    Some(prometheus::PrometheusConverter::with_provenance(
-                        ep.config.source_label().to_string(),
-                        ep.config.url.to_string(),
-                    ))
-                } else {
-                    None
-                };
-                Some(EndpointWriter { writer, converter })
+                Some(EndpointWriter { writer })
             } else {
                 None
             }
@@ -1480,37 +1455,52 @@ pub fn run(mut config: RecordingConfig) {
                         // most of a V1/V2-heavy fleet — `from_msgpack` is
                         // still the right-sized, version-agnostic fix here.
                         if rez_mode {
-                            match metriken_exposition::Snapshot::from_msgpack(&body) {
-                                Ok(snapshot) => {
-                                    let snapshot = inject_provenance(
+                            // A Prometheus endpoint converts its text to a
+                            // snapshot here; a rezolus one decodes msgpack.
+                            // Both reach the same `ingest` — the archive has no
+                            // opinion about which wire a recording came off.
+                            //
+                            // The converted snapshot is NOT run through
+                            // `inject_provenance`: the converter already writes
+                            // `source` and `endpoint` into every metric's
+                            // metadata, so injecting again would be a second
+                            // spelling of the same fact, free to disagree.
+                            let snapshot = match prom_converters[idx].as_mut() {
+                                Some(conv) => {
+                                    let text = String::from_utf8_lossy(&body);
+                                    Some(conv.convert(&text, request_ns, response_ns))
+                                }
+                                None => match metriken_exposition::Snapshot::from_msgpack(&body) {
+                                    Ok(snapshot) => Some(inject_provenance(
                                         snapshot,
                                         endpoints[idx].config.source_label(),
                                         endpoints[idx].config.url.as_str(),
-                                    );
-                                    if let Some(rec) = rez_recorder.as_mut() {
-                                        if let Err(e) = rec.ingest(
-                                            idx,
-                                            &endpoints[idx].config.url,
-                                            &snapshot,
-                                            anchored_ns,
-                                            wall_offset_ns,
-                                        ) {
-                                            ingest_failed.get_or_insert(e);
-                                        }
+                                    )),
+                                    Err(e) => {
+                                        warn!(
+                                            "msgpack decode error for {}: {e}",
+                                            endpoints[idx].config.source_label()
+                                        );
+                                        None
                                     }
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        "msgpack decode error for {}: {e}",
-                                        endpoints[idx].config.source_label()
-                                    );
+                                },
+                            };
+                            if let (Some(snapshot), Some(rec)) = (snapshot, rez_recorder.as_mut()) {
+                                if let Err(e) = rec.ingest(
+                                    idx,
+                                    &endpoints[idx].config.url,
+                                    &snapshot,
+                                    anchored_ns,
+                                    wall_offset_ns,
+                                ) {
+                                    ingest_failed.get_or_insert(e);
                                 }
                             }
                             continue;
                         }
 
                         if let Some(ref mut ew) = writers[idx] {
-                            let bytes = if let Some(ref mut conv) = ew.converter {
+                            let bytes = if let Some(ref mut conv) = prom_converters[idx] {
                                 // Prometheus: parse text → snapshot → msgpack
                                 let text = String::from_utf8_lossy(&body);
                                 // The real round trip, not the tick's clock:
@@ -1584,7 +1574,7 @@ pub fn run(mut config: RecordingConfig) {
             let pending_indices: Vec<usize> = endpoints
                 .iter()
                 .enumerate()
-                .filter(|(i, ep)| ep.status == EndpointStatus::Pending && !rez_excluded.contains(i))
+                .filter(|(_, ep)| ep.status == EndpointStatus::Pending)
                 .map(|(i, _)| i)
                 .collect();
 
@@ -1651,33 +1641,18 @@ pub fn run(mut config: RecordingConfig) {
                     // opened on the live archive instead, which is what keeps
                     // the "will retry each tick" warning honest.
                     if rez_mode {
-                        // A late endpoint that probes as prometheus cannot be
-                        // archived: the run committed to `.rez` at startup,
-                        // where the demotion check could not see this
-                        // endpoint's protocol because a Pending endpoint has
-                        // not been probed yet.
-                        //
-                        // Drop the endpoint rather than the run. Aborting here
-                        // would let a second, misconfigured endpoint destroy
-                        // hours of a healthy first one's capture — and it
-                        // would make the SAME misconfiguration behave two
-                        // ways: a clean pre-flight demotion when the endpoint
-                        // happens to be up at startup, a run-ending abort when
-                        // it happens to be down. The archive stays valid and
-                        // complete for every endpoint it can hold.
-                        if protocol != Protocol::Msgpack {
-                            eprintln!(
-                                "warning: {} answered as prometheus and cannot go into a \
-                                 .rez; it was unreachable at startup, so the archive was \
-                                 already committed. It will not be recorded — re-run with \
-                                 --format parquet to capture it",
-                                endpoints[idx].config.url
-                            );
-                            // Back to Pending and excluded, so it is neither
-                            // scraped into nothing nor re-probed every tick.
-                            endpoints[idx].status = EndpointStatus::Pending;
-                            rez_excluded.insert(idx);
-                        } else if let Some(rec) = rez_recorder.as_mut() {
+                        // A late endpoint that probes as prometheus gets a
+                        // converter now, the same as one present at startup —
+                        // a scrape becomes an acquisition group and lands in
+                        // the archive like any other recording.
+                        if protocol == Protocol::Prometheus && prom_converters[idx].is_none() {
+                            prom_converters[idx] =
+                                Some(prometheus::PrometheusConverter::with_provenance(
+                                    endpoints[idx].config.source_label().to_string(),
+                                    endpoints[idx].config.url.to_string(),
+                                ));
+                        }
+                        if let Some(rec) = rez_recorder.as_mut() {
                             if let Err(e) = rec.add_endpoint(
                                 idx,
                                 &config,
@@ -1693,18 +1668,16 @@ pub fn run(mut config: RecordingConfig) {
                             }
                         }
                     } else {
-                        let converter = if protocol == Protocol::Prometheus {
-                            Some(prometheus::PrometheusConverter::with_provenance(
-                                endpoints[idx].config.source_label().to_string(),
-                                endpoints[idx].config.url.to_string(),
-                            ))
-                        } else {
-                            None
-                        };
+                        if protocol == Protocol::Prometheus && prom_converters[idx].is_none() {
+                            prom_converters[idx] =
+                                Some(prometheus::PrometheusConverter::with_provenance(
+                                    endpoints[idx].config.source_label().to_string(),
+                                    endpoints[idx].config.url.to_string(),
+                                ));
+                        }
                         writers[idx] = Some(EndpointWriter {
                             writer: tempfile_in(out_dir.clone())
                                 .expect("failed to create temp file"),
-                            converter,
                         });
                     }
                 }
@@ -1856,7 +1829,7 @@ pub fn run(mut config: RecordingConfig) {
                                 let converter = build_parquet_converter(
                                     &config,
                                     &endpoints[idx],
-                                    &ew.converter,
+                                    &prom_converters[idx],
                                 );
                                 if let Err(e) = converter
                                     .convert_file_handle(ew.writer.try_clone().unwrap(), dest)
@@ -1891,7 +1864,7 @@ pub fn run(mut config: RecordingConfig) {
                                 let converter = build_parquet_converter(
                                     &config,
                                     &endpoints[idx],
-                                    &ew.converter,
+                                    &prom_converters[idx],
                                 );
                                 if let Err(e) = converter
                                     .convert_file_handle(ew.writer.try_clone().unwrap(), dest)
@@ -1929,7 +1902,7 @@ pub fn run(mut config: RecordingConfig) {
                                     let converter = build_parquet_converter(
                                         &config,
                                         &endpoints[idx],
-                                        &ew.converter,
+                                        &prom_converters[idx],
                                     );
                                     if let Err(e) = converter
                                         .convert_file_handle(ew.writer.try_clone().unwrap(), dest)

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -194,7 +194,7 @@ pub fn command() -> Command {
         .arg(
             clap::Arg::new("SEPARATE")
                 .long("separate")
-                .help("Write one file per endpoint instead of combining; each is named <OUTPUT-stem>_<source>.<ext> alongside the output path. Without an explicit source=, a rezolus agent endpoint is named \"rezolus\" and a Prometheus one falls back to its host-port (e.g. svc-9090). For parquet or raw output only: a .rez already keeps each endpoint as its own recording inside the one archive, so --separate does not apply to it")
+                .help("Write one file per endpoint instead of combining; each is named <OUTPUT-stem>_<source>.<ext> alongside the output path. Without an explicit source=, a rezolus agent endpoint is named \"rezolus\" and a Prometheus one falls back to its host-port plus any distinguishing path (e.g. svc-9090, or svc-9090-federate — the conventional /metrics is left off). For parquet or raw output only: a .rez already keeps each endpoint as its own recording inside the one archive, so --separate does not apply to it")
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(

--- a/src/recorder/prometheus.rs
+++ b/src/recorder/prometheus.rs
@@ -1,5 +1,9 @@
-use metriken_exposition::{Counter, Gauge, Histogram as SnapshotHistogram, Snapshot, SnapshotV2};
+use metriken_exposition::{
+    Counter, Gauge, GroupSchema, GroupSnapshot, Histogram as SnapshotHistogram, MetricDesc,
+    Snapshot, SnapshotV2, SnapshotV3,
+};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tracing::warn;
 
@@ -188,16 +192,108 @@ impl PrometheusConverter {
             }
         }
 
-        Snapshot::V2(SnapshotV2 {
+        // One scrape is one acquisition — one request, one response, one
+        // window — which is exactly what a V3 acquisition group models. See
+        // `PROMETHEUS_GROUP` for why this is a group rather than a flat V2
+        // snapshot.
+        //
+        // Sorted by assigned id, not by encounter order. Ids are stable across
+        // scrapes for a given (name, labels), so the schema then changes only
+        // when the metric SET does, rather than whenever an exporter reorders
+        // its output. A churning schema is not incorrect — every row carries
+        // its own hash and re-anchors when it changes — but it defeats the
+        // receiver's schema cache and pads every WAL row with a fresh copy.
+        by_id(&mut counters, |c| &c.name);
+        by_id(&mut gauges, |g| &g.name);
+        by_id(&mut histograms, |h| &h.name);
+
+        let schema = GroupSchema {
+            counters: counters.iter().map(desc_of).collect(),
+            gauges: gauges.iter().map(desc_of).collect(),
+            histograms: histograms.iter().map(desc_of).collect(),
+        };
+        let group = GroupSnapshot {
+            name: PROMETHEUS_GROUP.to_string(),
+            schema_hash: schema.hash(),
+            // Always sent. The producer contract allows omitting it on a cache
+            // hit, but a scrape's schema is rebuilt from scratch each tick
+            // here — there is no cheaper path to take, and a stateless payload
+            // is one less thing that can go stale.
+            schema: Some(Arc::new(schema)),
+            window,
+            counters: counters.into_iter().map(|c| Some(c.value)).collect(),
+            gauges: gauges.into_iter().map(|g| Some(g.value)).collect(),
+            histograms: histograms.into_iter().map(|h| Some(h.value)).collect(),
+        };
+
+        Snapshot::V3(SnapshotV3 {
             systemtime: SystemTime::now(),
-            duration: Duration::ZERO,
+            // The round trip. `duration` is documented as the snapshot's
+            // collection duration, and for a scrape that is exactly the
+            // interval the window brackets.
+            duration: Duration::from_nanos(response_ns.saturating_sub(request_ns)),
             metadata: HashMap::new(),
-            counters,
-            gauges,
-            histograms,
+            groups: vec![group],
         })
     }
 }
+
+/// The table an endpoint's scrape lands in: `<sampler>/<group>`.
+///
+/// **The slash is load-bearing, not cosmetic.** `.rez` dispatches a table's WAL
+/// rows between the V3 group-row decoder and the V1/V2 sampler-cell decoder on
+/// whether its key contains `/` (`rez::wal::is_group_table_key`), so a
+/// slash-less group name would send group rows down the sampler path.
+///
+/// `prometheus` as the sampler rather than the service's own name: a
+/// multi-endpoint `.rez` already puts each target in its own recording tagged
+/// `source=<service>`, so repeating the service here would say nothing new,
+/// while "these readings came from a Prometheus scrape" is not recorded
+/// anywhere else. One group, because one scrape is one acquisition.
+pub const PROMETHEUS_GROUP: &str = "prometheus/scrape";
+
+/// Sort by the numeric id assigned to each metric.
+///
+/// By VALUE, not lexically: ids are decimal strings, so a lexical sort puts
+/// `"10"` before `"2"` and the order changes shape as a target crosses a power
+/// of ten — which would rewrite the schema for no reason.
+fn by_id<T>(items: &mut [T], name: impl Fn(&T) -> &String) {
+    items.sort_by_key(|i| name(i).parse::<u64>().unwrap_or(u64::MAX));
+}
+
+/// One schema member from a snapshot value: the id it is keyed by, and the
+/// metadata that says what it actually is.
+fn desc_of<T: HasNameAndMetadata>(item: &T) -> MetricDesc {
+    MetricDesc {
+        name: item.name().to_string(),
+        metadata: item
+            .metadata()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    }
+}
+
+/// Read a name and metadata off any of the three snapshot value shapes, so
+/// [`desc_of`] is written once rather than three times.
+trait HasNameAndMetadata {
+    fn name(&self) -> &str;
+    fn metadata(&self) -> &HashMap<String, String>;
+}
+
+macro_rules! has_name_and_metadata {
+    ($($t:ty),*) => {$(
+        impl HasNameAndMetadata for $t {
+            fn name(&self) -> &str {
+                &self.name
+            }
+            fn metadata(&self) -> &HashMap<String, String> {
+                &self.metadata
+            }
+        }
+    )*};
+}
+has_name_and_metadata!(Counter, Gauge, SnapshotHistogram);
 
 /// Convert Prometheus cumulative histogram buckets into a histogram::Histogram.
 ///
@@ -421,10 +517,11 @@ mod tests {
         let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
         let (request_ns, response_ns) = (5_000_000_000u64, 5_002_000_000u64);
         let text = "m_total 3 1000\n";
-        let Snapshot::V2(s) = conv.convert(text, request_ns, response_ns) else {
-            panic!()
-        };
-        let w = s.counters[0].window.expect("window set");
+        // Read through the version-agnostic accessor: these assert a property
+        // of the READINGS, not of the wire shape, and it is the same accessor
+        // the parquet path uses.
+        let mut snap = conv.convert(text, request_ns, response_ns);
+        let w = snap.counters()[0].window.expect("window set");
         assert_eq!(
             (w.begin_ns, w.end_ns),
             (request_ns, response_ns),
@@ -440,11 +537,8 @@ mod tests {
         let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
         // A realistic recording clock: 2026-ish, not 1970.
         let fetch_ns = 1_780_000_000_000_000_000u64;
-        let Snapshot::V2(s) = conv.convert("m_total 3 1000\n", fetch_ns, fetch_ns + 2_000_000)
-        else {
-            panic!()
-        };
-        let w = s.counters[0].window.expect("window set");
+        let mut snap = conv.convert("m_total 3 1000\n", fetch_ns, fetch_ns + 2_000_000);
+        let w = snap.counters()[0].window.expect("window set");
         assert!(
             w.begin_ns >= fetch_ns.saturating_sub(1),
             "a window beginning {} against a row at {fetch_ns} would be decades of \
@@ -458,10 +552,8 @@ mod tests {
         let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
         let (request_ns, response_ns) = (5_000_000_000u64, 5_002_000_000u64);
         let text = "m_total 3\n";
-        let Snapshot::V2(s) = conv.convert(text, request_ns, response_ns) else {
-            panic!()
-        };
-        let w = s.counters[0].window.expect("window set");
+        let mut snap = conv.convert(text, request_ns, response_ns);
+        let w = snap.counters()[0].window.expect("window set");
         assert_eq!((w.begin_ns, w.end_ns), (request_ns, response_ns));
     }
 
@@ -483,20 +575,136 @@ a_total 1
 # TYPE b gauge
 b 2
 ";
-        let Snapshot::V2(s) = conv.convert(text, request_ns, response_ns) else {
-            panic!()
-        };
-        assert!(!s.counters.is_empty() && !s.gauges.is_empty(), "fixture");
-        for w in s
-            .counters
+        let mut snap = conv.convert(text, request_ns, response_ns);
+        let (cs, gs) = (snap.counters(), snap.gauges());
+        assert!(!cs.is_empty() && !gs.is_empty(), "fixture");
+        for w in cs
             .iter()
             .map(|c| c.window)
-            .chain(s.gauges.iter().map(|g| g.window))
+            .chain(gs.iter().map(|g| g.window))
         {
             let w = w.expect("every value carries a window");
             assert_eq!((w.begin_ns, w.end_ns), (request_ns, response_ns));
             assert!(w.width_ns() > 0, "a scrape is not an instant");
         }
+    }
+
+    /// The parquet path must not notice the version change.
+    ///
+    /// `metriken-exposition` contracts that a V3 snapshot and the V2 describing
+    /// the same readings produce the same `HashedSnapshot`, which is what
+    /// `MsgpackToParquet` consumes — but that is THEIR invariant about THEIR
+    /// types, and it says nothing about whether this converter still puts the
+    /// same names, values, metadata and windows into it. Pinned here, on our
+    /// side of the boundary: parquet is the shipping output for a Prometheus
+    /// source, and a silent change to it would be a regression nobody asked
+    /// for.
+    #[test]
+    fn the_flat_view_of_a_scrape_is_unchanged_by_the_group_shape() {
+        let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
+        let text = "\
+# TYPE a_total counter
+a_total 7
+# TYPE b gauge
+b{k=\"v\"} -3
+";
+        let mut snap = conv.convert(text, 1_000, 2_000);
+
+        let counters = snap.counters();
+        assert_eq!(counters.len(), 1);
+        assert_eq!(counters[0].value, 7);
+        assert_eq!(
+            counters[0].metadata.get("metric").map(String::as_str),
+            Some("a_total")
+        );
+        assert_eq!(
+            counters[0].metadata.get("source").map(String::as_str),
+            Some("svc")
+        );
+        let w = counters[0].window.expect("window survives the group");
+        assert_eq!((w.begin_ns, w.end_ns), (1_000, 2_000));
+
+        let gauges = snap.gauges();
+        assert_eq!(gauges.len(), 1);
+        assert_eq!(gauges[0].value, -3);
+        assert_eq!(gauges[0].metadata.get("k").map(String::as_str), Some("v"));
+    }
+
+    /// A scrape is ONE acquisition, so it is one group with one window — not a
+    /// group per metric, and not a flat V2 snapshot where every value column
+    /// drags its own `<name>:window_begin`/`:window_width` pair. That per-value
+    /// pair is what would triple a Prometheus table's schema width in a `.rez`,
+    /// which is exactly the cost acquisition groups removed.
+    #[test]
+    fn a_scrape_is_one_acquisition_group() {
+        let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
+        let text = "\
+# TYPE a_total counter
+a_total 1
+# TYPE c_total counter
+c_total 2
+# TYPE b gauge
+b 3
+";
+        let Snapshot::V3(v3) = conv.convert(text, 1_000, 2_000) else {
+            panic!("a scrape must convert to V3 — the flat V2 shape is what this replaced")
+        };
+        assert_eq!(v3.groups.len(), 1);
+        let g = &v3.groups[0];
+        assert_eq!(g.counters.len(), 2);
+        assert_eq!(g.gauges.len(), 1);
+        assert!(g.window.is_some(), "the group carries the scrape's window");
+        assert_eq!(v3.duration.as_nanos(), 1_000, "the round trip");
+    }
+
+    /// The table key has to contain a `/`.
+    ///
+    /// `.rez` dispatches a table's WAL rows between the V3 group decoder and
+    /// the V1/V2 sampler-cell decoder purely on whether the key contains one
+    /// (`rez::wal::is_group_table_key`). A slash-less group name would route
+    /// group rows into the sampler path — a decode error rather than silent
+    /// misrouting, but broken either way, and nothing else in the type system
+    /// catches it.
+    #[test]
+    fn the_group_name_is_a_sampler_slash_group_key() {
+        let (sampler, group) = PROMETHEUS_GROUP
+            .split_once('/')
+            .expect("a V3 group name is <sampler>/<group>");
+        assert!(!sampler.is_empty() && !group.is_empty());
+        assert!(rez::wal::is_group_table_key(PROMETHEUS_GROUP));
+        assert_eq!(rez::rez::table_sampler(PROMETHEUS_GROUP), "prometheus");
+    }
+
+    /// The schema changes only when the metric SET does — not when an exporter
+    /// reorders its output, and not as a target's ids cross a power of ten.
+    ///
+    /// A churning schema is not incorrect (each row carries its own hash and
+    /// re-anchors), but it defeats the receiver's schema cache and pads every
+    /// WAL row with a fresh copy of the membership.
+    #[test]
+    fn the_schema_hash_is_stable_across_scrapes_of_the_same_metrics() {
+        let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
+        // Enough metrics that ids run past 9, where a lexical sort would put
+        // "10" before "2" and reshuffle the schema.
+        let many = |vals: &[u64]| {
+            let mut t = String::new();
+            for (i, v) in vals.iter().enumerate() {
+                t.push_str(&format!("# TYPE m{i}_total counter\nm{i}_total {v}\n"));
+            }
+            t
+        };
+        let hash_of = |snap: Snapshot| match snap {
+            Snapshot::V3(v3) => v3.groups[0].schema_hash,
+            _ => panic!("V3"),
+        };
+
+        let first = hash_of(conv.convert(&many(&[0; 12]), 1_000, 2_000));
+        let second = hash_of(conv.convert(&many(&[1; 12]), 3_000, 4_000));
+        assert_eq!(first, second, "same metrics, same schema");
+
+        // A metric appearing IS a membership change, and must re-anchor.
+        let grown = hash_of(conv.convert(&many(&[1; 13]), 5_000, 6_000));
+        assert_ne!(first, grown, "a new metric changes the membership");
     }
 
     /// A wall clock that steps backwards mid-scrape (NTP, a VM migration) must

--- a/src/recorder/prometheus.rs
+++ b/src/recorder/prometheus.rs
@@ -67,7 +67,16 @@ impl PrometheusConverter {
         metadata
     }
 
-    pub fn convert(&mut self, text: &str, fetch_ns: u64) -> Snapshot {
+    /// Convert one scrape, bracketed by the round trip that produced it.
+    ///
+    /// `request_ns`/`response_ns` are when the request went out and when the
+    /// response finished arriving. Every value in `text` was read by the
+    /// exporter somewhere inside that interval, and nothing here can narrow it
+    /// further: exposition carries no acquisition instant, and the one
+    /// timestamp it may carry means something else entirely (see
+    /// [`sample_window`]).
+    pub fn convert(&mut self, text: &str, request_ns: u64, response_ns: u64) -> Snapshot {
+        let fetch_ns = response_ns;
         let sanitized = sanitize_metric_names(text);
         let lines = sanitized.lines().map(|l| Ok(l.to_string()));
         let fetch_time = chrono::DateTime::<chrono::Utc>::from_timestamp_nanos(fetch_ns as i64);
@@ -92,7 +101,7 @@ impl PrometheusConverter {
 
         // One window for the whole scrape: every sample in it was read by the
         // same request/response, so they share an acquisition instant.
-        let window = sample_window(fetch_ns);
+        let window = sample_window(request_ns, response_ns);
 
         for sample in scrape.samples {
             let mut labels: Vec<(String, String)> = sample
@@ -351,14 +360,31 @@ fn sanitize_metric_names(text: &str) -> String {
 /// but a ~56-year error in the operand `rate()` prices its uncertainty from.
 /// Any exporter that emits timestamps (pushgateway, federation) wrote that.
 ///
-/// Still zero-width, which understates: a scrape is one request and one
-/// response, so the honest bracket is the real round-trip
-/// `[request_sent, response_received]`. The converter is handed only parsed
-/// text and a single instant, so the request instant does not reach it — that
-/// is tracked with the Prometheus-in-`.rez` work, and is a widening of this
-/// window rather than a change of its anchor.
-fn sample_window(fetch_ns: u64) -> Option<metriken::Window> {
-    Some(metriken::Window::new(fetch_ns, fetch_ns))
+/// The window is the real round trip, `[request_sent, response_received]`. It
+/// was zero-width — a whole scrape asserted to have been read at an instant,
+/// which is the lie the all-sampler-observation-windows arc exists to kill.
+/// Every value in a response was read by the exporter somewhere inside the
+/// round trip and nothing here can say where, so that interval is the honest
+/// bound: `rate()` prices its uncertainty from a bracket that actually
+/// contains the reading rather than one asserted to be exact.
+///
+/// **A caching exporter under-states this, and that is still an improvement.**
+/// If an exporter serves values it computed before the request arrived, the
+/// true acquisition instant is earlier than `request_sent` and the real
+/// uncertainty is wider than what is recorded. Nothing observable from the
+/// client distinguishes that case — exposition carries no acquisition instant
+/// — so the recorded window is a lower bound on the uncertainty rather than a
+/// complete account of it. A zero-width window was a lower bound too, and a
+/// far worse one: it claimed no uncertainty at all.
+fn sample_window(request_ns: u64, response_ns: u64) -> Option<metriken::Window> {
+    // Defensive: a non-monotonic wall clock (NTP step, VM migration) can make
+    // the response read EARLIER than the request. A window whose end precedes
+    // its begin would give `rate()` a saturating-to-zero width, so collapse it
+    // to the instant we are surest of instead.
+    if response_ns < request_ns {
+        return Some(metriken::Window::new(response_ns, response_ns));
+    }
+    Some(metriken::Window::new(request_ns, response_ns))
 }
 
 fn empty_snapshot() -> Snapshot {
@@ -393,17 +419,17 @@ mod tests {
     #[test]
     fn an_embedded_timestamp_is_not_the_window() {
         let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
-        let fetch_ns = 5_000_000_000u64;
+        let (request_ns, response_ns) = (5_000_000_000u64, 5_002_000_000u64);
         let text = "m_total 3 1000\n";
-        let Snapshot::V2(s) = conv.convert(text, fetch_ns) else {
+        let Snapshot::V2(s) = conv.convert(text, request_ns, response_ns) else {
             panic!()
         };
         let w = s.counters[0].window.expect("window set");
         assert_eq!(
-            w.begin_ns, fetch_ns,
-            "the window is our fetch, not the exporter's 1000 ms epoch stamp"
+            (w.begin_ns, w.end_ns),
+            (request_ns, response_ns),
+            "the window is our round trip, not the exporter's 1000 ms epoch stamp"
         );
-        assert_eq!(w.end_ns, fetch_ns);
     }
 
     /// The offset is stored relative to the row timestamp, so an epoch-anchored
@@ -414,7 +440,8 @@ mod tests {
         let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
         // A realistic recording clock: 2026-ish, not 1970.
         let fetch_ns = 1_780_000_000_000_000_000u64;
-        let Snapshot::V2(s) = conv.convert("m_total 3 1000\n", fetch_ns) else {
+        let Snapshot::V2(s) = conv.convert("m_total 3 1000\n", fetch_ns, fetch_ns + 2_000_000)
+        else {
             panic!()
         };
         let w = s.counters[0].window.expect("window set");
@@ -429,12 +456,55 @@ mod tests {
     #[test]
     fn absent_timestamp_falls_back_to_fetch_time() {
         let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
-        let fetch_ns = 5_000_000_000u64;
+        let (request_ns, response_ns) = (5_000_000_000u64, 5_002_000_000u64);
         let text = "m_total 3\n";
-        let Snapshot::V2(s) = conv.convert(text, fetch_ns) else {
+        let Snapshot::V2(s) = conv.convert(text, request_ns, response_ns) else {
             panic!()
         };
         let w = s.counters[0].window.expect("window set");
-        assert_eq!(w.begin_ns, fetch_ns, "no embedded ts -> fetch time");
+        assert_eq!((w.begin_ns, w.end_ns), (request_ns, response_ns));
+    }
+
+    /// A scrape is one acquisition, and its honest bracket is the round trip.
+    ///
+    /// This was `Window::new(ns, ns)` — a whole scrape asserted to have been
+    /// read at an instant, which is the claim
+    /// `docs/journal/2026-07-10-all-sampler-observation-windows.md` calls the
+    /// lie the arc kills. A zero-width window tells `rate()` there is no
+    /// uncertainty to price; the round trip tells it the truth we can actually
+    /// observe.
+    #[test]
+    fn every_value_in_a_scrape_carries_the_round_trip_as_its_window() {
+        let mut conv = PrometheusConverter::with_provenance("svc".into(), "http://x".into());
+        let (request_ns, response_ns) = (10_000_000_000u64, 10_045_000_000u64);
+        let text = "\
+# TYPE a_total counter
+a_total 1
+# TYPE b gauge
+b 2
+";
+        let Snapshot::V2(s) = conv.convert(text, request_ns, response_ns) else {
+            panic!()
+        };
+        assert!(!s.counters.is_empty() && !s.gauges.is_empty(), "fixture");
+        for w in s
+            .counters
+            .iter()
+            .map(|c| c.window)
+            .chain(s.gauges.iter().map(|g| g.window))
+        {
+            let w = w.expect("every value carries a window");
+            assert_eq!((w.begin_ns, w.end_ns), (request_ns, response_ns));
+            assert!(w.width_ns() > 0, "a scrape is not an instant");
+        }
+    }
+
+    /// A wall clock that steps backwards mid-scrape (NTP, a VM migration) must
+    /// not produce a window whose end precedes its begin: the width saturates
+    /// to zero, which would silently re-assert the very claim this replaced.
+    #[test]
+    fn a_backwards_clock_collapses_rather_than_inverting() {
+        let w = sample_window(9_000, 8_000).unwrap();
+        assert_eq!((w.begin_ns, w.end_ns), (8_000, 8_000));
     }
 }

--- a/tests/record_lifecycle.rs
+++ b/tests/record_lifecycle.rs
@@ -80,6 +80,12 @@ fn spawn_fake_agent() -> u16 {
 /// exposition and 404s everything else, so the recorder's probe classifies it
 /// as prometheus rather than msgpack.
 fn spawn_fake_exporter() -> u16 {
+    spawn_fake_exporter_named("http_requests_total")
+}
+
+/// As `spawn_fake_exporter`, with the counter's name chosen by the caller so
+/// two exporters in one run are telling apart by what they expose.
+fn spawn_fake_exporter_named(counter: &'static str) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind the fake exporter");
     let port = listener.local_addr().unwrap().port();
     std::thread::spawn(move || {
@@ -95,9 +101,9 @@ fn spawn_fake_exporter() -> u16 {
             }
             tick += 1;
             let body = format!(
-                "# HELP http_requests_total Total requests.\n\
-                 # TYPE http_requests_total counter\n\
-                 http_requests_total{{code=\"200\"}} {tick}\n\
+                "# HELP {counter} Total requests.\n\
+                 # TYPE {counter} counter\n\
+                 {counter}{{code=\"200\"}} {tick}\n\
                  # TYPE queue_depth gauge\n\
                  queue_depth {}\n",
                 tick * 2
@@ -189,6 +195,134 @@ fn a_prometheus_endpoint_records_into_a_rez() {
     assert!(
         stdout.contains("http_requests_total"),
         "the exporter's metrics must be readable back out: {stdout}"
+    );
+}
+
+/// Several Prometheus endpoints in one run: each is its own recording, and
+/// each keeps its own metrics.
+///
+/// Every recording's table is keyed `prometheus/scrape` — the SAME key in all
+/// of them — so this is where a per-recording namespace either holds or does
+/// not. It also exercises the id space: each endpoint's converter counts from
+/// 0, so both recordings' first metric is column `"0"` while meaning entirely
+/// different things.
+#[test]
+fn several_prometheus_endpoints_each_become_their_own_recording() {
+    let a = spawn_fake_exporter_named("alpha_total");
+    let b = spawn_fake_exporter_named("beta_total");
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let output = dir.path().join("fleet.rez");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+        .arg("record")
+        .arg("--endpoint")
+        .arg(format!("http://127.0.0.1:{a}/metrics,source=alpha"))
+        .arg("--endpoint")
+        .arg(format!("http://127.0.0.1:{b}/metrics,source=beta"))
+        .arg("-o")
+        .arg(&output)
+        .arg("--interval")
+        .arg("100ms")
+        .arg("--duration")
+        .arg("1s")
+        .output()
+        .expect("failed to run rezolus record");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "two prometheus endpoints must record (status {:?})\nstderr:\n{stderr}",
+        out.status.code()
+    );
+
+    let described = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+        .arg("mcp")
+        .arg("describe-recording")
+        .arg(&output)
+        .output()
+        .expect("failed to run rezolus mcp describe-recording");
+    let listing = String::from_utf8_lossy(&described.stdout);
+    assert!(
+        listing.contains("source=alpha") && listing.contains("source=beta"),
+        "both targets must be recordings in the archive: {listing}"
+    );
+
+    // Each recording holds ITS OWN metric, not the other's. Both are column
+    // "0" in their own table, so a namespace collision would show up here as
+    // the wrong name coming back.
+    for (source, mine, theirs) in [
+        ("alpha", "alpha_total", "beta_total"),
+        ("beta", "beta_total", "alpha_total"),
+    ] {
+        let out = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+            .arg("mcp")
+            .arg("describe-metrics")
+            .arg(&output)
+            .arg("--recording")
+            .arg(format!("source={source}"))
+            .output()
+            .expect("failed to run rezolus mcp describe-metrics");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains(mine),
+            "the {source} recording must hold {mine}: {stdout}"
+        );
+        assert!(
+            !stdout.contains(theirs),
+            "the {source} recording must NOT hold {theirs}: {stdout}"
+        );
+    }
+}
+
+/// A rezolus agent and a Prometheus exporter in the SAME archive — newly
+/// possible, and the combination nothing else covers.
+///
+/// The two produce completely different table shapes (per-sampler V2 cells vs
+/// a V3 acquisition group), so this is where a container that quietly assumed
+/// one wire per archive would break.
+#[test]
+fn a_rezolus_agent_and_a_prometheus_exporter_share_one_archive() {
+    let agent = spawn_fake_agent();
+    let exporter = spawn_fake_exporter_named("http_requests_total");
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let output = dir.path().join("mixed.rez");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+        .arg("record")
+        .arg("--endpoint")
+        .arg(format!("http://127.0.0.1:{agent},source=rezolus"))
+        .arg("--endpoint")
+        .arg(format!("http://127.0.0.1:{exporter}/metrics,source=svc"))
+        .arg("-o")
+        .arg(&output)
+        .arg("--interval")
+        .arg("100ms")
+        .arg("--duration")
+        .arg("1s")
+        .output()
+        .expect("failed to run rezolus record");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "a mixed run must record (status {:?})\nstderr:\n{stderr}",
+        out.status.code()
+    );
+
+    let described = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+        .arg("recording")
+        .arg("metadata")
+        .arg("-i")
+        .arg(&output)
+        .output()
+        .expect("failed to run rezolus recording metadata");
+    let stdout = String::from_utf8_lossy(&described.stdout);
+    assert!(described.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("prometheus/scrape"),
+        "the exporter's acquisition group must be there: {stdout}"
+    );
+    assert!(
+        stdout.contains("fake"),
+        "and the agent's own sampler table alongside it: {stdout}"
     );
 }
 

--- a/tests/record_lifecycle.rs
+++ b/tests/record_lifecycle.rs
@@ -76,6 +76,122 @@ fn spawn_fake_agent() -> u16 {
     port
 }
 
+/// Minimal stand-in for a Prometheus exporter. Answers `/metrics` with text
+/// exposition and 404s everything else, so the recorder's probe classifies it
+/// as prometheus rather than msgpack.
+fn spawn_fake_exporter() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind the fake exporter");
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        let mut tick = 0u64;
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut buf = [0u8; 8192];
+            let Ok(n) = stream.read(&mut buf) else {
+                continue;
+            };
+            if n == 0 {
+                continue;
+            }
+            tick += 1;
+            let body = format!(
+                "# HELP http_requests_total Total requests.\n\
+                 # TYPE http_requests_total counter\n\
+                 http_requests_total{{code=\"200\"}} {tick}\n\
+                 # TYPE queue_depth gauge\n\
+                 queue_depth {}\n",
+                tick * 2
+            );
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(head.as_bytes());
+            let _ = stream.write_all(body.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    port
+}
+
+/// A Prometheus endpoint records into a `.rez` — it used to demote the whole
+/// run to parquet.
+///
+/// The refusal was a policy check, not a capability limit: a scrape is one
+/// request and one response, which is exactly one acquisition group, and the
+/// archive has always been able to hold those. This drives the real binary
+/// end to end because the conversion, the archive write and the read back are
+/// three separate layers and the interesting failures are between them.
+#[test]
+fn a_prometheus_endpoint_records_into_a_rez() {
+    let port = spawn_fake_exporter();
+    let dir = tempfile::tempdir().expect("failed to create a temp dir");
+    let output = dir.path().join("prom.rez");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+        .arg("record")
+        .arg("--endpoint")
+        .arg(format!("http://127.0.0.1:{port}/metrics,source=svc"))
+        .arg("-o")
+        .arg(&output)
+        .arg("--interval")
+        .arg("100ms")
+        .arg("--duration")
+        .arg("1s")
+        .output()
+        .expect("failed to run rezolus record");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "recording a prometheus endpoint to .rez must exit 0 (status {:?})\nstderr:\n{stderr}",
+        out.status.code()
+    );
+    assert!(
+        !stderr.contains("falling back") && !stderr.contains("requires a rezolus"),
+        "the run must NOT demote to parquet:\n{stderr}"
+    );
+
+    // A v3 archive, not the parquet fallback.
+    let head = std::fs::read(&output).expect("the recording should exist");
+    assert!(
+        head.starts_with(b"SQLite format 3\0"),
+        "a prometheus recording must be a real .rez, not a renamed parquet"
+    );
+
+    let described = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+        .arg("recording")
+        .arg("metadata")
+        .arg("-i")
+        .arg(&output)
+        .output()
+        .expect("failed to run rezolus recording metadata");
+    let stdout = String::from_utf8_lossy(&described.stdout);
+    assert!(described.status.success(), "{stdout}");
+    // The table is the acquisition group, keyed `<sampler>/<group>`.
+    assert!(
+        stdout.contains("prometheus/scrape"),
+        "the scrape must land in its own acquisition group table: {stdout}"
+    );
+    assert!(
+        stdout.contains("source=svc") || stdout.contains("svc"),
+        "the recording keeps its source label: {stdout}"
+    );
+
+    // And the metrics are queryable out of the archive by name.
+    let described = Command::new(env!("CARGO_BIN_EXE_rezolus"))
+        .arg("mcp")
+        .arg("describe-metrics")
+        .arg(&output)
+        .output()
+        .expect("failed to run rezolus mcp describe-metrics");
+    let stdout = String::from_utf8_lossy(&described.stdout);
+    assert!(
+        stdout.contains("http_requests_total"),
+        "the exporter's metrics must be readable back out: {stdout}"
+    );
+}
+
 /// A recorder that cannot create its output must exit non-zero.
 ///
 /// Regression this guards: a failure on the output path printed an error and


### PR DESCRIPTION
Closes the "Prometheus sources inside `.rez`" backlog entry, whose own analysis said it best: the refusal was **a policy check, not a capability limit**, and lifting it *improves* measurement honesty rather than compromising it.

Three commits, meant to be read in order — the first is a correctness fix that stands alone.

## 1. `fix`: a scrape's real acquisition window

Every value from a Prometheus endpoint carried `Window::new(ns, ns)` — a whole scrape asserted to have been read at **an instant**. That is the claim [all-sampler observation windows](docs/journal/2026-07-10-all-sampler-observation-windows.md) calls the lie the arc exists to kill, and it shipped on the **parquet** path: `rate()` was told there was no uncertainty to price.

A scrape is one acquisition — one request, one response — so the honest bracket is the round trip. `scrape_one` now returns when the request went out and when the response finished arriving. The response instant is read after the **body**, not the headers: the values are in the body, so a bracket closing at the response line would exclude part of the interval they were read over.

A backwards wall clock (NTP step, VM migration) collapses to an instant rather than inverting — `end < begin` saturates to zero width, silently re-asserting exactly the claim this replaces.

**The caching-exporter case is documented, not solved.** An exporter serving values it computed before the request arrived has a true acquisition instant earlier than `request_sent`, so the real uncertainty is wider than what is recorded. Nothing observable from the client distinguishes that, so the window is a *lower bound* on uncertainty rather than a complete account — but a zero-width window was a lower bound too, and a far worse one.

## 2. `feat`: one acquisition group per target

The converter emitted `SnapshotV2`, where every value column drags its own `<name>:window_begin`/`<name>:window_width` pair. Routing that into a `.rez` unchanged would **triple the schema width** of every Prometheus table — exactly the cost acquisition groups exist to remove. It emits `SnapshotV3` with one group per target instead.

- **`prometheus/scrape`, and the slash is load-bearing.** `.rez` dispatches a table's WAL rows between the V3 group decoder and the V1/V2 sampler-cell decoder purely on whether the key contains `/` (`rez::wal::is_group_table_key`), so a slash-less name routes group rows into the sampler path. `prometheus` as the sampler rather than the service's name: a multi-endpoint `.rez` already tags each recording `source=<service>`, so repeating it says nothing new, while "these came from a scrape" is recorded nowhere else.
- **Schema members ordered by assigned id, sorted numerically.** Ids are decimal strings, so a lexical sort puts `"10"` before `"2"` and reshuffles the schema as a target crosses a power of ten. Ordered this way, the schema changes only when the metric *set* does. Churn is not incorrect — every row carries its own hash and re-anchors — but it defeats the receiver's schema cache and pads every WAL row with a fresh copy of the membership.
- **The parquet path is unchanged, and a test pins that on our side of the boundary.** `metriken-exposition` contracts that a V3 snapshot and the equivalent V2 produce the same `HashedSnapshot`, but that is their invariant about their types; it says nothing about whether this converter still puts the same names, values, metadata and windows into it. Parquet is the shipping output for a Prometheus source — not something to take on trust.

## 3. `feat`: lift the refusal

Both demotions gone. A Prometheus endpoint is an ordinary recording in the archive now, alongside any number of rezolus ones.

- `EndpointWriter` no longer owns the converter — `.rez` mode has no writer to hang one on (no msgpack spool at all), so converters moved to a vec beside it. One per endpoint, because it holds the `(name, labels) -> id` map that keeps a column's identity stable across scrapes, and two endpoints' id spaces must not mix.
- The converted snapshot skips `inject_provenance`: the converter already writes `source`/`endpoint` into every metric's metadata, and a second spelling of the same fact is free to disagree.
- The late-activation path lost a whole branch. An endpoint that was down at startup and probed as Prometheus mid-run used to be **dropped from the run** with a warning; it just gets a converter and a recording now. `rez_excluded` went with it.

**Behavior change worth knowing:** a defaulted-format run against a Prometheus endpoint used to fall back to `rezolus.parquet` with a note on stderr. It writes `rezolus.rez` now. Keeping the fallback would have made the feature unreachable without an explicit `--format rez`.

## Tests

13 new, including an end-to-end run of the real binary against a stand-in exporter: the output is a v3 SQLite archive rather than a renamed parquet, the scrape lands in a `prometheus/scrape` group table, and the exporter's metrics read back out through `mcp describe-metrics`. Three layers, and the interesting failures are between them.

The four existing window tests now read through the version-agnostic accessors (`snapshot.counters()`), which is what they should have done anyway — they assert a property of the readings, not of the wire shape, and it is the same accessor the parquet path uses.

Full workspace green, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)