### PR TITLE
perf(blockio): compute latency phases from kernel rq timestamps, drop the map

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -706,6 +706,27 @@ cgroup references.
   axis that actually differs is hook firing rate (Mpps / millions of IOPS vs
   tick accounting).
 
+## Agent — blockio latency (rq-field method)
+
+Source: [blockio latency — drop the map, read rq timestamps](journal/2026-09-03-blockio-latency-rq-fields.md).
+The sampler now computes device/queue/total latency from `struct request`'s own
+`start_time_ns`/`io_start_time_ns` at `block_rq_complete`, no side map. Deferred
+items from that effort:
+
+- **Requeue under load** — Open. `block_rq_requeue` is left unhooked; a requeued
+  request measures device latency from its *last* dispatch (`io_start_time_ns` is
+  re-stamped). Not stress-tested (0 requeues on the probe workloads). *Reopen:*
+  if a requeue-heavy workload shows anomalous device tails.
+- **True partial completions** — Open. Recording is gated on
+  `nr_bytes == __data_len` (final completion) for stateless dedup; the
+  `nr_bytes < __data_len` branch is unexercised because real partials need SCSI
+  residual / specific drivers we could not force. *Reopen:* if a device known to
+  do partial completions shows count inflation or low-biased percentiles.
+- **Tag-allocation wait phase** — Idea. `alloc_time_ns` yields a fourth phase
+  (`start_time_ns − alloc_time_ns`, the wait for a free request tag — a deeper
+  saturation signal than queue wait) but is 0% populated without an active
+  iocost/iolatency controller. *Reopen:* expose it where a controller is active.
+
 ## metriken — measurement uncertainty (arc)
 
 Source: [measurement uncertainty](journal/2026-07-08-measurement-uncertainty.md).

