### PR TITLE
chore: drop the temporary metriken patch for the 0.21.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1090,7 +1090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2195,7 +2195,8 @@ dependencies = [
 [[package]]
 name = "metriken"
 version = "0.10.1"
-source = "git+https://github.com/iopsystems/metriken?rev=f052a95b1319da8dd69e191bd060b03c354fb986#f052a95b1319da8dd69e191bd060b03c354fb986"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674854d8e0c525f2630a859e4bfe6ca5f452d27e38592079950e3d396fa7f358"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -2207,7 +2208,8 @@ dependencies = [
 [[package]]
 name = "metriken-core"
 version = "0.3.1"
-source = "git+https://github.com/iopsystems/metriken?rev=f052a95b1319da8dd69e191bd060b03c354fb986#f052a95b1319da8dd69e191bd060b03c354fb986"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e343d088765ec5ad0ad60fd9faa2480a909afd627662f9bf5546a144362fe83"
 dependencies = [
  "histogram",
  "linkme",
@@ -2219,7 +2221,8 @@ dependencies = [
 [[package]]
 name = "metriken-derive"
 version = "0.6.0"
-source = "git+https://github.com/iopsystems/metriken?rev=f052a95b1319da8dd69e191bd060b03c354fb986#f052a95b1319da8dd69e191bd060b03c354fb986"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba9466276652f7134a720d6d7e004bb5277dfa85a349e63030bb80b9aacf3db5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2230,7 +2233,8 @@ dependencies = [
 [[package]]
 name = "metriken-exposition"
 version = "0.19.0"
-source = "git+https://github.com/iopsystems/metriken?rev=f052a95b1319da8dd69e191bd060b03c354fb986#f052a95b1319da8dd69e191bd060b03c354fb986"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27254ab0c2cb71085b17be543db1970d11bde2144b78ed82ccdee0a35001d4eb"
 dependencies = [
  "arrow",
  "chrono",
@@ -2243,8 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.20.1"
-source = "git+https://github.com/iopsystems/metriken?rev=f052a95b1319da8dd69e191bd060b03c354fb986#f052a95b1319da8dd69e191bd060b03c354fb986"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46a291ac1421b5992c6080fc9af6bcc6dd3a7fbb6e9e179ef41dd88762c4e8"
 dependencies = [
  "arrow",
  "bytes",
@@ -2351,7 +2356,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3158,7 +3163,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3215,7 +3220,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3447,7 +3452,7 @@ version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
- "errno 0.2.8",
+ "errno 0.3.14",
  "libc",
 ]
 
@@ -3498,7 +3503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3685,10 +3690,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4372,7 +4377,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libloading = "0.8"
 log = "0.4.29"
 metriken = "0.10.1"
 metriken-exposition = "0.19.0"
-metriken-query = { version = "0.20.1", default-features = false }
+metriken-query = { version = "0.21.0", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
@@ -225,19 +225,3 @@ assets = [
     ],
 ]
 
-# TEMPORARY: `.rez` composition needs `ParquetBuilder::source_labeled` and
-# `CompositionSource`, added in iopsystems/metriken#140 and not yet released to
-# crates.io. Patched rather than changing the dependency declarations, so the
-# whole rollback is deleting this section once metriken-query 0.21 ships.
-#
-# Every metriken crate is patched together, not just metriken-query: it depends
-# on metriken-exposition by path within that workspace, so patching it alone
-# would source metriken-exposition from git while this crate sources it from
-# crates.io -- two packages of the same name, and a type mismatch wherever a
-# snapshot crosses between them.
-[patch.crates-io]
-metriken = { git = "https://github.com/iopsystems/metriken", rev = "f052a95b1319da8dd69e191bd060b03c354fb986" }
-metriken-core = { git = "https://github.com/iopsystems/metriken", rev = "f052a95b1319da8dd69e191bd060b03c354fb986" }
-metriken-derive = { git = "https://github.com/iopsystems/metriken", rev = "f052a95b1319da8dd69e191bd060b03c354fb986" }
-metriken-exposition = { git = "https://github.com/iopsystems/metriken", rev = "f052a95b1319da8dd69e191bd060b03c354fb986" }
-metriken-query = { git = "https://github.com/iopsystems/metriken", rev = "f052a95b1319da8dd69e191bd060b03c354fb986" }


### PR DESCRIPTION
`ParquetBuilder::source_labeled` and `CompositionSource` shipped in
metriken-query 0.21.0 (iopsystems/metriken#141) — the deletion criterion the
patch block stated.

Removes the `[patch.crates-io]` pin on all five metriken crates and moves
`metriken-query` to `0.21.0`. All five resolve from the registry again, so
building rezolus no longer needs git access to a specific metriken rev — which
also unblocks cutting a rezolus release.

The five were pinned together because metriken-query depends on
metriken-exposition **by path** within that workspace; patching it alone would
have sourced metriken-exposition from git while this crate sourced it from
crates.io, giving two packages of one name. Publishing strips the path, so the
released 0.21.0 depends on metriken-exposition 0.19.0 from the registry and the
others need no pin at all.

## Verification

- `Cargo.lock` shows `metriken-query 0.21.0` from
  `registry+https://github.com/rust-lang/crates.io-index`, and no metriken crate
  from git.
- `cargo test -p rez --features test-support` — **179 passed**, 0 failed.
- `cargo clippy -p rez --all-targets --features test-support` — clean.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Jtzg9VbUHX56UpQ8JEJ83