### PR TITLE
feat(blockio): split latency into queue, device, and end-to-end phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## [Unreleased]
 
+### Added
+
+- Agent: block IO latency is now split into its three phases, each a histogram
+  broken down by `op` (read, write, flush, discard). `blockio_queue_latency` is
+  the time a request waited before the device began servicing it — the
+  component that grows under saturation, where device latency alone stays flat.
+  `blockio_total_latency` is the end-to-end span the issuing workload actually
+  experiences, measured directly rather than summed (two histograms cannot be
+  added). The sampler already traced `block_rq_insert`, but insert and issue
+  shared one timestamp and issue overwrote it, discarding the interval — so
+  this needs no new probe attach. A request that goes straight to the driver
+  has no queue phase and records no queue sample. (#1054, #1124)
+
+### Changed
+
+- **Agent: `blockio_latency` is renamed `blockio_device_latency`.** It is the
+  same measurement — the pre-split metric always reported the issue-to-complete
+  span — but the bare name became ambiguous once the queue and end-to-end
+  phases were split out alongside it. Readers treat the two names as one
+  metric: the viewer, dashboard, and TUI resolve whichever name a recording
+  carries (`blockio_device_latency_metric`), so existing recordings keep
+  rendering unchanged. External consumers that query `blockio_latency` by name
+  — Prometheus rules, Grafana dashboards, saved PromQL — need updating.
+  (#1054, #1124)
+
 ## [5.19.0] - 2026-08-31
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,9 @@ dependencies = [
 name = "dashboard"
 version = "0.1.0"
 dependencies = [
+ "histogram",
  "include_dir",
+ "metriken-exposition",
  "metriken-query",
  "serde",
  "serde_json",

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -131,8 +131,10 @@ enabled = true
 # Each sampler can then be individually configured to override the defaults. All
 # of the configuration options in the `[defaults]` section are allowed.
 
-# BPF sampler that instruments block_io request queue to measure the request
-# latency distribution.
+# BPF sampler that instruments the block_io request queue to measure each phase
+# of a request's life: how long it waited in the queue (`blockio_queue_latency`),
+# how long the device then took (`blockio_device_latency`), and the two together
+# (`blockio_total_latency`).
 [samplers.blockio_latency]
 
 # BPF sampler that instruments block_io request queue. Produces per-op

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -16,4 +16,7 @@ serde_json.workspace = true
 include_dir.workspace = true
 
 [dev-dependencies]
+histogram.workspace = true
+metriken-exposition.workspace = true
+metriken-query = { workspace = true, features = ["ingest"] }
 tempfile = "3"

--- a/crates/dashboard/src/dashboard/blockio.rs
+++ b/crates/dashboard/src/dashboard/blockio.rs
@@ -65,6 +65,36 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         );
     }
 
+    // Queue residency is only present on recordings made by an agent that
+    // collects it, and only on devices whose requests actually pass through an
+    // IO scheduler — blk-mq with the `none` elevator issues directly, so there
+    // is no queue phase to measure. Gate the subgroup on the metric being in
+    // the data rather than rendering empty plots where neither holds.
+    if metric_unique_label_count(data, "blockio_queue_latency", "op") > 0 {
+        let queue = latency.subgroup("Queue Wait");
+        queue.describe(
+            "Time requests spent queued before the device began servicing them. This is the \
+             component that grows under saturation — a device at its limit shows queue wait \
+             climbing while service latency above stays flat.",
+        );
+        for op in &["Read", "Write"] {
+            let op_lower = op.to_lowercase();
+            queue.histogram_rate_mean(
+                op,
+                &format!("queue-latency-{op_lower}"),
+                &format!("blockio_queue_latency{{op=\"{op_lower}\"}}"),
+                RateSource::Counter(format!(
+                    "sum(irate(blockio_operations{{op=\"{op_lower}\"}}[5m]))"
+                )),
+                Unit::Time,
+            );
+            queue.plot_promql(
+                PlotOpts::histogram_latency(*op, format!("queue-latency-{op_lower}")),
+                format!("blockio_queue_latency{{op=\"{op_lower}\"}}"),
+            );
+        }
+    }
+
     view.group(latency);
 
     let mut size = Group::new("Size", "size");
@@ -115,5 +145,17 @@ mod tests {
         // Percentile histograms still present.
         assert!(json.contains("blockio_latency{op=\"read\"}"));
         assert!(json.contains("blockio_size{op=\"write\"}"));
+    }
+
+    #[test]
+    fn queue_wait_subgroup_absent_when_the_metric_is() {
+        // An empty store models a recording from an agent that predates
+        // `blockio_queue_latency`, or a host whose requests never queue.
+        let view = generate(&MemoryStore::builder().build(), vec![]);
+        let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
+        assert!(!json.contains("blockio_queue_latency"));
+        assert!(!json.contains("Queue Wait"));
+        // The service-latency plots are unaffected by the gate.
+        assert!(json.contains("blockio_latency{op=\"read\"}"));
     }
 }

--- a/crates/dashboard/src/dashboard/blockio.rs
+++ b/crates/dashboard/src/dashboard/blockio.rs
@@ -46,14 +46,21 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
 
     let mut latency = Group::new("Latency", "latency");
 
-    let by_op = latency.subgroup("By Operation");
-    by_op.describe("Latency percentiles broken down by read vs write.");
+    // Pre-rename recordings call the device phase `blockio_latency`; the alias
+    // lives in one place so the web dashboard and the TUI cannot disagree.
+    let device = blockio_device_latency_metric(data);
+
+    let by_op = latency.subgroup("Device");
+    by_op.describe(
+        "How long the device took, from the moment it began servicing a request until the request \
+         completed. Percentiles broken down by read vs write.",
+    );
     for op in &["Read", "Write"] {
         let op_lower = op.to_lowercase();
         by_op.histogram_rate_mean(
             op,
             &format!("latency-{op_lower}"),
-            &format!("blockio_latency{{op=\"{op_lower}\"}}"),
+            &format!("{device}{{op=\"{op_lower}\"}}"),
             RateSource::Counter(format!(
                 "sum(irate(blockio_operations{{op=\"{op_lower}\"}}[5m]))"
             )),
@@ -61,21 +68,26 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         );
         by_op.plot_promql(
             PlotOpts::histogram_latency(*op, format!("latency-{op_lower}")),
-            format!("blockio_latency{{op=\"{op_lower}\"}}"),
+            format!("{device}{{op=\"{op_lower}\"}}"),
         );
     }
 
-    // Queue residency is only present on recordings made by an agent that
-    // collects it, and only on devices whose requests actually pass through an
-    // IO scheduler — blk-mq with the `none` elevator issues directly, so there
-    // is no queue phase to measure. Gate the subgroup on the metric being in
-    // the data rather than rendering empty plots where neither holds.
+    // Queue and end-to-end exist only on recordings from an agent that splits
+    // the phases. Gate on the metric being in the recording at all: this is an
+    // AGENT-VERSION gate and only that. `label_values` is a schema query, and
+    // `Histogram::refresh` calls `update_from` unconditionally
+    // (src/agent/bpf/histogram.rs:91), so a collecting agent publishes the
+    // series every tick whether or not any bucket is non-zero — it cannot tell
+    // us whether requests actually queued. Where nothing queues, these read a
+    // flat zero, which is the honest answer, not a gap; the rate beside them is
+    // derived from the same histogram so it reads zero too rather than showing
+    // a non-zero completion rate that would imply missing data.
     if metric_unique_label_count(data, "blockio_queue_latency", "op") > 0 {
         let queue = latency.subgroup("Queue Wait");
         queue.describe(
-            "Time requests spent queued before the device began servicing them. This is the \
+            "How long requests waited before the device began servicing them. This is the \
              component that grows under saturation — a device at its limit shows queue wait \
-             climbing while service latency above stays flat.",
+             climbing while the device phase above stays flat.",
         );
         for op in &["Read", "Write"] {
             let op_lower = op.to_lowercase();
@@ -83,14 +95,41 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 op,
                 &format!("queue-latency-{op_lower}"),
                 &format!("blockio_queue_latency{{op=\"{op_lower}\"}}"),
-                RateSource::Counter(format!(
-                    "sum(irate(blockio_operations{{op=\"{op_lower}\"}}[5m]))"
-                )),
+                // Not `blockio_operations`: that counts COMPLETED requests, not
+                // queued ones, and reusing it here would render a plot
+                // byte-identical to the one in "Device" above — while reading
+                // non-zero on a host where nothing ever queues.
+                RateSource::FromHistogram,
                 Unit::Time,
             );
             queue.plot_promql(
                 PlotOpts::histogram_latency(*op, format!("queue-latency-{op_lower}")),
                 format!("blockio_queue_latency{{op=\"{op_lower}\"}}"),
+            );
+        }
+    }
+
+    if metric_unique_label_count(data, "blockio_total_latency", "op") > 0 {
+        let total = latency.subgroup("End-to-End");
+        total.describe(
+            "Queue wait and device service together, from the request entering the queue until it \
+             completed — what the workload issuing the IO actually experiences. Measured \
+             directly rather than summed, because two histograms cannot be added.",
+        );
+        for op in &["Read", "Write"] {
+            let op_lower = op.to_lowercase();
+            total.histogram_rate_mean(
+                op,
+                &format!("total-latency-{op_lower}"),
+                &format!("blockio_total_latency{{op=\"{op_lower}\"}}"),
+                RateSource::Counter(format!(
+                    "sum(irate(blockio_operations{{op=\"{op_lower}\"}}[5m]))"
+                )),
+                Unit::Time,
+            );
+            total.plot_promql(
+                PlotOpts::histogram_latency(*op, format!("total-latency-{op_lower}")),
+                format!("blockio_total_latency{{op=\"{op_lower}\"}}"),
             );
         }
     }
