### PR TITLE
feat(rez): expose a recording's tables as composition sources

### DIFF
--- a/crates/rez/src/reader.rs
+++ b/crates/rez/src/reader.rs
@@ -427,12 +427,43 @@ impl RezReader {
     ///
     /// A table whose segments cannot be parsed is skipped rather than
     /// poisoning the composition, matching `SamplerReader::reader`.
-    pub fn composition_sources(&self) -> Vec<CompositionSource> {
-        self.tables
+    ///
+    /// # Errors
+    ///
+    /// Refuses a reader that **flattens several recordings**, which is what
+    /// [`open_with_pool`](Self::open_with_pool) produces. Every recording of a
+    /// multi-recording archive holds the same sampler names, so composing a
+    /// flattened reader hands the builder several children carrying the same
+    /// metric names under one label — and one silently wins, losing an arm's
+    /// data entirely. That is the exact failure this composer exists to
+    /// prevent, so it refuses rather than warns, mirroring `route`, which
+    /// groups owners by `(recording, sampler)` for the same reason.
+    ///
+    /// Open with [`open_recordings`](Self::open_recordings) instead: one
+    /// reader per recording, each composable under its own label.
+    pub fn composition_sources(
+        &self,
+    ) -> Result<Vec<CompositionSource>, Box<dyn std::error::Error>> {
+        let mut recordings: Vec<usize> = self.tables.iter().map(|t| t.recording).collect();
+        recordings.sort_unstable();
+        recordings.dedup();
+        if recordings.len() > 1 {
+            return Err(format!(
+                "cannot compose a reader flattening {} recordings: they share sampler \
+                 names, so composing them would let one recording's series silently \
+                 replace another's. Open the archive with `open_recordings` and compose \
+                 each recording under its own label.",
+                recordings.len()
+            )
+            .into());
+        }
+
+        Ok(self
+            .tables
             .iter()
             .filter_map(|t| t.reader())
             .map(TableReader::composition_source)
-            .collect()
+            .collect())
     }
 
     /// Whether this recording holds no tables at all.
@@ -1821,6 +1852,68 @@ mod tests {
         assert!(!from_bytes[0].1.counter_names().is_empty());
     }
 
+    /// The composition counterpart to the query refusal below: a flattened
+    /// multi-recording reader must not be composable either.
+    ///
+    /// Every recording carries the same sampler names, so composing a
+    /// flattened reader hands the builder several children holding the SAME
+    /// metric names under one label. Nothing downstream can tell them apart —
+    /// one silently replaces the other and an arm's data is simply gone, which
+    /// is the precise failure `composition_sources` exists to prevent. It was
+    /// reachable through `open_with_pool`, the path a multi-recording archive
+    /// actually takes in production.
+    #[test]
+    fn composition_sources_refuse_a_flattened_multi_recording_reader() {
+        let (_d, p) = two_sampler_rez();
+        let (m, rb) = crate::rez::read_archive_bytes(&p).unwrap();
+        let rec0 = m.recordings.into_iter().next().unwrap();
+        let bytes0: Vec<Vec<Vec<u8>>> = rb
+            .into_iter()
+            .next()
+            .unwrap()
+            .tables
+            .into_iter()
+            .map(|(_, b)| b)
+            .collect();
+
+        let mut a = rec0.clone();
+        a.dir = "arm0".to_string();
+        a.labels.insert("arm".to_string(), "arm0".to_string());
+        let mut b = rec0.clone();
+        b.dir = "arm1".to_string();
+        b.labels.insert("arm".to_string(), "arm1".to_string());
+
+        let d = tempfile::tempdir().unwrap();
+        let out = d.path().join("two_rec.rez");
+        crate::rez::write_archive_bytes(&out, &[(a, bytes0.clone()), (b, bytes0)]).unwrap();
+
+        let pool = BufferPool::new(64 * 1024 * 1024);
+        // The flattening path — NOT open_recordings.
+        let flattened = RezReader::open_with_pool(&out, Arc::clone(&pool)).unwrap();
+        // `CompositionSource` is opaque and not `Debug`, so match rather than
+        // `expect_err`.
+        let err = match flattened.composition_sources() {
+            Ok(_) => panic!("composing a flattened 2-recording reader must refuse"),
+            Err(e) => e,
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("open_recordings"),
+            "the error must point at the entry point that works: {msg}"
+        );
+
+        // ...and the same archive opened per recording composes fine, proving
+        // the refusal is about flattening and not about the fixture.
+        let per_recording = RezReader::open_recordings(&out, pool).unwrap();
+        assert_eq!(per_recording.len(), 2);
+        for (_labels, reader) in &per_recording {
+            assert!(
+                !reader.composition_sources().unwrap().is_empty(),
+                "each recording composes on its own"
+            );
+        }
+    }
+
     /// C1 regression: `RezReader::open_with_pool` — NOT `open_recordings` —
     /// is the path a multi-recording archive actually takes in production
     /// (`parquet combine a.rez b.rez` builds a 2-recording A/B archive, and
@@ -2108,16 +2201,6 @@ mod tests {
             RezReader::open_with_pool(path, BufferPool::new(64 * 1024 * 1024)).unwrap()
         }
 
-        /// A `.rez` is readable while it is being written, and hindsight's
-        /// retention deletes as it goes — so a table that had rows when the
-        /// reader probed it can have none by the time a query opens it.
-        ///
-        /// The reader used to `.expect("segments opened at probe time cannot
-        /// fail to reopen")`, which is true for a finished archive and false
-        /// for the live one the format advertises. The plausible sequence is
-        /// exactly this one: hindsight evicts everything older than the
-        /// cutoff, and a quiet sampler's only rows go with it, so the viewer
-        /// or MCP panics instead of answering.
         /// Two recordings compose into ONE labelled multi-source, each
         /// keeping its own injected label.
         ///
@@ -2135,18 +2218,22 @@ mod tests {
             write_v3(&fixture_rows(6), 2, true, &a_path);
             write_v3(&fixture_rows(6), 2, true, &b_path);
 
-            let a = open(&a_path);
-            let b = open(&b_path);
-            assert!(
-                !a.composition_sources().is_empty(),
-                "fixture sanity: the recording has tables to compose"
+            // `open_recordings` -- one reader per recording -- is the entry
+            // point composition requires; see the refusal test below.
+            let pool = BufferPool::new(64 * 1024 * 1024);
+            let a = RezReader::open_recordings(&a_path, Arc::clone(&pool)).unwrap();
+            let b = RezReader::open_recordings(&b_path, pool).unwrap();
+            assert_eq!(
+                (a.len(), b.len()),
+                (1, 1),
+                "fixture sanity: one recording each"
             );
 
             let mut builder = metriken_query::ParquetReader::builder();
-            for source in a.composition_sources() {
+            for source in a[0].1.composition_sources().unwrap() {
                 builder = builder.source_labeled(source, [("job", "a")]);
             }
-            for source in b.composition_sources() {
+            for source in b[0].1.composition_sources().unwrap() {
                 builder = builder.source_labeled(source, [("job", "b")]);
             }
             let combined = builder.build().unwrap();
@@ -2163,6 +2250,16 @@ mod tests {
             assert_eq!(jobs, vec!["a".to_string(), "b".to_string()]);
         }
 
+        /// A `.rez` is readable while it is being written, and hindsight's
+        /// retention deletes as it goes — so a table that had rows when the
+        /// reader probed it can have none by the time a query opens it.
+        ///
+        /// The reader used to `.expect("segments opened at probe time cannot
+        /// fail to reopen")`, which is true for a finished archive and false
+        /// for the live one the format advertises. The plausible sequence is
+        /// exactly this one: hindsight evicts everything older than the
+        /// cutoff, and a quiet sampler's only rows go with it, so the viewer
+        /// or MCP panics instead of answering.
         #[test]
         fn a_table_evicted_between_probe_and_query_does_not_panic() {
             let rows = fixture_rows(6);

--- a/crates/rez/src/reader.rs
+++ b/crates/rez/src/reader.rs
@@ -47,8 +47,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use metriken_query::{
-    BufferPool, MetricsSource, ParquetReader, QueryError, QueryOptions, QueryResult, RateMode,
-    SegmentedParquetReader, UnionChild, UnionError, UnionMetricsSource,
+    BufferPool, CompositionSource, MetricsSource, ParquetReader, QueryError, QueryOptions,
+    QueryResult, RateMode, SegmentedParquetReader, UnionChild, UnionError, UnionMetricsSource,
 };
 
 use crate::rez::{self, RecordingBytes};
@@ -238,6 +238,16 @@ impl TableReader {
             TableReader::Segmented(r) => UnionChild::from(r),
         }
     }
+
+    /// The same borrow as [`union_child`](Self::union_child), for the other
+    /// composition: merging this table into a labelled multi-source rather
+    /// than into a same-recording union.
+    fn composition_source(&self) -> CompositionSource {
+        match self {
+            TableReader::Single(r) => CompositionSource::from(r),
+            TableReader::Segmented(r) => CompositionSource::from(r),
+        }
+    }
 }
 
 /// One opened per-table reader. A table is one or more parquet segments, so
@@ -396,6 +406,35 @@ pub struct RezReader {
 pub type LabeledRecordings = Vec<(BTreeMap<String, String>, RezReader)>;
 
 impl RezReader {
+    /// This recording's tables as composition sources, for merging the whole
+    /// recording into a labelled multi-source next to other artifacts — see
+    /// `metriken_query::ParquetBuilder::source_labeled`.
+    ///
+    /// This is the cross-*artifact* composition, distinct from the
+    /// same-recording union `route` builds: there, several tables of one
+    /// sampler answer one query under their own identities; here, the whole
+    /// recording becomes one labelled participant among several recordings,
+    /// each contributing the SAME metric names under a different injected
+    /// label. That is why these are `CompositionSource` and not `UnionChild`
+    /// — the two composers have opposite disjointness rules.
+    ///
+    /// **This opens every table.** Routing deliberately builds only the tables
+    /// a query names (see `SamplerReader::reader`), because a typical query
+    /// touches a small fraction of a large archive. A composed source cannot
+    /// work that way: the builder dispatches across its children by metric
+    /// name and needs them all up front. Callers pay the archive's full open
+    /// cost, so compose once and reuse the result rather than per query.
+    ///
+    /// A table whose segments cannot be parsed is skipped rather than
+    /// poisoning the composition, matching `SamplerReader::reader`.
+    pub fn composition_sources(&self) -> Vec<CompositionSource> {
+        self.tables
+            .iter()
+            .filter_map(|t| t.reader())
+            .map(TableReader::composition_source)
+            .collect()
+    }
+
     /// Whether this recording holds no tables at all.
     ///
     /// An arm that produced no rows — an endpoint that was reachable but never
@@ -2079,6 +2118,51 @@ mod tests {
         /// exactly this one: hindsight evicts everything older than the
         /// cutoff, and a quiet sampler's only rows go with it, so the viewer
         /// or MCP panics instead of answering.
+        /// Two recordings compose into ONE labelled multi-source, each
+        /// keeping its own injected label.
+        ///
+        /// This is the cross-artifact path a consumer needs to answer a single
+        /// query spanning several recordings and slice the answer by which one
+        /// it came from. It is the opposite composition from `route`'s
+        /// same-recording union: there the children must hold DISJOINT metric
+        /// names, here both children hold the SAME name and must stay distinct
+        /// rather than one silently winning.
+        #[test]
+        fn composition_sources_merge_recordings_under_distinct_labels() {
+            let dir = tempfile::tempdir().unwrap();
+            let a_path = dir.path().join("a.rez");
+            let b_path = dir.path().join("b.rez");
+            write_v3(&fixture_rows(6), 2, true, &a_path);
+            write_v3(&fixture_rows(6), 2, true, &b_path);
+
+            let a = open(&a_path);
+            let b = open(&b_path);
+            assert!(
+                !a.composition_sources().is_empty(),
+                "fixture sanity: the recording has tables to compose"
+            );
+
+            let mut builder = metriken_query::ParquetReader::builder();
+            for source in a.composition_sources() {
+                builder = builder.source_labeled(source, [("job", "a")]);
+            }
+            for source in b.composition_sources() {
+                builder = builder.source_labeled(source, [("job", "b")]);
+            }
+            let combined = builder.build().unwrap();
+
+            // Both arms survive, told apart by the injected label -- neither
+            // merged into the other nor dropped.
+            let mut jobs: Vec<String> = combined
+                .counter_labels("cpu_cycles")
+                .into_iter()
+                .filter_map(|l| l.get("job").cloned())
+                .collect();
+            jobs.sort();
+            jobs.dedup();
+            assert_eq!(jobs, vec!["a".to_string(), "b".to_string()]);
+        }
+
         #[test]
         fn a_table_evicted_between_probe_and_query_does_not_panic() {
             let rows = fixture_rows(6);

--- a/crates/rez/src/reader.rs
+++ b/crates/rez/src/reader.rs
@@ -400,6 +400,20 @@ pub struct RezReader {
     /// stops earlier than the run did" is exactly the kind of thing a
     /// consumer must be able to say out loud. See [`Self::complete`].
     complete: bool,
+    /// How many recordings this reader's tables came from.
+    ///
+    /// Set once at construction rather than derived from
+    /// `SamplerReader::recording`, because that field's meaning is NOT uniform:
+    /// `from_v3_db` numbers recordings archive-globally while `from_recordings`
+    /// numbers them per call. Counting distinct values across tables therefore
+    /// happens to be right today only because `open_with_pool`'s tar branch
+    /// passes every recording in one call. Rebuilding that branch on top of
+    /// `open_recordings` -- the obvious cleanup -- would give every table
+    /// `recording == 0` and silently defeat the check in
+    /// [`composition_sources`](Self::composition_sources) with its test still
+    /// green. Carrying the count here makes the invariant explicit and
+    /// refactor-proof.
+    recordings: usize,
 }
 
 /// One `RezReader` per recording, paired with that recording's label set.
@@ -426,46 +440,95 @@ impl RezReader {
     /// cost, so compose once and reuse the result rather than per query.
     ///
     /// A table whose segments cannot be parsed is skipped rather than
-    /// poisoning the composition, matching `SamplerReader::reader`.
+    /// poisoning the composition, matching `SamplerReader::reader` — unless
+    /// EVERY table is skipped, which is an error rather than an empty vec (see
+    /// below).
+    ///
+    /// # The caller owns label uniqueness
+    ///
+    /// The injected label is what keeps two recordings' identically-named
+    /// series apart, and this method cannot see it. `open_recordings` does not
+    /// solve that on the caller's behalf: **two recordings may legally carry
+    /// identical label sets** — two endpoints that infer the same `source` and
+    /// `host` do exactly that, and the recorder only warns. A caller that
+    /// derives its injected label from a recording's own labels can therefore
+    /// give both arms the same one and reproduce the merge this method refuses,
+    /// one level up. Derive the label from something the caller knows is
+    /// unique per participant instead.
+    ///
+    /// # Composition tolerates name-sharing that `route` refuses
+    ///
+    /// `route` answers a query naming metrics from several tables of one
+    /// sampler through `UnionMetricsSource::try_new`, which REFUSES when those
+    /// tables share a metric name. This composition has no equivalent check,
+    /// because it is eager and whole-archive: refusing here would reject an
+    /// entire archive over a name the caller may never query. Shared names are
+    /// real and shipped — `gpu_nvidia` and `gpu_amd_smi` both publish
+    /// `gpu_utilization` — so on a host running both, a composed query that
+    /// aggregates the name away (`sum by (id) (gpu_utilization)`) sums across
+    /// vendors where `route` would have refused. The series remain
+    /// distinguishable by their `sampler` label; a caller that must not
+    /// conflate them should group by it.
     ///
     /// # Errors
     ///
     /// Refuses a reader that **flattens several recordings**, which is what
-    /// [`open_with_pool`](Self::open_with_pool) produces. Every recording of a
-    /// multi-recording archive holds the same sampler names, so composing a
-    /// flattened reader hands the builder several children carrying the same
-    /// metric names under one label — and one silently wins, losing an arm's
-    /// data entirely. That is the exact failure this composer exists to
-    /// prevent, so it refuses rather than warns, mirroring `route`, which
-    /// groups owners by `(recording, sampler)` for the same reason.
+    /// [`open_with_pool`](Self::open_with_pool) produces. Every recording holds
+    /// the same sampler names, so composing a flattened reader hands the
+    /// builder several children carrying the same metric names under one
+    /// label. `ParquetBuilder` does not dedup or dispatch — it CONCATENATES
+    /// (`MultiParquetSource`: "same (metric, label) pairs in multiple files
+    /// produce duplicate series") — so the result is duplicate,
+    /// indistinguishable series and a silently doubled aggregate, with
+    /// histograms interleaving into one series index. Not, as an earlier
+    /// version of this comment claimed, one recording replacing another: that
+    /// is `UnionSource`'s first-wins, a different composer.
     ///
     /// Open with [`open_recordings`](Self::open_recordings) instead: one
     /// reader per recording, each composable under its own label.
+    ///
+    /// Also refuses when every table was skipped but the recording has tables,
+    /// since an empty composition is indistinguishable from an arm that was
+    /// simply flat. A recording with no tables at all returns `Ok(vec![])` —
+    /// check [`is_empty`](Self::is_empty) first if that matters.
     pub fn composition_sources(
         &self,
     ) -> Result<Vec<CompositionSource>, Box<dyn std::error::Error>> {
-        let mut recordings: Vec<usize> = self.tables.iter().map(|t| t.recording).collect();
-        recordings.sort_unstable();
-        recordings.dedup();
-        if recordings.len() > 1 {
+        if self.recordings > 1 {
             return Err(format!(
-                "cannot compose a reader flattening {} recordings: they share sampler \
-                 names, so composing them would let one recording's series silently \
-                 replace another's. Open the archive with `open_recordings` and compose \
-                 each recording under its own label.",
-                recordings.len()
+                "cannot compose a reader flattening {} recordings: they publish the same \
+                 metric names, so composing them emits duplicate, indistinguishable series \
+                 and double-counts every aggregation over them. Open the archive with \
+                 `open_recordings` and compose each recording under its own label.",
+                self.recordings
             )
             .into());
         }
 
-        Ok(self
+        let sources: Vec<CompositionSource> = self
             .tables
             .iter()
             .filter_map(|t| t.reader())
             .map(TableReader::composition_source)
-            .collect())
-    }
+            .collect();
 
+        // A table whose segments cannot be opened is skipped above. Dropping
+        // EVERY table silently would be indistinguishable from a recording that
+        // was simply flat: the caller composes nothing, `build()` succeeds on
+        // the other arms, and every query about this one answers empty. That is
+        // the same silent per-arm loss the refusal above exists to prevent, so
+        // say it rather than return an empty vec.
+        if sources.is_empty() && !self.tables.is_empty() {
+            return Err(format!(
+                "none of this recording's {} tables could be opened -- their segments were \
+                 evicted or are unreadable -- so composing it would contribute nothing",
+                self.tables.len()
+            )
+            .into());
+        }
+
+        Ok(sources)
+    }
     /// Whether this recording holds no tables at all.
     ///
     /// An arm that produced no rows — an endpoint that was reachable but never
@@ -512,7 +575,9 @@ impl RezReader {
             let mut tables = Vec::new();
             let mut metadata = BTreeMap::new();
             let mut complete = true;
+            let mut recordings = 0usize;
             for (i, (_, reader)) in Self::from_v3(path, pool)?.into_iter().enumerate() {
+                recordings += 1;
                 if i == 0 {
                     metadata = reader.metadata;
                 }
@@ -524,6 +589,7 @@ impl RezReader {
                 metadata,
                 filename,
                 complete,
+                recordings,
             });
         }
         let recordings = read_recordings(path)?;
@@ -698,6 +764,7 @@ impl RezReader {
                     metadata: rec.meta.metadata,
                     filename: Some(rez::recording_dir_slug(&rec.meta.labels)),
                     complete: rec.complete,
+                    recordings: 1,
                 },
             ));
         }
@@ -713,6 +780,9 @@ impl RezReader {
             .first()
             .map(|r| r.metadata.clone())
             .unwrap_or_default();
+        // Captured before the Vec is consumed: this is the reader's recording
+        // count, which `composition_sources` refuses on.
+        let recording_count = recordings.len();
         let mut tables = Vec::new();
         let mut complete = true;
         for (recording, rec) in recordings.into_iter().enumerate() {
@@ -788,6 +858,7 @@ impl RezReader {
             metadata,
             filename,
             complete,
+            recordings: recording_count,
         })
     }
 
@@ -1850,6 +1921,42 @@ mod tests {
         .unwrap();
         assert_eq!(from_bytes.len(), 1);
         assert!(!from_bytes[0].1.counter_names().is_empty());
+    }
+
+    /// The v3/SQLite twin of the tar refusal below.
+    ///
+    /// The two flattening branches of `open_with_pool` reach their recording
+    /// count by DIFFERENT routes, so pinning one proves nothing about the
+    /// other — and v3 is the branch that matters: `parquet combine` emits v3,
+    /// and `record --endpoint a --endpoint b` writes a multi-recording v3
+    /// archive directly. The tar test below covers `from_recordings`; this one
+    /// covers `from_v3`.
+    #[test]
+    fn composition_sources_refuse_a_flattened_multi_recording_v3_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fleet.rez");
+        crate::rez::recorder_tests_support::multi_recording_v3_rez(
+            &path,
+            &[("redis", "web-01"), ("valkey", "web-01")],
+        );
+
+        let pool = BufferPool::new(16 * 1024 * 1024);
+        let flattened = RezReader::open_with_pool(&path, Arc::clone(&pool)).unwrap();
+        let err = match flattened.composition_sources() {
+            Ok(_) => panic!("composing a flattened 2-recording v3 archive must refuse"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err}").contains("open_recordings"),
+            "the error must point at the entry point that works: {err}"
+        );
+
+        // Per recording, each composes on its own.
+        let per_recording = RezReader::open_recordings(&path, pool).unwrap();
+        assert_eq!(per_recording.len(), 2);
+        for (_labels, reader) in &per_recording {
+            assert!(reader.composition_sources().is_ok());
+        }
     }
 
     /// The composition counterpart to the query refusal below: a flattened


### PR DESCRIPTION
A `.rez` cannot currently take part in a **cross-artifact** query.

Merging several recordings into one labelled multi-source — so a single query
spans them and the answer can be sliced by which recording it came from — needs
each participant as a `metriken_query::CompositionSource`. That is built only
`From<&ParquetReader>` / `From<&SegmentedParquetReader>`, and a `RezReader` is
neither: it is a composition of per-sampler tables, with no public way to reach
them.

This is the blocker for reading `.rez` in systemslab, whose core query path
merges N job artifacts into one reader with `artifact_id` / `job` labels
injected, so one PromQL query can span jobs
([design](https://github.com/iopsystems/systemslab/blob/main/docs/superpowers/specs/2026-09-01-rez-format-design.md)).

## The change

`crates/rez` already does exactly this privately, for its own unions:

```rust
fn union_child(&self) -> UnionChild {
    match self {
        TableReader::Single(r) => UnionChild::from(r),
        TableReader::Segmented(r) => UnionChild::from(r),
    }
}
```

`TableReader::composition_source()` sits next to it — same match, same borrow —
and `RezReader::composition_sources()` maps it over the recording's tables.

## Why two composers rather than one

They have opposite disjointness rules, and both are needed:

- **`union_child`** feeds `route`'s same-recording union, whose children must
  hold **disjoint** metric names. A collision there is a producer/archive bug
  and `try_new` refuses it.
- **`composition_source`** feeds the cross-artifact builder, where every child
  holds the **same** names and must stay distinct under its own injected label
  — the failure mode being one silently winning.

## Cost, stated in the API

`composition_sources()` **opens every table**, and the doc comment says so.
Routing deliberately builds only the tables a query names (`SamplerReader::reader`
is a lazy `OnceLock`) because a typical query touches a small fraction of a large
archive — the header notes ~1.37 ms per segment over 418 segments, of which a
typical query needs 11%. A composed source cannot work that way: the builder
dispatches across its children by metric name and needs them all up front. So
the guidance is compose once and reuse, not compose per query.

A table whose segments cannot be parsed is skipped rather than poisoning the
composition, matching `SamplerReader::reader`.

## Verification

- `cargo test -p rez --features test-support` — **174 passed**, 0 failed (173
  pre-existing plus the new one).
- `cargo clippy -p rez --all-targets --features test-support` — clean.
- `cargo +nightly fmt --all -- --check` — clean.

New test `composition_sources_merge_recordings_under_distinct_labels` writes two
v3 archives, composes both into one `ParquetBuilder` under `job=a` / `job=b`, and
asserts both arms survive distinguishable — neither merged nor dropped.

Note `cargo clippy -p rez --all-targets` *without* `--features test-support`
fails on the `write_rez_fixture` example, which references
`rez::recorder_tests_support`. That reproduces on a pristine `main` and is
untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Jtzg9VbUHX56UpQ8JEJ83