### PR TITLE
fix(recorder): warn when two recordings' labels differ only in case

### DIFF
--- a/crates/rez/src/seal_policy.rs
+++ b/crates/rez/src/seal_policy.rs
@@ -244,17 +244,33 @@ pub fn stagger_bucket(sampler: &str, recording_key: &str) -> u64 {
     // identity for bits 6-7 while leaving the low-bit structure — which
     // measures *better* than a well-avalanched finalizer here — intact.
     //
-    // It does NOT close bit 5, and the same algebra applies: `x ^ 0x20` is
+    // It does NOT close bit 5, and that is now a measured decision rather than
+    // a deferral. The same algebra applies one bit lower: `x ^ 0x20` is
     // `x + 32 (mod 64)` and `51 * 32 == 32 (mod 64)`, so flipping bit 5 of an
-    // absorbed byte just XORs 0x20 through the whole chain. Two label sets
-    // differing by an EVEN number of bit-5 flips still share every bucket. In
-    // printable ASCII bit 5 is the case bit, so this needs two recordings
-    // whose labels differ only by capitalisation (`host=Web-01` vs
-    // `host=weB-01`) — which within one `record` run means an operator typing
-    // two `source=` values that differ only in case. Left open rather than
-    // absorbing `b >> 5` as well, because each extra fold costs some of the
-    // low-bit advantage and this class is far narrower than the one closed.
-    // Tracked in docs/backlog.md.
+    // absorbed byte XORs 0x20 through the whole chain and a second flip
+    // cancels it. Two label sets differing by an EVEN number of bit-5 flips
+    // share every bucket. In printable ASCII bit 5 is the case bit, so this
+    // needs two recordings whose labels differ only by capitalisation.
+    //
+    // **Closing it costs more than it buys, because the spread and the alias
+    // are the same property.** The low-bit structure that makes this hash
+    // spread a real sampler set PERFECTLY is exactly the affine structure the
+    // alias exploits. Measured over 500 recording keys, as colliding
+    // sampler-pairs normalised by what a uniform random assignment would give
+    // (0 = perfect, 1.0 = random):
+    //
+    //     candidate                12 samplers   26 samplers   alias
+    //     this hash                0.000         0.394         total lockstep
+    //     + absorb `b >> 5`        1.939         1.378         8/26 (not closed!)
+    //     + fold `b>>5 ^ b>>6`     1.939         1.182         1/26
+    //     reduce from top bits     0.981         1.002         closed
+    //
+    // Every candidate that closes the alias lands at or WORSE than random,
+    // and the `b >> 5` fold the backlog proposed does not even close it. The
+    // alias needs an operator to type two labels differing only in case, so it
+    // is detected and warned about instead — see `staggers_identically`, which
+    // states the condition exactly rather than approximating it with a
+    // case-insensitive compare.
     let absorb = |h: &mut u64, b: u64| {
         *h ^= b;
         *h = h.wrapping_mul(PRIME);
@@ -273,6 +289,40 @@ pub fn stagger_bucket(sampler: &str, recording_key: &str) -> u64 {
         absorb(&mut h, *b as u64);
     }
     h % STAGGER_BUCKETS
+}
+
+/// Whether two recording keys draw the SAME stagger bucket for EVERY sampler.
+///
+/// Not a string comparison — an exact statement about
+/// [`stagger_bucket`](stagger_bucket)'s algebra. The absorb is affine in each
+/// byte modulo `STAGGER_BUCKETS`, and `x ^ 0x20` is `x + 32 (mod 64)` with
+/// `51 * 32 == 32 (mod 64)`, so flipping bit 5 of one absorbed byte XORs 0x20
+/// through the whole chain and flipping it in a second byte cancels that out.
+/// Two keys therefore share every bucket exactly when they differ only in
+/// bit 5, in an EVEN number of positions.
+///
+/// In printable ASCII bit 5 is the case bit, so among realistic label values
+/// this is: the same labels typed with different capitalisation, in an even
+/// number of letters. `arm=valkey`/`arm=VALKEY` (six letters) shares all 26
+/// buckets; `arm=redis`/`arm=REDIS` (five) shares none.
+///
+/// This exists so the recorder can WARN about the one situation the aliasing
+/// can be reached in, which is far cheaper than hashing around it — see the
+/// note on `stagger_bucket` for the measurements behind that choice.
+pub fn staggers_identically(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut bit5_flips = 0usize;
+    for (x, y) in a.bytes().zip(b.bytes()) {
+        match x ^ y {
+            0 => {}
+            0x20 => bit5_flips += 1,
+            // Any other difference reaches bits the absorb does not cancel.
+            _ => return false,
+        }
+    }
+    bit5_flips.is_multiple_of(2)
 }
 
 /// A recording's stagger identity: its label set, canonically rendered.
@@ -300,6 +350,113 @@ mod tests {
     /// which is why it is a hand-written FNV-1a and not `DefaultHasher`. The
     /// literals pin the constants: if the hash changes, every recording's
     /// segment boundaries move.
+    /// The realistic sampler set, for spread and aliasing checks alike.
+    const SAMPLERS: [&str; 26] = [
+        "cpu_usage",
+        "cpu_perf",
+        "cpu_bandwidth",
+        "cpu_migrations",
+        "cpu_tlb_flush",
+        "cpu_frequency",
+        "scheduler",
+        "blockio_latency",
+        "blockio_requests",
+        "network_interfaces",
+        "network_traffic",
+        "syscall_counts",
+        "syscall_latency",
+        "tcp_connect_latency",
+        "tcp_packet_latency",
+        "tcp_receive",
+        "tcp_retransmit",
+        "tcp_traffic",
+        "memory",
+        "page_cache",
+        "gpu_nvidia",
+        "softirq",
+        "rezolus",
+        "cgroup_cpu",
+        "cgroup_memory",
+        "filesystem",
+    ];
+
+    /// `staggers_identically` must agree with the hash it claims to describe.
+    ///
+    /// It is an algebraic shortcut — "differ only in bit 5, an even number of
+    /// times" — standing in for "draws the same bucket for every sampler". A
+    /// shortcut that drifted from the function it describes would make the
+    /// recorder warn about safe pairs, or stay silent on lockstep, and nothing
+    /// else would notice. So it is checked against `stagger_bucket` itself.
+    #[test]
+    fn staggers_identically_agrees_with_the_hash() {
+        let cases = [
+            // Even bit-5 flips: every sampler collides.
+            ("arm=valkey", "arm=VALKEY"),
+            ("arm=Ab", "arm=aB"),
+            ("host=Web-01", "host=weB-01"),
+            // Odd: none do.
+            ("arm=redis", "arm=REDIS"),
+            ("arm=ab", "arm=aB"),
+            // Not a case difference at all.
+            ("host=web-01", "host=webm01"),
+            ("host=web-01", "host=web-02"),
+            ("arm=a", "arm=ab"),
+            // Identical.
+            ("arm=a", "arm=a"),
+        ];
+        for (a, b) in cases {
+            let predicted = staggers_identically(a, b);
+            let shares_all = SAMPLERS
+                .iter()
+                .all(|s| stagger_bucket(s, a) == stagger_bucket(s, b));
+            assert_eq!(
+                predicted, shares_all,
+                "staggers_identically({a:?}, {b:?}) said {predicted}, but the hash \
+                 shares-all is {shares_all}"
+            );
+        }
+    }
+
+    /// The property the stagger exists for, stated as a number so a future
+    /// change to the hash has to answer for it.
+    ///
+    /// Colliding sampler-pairs, normalised by what a uniform random assignment
+    /// would give: 0 = every table its own bucket, 1.0 = random. This hash
+    /// spreads a 12-sampler recording PERFECTLY and a 26-sampler one better
+    /// than random — which is the reason bit-5 aliasing is warned about rather
+    /// than hashed away, since every candidate that closed it measured at or
+    /// worse than random here.
+    #[test]
+    fn the_stagger_spreads_a_real_sampler_set_better_than_random() {
+        fn clumping(key: &str, n: usize) -> f64 {
+            let mut counts = [0u32; STAGGER_BUCKETS as usize];
+            for s in &SAMPLERS[..n] {
+                counts[stagger_bucket(s, key) as usize] += 1;
+            }
+            let pairs: f64 = counts
+                .iter()
+                .map(|&c| f64::from(c) * (f64::from(c) - 1.0) / 2.0)
+                .sum();
+            let expected = (n as f64) * (n as f64 - 1.0) / 2.0 / STAGGER_BUCKETS as f64;
+            pairs / expected
+        }
+
+        // Over many recordings, not one: the bucket a sampler draws depends on
+        // both, and a hash that spread well for a single key would say nothing.
+        for i in 0..200 {
+            let key = format!("host=web-{i:03}\u{1}source=rezolus");
+            assert_eq!(
+                clumping(&key, 12),
+                0.0,
+                "12 samplers must each get their own bucket ({key})"
+            );
+            assert!(
+                clumping(&key, 26) < 1.0,
+                "26 samplers must clump less than random ({key})"
+            );
+        }
+    }
+
     #[test]
     fn stagger_is_deterministic() {
         assert_eq!(stagger_bucket("cpu_usage", SINGLE_RECORDING_KEY), 32);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -846,7 +846,30 @@ effort); promote one to a journal entry when it's picked up.
   `RecordingSelector` against `RezReader::open_recordings`; it must name
   exactly one recording, and matching none or several is an error listing the
   candidates.
-- **The seal stagger still aliases on bit 5 (ASCII case)** — Open, found in the
+- **The seal stagger still aliases on bit 5 (ASCII case)** — **DONE**, and not
+  by changing the hash. Revisited with numbers, as this entry asked. The
+  measurement overturned the proposed fix: **the spread and the alias are the
+  same property** — the low-bit affine structure that makes this hash spread a
+  real sampler set PERFECTLY is exactly what the alias exploits. Colliding
+  sampler-pairs normalised by a uniform random assignment (0 = perfect, 1.0 =
+  random), over 500 recording keys:
+  | candidate | 12 samplers | 26 samplers | alias |
+  |---|---|---|---|
+  | shipping hash | 0.000 | 0.394 | total lockstep |
+  | + absorb `b >> 5` (this entry's fix) | 1.939 | 1.378 | **8/26 — not closed** |
+  | + fold `b>>5 ^ b>>6` | 1.939 | 1.182 | 1/26 |
+  | reduce from top bits | 0.981 | 1.002 | closed |
+  Every candidate that closes it lands at or worse than random, and the
+  proposed `b >> 5` fold does not even close it. So the hash stands and the
+  situation is DETECTED instead: `seal_policy::staggers_identically` states the
+  condition exactly (differ only in bit 5, an even number of times — not a
+  case-insensitive compare, which would cry wolf on the odd-count pairs that
+  stagger fine) and the recorder warns at startup, beside the existing
+  identical-labels warning. A test pins the shortcut against `stagger_bucket`
+  itself, since a drifted shortcut would warn about safe pairs or stay silent
+  on lockstep with nothing else noticing. The spread numbers are pinned too, so
+  a future hash change has to answer for them.
+  *Original entry:* found in the
   second review pass on #1109. The first pass closed bits 6-7 of every absorbed
   byte, but the same algebra survives one bit lower: `x ^ 0x20` is
   `x + 32 (mod 64)` and `51 * 32 == 32 (mod 64)`, so flipping bit 5 XORs 0x20

--- a/src/recorder/mod.rs
+++ b/src/recorder/mod.rs
@@ -898,16 +898,51 @@ fn warn_if_indistinguishable(
     url: &Url,
 ) {
     let key = seal_policy::recording_stagger_key(labels);
-    match seen.get(&key) {
-        Some(other) => eprintln!(
+    if let Some(warning) = indistinguishable_warning(seen, &key, url) {
+        eprintln!("{warning}");
+    }
+    seen.insert(key, url.to_string());
+}
+
+/// What is wrong with this recording's labels against the ones already seen,
+/// or `None` when nothing is.
+///
+/// Split from the printing so the DECISION is testable: whether a pair warns,
+/// and which of the two warnings it earns, is the part with rules in it.
+fn indistinguishable_warning(
+    seen: &BTreeMap<String, String>,
+    key: &str,
+    url: &Url,
+) -> Option<String> {
+    if let Some(other) = seen.get(key) {
+        return Some(format!(
             "warning: {other} and {url} carry identical labels ({key:?}), so nothing \
              downstream can tell their recordings apart — give each --endpoint its own \
              source=NAME to distinguish them"
-        ),
-        None => {
-            seen.insert(key, url.to_string());
-        }
+        ));
     }
+    // Distinguishable to a reader, but NOT to the seal stagger: two keys
+    // differing only in bit 5 of an even number of bytes draw the same bucket
+    // for every sampler (in printable ASCII, the same labels in different
+    // capitalisation). Their recordings would then seal in permanent lockstep,
+    // doubling the co-seal batch exactly when the archive holds twice the
+    // tables — the failure the stagger exists to prevent, reached by two names
+    // an operator would read as different.
+    //
+    // Warned rather than hashed around: every hash that closes this aliasing
+    // spreads a real sampler set at or worse than random, where this one
+    // spreads it perfectly. See `seal_policy::stagger_bucket`.
+    if let Some((other_key, other_url)) = seen
+        .iter()
+        .find(|(k, _)| seal_policy::staggers_identically(k, key))
+    {
+        return Some(format!(
+            "warning: {other_url} ({other_key:?}) and {url} ({key:?}) differ only in \
+             capitalisation, which the seal stagger cannot tell apart — their recordings \
+             will seal in lockstep. Give them labels that differ by more than case"
+        ));
+    }
+    None
 }
 
 /// Derive one tick's row stamp from the recording's clock anchor.
@@ -2240,6 +2275,58 @@ mod tests {
             role: None,
             protocol: Some(Protocol::Msgpack),
         })
+    }
+
+    /// Labels an operator reads as different, that the seal stagger cannot
+    /// tell apart.
+    ///
+    /// Two keys differing only in bit 5 of an even number of bytes draw the
+    /// same bucket for EVERY sampler, and in printable ASCII bit 5 is the case
+    /// bit. Their recordings then seal in permanent lockstep — the failure the
+    /// stagger exists to prevent — reached by two names that look distinct.
+    /// Warned rather than hashed around, because every hash that closed the
+    /// aliasing spread a real sampler set at or worse than random where this
+    /// one spreads it perfectly (see `seal_policy::stagger_bucket`).
+    #[test]
+    fn labels_differing_only_in_case_are_warned_about() {
+        let url = |s: &str| Url::parse(s).unwrap();
+        let mut seen = BTreeMap::new();
+        seen.insert("arm=valkey".to_string(), "http://a:4241/".to_string());
+
+        // Even number of case flips: shares every bucket.
+        let w = super::indistinguishable_warning(&seen, "arm=VALKEY", &url("http://b:4241"))
+            .expect("an even-flip case difference must warn");
+        assert!(w.contains("lockstep"), "{w}");
+        assert!(w.contains("capitalisation"), "{w}");
+
+        // Odd: does not alias, so must NOT warn — a warning on every
+        // case-insensitive match would cry wolf on pairs that stagger fine.
+        assert!(
+            super::indistinguishable_warning(&seen, "arm=Valkey", &url("http://b:4241")).is_none(),
+            "an odd-flip case difference does not alias and must not warn"
+        );
+
+        // Genuinely distinct labels: silent.
+        assert!(
+            super::indistinguishable_warning(&seen, "arm=redis", &url("http://b:4241")).is_none()
+        );
+    }
+
+    /// The identical-labels warning still fires, and says the other thing:
+    /// nothing downstream can tell the recordings apart at all. The two
+    /// warnings are different problems and must not be collapsed.
+    #[test]
+    fn identical_labels_warn_about_identity_not_lockstep() {
+        let mut seen = BTreeMap::new();
+        seen.insert("arm=valkey".to_string(), "http://a:4241/".to_string());
+        let w = super::indistinguishable_warning(
+            &seen,
+            "arm=valkey",
+            &Url::parse("http://b:4241").unwrap(),
+        )
+        .expect("identical labels must warn");
+        assert!(w.contains("identical labels"), "{w}");
+        assert!(!w.contains("lockstep"), "{w}");
     }
 
     /// One tick of one counter for `endpoint`.


### PR DESCRIPTION
Closes "The seal stagger still aliases on bit 5 (ASCII case)" — **not by changing the hash.**

That entry asked for the trade to be "revisited with numbers, not an oversight." The numbers overturned its own proposed fix.

## The finding

**The spread and the alias are the same property.** The low-bit affine structure that makes this hash spread a real sampler set *perfectly* is exactly what the bit-5 alias exploits — so closing the alias costs the thing the stagger exists for.

Colliding sampler-pairs, normalised by what a uniform random assignment gives (0 = every table its own bucket, 1.0 = random), measured over 500 recording keys against a 26-sampler set:

| candidate | 12 samplers | 26 samplers | alias |
|---|---|---|---|
| shipping hash | **0.000** | **0.394** | total lockstep |
| + absorb `b >> 5` *(this entry's proposed fix)* | 1.939 | 1.378 | **8/26 — not closed** |
| + fold `b>>5 ^ b>>6` | 1.939 | 1.182 | 1/26 |
| reduce from the top bits | 0.981 | 1.002 | closed |

Every candidate that closes the alias lands **at or worse than random**, where the shipping hash is perfect at 12 samplers. And the `b >> 5` fold the entry proposed does not even close it — it leaves an 8/26 partial alias.

## So: detect it instead

`seal_policy::staggers_identically` states the condition **exactly** — differ only in bit 5, an even number of times — rather than approximating it with a case-insensitive compare, which would cry wolf on the odd-count pairs that stagger fine (`arm=redis`/`arm=REDIS`, five letters, shares no buckets).

The recorder warns at startup beside the existing identical-labels warning. The two are different problems and say different things: one is "nothing downstream can tell these apart", the other is "these will seal in lockstep."

## Tests

- **`staggers_identically` is checked against `stagger_bucket` itself.** It is an algebraic shortcut standing in for "draws the same bucket for every sampler"; a shortcut that drifted would warn about safe pairs or stay silent on lockstep, and nothing else would notice.
- **The spread numbers are pinned** — 12 samplers must each get their own bucket, 26 must clump less than random, across 200 recording keys — so a future hash change has to answer for them rather than quietly trading them away.
- Both warnings tested, including that an odd-flip case difference does **not** warn.

The decision split out of the printing (`indistinguishable_warning` returns `Option<String>`) so the part with rules in it is testable.

Full workspace green (184 in `rez`), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)