@@ -128,34 +167,131 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
 mod tests {
     use super::*;
     use metriken_query::MemoryStore;
+    use std::collections::HashMap;
+    use std::time::{Duration, SystemTime};
 
-    #[test]
-    fn blockio_latency_and_size_get_rate_mean_pairs() {
-        let view = generate(&MemoryStore::builder().build(), vec![]);
-        // serde escapes the inner `"` of PromQL label selectors; unescape
-        // so the substring checks read like the queries we actually emit.
-        let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
-        // Latency per-op rate uses the accurate operations counter; mean from histogram.
-        assert!(json.contains("sum(irate(blockio_operations{op=\"read\"}[5m]))"));
-        assert!(json.contains("histogram_mean(blockio_latency{op=\"read\"})"));
-        assert!(json.contains("histogram_mean(blockio_latency{op=\"write\"})"));
-        // Size: rate also from operations count; mean is mean IO size.
-        assert!(json.contains("histogram_mean(blockio_size{op=\"read\"})"));
-        assert!(json.contains("histogram_mean(blockio_size{op=\"write\"})"));
-        // Percentile histograms still present.
-        assert!(json.contains("blockio_latency{op=\"read\"}"));
-        assert!(json.contains("blockio_size{op=\"write\"}"));
+    /// Serialize a `View` and unescape the inner `"` of PromQL label selectors,
+    /// so substring checks read like the queries we actually emit.
+    fn view_json(view: &View) -> String {
+        serde_json::to_string(view).unwrap().replace("\\\"", "\"")
+    }
+
+    /// A `MemoryStore` where each metric in `names` exists with `op="read"` and
+    /// `op="write"` series across three timestamps one second apart, with
+    /// monotonically increasing values. `blockio_operations` is ingested as a
+    /// counter (matching production); everything else as a histogram. Several
+    /// increasing snapshots -- rather than one -- are needed so `irate()` and
+    /// `histogram_mean()` actually evaluate against the fixture.
+    fn fixture_with_metrics(names: &[&str]) -> MemoryStore {
+        let store = MemoryStore::builder().sampling_interval_ms(1000).build();
+        let t0 = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+
+        let mut counter_totals: HashMap<(String, &str), u64> = HashMap::new();
+        let mut histograms: HashMap<(String, &str), histogram::Histogram> = HashMap::new();
+
+        for step in 0..3u64 {
+            let ts = t0 + Duration::from_secs(step);
+            let mut counters = Vec::new();
+            let mut hist_snapshots = Vec::new();
+            for &name in names {
+                for op in ["read", "write"] {
+                    let mut metadata = HashMap::new();
+                    metadata.insert("op".to_string(), op.to_string());
+                    if name == "blockio_operations" {
+                        let total = counter_totals.entry((name.to_string(), op)).or_insert(0);
+                        *total += 100;
+                        counters.push(metriken_exposition::Counter::new(
+                            name.to_string(),
+                            *total,
+                            metadata,
+                        ));
+                    } else {
+                        let h = histograms
+                            .entry((name.to_string(), op))
+                            .or_insert_with(|| histogram::Histogram::new(3, 64).unwrap());
+                        h.increment(1_000_000 + step * 50_000).unwrap();
+                        hist_snapshots.push(metriken_exposition::Histogram::new(
+                            name.to_string(),
+                            h.clone(),
+                            metadata,
+                        ));
+                    }
+                }
+            }
+            let snapshot = metriken_exposition::Snapshot::V2(metriken_exposition::SnapshotV2 {
+                systemtime: ts,
+                duration: Duration::from_secs(0),
+                metadata: HashMap::new(),
+                counters,
+                gauges: vec![],
+                histograms: hist_snapshots,
+            });
+            store.ingest_snapshot(snapshot);
+        }
+        store
     }
 
     #[test]
-    fn queue_wait_subgroup_absent_when_the_metric_is() {
-        // An empty store models a recording from an agent that predates
-        // `blockio_queue_latency`, or a host whose requests never queue.
-        let view = generate(&MemoryStore::builder().build(), vec![]);
-        let json = serde_json::to_string(&view).unwrap().replace("\\\"", "\"");
-        assert!(!json.contains("blockio_queue_latency"));
-        assert!(!json.contains("Queue Wait"));
-        // The service-latency plots are unaffected by the gate.
+    fn blockio_latency_and_size_get_rate_mean_pairs() {
+        let data = fixture_with_metrics(&[
+            "blockio_device_latency",
+            "blockio_size",
+            "blockio_operations",
+        ]);
+        let json = view_json(&generate(&data, vec![]));
+        assert!(json.contains("sum(irate(blockio_operations{op=\"read\"}[5m]))"));
+        assert!(json.contains("histogram_mean(blockio_device_latency{op=\"read\"})"));
+        assert!(json.contains("histogram_mean(blockio_device_latency{op=\"write\"})"));
+        assert!(json.contains("histogram_mean(blockio_size{op=\"read\"})"));
+        assert!(json.contains("blockio_size{op=\"write\"}"));
+    }
+
+    /// A recording made before the rename must still render its device-latency
+    /// charts, under the old metric name.
+    #[test]
+    fn pre_rename_recording_still_renders_device_latency() {
+        let data = fixture_with_metrics(&["blockio_latency", "blockio_size", "blockio_operations"]);
+        let json = view_json(&generate(&data, vec![]));
         assert!(json.contains("blockio_latency{op=\"read\"}"));
+        assert!(!json.contains("blockio_device_latency"));
+        // ...and gets no queue / end-to-end sections, which it has no data for.
+        assert!(!json.contains("Queue Wait"));
+        assert!(!json.contains("End-to-End"));
+    }
+
+    /// A current recording prefers the new name even if both are somehow
+    /// present, and gets all three phases.
+    #[test]
+    fn post_rename_recording_renders_all_three_phases() {
+        let data = fixture_with_metrics(&[
+            "blockio_device_latency",
+            "blockio_queue_latency",
+            "blockio_total_latency",
+            "blockio_operations",
+        ]);
+        let json = view_json(&generate(&data, vec![]));
+        assert!(json.contains("Queue Wait"));
+        assert!(json.contains("End-to-End"));
+        assert!(json.contains("blockio_device_latency{op=\"read\"}"));
+        assert!(json.contains("blockio_queue_latency{op=\"read\"}"));
+        assert!(json.contains("blockio_total_latency{op=\"read\"}"));
+        // The queue rate comes from the queue histogram, not the completed-ops
+        // counter — otherwise it duplicates the Device plot and reads non-zero
+        // where nothing queued.
+        assert!(json.contains("sum(histogram_irate(blockio_queue_latency{op=\"read\"}))"));
+    }
+
+    /// The negative direction alone cannot tell "correctly gated out" from "the
+    /// gate names a metric that never exists" — a typo would render the
+    /// subgroups NEVER and still pass. Paired with the positive test above.
+    #[test]
+    fn queue_and_total_absent_when_the_metrics_are() {
+        let data = fixture_with_metrics(&["blockio_device_latency", "blockio_operations"]);
+        let json = view_json(&generate(&data, vec![]));
+        assert!(!json.contains("blockio_queue_latency"));
+        assert!(!json.contains("blockio_total_latency"));
+        assert!(!json.contains("Queue Wait"));
+        assert!(!json.contains("End-to-End"));
+        assert!(json.contains("blockio_device_latency{op=\"read\"}"));
     }
 }

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -23,6 +23,43 @@ pub fn metric_unique_label_count(data: &dyn MetricsSource, metric: &str, key: &s
     data.label_values(metric, key).len()
 }
 
+/// True if `metric` exists in `data` under any metric type. Unlike
+/// `metric_unique_label_count`, this does not require the metric to
+/// carry any particular label key.
+pub fn has_metric(data: &dyn MetricsSource, metric: &str) -> bool {
+    !data.counter_labels(metric).is_empty()
+        || !data.gauge_labels(metric).is_empty()
+        || !data.histogram_labels(metric).is_empty()
+}
+
+/// Pre-rename recordings carry `blockio_latency`; post-rename recordings carry
+/// `blockio_device_latency`. Pick whichever this recording actually has so old
+/// captures keep rendering. Selecting the name from the data (rather than
+/// emitting a PromQL `x or y` fallback) keeps generated queries readable and
+/// does not depend on `or` support in the query engine.
+///
+/// The two are the same measurement: before the phases were split out, the
+/// insert and issue hooks shared one timestamp and issue overwrote it, so
+/// `blockio_latency` always reported the issue-to-complete span.
+///
+/// If neither is present (e.g. a recording taken with the `blockio_latency`
+/// sampler disabled), name the metric a current agent would emit rather than
+/// the retired pre-rename name — the chart is empty either way, but the query
+/// text is user-visible (Query Explorer, copy-paste, TUI/MCP consumers).
+///
+/// This is the single source of truth for the alias: every consumer that needs
+/// to pick between the two names calls this rather than re-deriving it, so they
+/// cannot disagree about which name a given recording uses.
+pub fn blockio_device_latency_metric(data: &dyn MetricsSource) -> &'static str {
+    if has_metric(data, "blockio_device_latency") {
+        "blockio_device_latency"
+    } else if has_metric(data, "blockio_latency") {
+        "blockio_latency"
+    } else {
+        "blockio_device_latency"
+    }
+}
+
 #[derive(Default, Serialize)]
 pub struct View {
     // interval between consecutive datapoints as fractional seconds

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,8 +54,9 @@ distribution.
 
 | Metric | Description | Metadata |
 |--------|-------------|----------|
-| `blockio_latency` | Distribution of blockio operation latency in nanoseconds, from the moment the device began servicing the request until it completed | `op={read,write,flush,discard}` |
-| `blockio_queue_latency` | Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds. This is the component that grows under device saturation, where service latency alone stays flat. Requests that bypass the IO scheduler (blk-mq with the `none` elevator issues directly) have no queue phase and are absent rather than recorded as zero | `op={read,write,flush,discard}` |
+| `blockio_device_latency` | Distribution of block IO device service latency in nanoseconds, from the moment the device began servicing the request until it completed. Recordings made before this metric was renamed carry the same measurement as `blockio_latency` | `op={read,write,flush,discard}` |
+| `blockio_queue_latency` | Distribution of time requests spent queued before the device began servicing them, in nanoseconds. This is the component that grows under saturation, where device latency alone stays flat. A request that goes straight to the driver has no queue phase and records no sample, so on such a device the histogram is present but empty | `op={read,write,flush,discard}` |
+| `blockio_total_latency` | Distribution of end-to-end latency in nanoseconds, from the request entering the queue until it completed — queue and device together. Measured directly rather than summed, because two histograms cannot be added | `op={read,write,flush,discard}` |
 
 ### blockio_requests
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,7 +54,8 @@ distribution.
 
 | Metric | Description | Metadata |
 |--------|-------------|----------|
-| `blockio_latency` | Distribution of blockio operation latency in nanoseconds | `op={read,write,flush,discard}` |
+| `blockio_latency` | Distribution of blockio operation latency in nanoseconds, from the moment the device began servicing the request until it completed | `op={read,write,flush,discard}` |
+| `blockio_queue_latency` | Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds. This is the component that grows under device saturation, where service latency alone stays flat. Requests that bypass the IO scheduler (blk-mq with the `none` elevator issues directly) have no queue phase and are absent rather than recorded as zero | `op={read,write,flush,discard}` |
 
 ### blockio_requests
 

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -215,8 +215,9 @@ class="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white/95 dar
 <span class="material-symbols-outlined text-slate-400 group-open:rotate-180 transition-transform text-lg" data-icon="expand_more">expand_more</span>
 </summary>
 <div class="px-5 py-4 space-y-2 text-base border-t border-slate-200 dark:border-slate-800">
-<div class="flex flex-col md:flex-row md:flex-wrap md:gap-x-3 md:pl-[18.75rem]"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:min-w-[18rem] md:-ml-[18.75rem]">blockio_latency</code><span class="text-slate-500 pl-4 md:pl-0 md:flex-1 md:min-w-[26.5rem]">Histogram (ns) with <code>op</code>: read, write, flush, discard</span></div>
-</div>
+<div class="flex flex-col md:flex-row md:flex-wrap md:gap-x-3 md:pl-[18.75rem]"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:min-w-[18rem] md:-ml-[18.75rem]">blockio_device_latency</code><span class="text-slate-500 pl-4 md:pl-0 md:flex-1 md:min-w-[26.5rem]">Histogram (ns) with <code>op</code>: read, write, flush, discard</span></div>
+<div class="flex flex-col md:flex-row md:flex-wrap md:gap-x-3 md:pl-[18.75rem]"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:min-w-[18rem] md:-ml-[18.75rem]">blockio_queue_latency</code><span class="text-slate-500 pl-4 md:pl-0 md:flex-1 md:min-w-[26.5rem]">Histogram (ns) with <code>op</code>: read, write, flush, discard</span></div>
+<div class="flex flex-col md:flex-row md:flex-wrap md:gap-x-3 md:pl-[18.75rem]"><code class="text-blue-600 dark:text-blue-400 md:shrink-0 md:min-w-[18rem] md:-ml-[18.75rem]">blockio_total_latency</code><span class="text-slate-500 pl-4 md:pl-0 md:flex-1 md:min-w-[26.5rem]">Histogram (ns) with <code>op</code>: read, write, flush, discard</span></div></div>
 </details>
 
 <details class="group mb-4 rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden" open>

--- a/src/agent/samplers/blockio/linux/latency/mod.bpf.c
+++ b/src/agent/samplers/blockio/linux/latency/mod.bpf.c
@@ -23,6 +23,25 @@
 #define REQ_OP_FLUSH 2
 #define REQ_OP_DISCARD 3
 
+// Upper bound on a request phase we are willing to believe.
+//
+// `insert` is the one stamp a handler may read without having written it in
+// this request's lifetime, so it is the one that can be stale. The pre-split
+// code was self-healing -- both start hooks did an unconditional update, so a
+// leftover stamp from a previous life of a recycled `struct request *` was
+// always overwritten before it could be read. The split reads instead of
+// writing, so a leaked entry (a request inserted before the complete program
+// was attached, or during device teardown) can survive to meet a later request
+// at the same recycled address. Its `insert` would then be an age, not a wait
+// -- and `value_to_index` has a bucket for it, so it would surface as the max
+// of exactly the histogram someone opens to diagnose saturation.
+//
+// We cannot tell a stale stamp from a real one with a pointer key, so bound it
+// instead. The block layer's own request timeout is 30s, so nothing still in
+// flight at 60s is going to complete and be reported here anyway; a device
+// hung that long shows up in `blockio_errors`, not as a latency sample.
+#define MAX_PLAUSIBLE_SPAN_NS (60ULL * 1000000000ULL)
+
 // Both stamps for one in-flight request. `insert` is when the request entered
 // the scheduler queue, `issue` when the driver began servicing it; the gap
 // between them is queue residency, and it is the component that grows under
@@ -54,7 +73,7 @@ struct {
     __type(key, u32);
     __type(value, u64);
     __uint(max_entries, HISTOGRAM_BUCKETS);
-} read_latency SEC(".maps");
+} read_device_latency SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -62,7 +81,7 @@ struct {
     __type(key, u32);
     __type(value, u64);
     __uint(max_entries, HISTOGRAM_BUCKETS);
-} write_latency SEC(".maps");
+} write_device_latency SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -70,7 +89,7 @@ struct {
     __type(key, u32);
     __type(value, u64);
     __uint(max_entries, HISTOGRAM_BUCKETS);
-} flush_latency SEC(".maps");
+} flush_device_latency SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -78,7 +97,7 @@ struct {
     __type(key, u32);
     __type(value, u64);
     __uint(max_entries, HISTOGRAM_BUCKETS);
-} discard_latency SEC(".maps");
+} discard_device_latency SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
@@ -112,26 +131,65 @@ struct {
     __uint(max_entries, HISTOGRAM_BUCKETS);
 } discard_queue_latency SEC(".maps");
 
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} read_total_latency SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} write_total_latency SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} flush_total_latency SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} discard_total_latency SEC(".maps");
+
 // Classify a request's op once, for whichever histogram family is recording.
