### PR TITLE
docs(rez): correct how a flattened composition actually fails

### DIFF
--- a/crates/rez/src/reader.rs
+++ b/crates/rez/src/reader.rs
@@ -1964,11 +1964,19 @@ mod tests {
     ///
     /// Every recording carries the same sampler names, so composing a
     /// flattened reader hands the builder several children holding the SAME
-    /// metric names under one label. Nothing downstream can tell them apart —
-    /// one silently replaces the other and an arm's data is simply gone, which
-    /// is the precise failure `composition_sources` exists to prevent. It was
-    /// reachable through `open_with_pool`, the path a multi-recording archive
-    /// actually takes in production.
+    /// metric names under one label. Nothing downstream can tell them apart:
+    /// `ParquetBuilder` concatenates rather than dedups or dispatches
+    /// (`MultiParquetSource`: "same (metric, label) pairs in multiple files
+    /// produce duplicate series"), so the result is duplicate, indistinguishable
+    /// series and a silently doubled aggregate — the precise failure
+    /// `composition_sources` exists to prevent. It was reachable through
+    /// `open_with_pool`, the path a multi-recording archive actually takes in
+    /// production.
+    ///
+    /// NOT one recording replacing another: that is `UnionSource`'s first-wins,
+    /// which the `route` refusals elsewhere in this file are about. The two
+    /// composers fail differently and the distinction is easy to lose, since
+    /// every neighbouring comment here is legitimately about the other one.
     #[test]
     fn composition_sources_refuse_a_flattened_multi_recording_reader() {
         let (_d, p) = two_sampler_rez();


### PR DESCRIPTION
Follow-up to #1125, which merged while I was reviewing it.

That PR landed with **two accounts of the same failure**. Its API doc got it right — `ParquetBuilder` concatenates, so composing a flattened multi-recording reader emits duplicate, indistinguishable series and a silently doubled aggregate — and explicitly disavowed the earlier claim that one recording replaces another. The tar-branch test's doc comment (`crates/rez/src/reader.rs:1968`) still carried the disavowed version.

Upstream settles it (`metriken-query`, `MultiParquetSource`):

```rust
// NOTE: Counter series are naively concatenated across files.
// Same (metric, label) pairs in multiple files produce duplicate series.
```

Replacement is `UnionSource`'s first-wins — a **different composer**, the one every `route` refusal in this file is about. That is precisely why this was easy to miss and easy to trust: eight neighbouring comments say "first-wins silently answers from ONE recording" and *all of them are correct*, because they describe the other composer. The corrected comment now names which is which, so the next reader doesn't have to re-derive the distinction.

For the record, the disavowed version was originally mine — I reported the finding to #1125 as "one silently winning", inferring it from a scratch probe where `counter_labels` returned a single label set. It dedups label sets, so it could not distinguish concatenation from replacement. #1125's investigation was right and mine was not.

Comment only; no behavior change. 176 tests pass, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)