### PR TITLE
fix(rez): declare the fixture example's required feature

### DIFF
--- a/crates/rez/Cargo.toml
+++ b/crates/rez/Cargo.toml
@@ -47,5 +47,14 @@ write = [
 # under test next door.
 test-support = ["write"]
 
+# Builds only with `test-support`, which is what supplies the fixture builders
+# it calls. Declared rather than left implicit because `--all-targets` compiles
+# examples: without this, `cargo check -p rez --all-targets` fails on a crate
+# that is otherwise fine, and it fails for a reason that looks like a broken
+# crate rather than a missing feature.
+[[example]]
+name = "write_rez_fixture"
+required-features = ["test-support"]
+
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
`cargo check -p rez --all-targets` fails on `main`:

```
error[E0433]: cannot find `recorder_tests_support` in `rez`
  --> crates/rez/examples/write_rez_fixture.rs:27:15
note: found an item that was configured out
```

`--all-targets` compiles examples, and `write_rez_fixture` calls `recorder_tests_support`, which only exists behind `test-support`. The error reads like a broken crate rather than a missing feature.

`required-features` is what this is for. Cargo skips the example unless the feature is on and builds it when it is; the node test that drives it (`cargo run -p rez --features test-support --example write_rez_fixture`) is unaffected — verified, still 3/3.

Introduced in #1122; noticed while reviewing #1125, which reported it reproducing on a pristine `main`.

**Why CI missed it**, since that is the more useful half: the `check` job runs `cargo check --all-targets` with no `-p`/`--workspace`, which in a workspace with a root package selects only `rezolus` — this crate's examples were never built. `clippy-deny` does sweep the workspace with `--all-targets`, but with `--all-features`, which turns `test-support` on and compiles the example happily. Neither covers "a workspace crate at its default features."

I left CI alone: widening either job is a scope decision with its own runtime cost, and the declaration makes the crate correct under every feature combination regardless. Worth a separate look if this class recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)