+// A phase we are willing to report: the stamp was actually set, it does not
+// post-date the completion, and the span is not absurd. See
+// MAX_PLAUSIBLE_SPAN_NS.
+static bool __always_inline plausible_span(u64 begin, u64 end) {
+    return begin != 0 && begin <= end && (end - begin) < MAX_PLAUSIBLE_SPAN_NS;
+}
+
 static u32 __always_inline rq_op(struct request* rq) {
     return BPF_CORE_READ(rq, cmd_flags) & REQ_OP_MASK;
 }
 
-static void __always_inline record_service_latency(u32 op, u64 delta) {
+static void __always_inline record_device_latency(u32 op, u64 delta) {
     u32 idx = value_to_index(delta, HISTOGRAM_POWER);
 
     switch (op) {
     case REQ_OP_READ:
-        array_incr(&read_latency, idx);
+        array_incr(&read_device_latency, idx);
         break;
     case REQ_OP_WRITE:
-        array_incr(&write_latency, idx);
+        array_incr(&write_device_latency, idx);
         break;
     case REQ_OP_FLUSH:
-        array_incr(&flush_latency, idx);
+        array_incr(&flush_device_latency, idx);
         break;
     case REQ_OP_DISCARD:
-        array_incr(&discard_latency, idx);
+        array_incr(&discard_device_latency, idx);
         break;
     }
 }
@@ -155,6 +213,25 @@ static void __always_inline record_queue_latency(u32 op, u64 delta) {
     }
 }
 