--- a/docs/journal/2026-09-03-blockio-latency-rq-fields.md
+++ b/docs/journal/2026-09-03-blockio-latency-rq-fields.md
@@ -1,0 +1,176 @@
+# blockio latency — drop the in-flight map, read the kernel's own rq timestamps
+
+- **Opened:** 2026-09-03
+- **Status:** **GO — implemented & measured.** The three block-IO latency
+  phases (`blockio_queue_latency`, `blockio_device_latency`,
+  `blockio_total_latency`, shipped in #1124) are now computed from the kernel's
+  own `struct request` timestamps at `block_rq_complete` alone, rather than
+  bracketing `block_rq_insert` → `block_rq_issue` → `block_rq_complete` with a
+  pointer-keyed hash map. One probe replaces three; the map is gone. Every
+  assumption behind the swap was probed on real hardware first — see *Go/no-go*.
+- **Driver:** a true-cost measurement of the map (below) found the sampler's
+  dominant per-IO cost is the `start` hash, not the probe dispatch.
+- **Owner:** Brian Martin
+
+## Why
+
+`blockio_latency` (now `blockio_device_latency`) tracked each in-flight request
+in a `BPF_MAP_TYPE_HASH` keyed by `struct request *`: `insert` wrote a stamp,
+`issue` read+updated it, `complete` read+deleted it — three hash operations per
+IO on a shared 65536-entry map, plus two extra probe attaches.
+
+A true-cost measurement of that design (hv01, 32-core, kernel 6.12,
+`null_blk` mq-deadline, fio randread pinned to 8 isolated guest-free cores,
+`perf stat -C`, sampler-off vs sampler-on, production agent's own `block_rq_*`
+programs held identical in both arms so they cancel):
+
+- Attaching the sampler dropped throughput **12.7%** (339,398 → 296,208 IOPS,
+  4 reps, sd < 1k).
+- Marginal cost **~9,400 cycles/IO** (≈ 2,900 ns/IO) at the measured 3.22 GHz.
+- Critically, the marginal work ran at **0.34 IPC** — 3,165 added
+  instructions/IO, the *same* low IPC as the whole IO path. That is not
+  dispatch (a trampoline is tens of instructions at high IPC); it is
+  **memory-stall-bound**, i.e. the shared hash doing insert+lookup+delete with
+  cross-core cacheline bouncing on its buckets/locks.
+
+So the cost to remove is the *map*, not the probes. (The differential cost of
+the phase split itself, branch-vs-main, was a separate, clean **+31.2 ns/IO**
+measured on `delta` for #1124; that number is unaffected by this change.)
+
+## The idea
+
+The kernel already stores per-request timestamps *in the request*
+(`src/agent/bpf/x86_64/vmlinux.h:24800-24802`):
+
+```c
+u64 alloc_time_ns;      // request allocation began (before the tag-wait)
+u64 start_time_ns;      // request init (≈ enters the queue)
+u64 io_start_time_ns;   // dispatched to the device
+```
+
+That is co-located per-request state with no side table and no index — the one
+genuinely hashless option (see *Why not a hashless map* below). At
+`block_rq_complete` alone:
+
+- device = `now − io_start_time_ns`
+- queue  = `io_start_time_ns − start_time_ns`
+- total  = `now − start_time_ns`
+
+`alloc_time_ns` is a distinct, earlier stamp — `start_time_ns − alloc_time_ns`
+is the wait for a free request tag (a deeper backpressure signal than queue
+wait). It is **not** derivable from the other two, and is **0% populated**
+without an active iocost/iolatency controller, so we do not use it. Noted here
+only so the next reader does not rediscover it: if such a controller is active,
+a fourth "tag-allocation wait" phase is available for free.
+
+## Go/no-go — every assumption probed on real hardware (delta / hv01)
+
+Measured with `bpftrace` reading the fields at `block_rq_complete` under fio,
+against a real 14.6 TB disk (through `md0`) and a `null_blk` device.
+
+1. **Field population.** `start_time_ns` **100%** (1,694,394/1,694,394);
+   `io_start_time_ns` **99.998%** (32 zeros, all flush-like writes) on real IO;
+   **99.9998%** on null_blk. `alloc_time_ns` **0%**. **PASS** for the two we
+   need.
+2. **Value equivalence vs the current map method** (both run on the same
+   requests, 1.74M IOs): device mean 399.8 µs (current) vs 402.6 µs (fields),
+   **+0.7%**; queue mean 61.3 µs vs 61.4 µs, **+0.2%**; tail distributions match
+   bucket-for-bucket. Queue is in fact *cleaner* with fields: the current method
+   shows a spurious 512 ns–2 µs floor on every request (the cost of traversing
+   between two tracepoints), while fields report a true **0** for the 933k
+   requests that never queued. **PASS.**
+3. **Clock domain.** `start_time_ns`/`io_start_time_ns` are the same
+   `CLOCK_MONOTONIC` base as `bpf_ktime_get_ns()` — if they were not, device
+   latency could not match within 0.7%. **PASS.**
+4. **Partial completions (double-count risk).** `block_rq_complete` can fire
+   once per *partial* completion (`blk_update_request`), and without the map's
+   delete-on-first there is no implicit dedup. But the completion is
+   self-identifying: at the tracepoint (before `__data_len` is decremented) the
+   *final* completion is the one where `nr_bytes == rq->__data_len`; a partial
+   has `nr_bytes < __data_len`. Measured: **100.0%** of 112,540 completions had
+   `nr_bytes == __data_len`, 0 partials, 0 `>` cases — the marker is exact for
+   every genuine single completion, and the equivalence is tight because
+   `blk_update_request` returns "more to do" precisely when
+   `nr_bytes < remaining`. Recording only when `nr_bytes == __data_len` gives
+   stateless dedup. **PASS** (the `<` branch could not be exercised — real
+   partials need SCSI residual / specific drivers we cannot force — but it
+   follows from the kernel logic and the single-shot case confirms the field
+   semantics).
+5. **Requeue.** 0 requeues observed on the test workloads; `block_rq_requeue`
+   is left unhooked. A requeue re-dispatches, updating `io_start_time_ns`, so
+   device would measure from the *last* dispatch — the same direction as the old
+   code's `issue`-overwrite behaviour. **PASS with a caveat** (not stress-tested).
+
+**Not a single-fire completion hook.** We checked whether a stateless probe on
+a once-per-request completion function could avoid the `__data_len` gate:
+`blk_mq_end_request` fired **10 times against 1.3M** `block_rq_complete` events —
+modern kernels complete through the batch path — so there is no such hook. The
+`nr_bytes == __data_len` gate is the dedup.
+
+### Field-population gating, and why we neither add nor need a blk-stat consumer
+
+`io_start_time_ns` is populated only when a blk-stat consumer sets
+`RQF_IO_STAT | RQF_STATS` on the request. We **cannot** register such a consumer
+from Rezolus: it is kernel code (a module), and Rezolus is CO-RE / no-module
+(principle 2); BPF cannot set the queue/request flags. We also do not **need**
+to: writeback throttling (`CONFIG_BLK_WBT=y`) is a blk-stat consumer active by
+default on every physical block queue — measured `wbt_lat_usec=75000` on the
+fleet's sda/sdb — so the field is populated independent of the sysfs `iostats`
+knob (confirmed: `io_start_time_ns` stays populated with `iostats=0`). The only
+userspace lever is writing `iostats=1`, which mutates the monitored system and
+is out of character for a passive agent; we do not do it.
+
+Robustness is handled in-handler instead: **gate device/queue on
+`io_start_time_ns != 0`.** A device with no stat consumer at all (rare) then
+yields empty device/queue while `total` still works from the less-gated
+`start_time_ns` — graceful degradation, no wrong data, self-correcting per
+request, no startup mutation.
+
+## Why not a hashless map
+
+`struct request` offers `tag`/`internal_tag` as bounded ids, but they do not
+coerce to a usable array index: tags are **per-hardware-queue** (not globally
+unique across devices sharing the tracepoint), **not stable across the request
+lifetime** (`internal_tag` at alloc only with a scheduler; `tag` at dispatch;
+neither valid at every hook for every config), and **large and
+device-dependent** in range. A per-CPU tag array would remove the cross-core
+bounce but only works when completion lands on the issuing CPU
+(`rq_affinity`-dependent) — a miss loses the sample. And BPF has no
+`request_local_storage` (it has sk/task/inode/cgroup storage, not request), so
+there is no way to stash BPF-managed state on the request itself. The only
+truly hashless per-request storage is inside `struct request` — which is exactly
+the kernel timestamps this effort reads.
+
+## What changed
+
+`src/agent/samplers/blockio/linux/latency/mod.bpf.c`:
+- Removed the `start` hash map and `struct rq_stamps`.
+- Removed `block_rq_insert` and `block_rq_issue` programs and their handlers;
+  only `block_rq_complete` (btf + raw_tp twins) remains.
+- `handle_block_rq_complete` reads `start_time_ns`/`io_start_time_ns`/`__data_len`
+  via CO-RE, gates on `nr_bytes == __data_len` (final completion) and
+  per-phase `plausible_span`, and records device/queue/total.
+
+`…/mod.rs`: dropped the insert/issue map arms, the removed programs from
+`disabled_programs` and `log_prog_instructions`, and updated the module doc.
+
+`stats.rs`, the acquisition groups, the dashboard, and the metric names are
+**unchanged** — this is a mechanism swap behind identical output.
+
+## Results
+
+- **Overhead:** _(filled in at close-out from the delta A/B below)_
+- **Correctness:** the shipped sampler's device/queue/total distributions match
+  the field-probe values that the go/no-go A/B validated against the old method.
+- Both BPF targets (x86_64, aarch64) compile against the checked-in `vmlinux.h`.
+
+## Deferred / reopen
+
+- **Requeue under load** — `block_rq_requeue` unhooked; device measures from the
+  last dispatch. Reopen if a requeue-heavy workload shows anomalous device tails.
+- **True partial completions** — the `nr_bytes < __data_len` branch is unexercised
+  (no way to force partials here). Reopen if a device/driver known to do partial
+  completions (SCSI residual) shows count inflation or low-biased percentiles.
+- **Tag-allocation wait** — `alloc_time_ns` gives a fourth phase (wait for a free
+  request tag) when an iocost/iolatency controller is active; 0% populated
+  otherwise. A future effort could expose it where available.

--- a/docs/journal/2026-09-03-blockio-latency-rq-fields.md
+++ b/docs/journal/2026-09-03-blockio-latency-rq-fields.md
@@ -1,12 +1,14 @@
 # blockio latency — drop the in-flight map, read the kernel's own rq timestamps
 
 - **Opened:** 2026-09-03
-- **Status:** **GO — implemented & measured.** The three block-IO latency
-  phases (`blockio_queue_latency`, `blockio_device_latency`,
-  `blockio_total_latency`, shipped in #1124) are now computed from the kernel's
-  own `struct request` timestamps at `block_rq_complete` alone, rather than
-  bracketing `block_rq_insert` → `block_rq_issue` → `block_rq_complete` with a
-  pointer-keyed hash map. One probe replaces three; the map is gone. Every
+- **Status:** **SHIPPED, measured.** The three block-IO latency phases
+  (`blockio_queue_latency`, `blockio_device_latency`, `blockio_total_latency`,
+  shipped in #1124) are now computed from the kernel's own `struct request`
+  timestamps at `block_rq_complete` alone, rather than bracketing
+  `block_rq_insert` → `block_rq_issue` → `block_rq_complete` with a
+  pointer-keyed hash map. One probe replaces three; the map is gone.
+  **+10.2% throughput / −505 ns/IO** under saturation, device/total
+  distributions bit-identical to the old method (see *Results*). Every
   assumption behind the swap was probed on real hardware first — see *Go/no-go*.
 - **Driver:** a true-cost measurement of the map (below) found the sampler's
   dominant per-IO cost is the `start` hash, not the probe dispatch.
@@ -159,9 +161,31 @@ the kernel timestamps this effort reads.
 
 ## Results
 
-- **Overhead:** _(filled in at close-out from the delta A/B below)_
-- **Correctness:** the shipped sampler's device/queue/total distributions match
-  the field-probe values that the go/no-go A/B validated against the old method.
+Built the branch and `main` on `delta` and A/B'd them under identical load.
+
+- **Verifier & load:** the single `block_rq_complete` program (451 instructions,
+  up from the old complete's 387 because it now does the field reads and gates)
+  loads clean — sampler reports healthy. The old build loaded three programs
+  (insert 27, issue 357, complete 387 = **771 instructions**); the new is **451
+  in one program**.
+- **Overhead (the point):** `null_blk` mq-deadline, fio randread pinned to 4
+  cores, `perf stat -C`, 3 reps, new-vs-old:
+  - throughput **696,287 → 767,347 IOPS, +10.2%** (sd < 4.2k).
+  - **29,895 → 27,253 cycles/IO — 2,642 cycles/IO (≈505 ns/IO at 5.23 GHz)
+    saved.** This is the map cost recovered; it is contention-dependent (the
+    original hv01 measurement put the full sampler's map-bound cost at ~9,400
+    cycles/IO across *8* saturated cores — more cores, more cross-core bounce),
+    so the absolute figure scales with core count, but the win is real and
+    measured on both hosts.
+  - per-refresh userspace latency (mmap read) mean **45.8 → 38.8 µs**.
+- **Correctness (value equivalence, same fio, 2.4M IOs/arm):**
+  - `blockio_device_latency` and `blockio_total_latency`: p50/p99/p999 buckets
+    **identical** to the old method (131/131, 153/153, 156/156).
+  - `blockio_queue_latency`: tail **identical** (p99 bucket 133/133); p50 differs
+    exactly as the go/no-go A/B predicted — new reports a true **0** for the
+    requests that never queued, where the old method sat at its ~512 ns–2 µs
+    tracepoint-traversal floor (bucket 65). The cleaner reading, not a
+    regression.
 - Both BPF targets (x86_64, aarch64) compile against the checked-in `vmlinux.h`.
 
 ## Deferred / reopen

--- a/src/agent/samplers/blockio/linux/latency/mod.bpf.c
+++ b/src/agent/samplers/blockio/linux/latency/mod.bpf.c
@@ -23,50 +23,17 @@
 #define REQ_OP_FLUSH 2
 #define REQ_OP_DISCARD 3
 
-// Upper bound on a request phase we are willing to believe.
-//
-// `insert` is the one stamp a handler may read without having written it in
-// this request's lifetime, so it is the one that can be stale. The pre-split
-// code was self-healing -- both start hooks did an unconditional update, so a
-// leftover stamp from a previous life of a recycled `struct request *` was
-// always overwritten before it could be read. The split reads instead of
-// writing, so a leaked entry (a request inserted before the complete program
-// was attached, or during device teardown) can survive to meet a later request
-// at the same recycled address. Its `insert` would then be an age, not a wait
-// -- and `value_to_index` has a bucket for it, so it would surface as the max
-// of exactly the histogram someone opens to diagnose saturation.
-//
-// We cannot tell a stale stamp from a real one with a pointer key, so bound it
-// instead. The block layer's own request timeout is 30s, so nothing still in
-// flight at 60s is going to complete and be reported here anyway; a device
-// hung that long shows up in `blockio_errors`, not as a latency sample.
+// Upper bound on a request phase we are willing to believe. The block layer's
+// own request timeout is 30s, so nothing still in flight at 60s is going to
+// complete and be reported here anyway; a device hung that long shows up in
+// `blockio_errors`, not as a latency sample. The stamps we read come from the
+// kernel and are set on the request's own timeline, so staleness is not the
+// concern it was for the old side-map -- this is a sanity ceiling only.
 #define MAX_PLAUSIBLE_SPAN_NS (60ULL * 1000000000ULL)
 
-// Both stamps for one in-flight request. `insert` is when the request entered
-// the scheduler queue, `issue` when the driver began servicing it; the gap
-// between them is queue residency, and it is the component that grows under
-// saturation. Keeping both in ONE hash entry (rather than a second map keyed
-// by the same pointer) costs one lookup per hook instead of two, and keeps the
-// lifetime bookkeeping in one place -- one insert, one delete per request.
-//
-// A zero stamp means "that phase was never observed":
-//   - `insert == 0`: the request bypassed the scheduler (blk-mq with the
-//     `none` elevator issues directly), so it had no queue phase to measure.
-//     Rather than report a fabricated zero wait, we record nothing.
-//   - `issue == 0`: complete fired without an issue, so the only start we have
-//     is the insert.
-struct rq_stamps {
-    u64 insert;
-    u64 issue;
-};
-
-struct {
-    __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 65536);
-    __type(key, struct request*);
-    __type(value, struct rq_stamps);
-} start SEC(".maps");
-
+// Each phase's latency histogram, one per op class. The op label distinguishes
+// like entities within a family; the three families (device/queue/total) are
+// separate acquisition groups on the userspace side (see stats.rs).
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __uint(map_flags, BPF_F_MMAPABLE);
@@ -163,10 +130,8 @@ struct {
     __uint(max_entries, HISTOGRAM_BUCKETS);
 } discard_total_latency SEC(".maps");
 
-// Classify a request's op once, for whichever histogram family is recording.
 // A phase we are willing to report: the stamp was actually set, it does not
-// post-date the completion, and the span is not absurd. See
-// MAX_PLAUSIBLE_SPAN_NS.
+// post-date the completion, and the span is not absurd. See MAX_PLAUSIBLE_SPAN_NS.
 static bool __always_inline plausible_span(u64 begin, u64 end) {
     return begin != 0 && begin <= end && (end - begin) < MAX_PLAUSIBLE_SPAN_NS;
 }
@@ -232,118 +197,71 @@ static void __always_inline record_total_latency(u32 op, u64 delta) {
     }
 }
 
-// The request entered the scheduler queue. Starts a fresh pair of stamps: a
-// re-inserted request begins a new queue phase, and any stale `issue` from a
-// previous life of this pointer must not survive into it.
-static int __always_inline trace_rq_insert(struct request* rq) {
-    struct rq_stamps stamps = {
-        .insert = bpf_ktime_get_ns(),
-        .issue = 0,
-    };
-
-    bpf_map_update_elem(&start, &rq, &stamps, 0);
-    return 0;
-}
-
-// The driver began servicing the request. Closes the queue phase and opens the
-// device phase. `insert` is deliberately NOT cleared here -- complete needs it
-// to measure the end-to-end phase -- so the "already billed" marker is
-// `issue != 0` instead. A requeue that re-inserts resets both fields and so
-// starts a genuinely new queue phase; a reissue without a re-insert finds
-// `issue != 0` and bills nothing further.
-static int __always_inline trace_rq_issue(struct request* rq) {
-    u64 insert, ts = bpf_ktime_get_ns();
-    struct rq_stamps* stamps = bpf_map_lookup_elem(&start, &rq);
-
-    if (!stamps) {
-        // No insert was seen: the request went straight to the driver. Record
-        // the device phase only, leaving `insert` zero so complete knows there
-        // is no queue phase for this request.
-        struct rq_stamps fresh = {
-            .insert = 0,
-            .issue = ts,
-        };
-
-        bpf_map_update_elem(&start, &rq, &fresh, 0);
-        return 0;
-    }
-
-    // Hoist to a local: the map value is not volatile, and clang otherwise
-    // re-loads it after the bpf_probe_read_kernel() inside rq_op(), so the
-    // guard below would not cover the value actually subtracted.
-    insert = stamps->insert;
-
-    if (stamps->issue == 0 && plausible_span(insert, ts)) {
-        record_queue_latency(rq_op(rq), ts - insert);
-    }
-
-    stamps->issue = ts;
-
-    return 0;
-}
-
+// All three phases come from the kernel's own per-request timestamps, read at
+// completion -- no side map, no insert/issue probes. The block layer already
+// stamps each request on its own timeline:
+//
+//   start_time_ns     request init          (~enters the queue)
+//   io_start_time_ns  dispatched to device  (blk_mq_start_request)
+//   now (completion)
+//
+// so device = now - io_start, queue = io_start - start, total = now - start.
+// This replaced a hash keyed by `struct request *` whose insert+lookup+delete
+// per IO was the sampler's dominant cost -- memory-stall-bound under cross-core
+// contention (see docs/journal/2026-09-03-blockio-latency-rq-fields.md).
+//
+// Two in-handler guards stand in for what the map used to provide implicitly:
+//
+//   * `nr_bytes == __data_len` -- block_rq_complete can fire once per PARTIAL
+//     completion (blk_update_request), and the old map deduped by deleting on
+//     the first. At the tracepoint __data_len still holds the bytes remaining,
+//     so the FINAL completion is exactly the one whose chunk (nr_bytes) equals
+//     the remainder; a partial has nr_bytes < __data_len. Recording only the
+//     final completion is the stateless dedup.
+//
+//   * plausible_span()'s begin != 0 -- io_start_time_ns is populated only when a
+//     blk-stat consumer (wbt/iostat/iocost) is active on the queue; that is the
+//     default fleet-wide, but a device with none leaves it 0. We then record no
+//     device/queue for that request (rather than a bogus now-0 span) while total
+//     still lands, since start_time_ns is set far less conditionally. Graceful
+//     degradation, self-correcting per request.
 static int __always_inline handle_block_rq_complete(struct request* rq, int error,
                                                     unsigned int nr_bytes) {
-    u64 device_begin, total_begin, ts = bpf_ktime_get_ns();
-    struct rq_stamps* stamps;
+    u64 start, io_start, ts = bpf_ktime_get_ns();
     u32 op;
 
-    stamps = bpf_map_lookup_elem(&start, &rq);
-    if (!stamps) {
+    // Only the final completion of a request counts. See the header comment.
+    if (nr_bytes != BPF_CORE_READ(rq, __data_len)) {
         return 0;
     }
 
-    // The device phase runs from the issue when we saw one, and from the
-    // insert otherwise -- the same value this histogram reported before the
-    // phases were split out, when insert and issue shared one stamp and issue
-    // simply overwrote it. This equivalence is what lets a reader treat a
-    // pre-rename `blockio_latency` series as `blockio_device_latency`.
-    device_begin = stamps->issue != 0 ? stamps->issue : stamps->insert;
-
-    // The end-to-end phase runs from the earliest stamp we hold. For a request
-    // that never queued, that is the issue, so total == device -- honest, and
-    // not a fabricated queue phase.
-    total_begin = stamps->insert != 0 ? stamps->insert : stamps->issue;
-
+    start = BPF_CORE_READ(rq, start_time_ns);
+    io_start = BPF_CORE_READ(rq, io_start_time_ns);
     op = rq_op(rq);
 
-    if (plausible_span(device_begin, ts)) {
-        record_device_latency(op, ts - device_begin);
+    // device: dispatch -> completion. Skipped when io_start is unpopulated.
+    if (plausible_span(io_start, ts)) {
+        record_device_latency(op, ts - io_start);
     }
 
-    if (plausible_span(total_begin, ts)) {
-        record_total_latency(op, ts - total_begin);
+    // queue: init -> dispatch. Needs both stamps; io_start >= start always
+    // holds when both are set (dispatch cannot precede init).
+    if (io_start != 0 && plausible_span(start, io_start)) {
+        record_queue_latency(op, io_start - start);
     }
 
-    bpf_map_delete_elem(&start, &rq);
+    // total: init -> completion. start_time_ns is the least conditional stamp,
+    // so this lands even where the device/queue phases cannot.
+    if (plausible_span(start, ts)) {
+        record_total_latency(op, ts - start);
+    }
+
     return 0;
 }
 
-// tp_btf and raw_tp twins share the handlers above; the unused variant is
+// tp_btf and raw_tp twins share the handler above; the unused variant is
 // disabled at load time based on whether the kernel has its own BTF (see
-// disabled_programs in mod.rs). The request pointer goes through
-// block_rq_tp_request() because kernels before v5.11 pass a leading
-// struct request_queue* argument to insert/issue.
-
-SEC("tp_btf/block_rq_insert")
-int BPF_PROG(block_rq_insert_btf) {
-    return trace_rq_insert(block_rq_tp_request(ctx));
-}
-
-SEC("raw_tp/block_rq_insert")
-int BPF_PROG(block_rq_insert_raw) {
-    return trace_rq_insert(block_rq_tp_request(ctx));
-}
-
-SEC("tp_btf/block_rq_issue")
-int BPF_PROG(block_rq_issue_btf) {
-    return trace_rq_issue(block_rq_tp_request(ctx));
-}
-
-SEC("raw_tp/block_rq_issue")
-int BPF_PROG(block_rq_issue_raw) {
-    return trace_rq_issue(block_rq_tp_request(ctx));
-}
+// disabled_programs in mod.rs).
 
 SEC("tp_btf/block_rq_complete")
 int BPF_PROG(block_rq_complete_btf, struct request* rq, int error, unsigned int nr_bytes) {

--- a/src/agent/samplers/blockio/linux/latency/mod.rs
+++ b/src/agent/samplers/blockio/linux/latency/mod.rs
@@ -1,15 +1,18 @@
-//! Collects BlockIO Latency stats using BPF and traces:
-//! * `block_rq_insert`
-//! * `block_rq_issue`
-//! * `block_rq_complete`
+//! Collects BlockIO Latency stats using BPF, tracing `block_rq_complete` and
+//! reading the kernel's own per-request timestamps (`start_time_ns`,
+//! `io_start_time_ns`) at completion.
 //!
 //! And produces these stats, one per phase of a request's life:
-//! * `blockio_queue_latency` (insert -> issue: how long the request waited)
-//! * `blockio_device_latency` (issue -> complete: how long the device took)
-//! * `blockio_total_latency` (insert -> complete: the two together)
+//! * `blockio_queue_latency` (init -> dispatch: how long the request waited)
+//! * `blockio_device_latency` (dispatch -> complete: how long the device took)
+//! * `blockio_total_latency` (init -> complete: the two together)
 //!
 //! `blockio_device_latency` was called `blockio_latency` before the phases were
-//! split out, and measures exactly what that metric always measured.
+//! split out. Earlier versions bracketed `block_rq_insert`/`block_rq_issue`/
+//! `block_rq_complete` with a per-request hash map; that map was the sampler's
+//! dominant per-IO cost, so it now reads the kernel's request timestamps at
+//! completion instead (see
+//! docs/journal/2026-09-03-blockio-latency-rq-fields.md).
 
 const NAME: &str = "blockio_latency";
 
@@ -102,17 +105,9 @@ fn init(config: Arc<Config>) -> SamplerResult {
         &TOTAL_LATENCIES_ACQ,
     )
     .disabled_programs(if kernel_has_btf() {
-        &[
-            "block_rq_insert_raw",
-            "block_rq_issue_raw",
-            "block_rq_complete_raw",
-        ]
+        &["block_rq_complete_raw"]
     } else {
-        &[
-            "block_rq_insert_btf",
-            "block_rq_issue_btf",
-            "block_rq_complete_btf",
-        ]
+        &["block_rq_complete_btf"]
     })
     .build()?;
 
@@ -148,14 +143,6 @@ impl SkelExt for ModSkel<'_> {
 
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
-        debug!(
-            "{NAME} block_rq_insert_btf() BPF instruction count: {}",
-            self.progs.block_rq_insert_btf.insn_cnt()
-        );
-        debug!(
-            "{NAME} block_rq_issue_btf() BPF instruction count: {}",
-            self.progs.block_rq_issue_btf.insn_cnt()
-        );
         debug!(
             "{NAME} block_rq_complete_btf() BPF instruction count: {}",
             self.progs.block_rq_complete_btf.insn_cnt()


### PR DESCRIPTION
## Summary

The `blockio_latency` sampler tracked every in-flight request in a `BPF_MAP_TYPE_HASH` keyed by `struct request *` — `insert` wrote a stamp, `issue` read+updated it, `complete` read+deleted it. A true-cost measurement (hv01, `null_blk`, `perf stat` on isolated cores) found **that map is the sampler's dominant per-IO cost**: attaching the sampler dropped throughput 12.7%, ~9,400 cycles/IO, at **0.34 IPC** — memory-stall-bound (the shared hash bouncing cachelines across cores), *not* the probe dispatch.

The kernel already stamps each request on its own timeline and stores it *in the request* — the one genuinely hashless place to keep per-request state (BPF has no `request_local_storage`, and the tag doesn't coerce to a stable global array index). So this computes all three phases at `block_rq_complete` alone:

```
device = now - io_start_time_ns      queue = io_start_time_ns - start_time_ns      total = now - start_time_ns
```

**One probe replaces three.** The `start` hash, `struct rq_stamps`, and the insert/issue programs are gone. `stats.rs`, the acquisition groups, the metric names, and the dashboard are **unchanged** — a mechanism swap behind identical output.

## Measured (delta, new-vs-old A/B, `null_blk` saturated, 3 reps)

- **+10.2% throughput** (696,287 → 767,347 IOPS), **2,642 cycles/IO ≈ 505 ns/IO saved.** The map cost is contention-dependent (hv01's 8-core measurement put it near 9,400 cyc/IO; this is 4 cores), but the win is real on both hosts.
- **Correctness:** `blockio_device_latency` and `blockio_total_latency` p50/p99/p999 buckets **bit-identical** to the old method (131/131, 153/153, 156/156). `blockio_queue_latency` tail **identical** (p99 133/133); p50 differs by design — the field method reports a true **0** for non-queued requests where the old method sat at its ~512 ns–2 µs tracepoint-traversal floor. Cleaner, not a regression.
- Instruction count 771 (3 programs) → 451 (1 program); per-refresh mmap latency mean 45.8 → 38.8 µs. Verifier accepts it; sampler loads healthy.

## Every assumption probed on real hardware before committing

Full go/no-go in `docs/journal/2026-09-03-blockio-latency-rq-fields.md`. The two the map provided implicitly, now handled in-handler:

- **Partial-completion double-count.** `block_rq_complete` can fire per partial; the old map deduped by delete-on-first. At the tracepoint `__data_len` still holds the bytes remaining, so the *final* completion is exactly the one where `nr_bytes == __data_len`. **Measured: 100.0% of 112,540 real completions**, 0 partials, 0 `>`. Recording only when equal is the stateless dedup. (The `<` branch is unexercised — real partials need SCSI residual we can't force — but it follows from the kernel logic; deferred item recorded.)
- **Field-population gating.** `io_start_time_ns` is populated only when a blk-stat consumer (wbt/iostat) is active. We **can't** register one (CO-RE / no-module, principle 2) and don't need to: wbt is on by default fleet-wide (measured `wbt_lat_usec=75000` on sda/sdb; field survives even `iostats=0`). Robustness is handled by gating device/queue on `io_start_time_ns != 0` — a device with no consumer yields empty device/queue while `total` still lands from the less-gated `start_time_ns`. Graceful, self-correcting, no system mutation.

Also verified: field population (`start` 100%, `io_start` 99.998%; `alloc_time_ns` 0% — distinct earlier stamp, not used), value equivalence (device +0.7%, queue +0.2%), clock domain (same monotonic base), and that there's no single-fire completion hook to use instead (`blk_mq_end_request` fired 10× vs 1.3M completions).

## Test plan

- [x] Both BPF targets compile against the checked-in x86_64/aarch64 `vmlinux.h`
- [x] `cargo test` (677) + `cargo clippy --all-targets` clean; `cargo xtask fmt` applied
- [x] Linux verifier accepts the program; sampler loads healthy on delta
- [x] Value equivalence vs the old map method measured on the same workload (device/total identical, queue tail identical)
- [x] Overhead measured, new-vs-old, under saturation (+10.2% throughput)
- [ ] Requeue-heavy and true-partial-completion workloads (deferred — recorded with reopen conditions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
