### PR TITLE
ci: install cargo-audit --locked so a broken upstream release can't break audit

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -115,7 +115,13 @@ jobs:
           shared-key: check-ubuntu-latest
           save-if: false
       - name: install cargo-audit
-        run: cargo install cargo-audit
+        # `--locked` uses cargo-audit's own committed Cargo.lock. Without it,
+        # `cargo install` resolves the tool's dependencies fresh against
+        # crates.io and a broken upstream release breaks the audit job for
+        # every PR — e.g. tinyvec 1.13.0 (2026-09-03) fails to compile
+        # (`cannot find macro vec`), which has nothing to do with this repo's
+        # own dependency tree. `wasm-pack` below is pinned for the same reason.
+        run: cargo install cargo-audit --locked
       - run: |
           cargo audit
 


### PR DESCRIPTION
The `audit` job started failing on every PR today, for a reason external to this repo.

`cargo install cargo-audit` resolves the tool's own dependencies fresh against crates.io on every run — unpinned. **tinyvec 1.13.0** (published 2026-09-03) fails to compile (`cannot find macro vec in this scope`), cargo-audit pulls it in transitively, so installing the audit tool — and thus the whole job — breaks. Every substantive check (build, test, clippy, wasm) stays green; only the audit *tool's own build* fails.

`--locked` makes the install use cargo-audit's committed `Cargo.lock`, which predates the bad release. The `wasm-pack` install two steps below already uses `--locked` for exactly this reason — this brings `cargo-audit` in line.

Unblocks audit for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)