+static void __always_inline record_total_latency(u32 op, u64 delta) {
+    u32 idx = value_to_index(delta, HISTOGRAM_POWER);
+
+    switch (op) {
+    case REQ_OP_READ:
+        array_incr(&read_total_latency, idx);
+        break;
+    case REQ_OP_WRITE:
+        array_incr(&write_total_latency, idx);
+        break;
+    case REQ_OP_FLUSH:
+        array_incr(&flush_total_latency, idx);
+        break;
+    case REQ_OP_DISCARD:
+        array_incr(&discard_total_latency, idx);
+        break;
+    }
+}
+
 // The request entered the scheduler queue. Starts a fresh pair of stamps: a
 // re-inserted request begins a new queue phase, and any stale `issue` from a
 // previous life of this pointer must not survive into it.
@@ -168,17 +245,20 @@ static int __always_inline trace_rq_insert(struct request* rq) {
     return 0;
 }
 
-// The driver began servicing the request. Closes the queue phase (once -- the
-// `insert` stamp is cleared so a requeue-then-reissue does not bill the
-// original wait a second time) and opens the service phase.
+// The driver began servicing the request. Closes the queue phase and opens the
+// device phase. `insert` is deliberately NOT cleared here -- complete needs it
+// to measure the end-to-end phase -- so the "already billed" marker is
+// `issue != 0` instead. A requeue that re-inserts resets both fields and so
+// starts a genuinely new queue phase; a reissue without a re-insert finds
+// `issue != 0` and bills nothing further.
 static int __always_inline trace_rq_issue(struct request* rq) {
-    u64 ts = bpf_ktime_get_ns();
+    u64 insert, ts = bpf_ktime_get_ns();
     struct rq_stamps* stamps = bpf_map_lookup_elem(&start, &rq);
 
     if (!stamps) {
-        // No insert was seen: the request bypassed the scheduler. Record the
-        // service phase only, leaving `insert` zero so complete knows there is
-        // no queue phase for this request.
+        // No insert was seen: the request went straight to the driver. Record
+        // the device phase only, leaving `insert` zero so complete knows there
+        // is no queue phase for this request.
         struct rq_stamps fresh = {
             .insert = 0,
             .issue = ts,
@@ -188,11 +268,15 @@ static int __always_inline trace_rq_issue(struct request* rq) {
         return 0;
     }
 
-    if (stamps->insert != 0 && stamps->insert <= ts) {
-        record_queue_latency(rq_op(rq), ts - stamps->insert);
+    // Hoist to a local: the map value is not volatile, and clang otherwise
+    // re-loads it after the bpf_probe_read_kernel() inside rq_op(), so the
+    // guard below would not cover the value actually subtracted.
+    insert = stamps->insert;
+
+    if (stamps->issue == 0 && plausible_span(insert, ts)) {
+        record_queue_latency(rq_op(rq), ts - insert);
     }
 
-    stamps->insert = 0;
     stamps->issue = ts;
 
     return 0;
@@ -200,22 +284,35 @@ static int __always_inline trace_rq_issue(struct request* rq) {
 
 static int __always_inline handle_block_rq_complete(struct request* rq, int error,
                                                     unsigned int nr_bytes) {
-    u64 begin, ts = bpf_ktime_get_ns();
+    u64 device_begin, total_begin, ts = bpf_ktime_get_ns();
     struct rq_stamps* stamps;
+    u32 op;
 
     stamps = bpf_map_lookup_elem(&start, &rq);
     if (!stamps) {
         return 0;
     }
 
-    // Service latency runs from the issue when we saw one, and from the insert
-    // otherwise -- the same value this histogram reported before queue
-    // residency was split out, when insert and issue shared one stamp and
-    // issue simply overwrote it.
-    begin = stamps->issue != 0 ? stamps->issue : stamps->insert;
+    // The device phase runs from the issue when we saw one, and from the
+    // insert otherwise -- the same value this histogram reported before the
+    // phases were split out, when insert and issue shared one stamp and issue
+    // simply overwrote it. This equivalence is what lets a reader treat a
+    // pre-rename `blockio_latency` series as `blockio_device_latency`.
+    device_begin = stamps->issue != 0 ? stamps->issue : stamps->insert;
 
-    if (begin != 0 && begin <= ts) {
-        record_service_latency(rq_op(rq), ts - begin);
+    // The end-to-end phase runs from the earliest stamp we hold. For a request
+    // that never queued, that is the issue, so total == device -- honest, and
+    // not a fabricated queue phase.
+    total_begin = stamps->insert != 0 ? stamps->insert : stamps->issue;
+
+    op = rq_op(rq);
+
+    if (plausible_span(device_begin, ts)) {
+        record_device_latency(op, ts - device_begin);
+    }
+
+    if (plausible_span(total_begin, ts)) {
+        record_total_latency(op, ts - total_begin);
     }
 
     bpf_map_delete_elem(&start, &rq);

--- a/src/agent/samplers/blockio/linux/latency/mod.bpf.c
+++ b/src/agent/samplers/blockio/linux/latency/mod.bpf.c
@@ -23,11 +23,29 @@
 #define REQ_OP_FLUSH 2
 #define REQ_OP_DISCARD 3
 
+// Both stamps for one in-flight request. `insert` is when the request entered
+// the scheduler queue, `issue` when the driver began servicing it; the gap
+// between them is queue residency, and it is the component that grows under
+// saturation. Keeping both in ONE hash entry (rather than a second map keyed
+// by the same pointer) costs one lookup per hook instead of two, and keeps the
+// lifetime bookkeeping in one place -- one insert, one delete per request.
+//
+// A zero stamp means "that phase was never observed":
+//   - `insert == 0`: the request bypassed the scheduler (blk-mq with the
+//     `none` elevator issues directly), so it had no queue phase to measure.
+//     Rather than report a fabricated zero wait, we record nothing.
+//   - `issue == 0`: complete fired without an issue, so the only start we have
+//     is the insert.
+struct rq_stamps {
+    u64 insert;
+    u64 issue;
+};
+
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 65536);
     __type(key, struct request*);
-    __type(value, u64);
+    __type(value, struct rq_stamps);
 } start SEC(".maps");
 
 struct {
@@ -62,46 +80,142 @@ struct {
     __uint(max_entries, HISTOGRAM_BUCKETS);
 } discard_latency SEC(".maps");
 
-static int __always_inline trace_rq_start(struct request* rq) {
-    u64 ts = bpf_ktime_get_ns();
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} read_queue_latency SEC(".maps");
 
-    bpf_map_update_elem(&start, &rq, &ts, 0);
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} write_queue_latency SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} flush_queue_latency SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(map_flags, BPF_F_MMAPABLE);
+    __type(key, u32);
+    __type(value, u64);
+    __uint(max_entries, HISTOGRAM_BUCKETS);
+} discard_queue_latency SEC(".maps");
+
+// Classify a request's op once, for whichever histogram family is recording.
+static u32 __always_inline rq_op(struct request* rq) {
+    return BPF_CORE_READ(rq, cmd_flags) & REQ_OP_MASK;
+}
+
+static void __always_inline record_service_latency(u32 op, u64 delta) {
+    u32 idx = value_to_index(delta, HISTOGRAM_POWER);
+
+    switch (op) {
+    case REQ_OP_READ:
+        array_incr(&read_latency, idx);
+        break;
+    case REQ_OP_WRITE:
+        array_incr(&write_latency, idx);
+        break;
+    case REQ_OP_FLUSH:
+        array_incr(&flush_latency, idx);
+        break;
+    case REQ_OP_DISCARD:
+        array_incr(&discard_latency, idx);
+        break;
+    }
+}
+
+static void __always_inline record_queue_latency(u32 op, u64 delta) {
+    u32 idx = value_to_index(delta, HISTOGRAM_POWER);
+
+    switch (op) {
+    case REQ_OP_READ:
+        array_incr(&read_queue_latency, idx);
+        break;
+    case REQ_OP_WRITE:
+        array_incr(&write_queue_latency, idx);
+        break;
+    case REQ_OP_FLUSH:
+        array_incr(&flush_queue_latency, idx);
+        break;
+    case REQ_OP_DISCARD:
+        array_incr(&discard_queue_latency, idx);
+        break;
+    }
+}
+
+// The request entered the scheduler queue. Starts a fresh pair of stamps: a
+// re-inserted request begins a new queue phase, and any stale `issue` from a
+// previous life of this pointer must not survive into it.
+static int __always_inline trace_rq_insert(struct request* rq) {
+    struct rq_stamps stamps = {
+        .insert = bpf_ktime_get_ns(),
+        .issue = 0,
+    };
+
+    bpf_map_update_elem(&start, &rq, &stamps, 0);
+    return 0;
+}
+
+// The driver began servicing the request. Closes the queue phase (once -- the
+// `insert` stamp is cleared so a requeue-then-reissue does not bill the
+// original wait a second time) and opens the service phase.
+static int __always_inline trace_rq_issue(struct request* rq) {
+    u64 ts = bpf_ktime_get_ns();
+    struct rq_stamps* stamps = bpf_map_lookup_elem(&start, &rq);
+
+    if (!stamps) {
+        // No insert was seen: the request bypassed the scheduler. Record the
+        // service phase only, leaving `insert` zero so complete knows there is
+        // no queue phase for this request.
+        struct rq_stamps fresh = {
+            .insert = 0,
+            .issue = ts,
+        };
+
+        bpf_map_update_elem(&start, &rq, &fresh, 0);
+        return 0;
+    }
+
+    if (stamps->insert != 0 && stamps->insert <= ts) {
+        record_queue_latency(rq_op(rq), ts - stamps->insert);
+    }
+
+    stamps->insert = 0;
+    stamps->issue = ts;
+
     return 0;
 }
 
 static int __always_inline handle_block_rq_complete(struct request* rq, int error,
                                                     unsigned int nr_bytes) {
-    u64 delta, *tsp, ts = bpf_ktime_get_ns();
-    u32 idx, op;
-    unsigned int cmd_flags;
+    u64 begin, ts = bpf_ktime_get_ns();
+    struct rq_stamps* stamps;
 
-    tsp = bpf_map_lookup_elem(&start, &rq);
-    if (!tsp) {
+    stamps = bpf_map_lookup_elem(&start, &rq);
+    if (!stamps) {
         return 0;
     }
 
-    cmd_flags = BPF_CORE_READ(rq, cmd_flags);
-    op = cmd_flags & REQ_OP_MASK;
+    // Service latency runs from the issue when we saw one, and from the insert
+    // otherwise -- the same value this histogram reported before queue
+    // residency was split out, when insert and issue shared one stamp and
+    // issue simply overwrote it.
+    begin = stamps->issue != 0 ? stamps->issue : stamps->insert;
 
-    if (*tsp <= ts) {
-        delta = ts - *tsp;
-
-        idx = value_to_index(delta, HISTOGRAM_POWER);
-
-        switch (op) {
-        case REQ_OP_READ:
-            array_incr(&read_latency, idx);
-            break;
-        case REQ_OP_WRITE:
-            array_incr(&write_latency, idx);
-            break;
-        case REQ_OP_FLUSH:
-            array_incr(&flush_latency, idx);
-            break;
-        case REQ_OP_DISCARD:
-            array_incr(&discard_latency, idx);
-            break;
-        }
+    if (begin != 0 && begin <= ts) {
+        record_service_latency(rq_op(rq), ts - begin);
     }
 
     bpf_map_delete_elem(&start, &rq);
@@ -116,22 +230,22 @@ static int __always_inline handle_block_rq_complete(struct request* rq, int erro
 
 SEC("tp_btf/block_rq_insert")
 int BPF_PROG(block_rq_insert_btf) {
-    return trace_rq_start(block_rq_tp_request(ctx));
+    return trace_rq_insert(block_rq_tp_request(ctx));
 }
 
 SEC("raw_tp/block_rq_insert")
 int BPF_PROG(block_rq_insert_raw) {
-    return trace_rq_start(block_rq_tp_request(ctx));
+    return trace_rq_insert(block_rq_tp_request(ctx));
 }
 
 SEC("tp_btf/block_rq_issue")
 int BPF_PROG(block_rq_issue_btf) {
-    return trace_rq_start(block_rq_tp_request(ctx));
+    return trace_rq_issue(block_rq_tp_request(ctx));
 }
 
 SEC("raw_tp/block_rq_issue")
 int BPF_PROG(block_rq_issue_raw) {
-    return trace_rq_start(block_rq_tp_request(ctx));
+    return trace_rq_issue(block_rq_tp_request(ctx));
 }
 
 SEC("tp_btf/block_rq_complete")

--- a/src/agent/samplers/blockio/linux/latency/mod.rs
+++ b/src/agent/samplers/blockio/linux/latency/mod.rs
@@ -4,7 +4,8 @@
 //! * `block_rq_complete`
 //!
 //! And produces these stats:
-//! * `blockio_latency`
+//! * `blockio_latency` (issue -> complete: how long the device took)
+//! * `blockio_queue_latency` (insert -> issue: how long the request waited)
 
 const NAME: &str = "blockio_latency";
 
@@ -41,6 +42,28 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .histogram("write_latency", &BLOCKIO_WRITE_LATENCY, &LATENCIES_ACQ)
     .histogram("flush_latency", &BLOCKIO_FLUSH_LATENCY, &LATENCIES_ACQ)
     .histogram("discard_latency", &BLOCKIO_DISCARD_LATENCY, &LATENCIES_ACQ)
+    // Queue residency is its own family, so its own group — see stats.rs's
+    // `QUEUE_LATENCIES_ACQ` doc comment.
+    .histogram(
+        "read_queue_latency",
+        &BLOCKIO_READ_QUEUE_LATENCY,
+        &QUEUE_LATENCIES_ACQ,
+    )
+    .histogram(
+        "write_queue_latency",
+        &BLOCKIO_WRITE_QUEUE_LATENCY,
+        &QUEUE_LATENCIES_ACQ,
+    )
+    .histogram(
+        "flush_queue_latency",
+        &BLOCKIO_FLUSH_QUEUE_LATENCY,
+        &QUEUE_LATENCIES_ACQ,
+    )
+    .histogram(
+        "discard_queue_latency",
+        &BLOCKIO_DISCARD_QUEUE_LATENCY,
+        &QUEUE_LATENCIES_ACQ,
+    )
     .disabled_programs(if kernel_has_btf() {
         &[
             "block_rq_insert_raw",
@@ -73,6 +96,10 @@ impl SkelExt for ModSkel<'_> {
             "write_latency" => &self.maps.write_latency,
             "flush_latency" => &self.maps.flush_latency,
             "discard_latency" => &self.maps.discard_latency,
+            "read_queue_latency" => &self.maps.read_queue_latency,
+            "write_queue_latency" => &self.maps.write_queue_latency,
+            "flush_queue_latency" => &self.maps.flush_queue_latency,
+            "discard_queue_latency" => &self.maps.discard_queue_latency,
             _ => unimplemented!(),
         }
     }

--- a/src/agent/samplers/blockio/linux/latency/mod.rs
+++ b/src/agent/samplers/blockio/linux/latency/mod.rs
@@ -3,9 +3,13 @@
 //! * `block_rq_issue`
 //! * `block_rq_complete`
 //!
-//! And produces these stats:
-//! * `blockio_latency` (issue -> complete: how long the device took)
+//! And produces these stats, one per phase of a request's life:
 //! * `blockio_queue_latency` (insert -> issue: how long the request waited)
+//! * `blockio_device_latency` (issue -> complete: how long the device took)
+//! * `blockio_total_latency` (insert -> complete: the two together)
+//!
+//! `blockio_device_latency` was called `blockio_latency` before the phases were
+//! split out, and measures exactly what that metric always measured.
 
 const NAME: &str = "blockio_latency";
 
@@ -36,14 +40,27 @@ fn init(config: Arc<Config>) -> SamplerResult {
         },
         ModSkelBuilder::default,
     )
-    // All 4 op-class latency histograms share ONE group — see stats.rs's
-    // `LATENCIES_ACQ` doc comment.
-    .histogram("read_latency", &BLOCKIO_READ_LATENCY, &LATENCIES_ACQ)
-    .histogram("write_latency", &BLOCKIO_WRITE_LATENCY, &LATENCIES_ACQ)
-    .histogram("flush_latency", &BLOCKIO_FLUSH_LATENCY, &LATENCIES_ACQ)
-    .histogram("discard_latency", &BLOCKIO_DISCARD_LATENCY, &LATENCIES_ACQ)
-    // Queue residency is its own family, so its own group — see stats.rs's
-    // `QUEUE_LATENCIES_ACQ` doc comment.
+    // One group per phase — see stats.rs's acquisition-group doc comment.
+    .histogram(
+        "read_device_latency",
+        &BLOCKIO_READ_DEVICE_LATENCY,
+        &DEVICE_LATENCIES_ACQ,
+    )
+    .histogram(
+        "write_device_latency",
+        &BLOCKIO_WRITE_DEVICE_LATENCY,
+        &DEVICE_LATENCIES_ACQ,
+    )
+    .histogram(
+        "flush_device_latency",
+        &BLOCKIO_FLUSH_DEVICE_LATENCY,
+        &DEVICE_LATENCIES_ACQ,
+    )
+    .histogram(
+        "discard_device_latency",
+        &BLOCKIO_DISCARD_DEVICE_LATENCY,
+        &DEVICE_LATENCIES_ACQ,
+    )
     .histogram(
         "read_queue_latency",
         &BLOCKIO_READ_QUEUE_LATENCY,
@@ -63,6 +80,26 @@ fn init(config: Arc<Config>) -> SamplerResult {
         "discard_queue_latency",
         &BLOCKIO_DISCARD_QUEUE_LATENCY,
         &QUEUE_LATENCIES_ACQ,
+    )
+    .histogram(
+        "read_total_latency",
+        &BLOCKIO_READ_TOTAL_LATENCY,
+        &TOTAL_LATENCIES_ACQ,
+    )
+    .histogram(
+        "write_total_latency",
+        &BLOCKIO_WRITE_TOTAL_LATENCY,
+        &TOTAL_LATENCIES_ACQ,
+    )
+    .histogram(
+        "flush_total_latency",
+        &BLOCKIO_FLUSH_TOTAL_LATENCY,
+        &TOTAL_LATENCIES_ACQ,
+    )
+    .histogram(
+        "discard_total_latency",
+        &BLOCKIO_DISCARD_TOTAL_LATENCY,
+        &TOTAL_LATENCIES_ACQ,
     )
     .disabled_programs(if kernel_has_btf() {
         &[
@@ -92,14 +129,18 @@ static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry = crate::agent::sampl
 impl SkelExt for ModSkel<'_> {
     fn map(&self, name: &str) -> &libbpf_rs::Map<'_> {
         match name {
-            "read_latency" => &self.maps.read_latency,
-            "write_latency" => &self.maps.write_latency,
-            "flush_latency" => &self.maps.flush_latency,
-            "discard_latency" => &self.maps.discard_latency,
+            "read_device_latency" => &self.maps.read_device_latency,
+            "write_device_latency" => &self.maps.write_device_latency,
+            "flush_device_latency" => &self.maps.flush_device_latency,
+            "discard_device_latency" => &self.maps.discard_device_latency,
             "read_queue_latency" => &self.maps.read_queue_latency,
             "write_queue_latency" => &self.maps.write_queue_latency,
             "flush_queue_latency" => &self.maps.flush_queue_latency,
             "discard_queue_latency" => &self.maps.discard_queue_latency,
+            "read_total_latency" => &self.maps.read_total_latency,
+            "write_total_latency" => &self.maps.write_total_latency,
+            "flush_total_latency" => &self.maps.flush_total_latency,
+            "discard_total_latency" => &self.maps.discard_total_latency,
             _ => unimplemented!(),
         }
     }

--- a/src/agent/samplers/blockio/linux/latency/stats.rs
+++ b/src/agent/samplers/blockio/linux/latency/stats.rs
@@ -10,26 +10,21 @@ use linkme::distributed_slice;
 // identity stable across platforms, while `mod.rs`'s BPF sampler code is
 // Linux-only.
 //
-// ONE group for all 4 op-class latency histograms: LIKE ENTITIES (one
-// "blockio latency" family, distinguished by the `op` label) read as a
-// single sweep, not 4 independent read sections — see the `# Granularity
-// rule` on `crate::agent::samplers::ACQUISITION_GROUPS`.
-// `BpfBuilder::histogram` batches every call naming this group into one
+// ONE group per phase, three groups total. The 4 op classes within a phase are
+// LIKE ENTITIES (one family, distinguished by the `op` label) read as a single
+// sweep; the three phases are different families measuring different parts of a
+// request's life, and principle 18 keeps families in their own groups even when
+// they are read back-to-back in one refresh.
+// `BpfBuilder::histogram` batches every call naming a group into one
 // `HistogramBatch`, stamped once per refresh — see `bpf/histogram.rs`.
-pub static LATENCIES_ACQ: AcquisitionGroup = AcquisitionGroup::new(
+pub static DEVICE_LATENCIES_ACQ: AcquisitionGroup = AcquisitionGroup::new(
     crate::agent::samplers::bpf_sampler_name("blockio_latency"),
-    "blockio_latency_latencies",
+    "blockio_latency_device_latencies",
 );
 
 #[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
-static LATENCIES_ACQ_REG: &'static AcquisitionGroup = &LATENCIES_ACQ;
+static DEVICE_LATENCIES_ACQ_REG: &'static AcquisitionGroup = &DEVICE_LATENCIES_ACQ;
 
-// A SECOND group for the 4 queue-residency histograms. Queue residency and
-// service latency are different metric families -- they measure different
-// phases of a request's life and move independently under saturation -- and
-// principle 18 keeps families in their own groups even when they are read
-// back-to-back in the same refresh. Same shape as `LATENCIES_ACQ`: the 4 op
-// classes within THIS family are like entities and share one group.
 pub static QUEUE_LATENCIES_ACQ: AcquisitionGroup = AcquisitionGroup::new(
     crate::agent::samplers::bpf_sampler_name("blockio_latency"),
     "blockio_latency_queue_latencies",
@@ -37,6 +32,14 @@ pub static QUEUE_LATENCIES_ACQ: AcquisitionGroup = AcquisitionGroup::new(
 
 #[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
 static QUEUE_LATENCIES_ACQ_REG: &'static AcquisitionGroup = &QUEUE_LATENCIES_ACQ;
+
+pub static TOTAL_LATENCIES_ACQ: AcquisitionGroup = AcquisitionGroup::new(
+    crate::agent::samplers::bpf_sampler_name("blockio_latency"),
+    "blockio_latency_total_latencies",
+);
+
+#[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
+static TOTAL_LATENCIES_ACQ_REG: &'static AcquisitionGroup = &TOTAL_LATENCIES_ACQ;
 
 /*
  * bpf prog stats
@@ -61,40 +64,40 @@ pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
  */
 
 #[metric(
-    name = "blockio_latency",
-    description = "Distribution of blockio operation latency in nanoseconds",
-    metadata = { op = "read", unit = "nanoseconds", acq_group = "blockio_latency_latencies" }
+    name = "blockio_device_latency",
+    description = "Distribution of block IO device service latency in nanoseconds, from the moment the device began servicing the request until it completed. Excludes time spent waiting in the queue — see blockio_queue_latency. Recordings made before this metric was renamed carry the same measurement under the name blockio_latency",
+    metadata = { op = "read", unit = "nanoseconds", acq_group = "blockio_latency_device_latencies" }
 )]
-pub static BLOCKIO_READ_LATENCY: RwLockHistogram =
+pub static BLOCKIO_READ_DEVICE_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
-    name = "blockio_latency",
-    description = "Distribution of blockio operation latency in nanoseconds",
-    metadata = { op = "write", unit = "nanoseconds", acq_group = "blockio_latency_latencies" }
+    name = "blockio_device_latency",
+    description = "Distribution of block IO device service latency in nanoseconds, from the moment the device began servicing the request until it completed. Excludes time spent waiting in the queue — see blockio_queue_latency. Recordings made before this metric was renamed carry the same measurement under the name blockio_latency",
+    metadata = { op = "write", unit = "nanoseconds", acq_group = "blockio_latency_device_latencies" }
 )]
-pub static BLOCKIO_WRITE_LATENCY: RwLockHistogram =
+pub static BLOCKIO_WRITE_DEVICE_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
-    name = "blockio_latency",
-    description = "Distribution of blockio operation latency in nanoseconds",
-    metadata = { op = "flush", unit = "nanoseconds", acq_group = "blockio_latency_latencies" }
+    name = "blockio_device_latency",
+    description = "Distribution of block IO device service latency in nanoseconds, from the moment the device began servicing the request until it completed. Excludes time spent waiting in the queue — see blockio_queue_latency. Recordings made before this metric was renamed carry the same measurement under the name blockio_latency",
+    metadata = { op = "flush", unit = "nanoseconds", acq_group = "blockio_latency_device_latencies" }
 )]
-pub static BLOCKIO_FLUSH_LATENCY: RwLockHistogram =
+pub static BLOCKIO_FLUSH_DEVICE_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
-    name = "blockio_latency",
-    description = "Distribution of blockio operation latency in nanoseconds",
-    metadata = { op = "discard", unit = "nanoseconds", acq_group = "blockio_latency_latencies" }
+    name = "blockio_device_latency",
+    description = "Distribution of block IO device service latency in nanoseconds, from the moment the device began servicing the request until it completed. Excludes time spent waiting in the queue — see blockio_queue_latency. Recordings made before this metric was renamed carry the same measurement under the name blockio_latency",
+    metadata = { op = "discard", unit = "nanoseconds", acq_group = "blockio_latency_device_latencies" }
 )]
-pub static BLOCKIO_DISCARD_LATENCY: RwLockHistogram =
+pub static BLOCKIO_DISCARD_DEVICE_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
 
 #[metric(
     name = "blockio_queue_latency",
-    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds. This is the component that grows under device saturation, where service latency alone stays flat",
     metadata = { op = "read", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
 )]
 pub static BLOCKIO_READ_QUEUE_LATENCY: RwLockHistogram =
@@ -102,7 +105,7 @@ pub static BLOCKIO_READ_QUEUE_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "blockio_queue_latency",
-    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds. This is the component that grows under device saturation, where service latency alone stays flat",
     metadata = { op = "write", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
 )]
 pub static BLOCKIO_WRITE_QUEUE_LATENCY: RwLockHistogram =
@@ -110,7 +113,7 @@ pub static BLOCKIO_WRITE_QUEUE_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "blockio_queue_latency",
-    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds. This is the component that grows under device saturation, where service latency alone stays flat",
     metadata = { op = "flush", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
 )]
 pub static BLOCKIO_FLUSH_QUEUE_LATENCY: RwLockHistogram =
@@ -118,8 +121,40 @@ pub static BLOCKIO_FLUSH_QUEUE_LATENCY: RwLockHistogram =
 
 #[metric(
     name = "blockio_queue_latency",
-    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds. This is the component that grows under device saturation, where service latency alone stays flat",
     metadata = { op = "discard", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
 )]
 pub static BLOCKIO_DISCARD_QUEUE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_total_latency",
+    description = "Distribution of end-to-end block IO latency in nanoseconds, from the request entering the queue until it completed — the queue and device phases together. Measured directly rather than summed, because two histograms cannot be added",
+    metadata = { op = "read", unit = "nanoseconds", acq_group = "blockio_latency_total_latencies" }
+)]
+pub static BLOCKIO_READ_TOTAL_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_total_latency",
+    description = "Distribution of end-to-end block IO latency in nanoseconds, from the request entering the queue until it completed — the queue and device phases together. Measured directly rather than summed, because two histograms cannot be added",
+    metadata = { op = "write", unit = "nanoseconds", acq_group = "blockio_latency_total_latencies" }
+)]
+pub static BLOCKIO_WRITE_TOTAL_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_total_latency",
+    description = "Distribution of end-to-end block IO latency in nanoseconds, from the request entering the queue until it completed — the queue and device phases together. Measured directly rather than summed, because two histograms cannot be added",
+    metadata = { op = "flush", unit = "nanoseconds", acq_group = "blockio_latency_total_latencies" }
+)]
+pub static BLOCKIO_FLUSH_TOTAL_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_total_latency",
+    description = "Distribution of end-to-end block IO latency in nanoseconds, from the request entering the queue until it completed — the queue and device phases together. Measured directly rather than summed, because two histograms cannot be added",
+    metadata = { op = "discard", unit = "nanoseconds", acq_group = "blockio_latency_total_latencies" }
+)]
+pub static BLOCKIO_DISCARD_TOTAL_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);

