### PR TITLE
ci: run the JS viewer tests on node 24

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -164,6 +164,14 @@ jobs:
         run: cargo check -p rez --no-default-features --target wasm32-unknown-unknown --locked
       - name: Rebuild WASM viewer
         run: ./crates/viewer/build.sh
+      # The JS suite runs HERE rather than in its own job because four of its
+      # files drive the built bundle (tests/wasm_viewer_*.test.mjs); anywhere
+      # else they skip themselves and prove nothing.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Run the viewer JS tests
+        run: node --test tests/*.mjs
       - name: Check template symlinks are committed
         # build.sh self-heals missing symlinks under site/viewer/templates/
         # so the deploy doesn't break, but the symlinks must also be in

--- a/site/index.html
+++ b/site/index.html
@@ -726,14 +726,14 @@
                 </p>
             </div>
 
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div class="grid grid-cols-1 gap-4">
                 <a href="docs/installation.html"
                     class="group flex flex-col gap-2 p-6 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-blue-300 dark:hover:border-blue-700 transition-colors no-underline">
                     <div class="flex items-center gap-3">
                         <span
                             class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                             data-icon="download">download</span>
-                        <h3 class="text-base font-bold text-slate-900 dark:text-white">Installation</h3>
+                        <h3 class="text-xl font-bold text-slate-900 dark:text-white">Installation</h3>
                     </div>
                     <p class="text-base text-slate-500 dark:text-slate-400">Packages, source builds, platform support</p>
                 </a>
@@ -743,7 +743,7 @@
                         <span
                             class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                             data-icon="account_tree">account_tree</span>
-                        <h3 class="text-base font-bold text-slate-900 dark:text-white">Architecture</h3>
+                        <h3 class="text-xl font-bold text-slate-900 dark:text-white">Architecture</h3>
                     </div>
                     <p class="text-base text-slate-500 dark:text-slate-400">Modes, samplers, eBPF integration</p>
                 </a>
@@ -753,7 +753,7 @@
                         <span
                             class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                             data-icon="terminal">terminal</span>
-                        <h3 class="text-base font-bold text-slate-900 dark:text-white">CLI &amp; Configuration</h3>
+                        <h3 class="text-xl font-bold text-slate-900 dark:text-white">CLI &amp; Configuration</h3>
                     </div>
                     <p class="text-base text-slate-500 dark:text-slate-400">Commands, flags, TOML config reference</p>
                 </a>
@@ -763,7 +763,7 @@
                         <span
                             class="material-symbols-outlined text-2xl text-slate-400 group-hover:text-blue-600 transition-colors"
                             data-icon="api">api</span>
-                        <h3 class="text-base font-bold text-slate-900 dark:text-white">API Reference</h3>
+                        <h3 class="text-xl font-bold text-slate-900 dark:text-white">API Reference</h3>
                     </div>
                     <p class="text-base text-slate-500 dark:text-slate-400">HTTP endpoints for every mode</p>
                 </a>

--- a/site/index.html
+++ b/site/index.html
@@ -261,7 +261,7 @@
                     Get Started
                 </a>
                 <a href="docs/architecture.html"
-                    class="border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 px-10 py-4 rounded-lg text-lg font-bold no-underline hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
+                    class="border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 bg-white/70 dark:bg-slate-900/60 px-10 py-4 rounded-lg text-lg font-bold no-underline hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors">
                     How It Works
                 </a>
             </div>

--- a/tests/wasm_viewer_histogram_kpis.test.mjs
+++ b/tests/wasm_viewer_histogram_kpis.test.mjs
@@ -6,16 +6,24 @@ import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkgJs = path.join(repoRoot, 'site/viewer/pkg/wasm_viewer.js');
+const pkgWasm = path.join(repoRoot, 'site/viewer/pkg/wasm_viewer_bg.wasm');
+
+// Skip cleanly if the bundle hasn't been built, the way the sibling
+// wasm_viewer_* tests do. Without this the file throws ENOENT at import time,
+// which `node --test tests/*.mjs` reports as a failure rather than a skip.
+if (!fs.existsSync(pkgJs) || !fs.existsSync(pkgWasm)) {
+    test('WASM histogram KPIs (bundle not built — skipped)', { skip: true }, () => {});
+} else {
+
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rezolus-wasm-viewer-'));
 const wasmJsCopy = path.join(tmpDir, 'wasm_viewer.mjs');
 
-fs.copyFileSync(path.join(repoRoot, 'site/viewer/pkg/wasm_viewer.js'), wasmJsCopy);
+fs.copyFileSync(pkgJs, wasmJsCopy);
 
 const { initSync, WasmCaptureRegistry } = await import(pathToFileURL(wasmJsCopy).href);
 
-initSync({
-    module: fs.readFileSync(path.join(repoRoot, 'site/viewer/pkg/wasm_viewer_bg.wasm')),
-});
+initSync({ module: fs.readFileSync(pkgWasm) });
 
 test('static WASM viewer keeps vLLM latency histograms available', () => {
     const registry = new WasmCaptureRegistry();
@@ -47,3 +55,5 @@ test('static WASM viewer keeps vLLM latency histograms available', () => {
         );
     }
 });
+
+}


### PR DESCRIPTION
## Summary

Follows #1129, which merged before these commits landed on its branch.

- **CI never ran node.** No `setup-node`, no job invoking `node --test`. The 39 files under `tests/*.mjs` — the pure-JS viewer tests plus four that drive the built WASM bundle — are documented in `CLAUDE.md` and were running by hand or not at all. They now run in the **`wasm-viewer` job**, which is the one place the bundle already exists; anywhere else the four `wasm_viewer_*` files skip themselves and prove nothing.
- **Pinned to node 24** via `actions/setup-node@v7`, rather than inheriting whatever the runner image ships, so a runner image bump cannot silently change the JS runtime under the tests.
- **Running them locally found a real defect.** `wasm_viewer_histogram_kpis.test.mjs` copies the bundle at import time with no existence check, unlike its three siblings — so with no bundle it throws ENOENT and `node --test` reports a *failure* where the others report a skip. It now carries the same guard.
- **Two small site changes**: the hero's "How It Works" button was fully transparent, putting the graph-paper grid behind its label, so it takes the same translucent surface the content blocks use; and the documentation blocks go to one full-width row each with `text-xl` titles, reversing the 1×4 layout from #1129.

### On runner versions

Everything else was already current — `ubuntu-latest` throughout and `actions/*` at v4/v5. The one older image is `ubuntu-22.04` in the build matrix, and it stays: it sits alongside `ubuntu-24.04` in the same matrix, so it is deliberate coverage against an older glibc rather than drift, and bumping it would silently drop that.

## Test plan

- [x] `node --test tests/*.mjs` locally: **242 pass, 0 fail, 12 skipped** (the skips are the bundle-dependent files; before the guard fix it was 242 pass / 1 fail)
- [x] `actions/setup-node@v7` confirmed as the current major tag, not assumed
- [x] Workflow YAML parses
- [x] `site/index.html` tag balance checked
- [ ] **First CI run is the real test** — those 254 JS tests have never executed on a GitHub runner, so a local-environment assumption in any of them surfaces here. In CI the bundle exists, so the 12 local skips become real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)