### PR TITLE
refactor(viewer): the capture registry holds N, not just two

### DIFF
--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -1,11 +1,27 @@
-//! Holds the two capture stores (baseline + optional experiment) plus their
-//! per-capture metadata. All cross-capture composition lives outside this
-//! module; the registry is intentionally dumb about comparison.
+//! Holds the capture stores — a mandatory `baseline` anchor plus any number of
+//! other captures — and their per-capture metadata. All cross-capture
+//! composition lives outside this module; the registry is intentionally dumb
+//! about comparison.
+//!
+//! **Baseline is the anchor, the rest are a collection.** `baseline` is always
+//! present and keeps the wire-stable id `"baseline"` (absence of a `?capture=`
+//! param resolves to it). Every other capture lives in `others`, keyed by a
+//! string id; the first of them is conventionally `"experiment"`, so the
+//! two-capture A/B path and every existing URL keep working unchanged while the
+//! store itself holds N. See `docs/superpowers/plans/2026-09-03-n-way-compare.md`.
 
 use std::sync::Arc;
 
 use metriken_query::MetricsSource;
 use parking_lot::RwLock;
+
+/// The conventional id of the first non-anchor capture — the "experiment" of a
+/// classic A/B, and what `CaptureId::Experiment` and legacy `?capture=experiment`
+/// URLs resolve to.
+pub const EXPERIMENT_ID: &str = "experiment";
+
+/// The anchor's id. Absence of `?capture=` resolves here; never renamed.
+pub const BASELINE_ID: &str = "baseline";
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -18,8 +34,8 @@ pub enum CaptureId {
 impl CaptureId {
     pub fn parse(s: &str) -> Option<Self> {
         match s {
-            "baseline" => Some(CaptureId::Baseline),
-            "experiment" => Some(CaptureId::Experiment),
+            BASELINE_ID => Some(CaptureId::Baseline),
+            EXPERIMENT_ID => Some(CaptureId::Experiment),
             _ => None,
         }
     }
@@ -28,6 +44,14 @@ impl CaptureId {
     /// values resolve to the default (Baseline).
     pub fn parse_opt(s: Option<&str>) -> Self {
         s.and_then(Self::parse).unwrap_or_default()
+    }
+
+    /// The wire id for this capture.
+    pub fn id(self) -> &'static str {
+        match self {
+            CaptureId::Baseline => BASELINE_ID,
+            CaptureId::Experiment => EXPERIMENT_ID,
+        }
     }
 }
 
@@ -39,13 +63,32 @@ pub struct CaptureSlot {
     pub systeminfo: RwLock<Option<String>>,
     pub file_metadata: RwLock<Option<String>>,
     /// Optional display alias for this capture (e.g. "redis", "valkey").
-    /// Purely cosmetic — internal identifiers stay "baseline"/"experiment".
+    /// Purely cosmetic — internal identifiers stay id strings.
     pub alias: RwLock<Option<String>>,
+}
+
+impl CaptureSlot {
+    fn new(
+        data: Arc<dyn MetricsSource>,
+        systeminfo: Option<String>,
+        file_metadata: Option<String>,
+        alias: Option<String>,
+    ) -> Self {
+        Self {
+            data: RwLock::new(data),
+            systeminfo: RwLock::new(systeminfo),
+            file_metadata: RwLock::new(file_metadata),
+            alias: RwLock::new(alias),
+        }
+    }
 }
 
 pub struct CaptureRegistry {
     baseline: CaptureSlot,
-    experiment: RwLock<Option<CaptureSlot>>,
+    /// Non-anchor captures, in attach order, keyed by wire id. The first is
+    /// conventionally `EXPERIMENT_ID`. A `Vec` rather than a map because the
+    /// order is the display order and N is small (a handful of arms).
+    others: RwLock<Vec<(String, CaptureSlot)>>,
 }
 
 impl CaptureRegistry {
@@ -56,76 +99,90 @@ impl CaptureRegistry {
         baseline_alias: Option<String>,
     ) -> Self {
         Self {
-            baseline: CaptureSlot {
-                data: RwLock::new(baseline_data),
-                systeminfo: RwLock::new(baseline_systeminfo),
-                file_metadata: RwLock::new(baseline_file_metadata),
-                alias: RwLock::new(baseline_alias),
-            },
-            experiment: RwLock::new(None),
+            baseline: CaptureSlot::new(
+                baseline_data,
+                baseline_systeminfo,
+                baseline_file_metadata,
+                baseline_alias,
+            ),
+            others: RwLock::new(Vec::new()),
         }
     }
 
-    pub fn get(&self, id: CaptureId) -> Option<Arc<dyn MetricsSource>> {
-        match id {
-            CaptureId::Baseline => Some(self.baseline.data.read().clone()),
-            CaptureId::Experiment => self
-                .experiment
-                .read()
-                .as_ref()
-                .map(|slot| slot.data.read().clone()),
+    /// Run `f` against the slot for `id`, or return `None` if no such capture.
+    /// The single read-locking primitive the id-keyed accessors share.
+    fn with_slot<T>(&self, id: &str, f: impl FnOnce(&CaptureSlot) -> T) -> Option<T> {
+        if id == BASELINE_ID {
+            return Some(f(&self.baseline));
         }
+        self.others
+            .read()
+            .iter()
+            .find(|(other, _)| other == id)
+            .map(|(_, slot)| f(slot))
+    }
+
+    /// Every attached capture's id, anchor first, in display order.
+    ///
+    /// Consumed by the `/api/v1/captures` listing and the N-way frontend (PR 2+
+    /// of the N-way-compare plan); the storage generalization lands first, on
+    /// its own, so it can be reviewed and tested in isolation.
+    #[allow(dead_code)]
+    pub fn capture_ids(&self) -> Vec<String> {
+        let mut ids = vec![BASELINE_ID.to_string()];
+        ids.extend(self.others.read().iter().map(|(id, _)| id.clone()));
+        ids
+    }
+
+    pub fn get_by_id(&self, id: &str) -> Option<Arc<dyn MetricsSource>> {
+        self.with_slot(id, |slot| slot.data.read().clone())
+    }
+
+    pub fn get(&self, id: CaptureId) -> Option<Arc<dyn MetricsSource>> {
+        self.get_by_id(id.id())
     }
 
     /// Returns the display filename for the given capture.
     /// Reads it from the data source's `filename()` method — no separate
     /// storage needed since the reader/store carries the name.
     pub fn filename(&self, id: CaptureId) -> String {
-        match id {
-            CaptureId::Baseline => self.baseline.data.read().filename().unwrap_or_default(),
-            CaptureId::Experiment => self
-                .experiment
-                .read()
-                .as_ref()
-                .and_then(|slot| slot.data.read().filename())
-                .unwrap_or_default(),
-        }
+        self.filename_by_id(id.id())
+    }
+
+    pub fn filename_by_id(&self, id: &str) -> String {
+        self.with_slot(id, |slot| slot.data.read().filename())
+            .flatten()
+            .unwrap_or_default()
     }
 
     pub fn systeminfo(&self, id: CaptureId) -> Option<String> {
-        match id {
-            CaptureId::Baseline => self.baseline.systeminfo.read().clone(),
-            CaptureId::Experiment => self
-                .experiment
-                .read()
-                .as_ref()
-                .and_then(|slot| slot.systeminfo.read().clone()),
-        }
+        self.systeminfo_by_id(id.id())
+    }
+
+    pub fn systeminfo_by_id(&self, id: &str) -> Option<String> {
+        self.with_slot(id, |slot| slot.systeminfo.read().clone())
+            .flatten()
     }
 
     pub fn file_metadata(&self, id: CaptureId) -> Option<String> {
-        match id {
-            CaptureId::Baseline => self.baseline.file_metadata.read().clone(),
-            CaptureId::Experiment => self
-                .experiment
-                .read()
-                .as_ref()
-                .and_then(|slot| slot.file_metadata.read().clone()),
-        }
+        self.file_metadata_by_id(id.id())
+    }
+
+    pub fn file_metadata_by_id(&self, id: &str) -> Option<String> {
+        self.with_slot(id, |slot| slot.file_metadata.read().clone())
+            .flatten()
     }
 
     /// Display alias for the given capture, when one was provided on the
     /// command line (or via attach). None = fall back to the identifier
     /// name on the UI side.
     pub fn alias(&self, id: CaptureId) -> Option<String> {
-        match id {
-            CaptureId::Baseline => self.baseline.alias.read().clone(),
-            CaptureId::Experiment => self
-                .experiment
-                .read()
-                .as_ref()
-                .and_then(|slot| slot.alias.read().clone()),
-        }
+        self.alias_by_id(id.id())
+    }
+
+    pub fn alias_by_id(&self, id: &str) -> Option<String> {
+        self.with_slot(id, |slot| slot.alias.read().clone())
+            .flatten()
     }
 
     /// Overwrite the baseline slot's alias.
@@ -149,6 +206,9 @@ impl CaptureRegistry {
         *self.baseline.data.write() = data;
     }
 
+    /// Attach (or replace) the conventional single experiment — the classic
+    /// A/B second arm. Kept as its own method because it is the two-capture
+    /// path every existing caller uses; `attach_capture` is the N-way form.
     pub fn attach_experiment(
         &self,
         data: Arc<dyn MetricsSource>,
@@ -156,26 +216,62 @@ impl CaptureRegistry {
         file_metadata: Option<String>,
         alias: Option<String>,
     ) {
-        *self.experiment.write() = Some(CaptureSlot {
-            data: RwLock::new(data),
-            systeminfo: RwLock::new(systeminfo),
-            file_metadata: RwLock::new(file_metadata),
-            alias: RwLock::new(alias),
-        });
+        self.attach_capture(EXPERIMENT_ID, data, systeminfo, file_metadata, alias);
     }
 
+    /// Attach (or replace, by id) a non-anchor capture. Replacing preserves the
+    /// capture's position, so re-uploading one arm of a comparison does not
+    /// reorder the rest.
+    pub fn attach_capture(
+        &self,
+        id: &str,
+        data: Arc<dyn MetricsSource>,
+        systeminfo: Option<String>,
+        file_metadata: Option<String>,
+        alias: Option<String>,
+    ) {
+        let slot = CaptureSlot::new(data, systeminfo, file_metadata, alias);
+        let mut others = self.others.write();
+        match others.iter_mut().find(|(other, _)| other == id) {
+            Some((_, existing)) => *existing = slot,
+            None => others.push((id.to_string(), slot)),
+        }
+    }
+
+    /// Remove the conventional single experiment, if present.
     pub fn detach_experiment(&self) {
-        *self.experiment.write() = None;
+        self.detach_capture(EXPERIMENT_ID);
+    }
+
+    /// Remove a non-anchor capture by id (no-op if absent; baseline cannot be
+    /// detached — it is the anchor).
+    pub fn detach_capture(&self, id: &str) {
+        self.others.write().retain(|(other, _)| other != id);
     }
 
     pub fn experiment_attached(&self) -> bool {
-        self.experiment.read().is_some()
+        self.with_slot(EXPERIMENT_ID, |_| ()).is_some()
+    }
+
+    /// How many non-anchor captures are attached. Consumed by PR 2+ (see
+    /// `capture_ids`).
+    #[allow(dead_code)]
+    pub fn other_count(&self) -> usize {
+        self.others.read().len()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn store(name: &str) -> Arc<dyn MetricsSource> {
+        Arc::new(metriken_query::MemoryStore::builder().filename(name).build())
+    }
+
+    fn registry() -> CaptureRegistry {
+        CaptureRegistry::new(store("base.parquet"), None, None, Some("base".into()))
+    }
 
     #[test]
     fn parse_capture_id() {
@@ -191,10 +287,75 @@ mod tests {
 
     #[test]
     fn registry_experiment_attached_toggles() {
-        // Compile-only smoke: the types exist and the method signatures are reachable.
-        #[allow(dead_code)]
-        fn _compile_only(reg: &CaptureRegistry) -> bool {
-            reg.experiment_attached()
-        }
+        let reg = registry();
+        assert!(!reg.experiment_attached());
+        reg.attach_experiment(store("exp.parquet"), None, None, Some("exp".into()));
+        assert!(reg.experiment_attached());
+        reg.detach_experiment();
+        assert!(!reg.experiment_attached());
+    }
+
+    /// The two-capture path is unchanged: `CaptureId::Experiment` and the
+    /// `experiment` string id resolve to the same slot, and detach clears it.
+    #[test]
+    fn the_experiment_id_and_enum_resolve_to_one_slot() {
+        let reg = registry();
+        reg.attach_experiment(store("exp.parquet"), None, None, Some("valkey".into()));
+        assert_eq!(reg.alias(CaptureId::Experiment).as_deref(), Some("valkey"));
+        assert_eq!(reg.alias_by_id(EXPERIMENT_ID).as_deref(), Some("valkey"));
+        assert_eq!(reg.filename(CaptureId::Experiment), "exp.parquet");
+        assert!(reg.get(CaptureId::Experiment).is_some());
+    }
+
+    /// The store holds N. Attaching beyond the experiment keeps each capture
+    /// reachable by its own id, anchor first, in attach order.
+    #[test]
+    fn the_store_holds_more_than_two_captures() {
+        let reg = registry();
+        reg.attach_experiment(store("a.parquet"), None, None, Some("redis".into()));
+        reg.attach_capture("valkey", store("b.parquet"), None, None, Some("valkey".into()));
+        reg.attach_capture("envoy", store("c.parquet"), None, None, Some("envoy".into()));
+
+        assert_eq!(
+            reg.capture_ids(),
+            vec![
+                "baseline".to_string(),
+                "experiment".to_string(),
+                "valkey".to_string(),
+                "envoy".to_string(),
+            ],
+        );
+        // Each resolves to its own data, by value — not one shadowing another.
+        assert_eq!(reg.filename_by_id("baseline"), "base.parquet");
+        assert_eq!(reg.filename_by_id("valkey"), "b.parquet");
+        assert_eq!(reg.filename_by_id("envoy"), "c.parquet");
+        assert_eq!(reg.alias_by_id("envoy").as_deref(), Some("envoy"));
+        assert_eq!(reg.other_count(), 3);
+    }
+
+    /// Re-attaching a capture by id replaces it in place, so re-uploading one
+    /// arm does not reorder the others.
+    #[test]
+    fn re_attaching_by_id_replaces_in_place() {
+        let reg = registry();
+        reg.attach_capture("redis", store("old.parquet"), None, None, None);
+        reg.attach_capture("valkey", store("v.parquet"), None, None, None);
+        reg.attach_capture("redis", store("new.parquet"), None, None, None);
+
+        assert_eq!(
+            reg.capture_ids(),
+            vec!["baseline".to_string(), "redis".to_string(), "valkey".to_string()],
+        );
+        assert_eq!(reg.filename_by_id("redis"), "new.parquet");
+    }
+
+    /// An unknown id resolves to nothing rather than the anchor — the caller
+    /// asked for a capture that is not attached.
+    #[test]
+    fn an_unknown_id_is_absent_not_the_anchor() {
+        let reg = registry();
+        assert!(reg.get_by_id("nope").is_none());
+        assert!(reg.alias_by_id("nope").is_none());
+        assert_eq!(reg.filename_by_id("nope"), "");
     }
 }

--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -266,7 +266,11 @@ mod tests {
     use super::*;
 
     fn store(name: &str) -> Arc<dyn MetricsSource> {
-        Arc::new(metriken_query::MemoryStore::builder().filename(name).build())
+        Arc::new(
+            metriken_query::MemoryStore::builder()
+                .filename(name)
+                .build(),
+        )
     }
 
     fn registry() -> CaptureRegistry {
@@ -313,8 +317,20 @@ mod tests {
     fn the_store_holds_more_than_two_captures() {
         let reg = registry();
         reg.attach_experiment(store("a.parquet"), None, None, Some("redis".into()));
-        reg.attach_capture("valkey", store("b.parquet"), None, None, Some("valkey".into()));
-        reg.attach_capture("envoy", store("c.parquet"), None, None, Some("envoy".into()));
+        reg.attach_capture(
+            "valkey",
+            store("b.parquet"),
+            None,
+            None,
+            Some("valkey".into()),
+        );
+        reg.attach_capture(
+            "envoy",
+            store("c.parquet"),
+            None,
+            None,
+            Some("envoy".into()),
+        );
 
         assert_eq!(
             reg.capture_ids(),
@@ -344,7 +360,11 @@ mod tests {
 
         assert_eq!(
             reg.capture_ids(),
-            vec!["baseline".to_string(), "redis".to_string(), "valkey".to_string()],
+            vec![
+                "baseline".to_string(),
+                "redis".to_string(),
+                "valkey".to_string()
+            ],
         );
         assert_eq!(reg.filename_by_id("redis"), "new.parquet");
     }


### PR DESCRIPTION
First step of the **N-way compare** arc (`docs/superpowers/plans/2026-09-03-n-way-compare.md`, gitignored). Scope for the whole arc, decided up front: overlay line/scatter compare N captures; diff and side-by-side heatmaps stay gated to exactly 2 (they're intrinsically pairwise); capture ids on the wire are named-from-labels with a positional fallback.

This PR is only the **server storage generalization** — deliberately behavior-identical and self-contained, split from the WASM registry and the frontend so it can be reviewed in isolation.

## The shape

Today: `CaptureRegistry { baseline: CaptureSlot, experiment: Option<CaptureSlot> }` — two named slots, nowhere for a third capture to live.

Now: an **anchor plus a collection**. `baseline` stays special — always present, the wire-stable id nothing renames, what an absent `?capture=` resolves to. The single optional `experiment` becomes `others: Vec<(String, CaptureSlot)>` keyed by wire id, the first conventionally `experiment`. The two-capture A/B path and every existing URL keep resolving unchanged while the store holds any number.

This is the backward-compat reconciliation the plan calls for: **the anchor keeps `baseline`; every non-anchor capture is a keyed collection member; `experiment` is just the conventional id of the first one.**

## Why it's safe

- **`CaptureId` and its 28 call sites are untouched.** The enum still names the first two captures; `CaptureId::Experiment` and the `experiment` string id resolve to the same first `other`. `get` / `filename` / `alias` / `systeminfo` / `file_metadata`, `attach_experiment`, `detach_experiment`, `experiment_attached` are now thin shims over id-keyed accessors, behaving exactly as before.
- **The N-way surface** (`get_by_id`, `alias_by_id`, `attach_capture`, `capture_ids`, `detach_capture`, `other_count`) is added but wired to no consumer yet — the WASM registry, the multi-recording `.rez` load, and the frontend land in their own PRs. `capture_ids`/`other_count` carry `#[allow(dead_code)]` with a pointer until PR 2/3 (clippy-deny would otherwise fail; the caller ships next).

## Tests

Cover what the change must preserve and what it adds: the `experiment` id and enum resolve to one slot; the store holds and distinguishes >2 captures **by value** (not one shadowing another); re-attach by id replaces in place, so re-uploading one arm doesn't reorder the rest; an unknown id is absent rather than silently the anchor.

Full viewer suite green (104), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)