--- a/src/agent/samplers/blockio/linux/latency/stats.rs
+++ b/src/agent/samplers/blockio/linux/latency/stats.rs
@@ -24,6 +24,20 @@ pub static LATENCIES_ACQ: AcquisitionGroup = AcquisitionGroup::new(
 #[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
 static LATENCIES_ACQ_REG: &'static AcquisitionGroup = &LATENCIES_ACQ;
 
+// A SECOND group for the 4 queue-residency histograms. Queue residency and
+// service latency are different metric families -- they measure different
+// phases of a request's life and move independently under saturation -- and
+// principle 18 keeps families in their own groups even when they are read
+// back-to-back in the same refresh. Same shape as `LATENCIES_ACQ`: the 4 op
+// classes within THIS family are like entities and share one group.
+pub static QUEUE_LATENCIES_ACQ: AcquisitionGroup = AcquisitionGroup::new(
+    crate::agent::samplers::bpf_sampler_name("blockio_latency"),
+    "blockio_latency_queue_latencies",
+);
+
+#[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
+static QUEUE_LATENCIES_ACQ_REG: &'static AcquisitionGroup = &QUEUE_LATENCIES_ACQ;
+
 /*
  * bpf prog stats
  */
@@ -76,4 +90,36 @@ pub static BLOCKIO_FLUSH_LATENCY: RwLockHistogram =
     metadata = { op = "discard", unit = "nanoseconds", acq_group = "blockio_latency_latencies" }
 )]
 pub static BLOCKIO_DISCARD_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_queue_latency",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    metadata = { op = "read", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
