### PR TITLE
feat(viewer): a multi-recording .rez attaches every recording

### DIFF
--- a/crates/dashboard/src/capture_alias.rs
+++ b/crates/dashboard/src/capture_alias.rs
@@ -55,8 +55,201 @@ pub fn discriminating_alias_key(recordings: &[BTreeMap<String, String>]) -> Opti
         })
 }
 
+/// A capture's wire id and its display alias.
+pub struct CaptureIdentity {
+    /// The stable id used on the wire (`?capture=<id>`), as a map key, and in
+    /// saved selections. Unique within one archive.
+    pub id: String,
+    /// What the UI shows for this capture — the discriminating label value, or
+    /// the id when nothing distinguishes it.
+    pub alias: String,
+}
+
+/// Assign a stable id and display alias to each capture, in DISPLAY ORDER
+/// (the anchor first, its conventional A/B partner second, the rest after).
+///
+/// The one place the named-from-labels / positional-fallback wire-id scheme
+/// lives, shared by both viewers so a `.rez` opened in the browser and from the
+/// CLI names its captures identically — the same reason `discriminating_alias_key`
+/// is shared.
+///
+/// - position 0 → `baseline`; position 1 → `experiment`. These keep the
+///   wire-stable ids every existing URL and saved selection depends on.
+/// - position k ≥ 2 → the discriminating label value when it is a safe, unused,
+///   non-reserved token; otherwise positional `capture{k}`. So an archive with
+///   distinguishing labels gets self-describing ids (`?capture=envoy`) while a
+///   set of identically-labelled or bare-parquet captures still gets unique
+///   ones.
+///
+/// The alias is the discriminating value whenever one exists — including for
+/// `baseline`/`experiment`, so a `.rez` labelled `source=redis`/`source=valkey`
+/// shows those names rather than the positional slot ids.
+pub fn assign_capture_identities(
+    order: &[BTreeMap<String, String>],
+    all: &[BTreeMap<String, String>],
+) -> Vec<CaptureIdentity> {
+    // What a capture's alias must distinguish it from. Normally the recordings
+    // shown alongside it (`order`); but a single recording shown out of a
+    // larger archive is confused with the arms LEFT BEHIND, not with nothing —
+    // aliasing it "baseline" under a window titled `fleet.rez` would say
+    // nothing about which arm it is. So below two shown, discriminate against
+    // the whole archive. (A label can tell a chosen PAIR apart while failing to
+    // tell three apart, which is why the pair case stays scoped to `order`.)
+    let context: &[BTreeMap<String, String>] = if order.len() < 2 && all.len() > 1 {
+        all
+    } else {
+        order
+    };
+    let key = discriminating_alias_key(context);
+    // A candidate id must be a clean wire/URL/JS-key token and must not poach a
+    // reserved slot id or the positional namespace (`capture\d+`) — otherwise a
+    // label value of "capture2" could alias position 2's fallback. The
+    // `!taken` check is belt-and-braces: `discriminating_alias_key` only
+    // returns a key whose values are all distinct, so two extras cannot share
+    // one, but the id map must be collision-free no matter what feeds it.
+    let safe = |v: &str| {
+        !v.is_empty()
+            && v.chars()
+                .all(|c| c.is_ascii_alphanumeric() || "_-.".contains(c))
+    };
+    let reserved = |v: &str| {
+        v == "baseline"
+            || v == "experiment"
+            || (v
+                .strip_prefix("capture")
+                .is_some_and(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_digit())))
+    };
+
+    let mut taken: HashSet<String> = HashSet::new();
+    let mut out = Vec::with_capacity(order.len());
+    for (i, labels) in order.iter().enumerate() {
+        let value = key.as_ref().and_then(|k| labels.get(k)).cloned();
+        let id = match i {
+            0 => "baseline".to_string(),
+            1 => "experiment".to_string(),
+            _ => value
+                .as_deref()
+                .filter(|v| safe(v) && !reserved(v) && !taken.contains(*v))
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("capture{i}")),
+        };
+        taken.insert(id.clone());
+        let alias = value.unwrap_or_else(|| id.clone());
+        out.push(CaptureIdentity { id, alias });
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
+    use super::assign_capture_identities;
+
+    fn recs(pairs: &[&[(&str, &str)]]) -> Vec<std::collections::BTreeMap<String, String>> {
+        pairs
+            .iter()
+            .map(|rec| {
+                rec.iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn ids(order: &[std::collections::BTreeMap<String, String>]) -> Vec<(String, String)> {
+        assign_capture_identities(order, order)
+            .into_iter()
+            .map(|c| (c.id, c.alias))
+            .collect()
+    }
+
+    /// The first two keep the wire-stable slot ids; extras are named from the
+    /// discriminating label. Aliases are the label value throughout.
+    #[test]
+    fn distinguishing_labels_give_named_ids_for_extras() {
+        let order = recs(&[
+            &[("source", "redis")],
+            &[("source", "valkey")],
+            &[("source", "envoy")],
+        ]);
+        assert_eq!(
+            ids(&order),
+            vec![
+                ("baseline".into(), "redis".into()),
+                ("experiment".into(), "valkey".into()),
+                ("envoy".into(), "envoy".into()),
+            ],
+        );
+    }
+
+    /// No distinguishing label (identical sets) → positional ids, and the alias
+    /// falls back to the id so the UI still has a name.
+    #[test]
+    fn identical_labels_fall_back_to_positional_ids() {
+        let order = recs(&[
+            &[("source", "rezolus")],
+            &[("source", "rezolus")],
+            &[("source", "rezolus")],
+        ]);
+        assert_eq!(
+            ids(&order),
+            vec![
+                ("baseline".into(), "baseline".into()),
+                ("experiment".into(), "experiment".into()),
+                ("capture2".into(), "capture2".into()),
+            ],
+        );
+    }
+
+    /// A label value that would poach a reserved id or the positional namespace
+    /// is refused, so no extra can collide with a slot id or another position.
+    #[test]
+    fn a_reserved_looking_label_value_does_not_poach_an_id() {
+        let order = recs(&[
+            &[("host", "a")],
+            &[("host", "b")],
+            &[("host", "experiment")],
+            &[("host", "capture2")],
+        ]);
+        let got = ids(&order);
+        // Extra 2's value "experiment" is reserved → positional capture2;
+        // extra 3's value "capture2" is in the positional namespace → capture3.
+        assert_eq!(got[2].0, "capture2");
+        assert_eq!(got[3].0, "capture3");
+        // Every id is unique.
+        let mut all: Vec<&str> = got.iter().map(|(id, _)| id.as_str()).collect();
+        all.sort();
+        all.dedup();
+        assert_eq!(all.len(), got.len(), "ids must be unique: {got:?}");
+    }
+
+    /// A single recording shown out of a larger archive is still aliased by
+    /// what tells it apart from the arms left behind — not the bare slot id.
+    #[test]
+    fn a_single_shown_recording_is_named_against_the_whole_archive() {
+        let all = recs(&[
+            &[("source", "redis")],
+            &[("source", "valkey")],
+            &[("source", "envoy")],
+        ]);
+        // Only the second recording is shown.
+        let shown = vec![all[1].clone()];
+        let got: Vec<(String, String)> = super::assign_capture_identities(&shown, &all)
+            .into_iter()
+            .map(|c| (c.id, c.alias))
+            .collect();
+        assert_eq!(got, vec![("baseline".to_string(), "valkey".to_string())]);
+    }
+
+    /// One and two recordings are unchanged: the slot ids, and no discriminator
+    /// needed (nothing to distinguish against).
+    #[test]
+    fn one_and_two_recordings_use_the_slot_ids() {
+        assert_eq!(ids(&recs(&[&[("source", "x")]]))[0].0, "baseline");
+        let two = ids(&recs(&[&[("source", "redis")], &[("source", "valkey")]]));
+        assert_eq!(two[0], ("baseline".to_string(), "redis".to_string()));
+        assert_eq!(two[1], ("experiment".to_string(), "valkey".to_string()));
+    }
+
     use super::discriminating_alias_key;
     use std::collections::BTreeMap;
 

--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -18,9 +18,6 @@ mod report_save;
 /// The anchor capture's id — what an absent `?capture=` resolves to, never
 /// renamed. Mirrors the server registry's `BASELINE_ID`.
 const BASELINE_ID: &str = "baseline";
-/// The conventional id of the first non-anchor capture (the classic A/B
-/// experiment). Mirrors the server registry's `EXPERIMENT_ID`.
-const EXPERIMENT_ID: &str = "experiment";
 
 #[wasm_bindgen(start)]
 pub fn init() {
@@ -79,15 +76,6 @@ fn classify_sources(
         service_names,
         Some(filename_stem),
     )
-}
-
-/// Render a recording's labels for a message: `k=v, k=v` in key order.
-fn render_labels(labels: &std::collections::BTreeMap<String, String>) -> String {
-    labels
-        .iter()
-        .map(|(k, v)| format!("{k}={v}"))
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 /// Open every recording of a `.rez` held as bytes.
@@ -725,11 +713,10 @@ impl WasmCaptureRegistry {
     /// Attach a capture under the given slot ("baseline" or "experiment").
     /// Replaces any previously attached capture in that slot.
     ///
-    /// A multi-recording `.rez` is the exception: it carries both sides of a
-    /// comparison itself, so it fills BOTH slots and the requested one is
-    /// ignored. That is the same mapping `rezolus view` makes for the same
-    /// file — the alternative, loading one arm into one slot, would show an
-    /// A/B archive as a single capture with no sign that half of it is missing.
+    /// A multi-recording `.rez` is the exception: it carries a whole
+    /// comparison itself, so it attaches EVERY recording (under the shared
+    /// id/alias scheme) and the requested slot id is ignored. That is the same
+    /// mapping `rezolus view` makes for the same file.
     pub fn attach(&mut self, capture: &str, data: &[u8], filename: &str) -> Result<(), JsValue> {
         self.notices.clear();
         if rez::rez::detect_rez_format_bytes(data) != rez::rez::RezFormat::NotRez {
@@ -768,38 +755,21 @@ impl WasmCaptureRegistry {
         pool: Arc<BufferPool>,
         filename: &str,
     ) -> Result<(), JsValue> {
-        let total = recordings.len();
-        let mut recordings = recordings;
-        let extra: Vec<String> = recordings
-            .split_off(2)
-            .into_iter()
-            .map(|(labels, _)| render_labels(&labels))
-            .collect();
-        let shown: Vec<std::collections::BTreeMap<String, String>> =
+        // Attach EVERY recording, each under the shared id/alias scheme — the
+        // same one the server viewer uses, so an archive names its captures
+        // identically wherever it is opened. The browser has no `--baseline`/
+        // `--experiment` selectors, so the whole archive is always shown, in
+        // manifest order: recording 0 is `baseline`, 1 is `experiment`, the
+        // rest are named-or-positional.
+        let labels: Vec<std::collections::BTreeMap<String, String>> =
             recordings.iter().map(|(l, _)| l.clone()).collect();
-        let alias_key = dashboard::capture_alias::discriminating_alias_key(&shown);
+        let identities = dashboard::capture_alias::assign_capture_identities(&labels, &labels);
 
-        let mut it = recordings.into_iter();
-        for (id, fallback) in [(BASELINE_ID, "baseline"), (EXPERIMENT_ID, "experiment")] {
-            let (labels, reader) = it.next().expect("split_off(2) leaves exactly two");
-            let alias = alias_key
-                .as_ref()
-                .and_then(|k| labels.get(k))
-                .cloned()
-                .unwrap_or_else(|| fallback.to_string());
+        for ((_, reader), identity) in recordings.into_iter().zip(identities) {
             let mut viewer =
                 Viewer::from_source(Arc::new(reader), Arc::clone(&pool), Bytes::new(), filename);
-            viewer.set_alias(Some(alias));
-            self.set_capture(id, viewer);
-        }
-
-        if !extra.is_empty() {
-            self.notices.push(format!(
-                "{filename} holds {total} recordings; showing the first two. Not shown: {}. \
-                 Pick different ones with `rezolus view {filename} --baseline k=v --experiment \
-                 k=v`.",
-                extra.join("; ")
-            ));
+            viewer.set_alias(Some(identity.alias));
+            self.set_capture(&identity.id, viewer);
         }
         Ok(())
     }
@@ -831,6 +801,26 @@ impl WasmCaptureRegistry {
     /// Whether a capture is currently attached in the given slot.
     pub fn has(&self, capture: &str) -> bool {
         self.slot(capture).is_some()
+    }
+
+    /// The attached captures as JSON `[{ "id", "alias" }]`, anchor first, in
+    /// display order. The frontend enumerates this to know what to overlay —
+    /// the browser analogue of the server's `/api/v1/captures`.
+    pub fn captures(&self) -> String {
+        let mut list: Vec<serde_json::Value> = Vec::new();
+        let entry = |id: &str, viewer: &Viewer| {
+            serde_json::json!({
+                "id": id,
+                "alias": viewer.alias.clone().unwrap_or_else(|| id.to_string()),
+            })
+        };
+        if let Some(b) = self.baseline.as_ref() {
+            list.push(entry(BASELINE_ID, b));
+        }
+        for (id, viewer) in &self.others {
+            list.push(entry(id, viewer));
+        }
+        serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
     }
 
     pub fn metadata(&self, capture: &str) -> Result<String, JsValue> {
@@ -1367,7 +1357,7 @@ mod tests {
     /// because an archive whose third arm is silently missing looks exactly
     /// like an archive with two arms.
     #[test]
-    fn recordings_beyond_the_first_two_are_reported_not_dropped() {
+    fn every_recording_of_a_multi_recording_rez_attaches() {
         let mut reg = WasmCaptureRegistry::new();
         reg.attach(
             "baseline",
@@ -1380,19 +1370,24 @@ mod tests {
         )
         .unwrap();
 
-        let notices: Vec<String> = serde_json::from_str(&reg.notices()).unwrap();
-        assert_eq!(notices.len(), 1, "{notices:?}");
-        assert!(notices[0].contains("3 recordings"), "{}", notices[0]);
+        // No "some recordings not shown" notice any more — every recording is
+        // attached under the shared id scheme, ready for an N-way overlay.
+        assert_eq!(reg.notices(), "[]");
+        let captures: Vec<serde_json::Value> = serde_json::from_str(&reg.captures()).unwrap();
+        let ids: Vec<&str> = captures.iter().map(|c| c["id"].as_str().unwrap()).collect();
+        assert_eq!(ids, vec!["baseline", "experiment", "envoy"]);
+        // Each is its own capture with its own metadata, identity intact.
         assert!(
-            notices[0].contains("source=envoy"),
-            "the notice must name what is NOT shown: {}",
-            notices[0]
+            reg.file_metadata_json("baseline")
+                .unwrap()
+                .contains("redis")
         );
         assert!(
-            !notices[0].contains("source=redis"),
-            "and not the ones that are: {}",
-            notices[0]
+            reg.file_metadata_json("experiment")
+                .unwrap()
+                .contains("valkey")
         );
+        assert!(reg.file_metadata_json("envoy").unwrap().contains("envoy"));
     }
 
     /// An archive that was never finalized must SAY so.

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -810,61 +810,54 @@ fn init_file_mode_rez(
         std::process::exit(1);
     });
 
-    // The alias label names a recording against whatever it could be confused
-    // with.
+    // Display order: the anchor (baseline) first, its conventional A/B partner
+    // (experiment) second, and — when no recording was explicitly selected —
+    // every other recording after, in manifest order.
     //
-    // Showing TWO: that is each other. A label can fail to tell three
-    // recordings apart while telling the chosen two apart perfectly (two hosts
-    // running the same service, plus a third recording of one of them), and
-    // scoping the choice to the archive would fall back to
-    // "baseline"/"experiment" for a pair the labels describe exactly.
-    //
-    // Showing ONE out of several: the confusion is with the arms left behind.
-    // The window says `fleet.rez`, so aliasing the single shown recording
-    // "baseline" would leave nothing on screen saying WHICH arm of that
-    // archive is being read — the same unattributed-answer failure the
-    // selector exists to prevent. A single-recording archive keeps the
-    // positional name (a hindsight snapshot's `{source: rezolus}` is not a
-    // useful title).
-    let shown: Vec<BTreeMap<String, String>> = std::iter::once(b_idx)
-        .chain(e_idx)
-        .map(|i| all_labels[i].clone())
-        .collect();
-    let alias_key = if shown.len() < 2 && n > 1 {
-        discriminating_alias_key(&all_labels)
-    } else {
-        discriminating_alias_key(&shown)
-    };
-    let alias_of = |labels: &BTreeMap<String, String>, fallback: &str| -> String {
-        alias_key
-            .as_ref()
-            .and_then(|k| labels.get(k))
-            .cloned()
-            .unwrap_or_else(|| fallback.to_string())
-    };
+    // `--baseline`/`--experiment` are SELECTORS: giving them shows exactly the
+    // chosen recordings (the subset-view #1120 introduced, when only two could
+    // show). Giving NEITHER shows the whole archive, which is the N-way
+    // default. The two-slot ids stay wire-stable for the A/B path either way.
+    let selected = !config.baseline_recording.is_empty() || !config.experiment_recording.is_empty();
+    let mut order: Vec<usize> = vec![b_idx];
+    order.extend(e_idx);
+    if !selected {
+        order.extend((0..n).filter(|i| *i != b_idx && e_idx != Some(*i)));
+    }
 
-    // Take the two chosen recordings out by index. `Option::take` rather than
-    // `Vec::remove` because the indices are arbitrary now: removing one would
-    // shift the other.
+    // Ids and aliases from the shared scheme, over the recordings AS SHOWN, so
+    // one archive names its captures identically here and in the browser.
+    let ordered_labels: Vec<BTreeMap<String, String>> =
+        order.iter().map(|&i| all_labels[i].clone()).collect();
+    let identities =
+        dashboard::capture_alias::assign_capture_identities(&ordered_labels, &all_labels);
+
     let mut slots: Vec<Option<(BTreeMap<String, String>, crate::rez_reader::RezReader)>> =
         readers.into_iter().map(Some).collect();
-    let (b_labels, b_reader) = slots[b_idx].take().expect("baseline index is in range");
-    // A selected recording that holds no rows renders an empty dashboard.
-    // That is the truthful outcome — an endpoint that was scraped and reported
-    // nothing is itself a finding — but it looks identical to a failed load,
-    // so say which it is.
-    if b_reader.is_empty() {
-        warn!(
-            "recording {} holds no rows; its dashboard will be empty",
-            crate::mcp::render_labels(&b_labels)
-        );
-    }
+
+    // A recording that holds no rows renders an empty dashboard — the truthful
+    // outcome for an endpoint scraped but silent, but it looks like a failed
+    // load, so say which it is.
+    let warn_if_empty = |labels: &BTreeMap<String, String>,
+                         reader: &crate::rez_reader::RezReader| {
+        if reader.is_empty() {
+            warn!(
+                "recording {} holds no rows; its dashboard will be empty",
+                crate::mcp::render_labels(labels)
+            );
+        }
+    };
+
+    // The anchor (order[0]) becomes the AppState's baseline capture.
+    let (b_labels, b_reader) = slots[order[0]].take().expect("anchor index is in range");
+    warn_if_empty(&b_labels, &b_reader);
     let b_systeminfo = b_reader.metadata_get("systeminfo");
     let b_file_meta = file_meta_json(&b_reader);
+    // A CLI --baseline-alias still wins over the label-derived one.
     let b_alias = config
         .baseline_alias
         .clone()
-        .unwrap_or_else(|| alias_of(&b_labels, "baseline"));
+        .unwrap_or_else(|| identities[0].alias.clone());
 
     let state = AppState::with_pool(
         std::sync::Arc::new(b_reader) as std::sync::Arc<dyn metriken_query::MetricsSource>,
@@ -876,34 +869,20 @@ fn init_file_mode_rez(
     state.captures.set_baseline_file_metadata(b_file_meta);
     state.captures.set_baseline_alias(Some(b_alias));
 
-    if let Some(e_idx) = e_idx {
-        let (e_labels, e_reader) = slots[e_idx].take().expect("experiment index is in range");
-        if e_reader.is_empty() {
-            warn!(
-                "recording {} holds no rows; its dashboard will be empty",
-                crate::mcp::render_labels(&e_labels)
-            );
-        }
-        let e_systeminfo = e_reader.metadata_get("systeminfo");
-        let e_file_meta = file_meta_json(&e_reader);
-        let e_alias = alias_of(&e_labels, "experiment");
-        state.captures.attach_experiment(
-            std::sync::Arc::new(e_reader) as std::sync::Arc<dyn metriken_query::MetricsSource>,
-            e_systeminfo,
-            e_file_meta,
-            Some(e_alias),
+    // Every other recording attaches under its own id — the first is
+    // `experiment` (the classic A/B second arm), the rest named-or-positional.
+    for (pos, &idx) in order.iter().enumerate().skip(1) {
+        let (labels, reader) = slots[idx].take().expect("index is in range");
+        warn_if_empty(&labels, &reader);
+        let systeminfo = reader.metadata_get("systeminfo");
+        let file_meta = file_meta_json(&reader);
+        state.captures.attach_capture(
+            &identities[pos].id,
+            std::sync::Arc::new(reader) as std::sync::Arc<dyn metriken_query::MetricsSource>,
+            systeminfo,
+            file_meta,
+            Some(identities[pos].alias.clone()),
         );
-        if n > 2 && config.baseline_recording.is_empty() && config.experiment_recording.is_empty() {
-            // Only when the pair was NOT chosen: telling a caller how to pick
-            // recordings it just picked is noise, and the warning exists to
-            // flag a choice made for them.
-            warn!(
-                "{n}-recording .rez: showing the first two as baseline/experiment \
-                 (simultaneous N-way faceting is not yet supported). Choose which two with \
-                 {BASELINE_FLAG}/{EXPERIMENT_FLAG}:\n{}",
-                crate::mcp::describe_candidates(&all_labels, &[], BASELINE_SYNTAX),
-            );
-        }
     }
 
     info!("Generating dashboards...");
@@ -1639,7 +1618,7 @@ mod tests {
     /// still loads recordings 0 and 1. This also drives the warning that lists
     /// the archive, which only runs on this path.
     #[test]
-    fn without_flags_a_three_recording_archive_still_loads_the_first_two() {
+    fn without_flags_a_three_recording_archive_attaches_every_recording() {
         use crate::viewer::capture_registry::CaptureId;
         let dir = tempfile::tempdir().unwrap();
         let rez_path = dir.path().join("fleet.rez");
@@ -1667,6 +1646,22 @@ mod tests {
             state.captures.alias(CaptureId::Experiment).as_deref(),
             Some("valkey"),
         );
+        // The third recording is no longer dropped: it attaches under its own
+        // named id (the discriminating `source` value), so the whole archive
+        // is available for an N-way overlay.
+        assert_eq!(
+            state.captures.capture_ids(),
+            vec![
+                "baseline".to_string(),
+                "experiment".to_string(),
+                "envoy".to_string(),
+            ],
+        );
+        assert_eq!(
+            state.captures.alias_by_id("envoy").as_deref(),
+            Some("envoy")
+        );
+        assert!(state.captures.get_by_id("envoy").is_some());
     }
 
     /// A label that cannot tell the whole archive apart can still tell the

--- a/tests/wasm_viewer_rez_archive.test.mjs
+++ b/tests/wasm_viewer_rez_archive.test.mjs
@@ -64,14 +64,19 @@ if (!fs.existsSync(pkgJs) || !fs.existsSync(pkgWasm)) {
         assert.equal(JSON.parse(registry.notices()).length, 0);
     });
 
-    test('a third recording is reported rather than silently dropped', () => {
+    test('every recording of a 3-recording .rez attaches', () => {
         const registry = new WasmCaptureRegistry();
         registry.attach('baseline', fixture('three.rez', 3), 'fleet.rez');
 
-        const notices = JSON.parse(registry.notices());
-        assert.equal(notices.length, 1, JSON.stringify(notices));
-        assert.match(notices[0], /3 recordings/);
-        assert.match(notices[0], /source=envoy/, 'names the arm that is NOT shown');
+        // No "some recordings not shown" notice any more — all three attach,
+        // ready for an N-way overlay.
+        assert.equal(JSON.parse(registry.notices()).length, 0);
+        const captures = JSON.parse(registry.captures());
+        assert.deepEqual(captures.map((c) => c.id), ['baseline', 'experiment', 'envoy']);
+        // Identity intact: each capture is its own recording.
+        assert.match(registry.file_metadata_json('baseline'), /redis/);
+        assert.match(registry.file_metadata_json('experiment'), /valkey/);
+        assert.match(registry.file_metadata_json('envoy'), /envoy/);
     });
 
     test('a single-recording .rez is one capture', () => {


### PR DESCRIPTION
PR 3 of the **N-way compare** arc — and the first user-visible step. A `.rez` with more than two recordings no longer shows only the first two: **every recording attaches**, ready for an N-way overlay once the frontend can draw one (PR 4+).

## The shared id scheme

The named/positional wire-id scheme lives in one place — `dashboard::capture_alias::assign_capture_identities` — so a `.rez` names its captures identically in the CLI viewer and the browser (the same reason `discriminating_alias_key` is shared; two spellings would drift). It assigns:

- position 0 → `baseline`, position 1 → `experiment` — the wire-stable slot ids every existing URL and saved selection depends on;
- position k ≥ 2 → the discriminating label value when it's a safe, unused, non-reserved token (so `?capture=envoy`), else positional `capture{k}` (identical labels / bare uploads).

Reserved-id and positional-namespace poaching are refused (a label value of `capture2` can't alias position 2's fallback), and it folds in **#1120's alias-context rule**: a single recording shown out of a larger archive is aliased by what tells it apart from the arms left *behind*, not the bare slot id — so a lone selected arm of `fleet.rez` still has a name. The helper takes both the display order and the full archive to apply that.

## Server vs browser

- **Server** (`init_file_mode_rez`): `--baseline`/`--experiment` stay **selectors** — giving them shows exactly the chosen subset (the #1120 behaviour, preserved); giving neither shows the whole archive, the N-way default. **Every #1120 selection/alias test passes unchanged.**
- **WASM** (`attach_rez_comparison`): the browser has no selectors, so a multi-recording `.rez` always attaches every recording. Adds `WasmCaptureRegistry::captures()` → `[{id, alias}]`, the browser's enumeration contract (the server's HTTP `/api/v1/captures` lands in PR 4 with its frontend consumer). The old "some recordings not shown" notice is gone.

## Tests

The shared helper's id scheme and context rule (11 in `dashboard`); a 3-recording `.rez` attaches all three under the expected ids **in both viewers** — in Rust and against the shipped WASM bundle from node. Full workspace green, clippy clean, fmt clean, wasm32 build clean, all 249 node tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)