### PR TITLE
fix(mcp): shell-escape selector output and de-alias the cache identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shlex",
  "syscall-numbers",
  "sysconf",
  "systeminfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,10 @@ tar = { version = "0.4.45", default-features = false }
 # builders. A `#[cfg(test)]` module over there would be invisible here, so they
 # live behind a feature that only the test build turns on.
 rez = { workspace = true, features = ["test-support"] }
+# A real shell-word splitter, used ONLY to verify `shell_word`'s quoting
+# round-trips — a different implementation from the quoter, so the test cannot
+# share a bug with the code it checks. Already in the tree via `cc`.
+shlex = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libbpf-rs = { version = "0.26.2" }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -922,7 +922,22 @@ effort); promote one to a journal entry when it's picked up.
   *Why:* the failure mode is "the retry says the file already exists", which
   reads as a bug in the retry rather than fallout from the original error.
 - **Selector output is not shell-escaped, and the cache identity can alias** —
-  Open, found reviewing MCP recording selection (#1117). Two narrow holes, both
+  **DONE**. Both closed. (a) `picker_form`'s flag branch now runs each `k=v`
+  through `shell_word`, POSIX single-quoting any token that is not already
+  shell-safe — so `select with: --recording note='first run'` survives being
+  pasted, and a value containing the literal ` --recording ` stays one word
+  instead of parsing back as a duplicate key. Single-quote style because it is
+  total: inside `'...'` the only escape needed is `'` itself. The round-trip
+  tests now shell-split the rendered line with `shlex` (a dev-dependency, a
+  DIFFERENT implementation from the quoter) before parsing, so a quoting bug
+  surfaces as a wrong word count rather than passing on a shared mistake;
+  mutation-checked by reverting to the raw join, which fails them. (b) The
+  server's post-open identity dedup keys on the label `BTreeMap` itself, not
+  `recording_stagger_key`'s `\u{1}`-joined string — `{x: "a\u{1}y=b"}` and
+  `{x: "a", y: "b"}` flatten identically but compare unequal as maps, so the
+  second lookup no longer returns the first's reader; mutation-checked by
+  reverting to the flattened identity, which conflates them.
+  *Original entry:* Two narrow holes, both
   needing an operator-chosen label value with an unusual character. (a)
   `flag_form` joins raw label values with `" --recording "` and presents the
   result as something to paste, so a value containing a space —

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1616,6 +1616,50 @@ mod tests {
         archive.join().unwrap();
     }
 
+    /// Build a multi-recording archive from arbitrary label maps.
+    ///
+    /// The general form behind the `source`/`arm` helpers, for tests that need
+    /// label sets those cannot express — e.g. two recordings whose canonical
+    /// `\u{1}`-joined renders COLLIDE while the maps differ, which is what the
+    /// cache-identity aliasing test needs. Each recording gets three rows of a
+    /// counter and its `source` (if any) mirrored into its metadata.
+    pub(crate) fn multi_recording_rez_with_labels(
+        path: &std::path::Path,
+        recordings: &[std::collections::BTreeMap<String, String>],
+    ) {
+        use crate::recorder::rez_v3_writer::{ManifestSeed, RezArchive, StreamRecorderV3};
+        let mut archive = RezArchive::create(path).unwrap();
+        let mut recs: Vec<StreamRecorderV3> = Vec::new();
+        for labels in recordings {
+            let metadata = labels
+                .get("source")
+                .map(|s| [("source".to_string(), s.clone())].into_iter().collect())
+                .unwrap_or_default();
+            let seed = ManifestSeed {
+                labels: labels.clone(),
+                metadata,
+                clock_anchor_wall_ns: 1_000_000_000,
+            };
+            recs.push(StreamRecorderV3::new(archive.add_recording(seed).unwrap()));
+        }
+        for rec in recs.iter_mut() {
+            for t in 0..3u64 {
+                let ts = 1_000_000_000 * (t + 1);
+                let w = Some(Window::new(ts - 50_000_000, ts));
+                rec.ingest(
+                    &snap(ts, vec![counter("cpu_cycles", "cpu_usage", t, w)]),
+                    ts,
+                    0,
+                )
+                .unwrap();
+            }
+        }
+        for rec in recs {
+            rec.finalize((4_000_000_000, 0)).unwrap();
+        }
+        archive.join().unwrap();
+    }
+
     /// A multi-recording archive must be refused HERE, with a message, rather
     /// than opening into a reader that answers nothing.
     ///

--- a/src/mcp/recording_selector.rs
+++ b/src/mcp/recording_selector.rs
@@ -200,7 +200,7 @@ fn picker_form(
             "{flag} {}",
             pairs
                 .iter()
-                .map(|(k, v)| format!("{k}={v}"))
+                .map(|(k, v)| shell_word(&format!("{k}={v}")))
                 .collect::<Vec<_>>()
                 .join(&format!(" {flag} "))
         ),
@@ -218,6 +218,34 @@ fn picker_form(
 /// One JSON string literal, escaped.
 fn json_str(s: &str) -> String {
     serde_json::Value::String(s.to_string()).to_string()
+}
+
+/// `word` as a single POSIX shell word, quoted only if it would not survive
+/// the shell as-is.
+///
+/// The flag form is advice to PASTE — `select with: --recording note=first run`
+/// — so a value with a space splits in the shell into a flag plus a stray
+/// positional (which for `detect-anomalies` lands in the optional `QUERY`
+/// slot), and a value containing the literal ` --recording ` parses back as a
+/// duplicate key. Neither is something an operator types on purpose, but both
+/// are a wrong answer wearing a right one's clothes — the species this arc kept
+/// finding.
+///
+/// Single-quote style, because it is TOTAL: inside `'...'` every byte is
+/// literal, so the only escape needed is for `'` itself, rendered `'\''` (close
+/// the quote, an escaped apostrophe, reopen). No character can slip through the
+/// way double-quote escaping lets `$`, `` ` ``, `\` and `!` do. Left bare when
+/// the word is already shell-safe, so the common `source=redis` reads unchanged
+/// and existing captures' advice does not churn.
+fn shell_word(word: &str) -> String {
+    // The set that never needs quoting in POSIX sh. `=` is here because the
+    // token is `k=v`; the rest are the label-value characters that occur in
+    // practice (paths, versions, hostports).
+    let safe = |c: char| c.is_ascii_alphanumeric() || "_-.,:/=@%+".contains(c);
+    if !word.is_empty() && word.chars().all(safe) {
+        return word.to_string();
+    }
+    format!("'{}'", word.replace('\'', "'\\''"))
 }
 
 /// Render a recording's labels for display: `k=v, k=v` in key order.
@@ -500,15 +528,30 @@ mod tests {
     /// told to type something that does not work.
     fn reparse(rendered: &str, syntax: SelectorSyntax) -> RecordingSelector {
         match syntax {
-            SelectorSyntax::Flag(flag) => RecordingSelector::parse(
-                flag,
-                rendered
-                    .strip_prefix(&format!("{flag} "))
-                    .unwrap_or_else(|| panic!("not a flag-form selector: {rendered:?}"))
-                    .split(&format!(" {flag} "))
-                    .map(str::to_string),
-            )
-            .unwrap_or_else(|e| panic!("unparseable flag selector {rendered:?}: {e}")),
+            // Model the real round trip: the rendered line is PASTED into a
+            // shell, which unquotes it into argv, and clap hands `parse` the
+            // words that followed each flag. `shlex::split` is that shell step
+            // — a DIFFERENT implementation from `shell_word`'s quoting, so a
+            // quoting bug (a bare space, a mangled apostrophe) surfaces here as
+            // a wrong word count rather than passing on a shared mistake.
+            SelectorSyntax::Flag(flag) => {
+                let argv = shlex::split(rendered)
+                    .unwrap_or_else(|| panic!("rendered form does not shell-split: {rendered:?}"));
+                let mut pairs = Vec::new();
+                let mut it = argv.into_iter();
+                while let Some(word) = it.next() {
+                    assert_eq!(
+                        word, flag,
+                        "expected {flag:?} in {rendered:?}, got {word:?}"
+                    );
+                    pairs.push(
+                        it.next()
+                            .unwrap_or_else(|| panic!("{flag} with no value in {rendered:?}")),
+                    );
+                }
+                RecordingSelector::parse(flag, pairs)
+                    .unwrap_or_else(|e| panic!("unparseable flag selector {rendered:?}: {e}"))
+            }
             SelectorSyntax::Json => {
                 let body = rendered
                     .strip_prefix("recording ")
@@ -549,6 +592,72 @@ mod tests {
             ),
             s,
             "the flag form must round-trip through parse"
+        );
+    }
+
+    /// A label value with a space must survive being pasted into a shell.
+    ///
+    /// The flag form is advice to paste (`select with: --recording ...`), so an
+    /// un-quoted space turns one selector into a flag plus a stray positional —
+    /// which for `detect-anomalies` lands in its optional `QUERY` slot and
+    /// quietly runs a different analysis. `reparse` shell-splits the rendered
+    /// line with `shlex` (a different implementation from the quoter), so this
+    /// asserts the value comes back BYTE-for-byte after a real round trip
+    /// through the shell.
+    #[test]
+    fn a_value_with_a_space_round_trips_through_the_shell() {
+        let s = RecordingSelector::parse("--recording", ["note=first run".to_string()]).unwrap();
+        let rendered = s.render(SelectorSyntax::Flag("--recording"));
+        // The token is quoted, so the shell keeps it one word.
+        assert!(
+            rendered.contains("'note=first run'"),
+            "a spaced value must be quoted: {rendered}"
+        );
+        assert_eq!(
+            reparse(&rendered, SelectorSyntax::Flag("--recording")),
+            s,
+            "a spaced value must survive the shell unchanged"
+        );
+    }
+
+    /// The nastier inputs, each round-tripped through the shell: a value that
+    /// contains the literal flag delimiter (which un-quoted would parse back as
+    /// a second key), an apostrophe (the one character single-quoting must
+    /// escape), and shell metacharacters.
+    #[test]
+    fn awkward_values_round_trip_through_the_shell() {
+        for pair in [
+            "note=a --recording b",
+            "note=it's fine",
+            "note=$(reboot)",
+            "cmd=a|b;c",
+            "q=*",
+        ] {
+            let s = RecordingSelector::parse("--recording", [pair.to_string()]).unwrap();
+            assert_eq!(
+                reparse(
+                    &s.render(SelectorSyntax::Flag("--recording")),
+                    SelectorSyntax::Flag("--recording")
+                ),
+                s,
+                "value {pair:?} must survive the shell unchanged"
+            );
+        }
+    }
+
+    /// Quoting only when needed: the common selector reads exactly as before,
+    /// so existing captures' advice does not churn and the output stays terse.
+    #[test]
+    fn a_safe_value_is_not_quoted() {
+        let s = RecordingSelector::parse(
+            "--recording",
+            ["source=redis".to_string(), "host=web-01".to_string()],
+        )
+        .unwrap();
+        assert_eq!(
+            s.render(SelectorSyntax::Flag("--recording")),
+            "--recording host=web-01 --recording source=redis",
+            "a shell-safe selector must not gain quotes"
         );
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -70,11 +70,16 @@ const MCP_CACHE_SIZE_BYTES: usize = 500 * 1024 * 1024;
 
 /// A cached reader, tagged with the recording it was opened from.
 struct CachedReader {
-    /// The chosen recording's label set, canonically rendered by
-    /// `recording_stagger_key`. Two selectors that name the same recording of
-    /// the same file share the reader under this identity rather than each
-    /// retaining their own copy of the archive.
-    identity: String,
+    /// The chosen recording's label set — the recording's own identity, so
+    /// two selectors that name the same recording of the same file share one
+    /// reader rather than each retaining a copy of the archive.
+    ///
+    /// The `BTreeMap` itself, NOT a flattened string. A `\u{1}`-joined `k=v`
+    /// render aliases: `{a: "\u{1}b=c"}` and `{a: "", b: "c"}` flatten to the
+    /// same bytes, so the second lookup would hand back the first's reader and
+    /// answer about the wrong recording. Comparing the maps cannot alias — the
+    /// same shape of bug this whole selector arc kept closing.
+    identity: std::collections::BTreeMap<String, String>,
     source: Arc<dyn metriken_query::MetricsSource>,
     /// What the analysis layer may trust this recording's metric names to
     /// mean, as the OPEN determined it. Cached alongside the reader because
@@ -690,7 +695,7 @@ impl Server {
         )?;
         let provenance = opened.provenance();
         let reader = opened.reader;
-        let identity = crate::recorder::seal_policy::recording_stagger_key(&opened.labels);
+        let identity = opened.labels.clone();
 
         let mut cache = self.reader_cache.write().unwrap();
         // Distinct selectors can name the SAME recording (`source=redis` and
@@ -698,7 +703,7 @@ impl Server {
         // a session. Collapse them onto one reader by the recording's own
         // identity so the archive is not retained once per spelling. Matching
         // on the path too: an identity is only meaningful within one file, and
-        // an archive with no labels at all renders the empty identity.
+        // an archive with no labels at all has the empty map as its identity.
         let source = cache
             .iter()
             .find(|((p, _), c)| p == parquet_file && c.identity == identity)
@@ -1092,6 +1097,63 @@ mod tests {
         assert!(
             Arc::ptr_eq(&narrow, &wide),
             "two selectors naming one recording must not retain two readers"
+        );
+    }
+
+    /// Two recordings whose OLD flattened identity would collide must not
+    /// share a cached reader.
+    ///
+    /// The dedup once rendered a recording's labels to a `\u{1}`-joined `k=v`
+    /// string, which aliases: `{x: "a\u{1}y=b"}` and `{x: "a", y: "b"}` render
+    /// the same bytes, so the second lookup would return the first's reader and
+    /// answer about the wrong recording. Keying on the label MAP cannot alias.
+    /// Reachable only with an operator-chosen label value carrying a `\u{1}` —
+    /// nobody types it by accident, but it is the same wrong-answer-looking-
+    /// right species this arc kept closing behind unusual inputs.
+    #[tokio::test]
+    async fn recordings_whose_flattened_identity_collides_do_not_share_a_reader() {
+        use std::collections::BTreeMap;
+        let a: BTreeMap<String, String> = [("x".to_string(), "a\u{1}y=b".to_string())]
+            .into_iter()
+            .collect();
+        let b: BTreeMap<String, String> = [
+            ("x".to_string(), "a".to_string()),
+            ("y".to_string(), "b".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        // Precondition: the OLD identity really would have conflated them.
+        assert_eq!(
+            crate::recorder::seal_policy::recording_stagger_key(&a),
+            crate::recorder::seal_policy::recording_stagger_key(&b),
+            "fixture must actually exercise the aliasing the fix removes",
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("collide.rez");
+        crate::mcp::tests::multi_recording_rez_with_labels(&path, &[a, b]);
+        let p = path.to_str().unwrap();
+
+        let server = Server::new();
+        // Select each uniquely: `y=b` names only B, the whole odd value names A.
+        let ra = server
+            .get_reader_selected(
+                p,
+                &crate::mcp::RecordingSelector::parse("--recording", ["x=a\u{1}y=b".to_string()])
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let rb = server
+            .get_reader_selected(
+                p,
+                &crate::mcp::RecordingSelector::parse("--recording", ["y=b".to_string()]).unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !Arc::ptr_eq(&ra, &rb),
+            "two distinct recordings must not be conflated by a flattened identity"
         );
     }
 


### PR DESCRIPTION
Closes the last open item from the #1117 review: two narrow holes, both needing an operator-chosen label value with an unusual character, and both the same species the arc kept finding — a wrong answer wearing a right one's clothes.

## (a) The pasteable flag form wasn't shell-safe

`select with: --recording k=v` is advice to **paste**, but it joined raw label values. So:

- a value with a space — `--recording note=first run` — splits in the shell into a flag plus a stray positional, which for `detect-anomalies` lands in its optional `QUERY` slot and quietly runs a *different* analysis;
- a value containing the literal ` --recording ` parses back as a duplicate key.

`picker_form`'s flag branch now runs each `k=v` through `shell_word`, which POSIX single-quotes any token that isn't already shell-safe. **Single-quote style because it is total**: inside `'...'` the only character needing an escape is `'` itself (`'\''`), so nothing can slip through the way `$`, `` ` ``, `\`, `!` do under double quotes. Left bare when safe, so `source=redis` reads unchanged and existing captures' advice doesn't churn.

**The round-trip tests now model the real path.** `reparse` shell-splits the rendered line with `shlex::split` — a dev-dependency, and a *different implementation* from the quoter — into argv before parsing, exactly as a shell then clap would. A quoting bug surfaces as a wrong word count rather than being waved through by a test that shares the mistake. Awkward values covered: embedded ` --recording `, an apostrophe, `$(reboot)`, `a|b;c`, `*`.

## (b) The cache identity could alias

The stdio server's post-open dedup rendered a recording's labels to `recording_stagger_key`'s `\u{1}`-joined `k=v` string. That aliases: `{x: "a\u{1}y=b"}` and `{x: "a", y: "b"}` flatten to identical bytes, so the second lookup returned the **first's reader** and answered about the wrong recording.

It keys on the label `BTreeMap` itself now — two different maps compare unequal, so the aliasing is structurally gone. The collision test asserts its own precondition (that the *old* `recording_stagger_key` really would have conflated the two) so it can't rot into a no-op.

## Verification

- Full workspace green; clippy clean.
- **Both mutation-checked**: reverting the quoting fails the shell round-trip tests; reverting to the flattened identity fails the collision test.
- `shlex` was already in the tree (via `cc`); added as a dev-dependency pinned to the same 2.x so no second copy is pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)