+)]
+pub static BLOCKIO_READ_QUEUE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_queue_latency",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    metadata = { op = "write", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
+)]
+pub static BLOCKIO_WRITE_QUEUE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_queue_latency",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    metadata = { op = "flush", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
+)]
+pub static BLOCKIO_FLUSH_QUEUE_LATENCY: RwLockHistogram =
+    RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);
+
+#[metric(
+    name = "blockio_queue_latency",
+    description = "Distribution of time block IO requests spent queued before the device began servicing them, in nanoseconds",
+    metadata = { op = "discard", unit = "nanoseconds", acq_group = "blockio_latency_queue_latencies" }
+)]
+pub static BLOCKIO_DISCARD_QUEUE_LATENCY: RwLockHistogram =
     RwLockHistogram::new(HISTOGRAM_GROUPING_POWER, 64);

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -122,11 +122,13 @@ pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
     ("blockio_bytes", "blockio_requests"),
     ("blockio_errors", "blockio_requests"),
     ("blockio_operations", "blockio_requests"),
-    // Not recoverable by prefix: neither `blockio_latency` nor
-    // `blockio_requests` is a `_`-boundary prefix of this name.
     ("blockio_queue_latency", "blockio_latency"),
+    // None of the three phase metrics is prefix-recoverable: the sampler is
+    // `blockio_latency`, and no phase name starts with `blockio_latency_`.
+    ("blockio_device_latency", "blockio_latency"),
     ("blockio_requeues", "blockio_requests"),
     ("blockio_size", "blockio_requests"),
