### PR TITLE
perf(rez): commit a tick once, not once per recording

### DIFF
--- a/crates/rez/src/rez_sqlite.rs
+++ b/crates/rez/src/rez_sqlite.rs
@@ -163,6 +163,9 @@ const LIVE_WAL_PREDICATE: &str = "recording_id = ?1 AND sampler = ?2 \
 /// An open handle on a `.rez` v3 file.
 pub struct RezDb {
     conn: Connection,
+    /// Committed transactions. See [`RezDb::commits`].
+    #[cfg(any(test, feature = "test-support"))]
+    commits: std::cell::Cell<u64>,
 }
 
 impl RezDb {
@@ -198,7 +201,11 @@ impl RezDb {
         // with `file:` stays a filename.
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)
             .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
-        let db = RezDb { conn };
+        let db = RezDb {
+            conn,
+            #[cfg(any(test, feature = "test-support"))]
+            commits: std::cell::Cell::new(0),
+        };
 
         // ORDER IS LOAD-BEARING, and a reordering here fails invisibly — the
         // file is written with the wrong geometry and only a full VACUUM of
@@ -245,7 +252,11 @@ impl RezDb {
         // error, not an empty new recording.
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)
             .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
-        let db = RezDb { conn };
+        let db = RezDb {
+            conn,
+            #[cfg(any(test, feature = "test-support"))]
+            commits: std::cell::Cell::new(0),
+        };
         // `page_size`, `auto_vacuum` and `journal_mode` persist in the file;
         // these do not, and forgetting them silently downgrades durability
         // (synchronous falls back to NORMAL) on every subsequent write.
@@ -309,7 +320,11 @@ impl RezDb {
         // its own copy of the image.
         conn.deserialize_read_exact(rusqlite::MAIN_DB, &mut bytes.as_slice(), len, true)
             .map_err(|e| format!("failed to read the .rez archive: {e}"))?;
-        let db = RezDb { conn };
+        let db = RezDb {
+            conn,
+            #[cfg(any(test, feature = "test-support"))]
+            commits: std::cell::Cell::new(0),
+        };
         db.apply_connection_pragmas(READER_CACHE_SIZE_KIB)?;
 
         // A `.rez` always has a `recordings` table. Its absence has one
@@ -484,6 +499,17 @@ impl RezDb {
     /// prune runs outside the seal transaction" is made unrepresentable rather
     /// than merely documented — inside it, a quiet sampler's accumulated rows
     /// make the delete long enough to threaten the tick.
+    /// How many transactions this connection has COMMITTED.
+    ///
+    /// Exists so "one commit per tick, whatever the endpoint count" is a
+    /// property a test can assert rather than one a comment claims. At
+    /// `synchronous=FULL` a commit is an fsync, and fsyncs are not otherwise
+    /// observable from inside the process.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn commits(&self) -> u64 {
+        self.commits.get()
+    }
+
     pub fn transaction<T>(
         &mut self,
         f: impl FnOnce(&RezTx<'_>) -> Result<T, String>,
@@ -500,6 +526,8 @@ impl RezDb {
         tx.tx
             .commit()
             .map_err(|e| format!("failed to commit transaction: {e}"))?;
+        #[cfg(any(test, feature = "test-support"))]
+        self.commits.set(self.commits.get() + 1);
         Ok(out)
     }
 
@@ -795,6 +823,25 @@ impl RezDb {
     /// one. Reads stay on `&self`.
     pub fn insert_wal_rows(&mut self, recording_id: i64, rows: &[WalRow]) -> Result<(), String> {
         self.transaction(|tx| tx.insert_wal_rows(recording_id, rows))
+    }
+
+    /// One tick's rows for several recordings, in ONE transaction.
+    ///
+    /// **The transaction count is the point, not the row count.** At
+    /// `synchronous=FULL` every commit is an fsync, and the send that carries
+    /// this is a blocking hand-off from inside the scrape tick — so a commit
+    /// per recording made the tick's cost scale linearly with endpoint count.
+    /// Committing the tick once makes it constant. It also makes the tick
+    /// atomic across recordings: a crash cannot leave one endpoint's row for
+    /// tick N present and another's missing, which is the state a reader
+    /// comparing two arms would have to interpret.
+    pub fn insert_wal_rows_batch(&mut self, ticks: &[(i64, Vec<WalRow>)]) -> Result<(), String> {
+        self.transaction(|tx| {
+            for (recording_id, rows) in ticks {
+                tx.insert_wal_rows(*recording_id, rows)?;
+            }
+            Ok(())
+        })
     }
 
     /// Every WAL row for `(recording_id, sampler)`, sealed or not, oldest

--- a/crates/rez/src/rez_v3_writer.rs
+++ b/crates/rez/src/rez_v3_writer.rs
@@ -62,12 +62,17 @@ enum Msg {
         seed: Box<ManifestSeed>,
         reply: SyncSender<Result<i64, String>>,
     },
-    /// One tick's WAL rows for one recording, across all its samplers — one
-    /// transaction.
-    Wal {
-        recording_id: i64,
-        rows: Vec<WalRow>,
-    },
+    /// One tick's WAL rows for EVERY recording in the archive, across all
+    /// their samplers — one transaction, and therefore one fsync at
+    /// `synchronous=FULL`.
+    ///
+    /// Per tick rather than per recording, because the cost is paid on the
+    /// scrape loop: `wal`/`wal_tick` is a blocking send on a bound-1 channel
+    /// from inside the tick, and a commit per recording made that cost scale
+    /// linearly with endpoint count. `seal_batch` already refused the same
+    /// trade ("12 implicit commits would be 12 fsyncs at `synchronous=FULL`
+    /// against a ~46 ms tick"); this carries the argument across recordings.
+    Wal { ticks: Vec<(i64, Vec<WalRow>)> },
     /// One seal batch for one recording = one transaction.
     Seal {
         recording_id: i64,
@@ -97,6 +102,12 @@ enum Msg {
     /// no data and changes nothing — see [`RecordingWriter::sync`].
     #[cfg(any(test, feature = "test-support"))]
     Sync(SyncSender<()>),
+    /// Answer with how many transactions the writer's connection has
+    /// committed. A barrier as well as a question, exactly as `Sync` is: the
+    /// reply means everything queued ahead of it has been handled, so a caller
+    /// can count a tick's commits without racing the writer.
+    #[cfg(any(test, feature = "test-support"))]
+    Commits(SyncSender<u64>),
 }
 
 /// Where the writer thread leaves its failure so a *handle* can report it.
@@ -262,6 +273,68 @@ impl RezArchive {
         take_writer_error(&self.err)
     }
 
+    /// Commit one tick's staged rows for EVERY recording, as one transaction.
+    ///
+    /// The multi-recording counterpart to [`RecordingWriter::wal`]. Each
+    /// recording's rows come from [`StreamRecorderV3::stage`]; this hands them
+    /// over together so the archive pays one commit — one fsync at
+    /// `synchronous=FULL` — per tick rather than one per endpoint.
+    ///
+    /// **Why the cost is worth naming:** the hand-off is a blocking send on a
+    /// bound-1 channel from inside the scrape tick, so a per-recording commit
+    /// put a linear-in-endpoint-count fsync bill on the loop that has to keep
+    /// up with the sampling interval. `seal_batch` already refused exactly this
+    /// trade within one recording; this is the same argument across them.
+    ///
+    /// An empty batch does not send: it still checks the writer is alive, so a
+    /// tick where nothing advanced cannot mask a dead writer.
+    pub fn wal_tick(&mut self, ticks: Vec<(i64, Vec<WalRow>)>) -> Result<(), String> {
+        let ticks: Vec<(i64, Vec<WalRow>)> = ticks
+            .into_iter()
+            .filter(|(_, rows)| !rows.is_empty())
+            .collect();
+        if ticks.is_empty() {
+            return self.check_alive();
+        }
+        let Some(tx) = self.tx.as_ref() else {
+            return Err("the .rez writer thread has already been joined".to_string());
+        };
+        if tx.send(Msg::Wal { ticks }).is_ok() {
+            return Ok(());
+        }
+        Err(take_writer_error(&self.err))
+    }
+
+    /// How many transactions the writer has committed, as a barrier: the
+    /// answer arrives only after everything queued ahead of it is handled.
+    ///
+    /// Exists so "one commit per tick, whatever the endpoint count" is a
+    /// property a test asserts rather than a comment claims — an fsync is not
+    /// observable from inside the process, but the commit that causes it is.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn commits_for_test(&mut self) -> u64 {
+        let (tx, rx) = sync_channel(0);
+        let Some(sender) = self.tx.as_ref() else {
+            return 0;
+        };
+        if sender.send(Msg::Commits(tx)).is_err() {
+            return 0;
+        }
+        rx.recv().unwrap_or(0)
+    }
+
+    /// Whether the writer thread is still alive, without writing anything.
+    ///
+    /// Mirrors `RecordingWriter::check_alive`: the shared error slot is the
+    /// only signal available, since the archive cannot ask a thread it owns
+    /// whether it has finished without joining it.
+    fn check_alive(&mut self) -> Result<(), String> {
+        match self.err.lock() {
+            Ok(guard) if guard.is_some() => Err(guard.clone().unwrap_or_default()),
+            _ => Ok(()),
+        }
+    }
+
     /// Create an archive holding exactly one recording.
     ///
     /// The shape every caller had before archives could hold several, and
@@ -350,7 +423,6 @@ impl RecordingWriter {
     }
 
     /// The `recordings` row this handle appends to.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub fn recording_id(&self) -> i64 {
         self.recording_id
     }
@@ -361,14 +433,18 @@ impl RecordingWriter {
         &self.stagger_key
     }
 
-    /// Hand one tick's WAL rows to the writer.
+    /// Hand one tick's WAL rows to the writer, for THIS recording alone.
+    ///
+    /// The single-recording spelling — hindsight, and a one-endpoint `record`.
+    /// An archive with several recordings should stage each one and commit the
+    /// tick once, through [`RezArchive::wal_tick`]: one transaction instead of
+    /// one per recording.
     pub fn wal(&mut self, rows: Vec<WalRow>) -> Result<(), String> {
         if rows.is_empty() {
             return self.check_alive();
         }
         self.send(Msg::Wal {
-            recording_id: self.recording_id,
-            rows,
+            ticks: vec![(self.recording_id, rows)],
         })
     }
 
@@ -605,7 +681,11 @@ fn writer_loop(
                 }
                 let _ = reply.send(inserted);
             }
-            Ok(Msg::Wal { recording_id, rows }) => db.insert_wal_rows(recording_id, &rows)?,
+            Ok(Msg::Wal { ticks }) => db.insert_wal_rows_batch(&ticks)?,
+            #[cfg(any(test, feature = "test-support"))]
+            Ok(Msg::Commits(reply)) => {
+                let _ = reply.send(db.commits());
+            }
             Ok(Msg::Seal {
                 recording_id,
                 batch,
@@ -1000,6 +1080,34 @@ impl StreamRecorderV3 {
         anchored_ts: u64,
         wall_offset_ns: i64,
     ) -> Result<(), String> {
+        let rows = self.stage(snapshot, anchored_ts, wall_offset_ns)?;
+        self.handle.wal(rows)
+    }
+
+    /// Build this tick's WAL rows for THIS recording without committing them.
+    ///
+    /// The archive-level half of [`ingest`](Self::ingest): a caller holding
+    /// several recordings stages each one and commits the tick once, through
+    /// [`RezArchive::wal_tick`], so an archive pays one transaction — one fsync
+    /// at `synchronous=FULL` — per tick rather than one per endpoint.
+    ///
+    /// Everything except the hand-off happens here, dedup and seal accounting
+    /// included, so the two spellings cannot drift on what a tick MEANS. The
+    /// accounting advances even if the caller then fails to commit: that is
+    /// unchanged from `ingest`, whose send could always fail after the same
+    /// state moved.
+    /// The `recordings` row this recorder appends to — the key a batched tick
+    /// commit is addressed by.
+    pub fn recording_id(&self) -> i64 {
+        self.handle.recording_id()
+    }
+
+    pub fn stage(
+        &mut self,
+        snapshot: &Snapshot,
+        anchored_ts: u64,
+        wall_offset_ns: i64,
+    ) -> Result<Vec<WalRow>, String> {
         // Native V3 ingest is keyed by GROUP, not sampler, and its WAL payload
         // shape (`WalGroupRow`) differs entirely from V1/V2's `WalCell`s — so
         // it is its own path rather than a fork inside the loop below.
@@ -1098,7 +1206,7 @@ impl StreamRecorderV3 {
                 .or_insert_with(|| SegmentAccount::open_first(sampler, stagger_key, policy))
                 .add_row(entries_approx_bytes(&entries));
         }
-        self.handle.wal(wal_rows)
+        Ok(wal_rows)
     }
 
     /// The native V3 path: one WAL row per acquisition group whose window
@@ -1125,7 +1233,7 @@ impl StreamRecorderV3 {
         groups: &[GroupSnapshot],
         anchored_ts: u64,
         wall_offset_ns: i64,
-    ) -> Result<(), String> {
+    ) -> Result<Vec<WalRow>, String> {
         let mut wal_rows = Vec::new();
         let mut accepted: Vec<(&str, u64, usize)> = Vec::new();
         // Names already accepted THIS TICK. `group_by_sampler`'s V1/V2 path is
@@ -1339,7 +1447,7 @@ impl StreamRecorderV3 {
                 .or_insert_with(|| SegmentAccount::open_first(name, stagger_key, policy))
                 .add_row(bytes);
         }
-        self.handle.wal(wal_rows)
+        Ok(wal_rows)
     }
 
     /// Seal every open segment past any threshold, as ONE batch → one
@@ -1527,6 +1635,84 @@ mod tests {
             }])
             .unwrap(),
         }
+    }
+
+    /// THE property the batched tick exists for: an archive's commit count per
+    /// tick does not grow with its recording count.
+    ///
+    /// At `synchronous=FULL` a commit is an fsync, and the hand-off is a
+    /// blocking send from inside the scrape loop — so a commit per recording
+    /// put a linear-in-endpoint-count fsync bill on the loop that has to keep
+    /// up with the sampling interval. `seal_batch` already refused that trade
+    /// within one recording ("12 implicit commits would be 12 fsyncs at
+    /// `synchronous=FULL` against a ~46 ms tick"); this is the same argument
+    /// across recordings.
+    ///
+    /// Asserted as ONE commit for FOUR recordings, and separately that a
+    /// 4-recording tick costs the same as a 1-recording tick — a count alone
+    /// could be satisfied by a writer that committed once and dropped three
+    /// recordings' rows, so the row check below is not decoration.
+    #[test]
+    fn a_tick_costs_one_commit_however_many_recordings_it_spans() {
+        fn commits_for(recordings: usize, dir: &Path) -> (u64, usize) {
+            let path = dir.join(format!("{recordings}.rez"));
+            let mut archive = RezArchive::create(&path).unwrap();
+            let mut recs: Vec<StreamRecorderV3> = (0..recordings)
+                .map(|i| {
+                    let mut seed = seed();
+                    seed.labels.insert("source".to_string(), format!("svc{i}"));
+                    StreamRecorderV3::new(archive.add_recording(seed).unwrap())
+                })
+                .collect();
+
+            // Baseline AFTER the recordings exist: `add_recording` commits, and
+            // what is being measured is the per-TICK cost.
+            let baseline = archive.commits_for_test();
+
+            let ts = 1_000_000_000u64;
+            let staged: Vec<(i64, Vec<WalRow>)> = recs
+                .iter_mut()
+                .map(|rec| {
+                    let rows = rec
+                        .stage(
+                            &snap(ts, vec![counter("cpu_cycles", "cpu_usage", 1, None)]),
+                            ts,
+                            0,
+                        )
+                        .unwrap();
+                    (rec.recording_id(), rows)
+                })
+                .collect();
+            archive.wal_tick(staged).unwrap();
+
+            // `commits_for_test` is itself the barrier: the writer answers it
+            // only after the tick ahead of it is committed.
+            let commits = archive.commits_for_test() - baseline;
+            let rows: usize = {
+                let db = RezDb::open(&path).unwrap();
+                (0..recordings)
+                    .map(|i| db.read_wal(i as i64 + 1, "cpu_usage").unwrap().len())
+                    .sum()
+            };
+            drop(recs);
+            drop(archive);
+            (commits, rows)
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let (one_commit, one_rows) = commits_for(1, dir.path());
+        let (four_commits, four_rows) = commits_for(4, dir.path());
+
+        assert_eq!(one_commit, 1, "a one-recording tick is one commit");
+        assert_eq!(
+            four_commits, one_commit,
+            "a four-recording tick must cost the same as a one-recording tick, \
+             not four times as much"
+        );
+        // ...and all four recordings' rows are actually in it. Without this, a
+        // writer that committed once and dropped three would pass above.
+        assert_eq!(one_rows, 1);
+        assert_eq!(four_rows, 4, "every recording's row must be in that commit");
     }
 
     /// THE guarantee this cadence exists for: a plain copy of a live archive

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -792,7 +792,24 @@ effort); promote one to a journal entry when it's picked up.
   `Plot`/`View` descriptor + component API, for live data — plus a `<rezolus-section>`
   wrapper. *Why:* a clean split between the static file-mode viewer and a future
   streaming server viewer without forking the frontend.
-- **One WAL commit (and fsync) per recording per tick** — Open, found reviewing
+- **One WAL commit (and fsync) per recording per tick** — **DONE**. A tick is
+  staged per recording (`StreamRecorderV3::stage`) and committed once
+  (`RezArchive::wal_tick` -> `RezDb::insert_wal_rows_batch`), so an archive
+  pays one transaction — one fsync at `synchronous=FULL` — per tick however
+  many endpoints it holds. `RezDb::commits()` makes that assertable: the test
+  pins one commit for four recordings AND that all four recordings' rows are in
+  it, since a count alone would be satisfied by a writer that committed once
+  and dropped three. Mutation-checked against the old per-recording commit,
+  which reads 4. A side benefit worth knowing: the tick is now atomic across
+  recordings, so a crash cannot leave one endpoint's row for tick N present and
+  another's missing. *Considered and declined:* moving to `synchronous=NORMAL`
+  with an fsync on a uniform clock. It trades the documented "survives power
+  loss, not merely process death" property for a win the existing measurement
+  says is not where the tail is ("the tail is checkpoint and prune work, not
+  fsync"), and it would leave the cost linear in endpoint count — N commits
+  still cost N commit records and N sets of page writes, just without the
+  fsyncs. Coalescing fixes the linearity at its root and keeps durability.
+  *Original entry:* found reviewing
   multi-endpoint `.rez` (#1109). `writer_loop` handles one `Msg::Wal` per
   recording per tick, and `RezDb::insert_wal_rows` is one transaction — one
   fsync at `synchronous=FULL`. An archive used to be one recording, so a tick

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -648,6 +648,13 @@ struct RezStream {
     /// msgpack endpoints get a recording: a sparse map says which endpoints
     /// are being archived without a `None` per endpoint that is not.
     recs: BTreeMap<usize, rez_v3_writer::StreamRecorderV3>,
+    /// This tick's rows, per recording, waiting for one commit.
+    ///
+    /// Cleared by `commit_tick`. Rows sitting here have already advanced each
+    /// recorder's dedup and seal accounting — the same as the moment between
+    /// `StreamRecorderV3::ingest` building its rows and its send returning, so
+    /// a failure to commit loses the tick exactly as a failed send always did.
+    staged: Vec<(i64, Vec<rez_sqlite::WalRow>)>,
     /// Canonical label key -> the endpoint URL that claimed it first, for the
     /// indistinguishable-labels warning.
     ///
@@ -678,7 +685,14 @@ impl RezStream {
     /// archive would finalize successfully one recording short. Every endpoint
     /// that scrapes in this mode opens its recording first, at startup or on
     /// activation, so reaching this arm means that invariant broke.
-    fn ingest(
+    /// Stage one endpoint's tick. Nothing reaches the archive until
+    /// [`commit_tick`](Self::commit_tick).
+    ///
+    /// Staged rather than committed because the archive commits the whole tick
+    /// at once: at `synchronous=FULL` every commit is an fsync, and the
+    /// hand-off is a blocking send from inside the scrape loop, so a commit per
+    /// endpoint put a linear-in-endpoint-count fsync bill on the tick.
+    fn stage(
         &mut self,
         endpoint: usize,
         url: &Url,
@@ -686,13 +700,30 @@ impl RezStream {
         anchored_ts: u64,
         wall_offset_ns: i64,
     ) -> Result<(), String> {
-        match self.recs.get_mut(&endpoint) {
-            Some(rec) => rec.ingest(snapshot, anchored_ts, wall_offset_ns),
-            None => Err(format!(
-                "{url} was scraped with no .rez recording open for it; its samples \
-                 would be discarded"
-            )),
+        let rows = match self.recs.get_mut(&endpoint) {
+            Some(rec) => rec.stage(snapshot, anchored_ts, wall_offset_ns)?,
+            None => {
+                return Err(format!(
+                    "{url} was scraped with no .rez recording open for it; its samples \
+                     would be discarded"
+                ))
+            }
+        };
+        // Keyed by recording id, which is what the writer commits against.
+        if let Some(rec) = self.recs.get(&endpoint) {
+            self.staged.push((rec.recording_id(), rows));
         }
+        Ok(())
+    }
+
+    /// Commit every endpoint staged this tick, as one transaction.
+    ///
+    /// Called once per tick whether or not anything staged: an empty commit
+    /// does not write, but it does check the writer is still alive, so a run
+    /// whose endpoints all went quiet cannot sit on a dead writer unnoticed.
+    fn commit_tick(&mut self) -> Result<(), String> {
+        let staged = std::mem::take(&mut self.staged);
+        self.archive.wal_tick(staged)
     }
 
     /// Open a recording for an endpoint that became reachable after the
@@ -757,6 +788,7 @@ impl RezStream {
             recs,
             mut archive,
             seen_labels: _,
+            staged: _,
         } = self;
         // Every recording is finalized, even if an earlier one failed: they
         // are independent rows in one archive, and stopping at the first
@@ -832,6 +864,7 @@ fn start_rez_recorder(
     let mut stream = RezStream {
         recs: BTreeMap::new(),
         seen_labels: BTreeMap::new(),
+        staged: Vec::new(),
         archive,
     };
 
@@ -1486,7 +1519,7 @@ pub fn run(mut config: RecordingConfig) {
                                 },
                             };
                             if let (Some(snapshot), Some(rec)) = (snapshot, rez_recorder.as_mut()) {
-                                if let Err(e) = rec.ingest(
+                                if let Err(e) = rec.stage(
                                     idx,
                                     &endpoints[idx].config.url,
                                     &snapshot,
@@ -1683,6 +1716,21 @@ pub fn run(mut config: RecordingConfig) {
                 }
             }
 
+            // Commit the whole tick — every endpoint staged above — as ONE
+            // transaction, before the seal check. One commit means one fsync at
+            // `synchronous=FULL` however many endpoints the archive holds; a
+            // commit per endpoint made the tick's cost scale with their count,
+            // on the loop that has to keep up with the sampling interval.
+            //
+            // Every tick, scrape or not, for the same reason `maybe_seal` runs
+            // unconditionally: an empty commit writes nothing but does check
+            // the writer is alive, so a run whose endpoints all went quiet
+            // cannot sit on a dead writer unnoticed.
+            let committed = match rez_recorder.as_mut() {
+                Some(rec) => rec.commit_tick(),
+                None => Ok(()),
+            };
+
             // Seal checks run every tick, scrape or not: if they were
             // ingest-driven an unreachable endpoint would leave its pre-outage
             // rows unsealed forever and the age bound would stop bounding the
@@ -1694,6 +1742,7 @@ pub fn run(mut config: RecordingConfig) {
             if let Some(e) = late_endpoint_failure
                 .take()
                 .or(ingest_failed)
+                .or_else(|| committed.err())
                 .or_else(|| sealed.err())
             {
                 eprintln!("error: recording failed: {e}");
@@ -2202,7 +2251,11 @@ mod tests {
         );
         let snapshot = rez::recorder_tests_support::snap(ts, vec![c]);
         let url = Url::parse("http://localhost:4241").unwrap();
-        rec.ingest(endpoint, &url, &snapshot, ts, 0)
+        // A whole tick, as the recorder does one: stage every endpoint, then
+        // commit once. Testing `stage` alone would leave the rows uncommitted
+        // and every assertion about the file vacuous.
+        rec.stage(endpoint, &url, &snapshot, ts, 0)?;
+        rec.commit_tick()
     }
 
     #[test]
@@ -2296,8 +2349,9 @@ mod tests {
                 Some(::rez::window::Window::new(ts - 500, ts)),
             );
             let snapshot = rez::recorder_tests_support::snap(ts, vec![c]);
-            rec.ingest(0, &rez_endpoint().config.url, &snapshot, ts, 0)
-                .expect("ingest");
+            rec.stage(0, &rez_endpoint().config.url, &snapshot, ts, 0)
+                .expect("stage");
+            rec.commit_tick().expect("commit");
             rec.maybe_seal().expect("seal");
         }
     }


### PR DESCRIPTION
Closes the "One WAL commit (and fsync) per recording per tick" backlog entry.

`writer_loop` handled one `Msg::Wal` per recording per tick, and `insert_wal_rows` is one transaction — **one fsync at `synchronous=FULL`**. An archive used to be one recording, so a tick was one commit; N recordings made it N. The hand-off is a blocking send on a bound-1 channel *from inside the scrape tick*, so that cost landed on the loop that has to keep up with the sampling interval, and it grew with endpoint count — which `record --endpoint a --endpoint b` and the documented multi-host example make ordinary.

`seal_batch` already refused exactly this trade within one recording ("12 implicit commits would be 12 fsyncs at `synchronous=FULL` against a ~46 ms tick"). This carries the argument across recordings.

## The change

`StreamRecorderV3::stage` builds a tick's rows without handing them over; `RezArchive::wal_tick` commits every recording's together in one transaction.

`ingest` keeps its meaning as stage-then-commit, so **hindsight and every existing caller are untouched** — and the two spellings cannot drift on what a tick MEANS, since everything except the hand-off (dedup, seal accounting) happens in the shared half.

A side effect worth having: the tick is now **atomic across recordings**. A crash cannot leave one endpoint's row for tick N present and another's missing — a state a reader comparing two arms would have had to interpret.

## How it is tested

An fsync is not observable from inside the process, but the commit that causes it is. `RezDb::commits()` counts committed transactions, and `RezArchive::commits_for_test()` asks the writer thread — a barrier as well as a question, exactly as the existing `Sync` message is, so the count cannot race the writer.

The test asserts **one commit for four recordings**, and separately that **all four recordings' rows are in that commit** — a count alone would be satisfied by a writer that committed once and dropped three, so the row check is not decoration.

Mutation-checked: restoring the per-recording commit gives

```
assertion `left == right` failed: a four-recording tick must cost the same as a
one-recording tick, not four times as much
  left: 4
 right: 1
```

## On fsyncing to a uniform clock instead

Considered and declined; recorded in the backlog with the reasoning. `synchronous=NORMAL` plus a periodic fsync would trade the documented "survives power loss, not merely process death" property for a win the existing measurement says is not where the tail is ("the tail is checkpoint and prune work, not fsync") — and it would leave the cost **linear in endpoint count** regardless: N commits still cost N commit records and N sets of page writes, just without the fsyncs. Coalescing fixes the linearity at its root and keeps durability. The 10s checkpoint timer added earlier already bounds the other axis.

Full workspace green (177 in `rez`), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)