+    ("blockio_total_latency", "blockio_latency"),
     ("cgroup_cpu_bandwidth_period_duration", "cpu_bandwidth"),
     ("cgroup_cpu_bandwidth_periods", "cpu_bandwidth"),
     ("cgroup_cpu_bandwidth_quota", "cpu_bandwidth"),

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -122,6 +122,9 @@ pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
     ("blockio_bytes", "blockio_requests"),
     ("blockio_errors", "blockio_requests"),
     ("blockio_operations", "blockio_requests"),
+    // Not recoverable by prefix: neither `blockio_latency` nor
+    // `blockio_requests` is a `_`-boundary prefix of this name.
+    ("blockio_queue_latency", "blockio_latency"),
     ("blockio_requeues", "blockio_requests"),
     ("blockio_size", "blockio_requests"),
     ("cgroup_cpu_bandwidth_period_duration", "cpu_bandwidth"),

--- a/src/viewer/tui/mod.rs
+++ b/src/viewer/tui/mod.rs
@@ -158,7 +158,7 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
     metadata::regenerate_dashboards(&state);
 
     let mut app = App::new(initial_sections(&state));
-    let overview_tiles = render::overview::tiles();
+    let mut overview_tiles = render::overview::tiles(state.baseline_data().as_ref());
 
     // A panic inside the draw loop, or an external SIGINT (`kill -INT`, a
     // supervisor) delivered while the terminal is in raw mode, would
@@ -201,6 +201,12 @@ pub fn run_tui(state: AppState, live: bool, _rt: &tokio::runtime::Runtime) {
         if live {
             metadata::regenerate_dashboards(&state);
             app.reconcile_sections(initial_sections(&state));
+            // In live mode the store is typically EMPTY at startup —
+            // `init_live_mode` only spawns `ingest_loop`, which awaits its
+            // first interval tick before fetching. Anything derived from the
+            // metric catalog, the blockio name alias included, has to be
+            // recomputed here rather than once before the loop.
+            overview_tiles = render::overview::tiles(state.baseline_data().as_ref());
             dirty = true;
         }
 

--- a/src/viewer/tui/render/overview.rs
+++ b/src/viewer/tui/render/overview.rs
@@ -5,6 +5,9 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::widgets::{Block, Borders};
 use ratatui::Frame;
 
+use ::dashboard::blockio_device_latency_metric;
+use metriken_query::MetricsSource;
+
 use super::chart::draw_chart;
 use crate::viewer::tui::layout::{overview_grid, too_small};
 use crate::viewer::tui::model::{PlotDef, PlotKind, DEFAULT_PERCENTILES};
@@ -40,7 +43,15 @@ fn pct(query: &str) -> PlotDef {
 /// first when the terminal is small). Queries mirror the web overview
 /// section (`crates/dashboard/src/dashboard/overview.rs`) and the memory
 /// section so they resolve against the real metric catalog.
-pub fn tiles() -> Vec<Tile> {
+/// `data` is consulted only to resolve metric-name aliases (currently just the
+/// blockio latency either-name pick via `blockio_device_latency_metric`)
+/// against the recording actually loaded. The tile list's length and order are
+/// otherwise data-independent — callers and tests may rely on both staying
+/// fixed; only individual tiles' query text adapts to `data`. Because the
+/// resolution happens at call time, a caller whose data can gain metrics later
+/// (a live agent still filling in its catalog) must re-call `tiles()` after
+/// that data changes, not just once at startup.
+pub fn tiles(data: &dyn MetricsSource) -> Vec<Tile> {
     vec![
         // CPU busy fraction: ns of CPU consumed per second / cores / 1e9.
         Tile {
@@ -64,7 +75,7 @@ pub fn tiles() -> Vec<Tile> {
         },
         Tile {
             title: "Block IO Latency",
-            def: pct("blockio_latency"),
+            def: pct(blockio_device_latency_metric(data)),
         },
         Tile {
             title: "Memory Used",
@@ -144,11 +155,13 @@ fn draw_tile(f: &mut Frame, area: Rect, tile: &Tile, data: &ChartData) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use metriken_query::MemoryStore;
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
     fn render_at(w: u16, h: u16) {
-        let tiles = tiles();
+        let store = MemoryStore::builder().build();
+        let tiles = tiles(&store);
         let data: Vec<ChartData> = tiles.iter().map(|_| ChartData::Empty).collect();
         assert_eq!(data.len(), tiles.len());
         let backend = TestBackend::new(w, h);
@@ -173,6 +186,20 @@ mod tests {
 
     #[test]
     fn tile_count_is_stable() {
-        assert_eq!(tiles().len(), 6);
+        let store = MemoryStore::builder().build();
+        assert_eq!(tiles(&store).len(), 6);
+    }
+
+    /// The blockio tile follows the recording's metric name. An empty store has
+    /// neither name, so it must fall back to the one a current agent emits
+    /// rather than the retired pre-rename name.
+    #[test]
+    fn blockio_tile_uses_the_name_the_recording_has() {
+        let store = MemoryStore::builder().build();
+        let blockio = tiles(&store)
+            .into_iter()
+            .find(|t| t.title == "Block IO Latency")
+            .expect("blockio tile present");
+        assert_eq!(blockio.def.base_query, "blockio_device_latency");
     }
 }


### PR DESCRIPTION
## Summary

Closes #1054.

`blockio_latency` measured only the **device** phase, so a saturated device and a merely busy one looked alike. In the reproducer on the issue, a victim service's client-observed p99 went 55.8 ms → 454 ms (8.1x) while `blockio_latency` p99 did not move a single bucket. The delay was real and was being spent where the histogram never looked — waiting in the queue.

Block IO latency is now split into its three phases:

| metric | span | |
|---|---|---|
| `blockio_queue_latency` | insert → issue | the component that grows under saturation, while device latency stays flat |
| `blockio_device_latency` | issue → complete | **renamed** from `blockio_latency` — the same measurement |
| `blockio_total_latency` | insert → complete | what the issuing workload experiences. Measured directly, not summed: two histograms cannot be added |

**The hooks were already there.** `block_rq_insert` and `block_rq_issue` both called `trace_rq_start`, writing one timestamp keyed by the request — so issue overwrote insert's stamp and the interval was thrown away. **No new probe attach**, so no principle-11 concern.

## The rename, and reading old recordings

`blockio_latency` always reported the issue-to-complete span (issue overwrote insert), so `blockio_device_latency` is the identical measurement under an unambiguous name. Device-phase equivalence was verified across **every** hook ordering — insert only, issue only, insert→issue, requeue+reinsert, reissue without reinsert, issue→insert, repeated inserts, map-full — and in all of them `begin` equals the last-written stamp, exactly as before.

That equivalence is what makes the reader-side alias sound: `blockio_device_latency_metric()` picks whichever name a recording actually carries, so **existing recordings keep rendering unchanged**. The web dashboard and the TUI both call it rather than re-deriving, so they cannot disagree. External consumers that query `blockio_latency` by name — Prometheus rules, Grafana, saved PromQL — do need updating; that's in the CHANGELOG.

## Measured on Linux (principle 16)

32-core Debian 13, kernel 6.12, `mq-deadline` on every device. fio: 8 jobs, iodepth 32, randread, `--direct=1`. Both arms saw **153k IOPS** and call counts within 0.1%. Per-program figures come from `bpftool prog show`, **excluding the 5 pre-existing programs belonging to the host's production agent** (partitioned on `loaded_at`).

| program | baseline (`main`) | this branch | delta |
|---|---|---|---|
| `block_rq_insert` | 211.3 ns/call | 218.4 ns/call | +7.1 ns |
| `block_rq_issue` | 176.5 ns/call | 177.5 ns/call | **+0.9 ns** |
| `block_rq_complete` | 210.2 ns/call | 233.4 ns/call | +23.2 ns |
| **per IO (3 programs)** | **598.1 ns** | **629.3 ns** | **+31.2 ns (+5.2%)** |

At the measured 153k IOPS that is 4.77 ms/s — **0.48% of one core** at a load few fleet hosts sustain.

**The interesting part: `block_rq_issue` is where the review expected the cost, and it is the one that barely moved.** It grew 21 → 91 instructions, but it also swapped a full `bpf_map_update_elem` (hash, bucket walk, possible alloc) for a `lookup` plus two in-place stores. The cheaper map operation almost exactly cancels the added histogram record. The real cost landed on `block_rq_complete`, which now records two histograms instead of one.

Userspace refresh, from the `sampling latency` debug line at 10 Hz scrape (n≈300/arm): p50 **34 → 39 µs**, mean 37.8 → 43.1 µs, p99 96 → 105 µs — reading 12 histograms instead of 4.

All three families verified populated over a 30 s window: `blockio_queue_latency` 4,933,037 read samples, `blockio_device_latency` 4,933,036, `blockio_total_latency` 4,933,037.

> Aside, worth its own fix: `kernel.bpf_stats_enabled` was `0` on the host, so `rezolus_bpf_run_time`/`run_count` were silently absent until I set it. That is exactly the premise of #1047 — the numbers principle 16 demands require a host-wide sysctl nobody sets. Restored to `0` afterwards.

## Adversarial review

Two reviewers ran against `main...HEAD`, one on BPF correctness and one on the Rust wiring.

**Fixed:**
- **A leaked map entry could poison the new metrics.** The pre-split code was self-healing — both start hooks did an unconditional update, so a stale stamp at a recycled `struct request *` was always overwritten before it was read. The split *reads* `insert` without writing it, so a leaked entry (a request inserted before the complete program attached, or during device teardown) could surface as a multi-minute sample in exactly the histogram someone opens to diagnose saturation — and `value_to_index` has a bucket for it. A pointer key cannot distinguish stale from real, so `plausible_span()` bounds it; the block layer's own request timeout is 30 s.
- **A compiler-introduced double read.** clang reloaded `stamps->insert` after the `bpf_probe_read_kernel` inside `rq_op()`, so the guard did not cover the value actually subtracted. Hoisted to a local — also removes a load.
- **The Queue Wait rate used the wrong population.** `blockio_operations` counts *completed* requests: both a byte-identical duplicate of the Device plot, and non-zero on a host where nothing queues. Now `RateSource::FromHistogram`.
- **The dashboard gate comment overclaimed.** It said the gate suppresses the subgroup where nothing queues; it cannot — `Histogram::refresh` calls `update_from` unconditionally, so a collecting agent publishes the series every tick. It is an agent-version gate and only that. Comment and `docs/metrics.md` corrected.
- **Added a positive dashboard test.** The negative one alone could not distinguish "correctly gated out" from "the gate names a metric that never exists" — a typo would render the subgroups *never* and still pass. Mutation-checked: with a typo'd gate the negative test still passes and the new positive test fails.
- Surfaces the first cut missed: `site/docs/telemetry.html`, `CHANGELOG.md`, `config/agent.toml`.

**Verified safe:** acquisition-group split (three phases = three families, principle 18; `batch_by_group` batches by pointer identity so each gets its own single-writer `HistogramBatch`); all 12 `SkelExt::map` arms present and matching the BPF map names; cross-platform metric identity via the non-Linux `stats.rs` include; `METRIC_SAMPLERS` entries required and correctly placed; no viewer-parity gap (both backends share `crates/dashboard`).

## Prior art

The naming decision and two pieces of this were already worked out in WIP on the `delta` host and are adopted here: the `blockio_device_latency_metric` alias helper, and the TUI live-mode fix — in live mode the store is empty at `run_tui` time, because `init_live_mode` only spawns `ingest_loop` and that awaits its first tick, so anything derived from the metric catalog must be recomputed per tick rather than once before the loop.

## Test plan

- [x] Both BPF targets compile against the checked-in `x86_64` and `aarch64` `vmlinux.h`
- [x] `cargo test` (676) and `cargo clippy --all-targets` clean; `cargo xtask fmt` applied
- [x] Device-phase equivalence with `main` verified across every hook ordering
- [x] Runtime verification on Linux: all three families populate under load
- [x] Principle-16 overhead measured, per program, against a `main` baseline at identical load
- [x] Pre-rename recording still renders (test), post-rename renders all three phases (test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
