### PR TITLE
feat(viewer): expose the attached captures over the wire

### DIFF
--- a/site/viewer/lib/viewer_api.js
+++ b/site/viewer/lib/viewer_api.js
@@ -67,6 +67,18 @@ const ViewerApi = {
         registry.detach('experiment');
     },
 
+    // The attached captures, anchor first: `[{ id, alias }, ...]`. Mirrors the
+    // server copy's `/api/v1/captures`; the WASM registry answers directly.
+    async getCaptures() {
+        if (!registry || typeof registry.captures !== 'function') return [];
+        try {
+            const parsed = JSON.parse(registry.captures());
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (_) {
+            return [];
+        }
+    },
+
     async getMetadata(captureId = 'baseline') {
         ensureAttached(captureId);
         const response = JSON.parse(registry.metadata(captureId));

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -34,6 +34,12 @@ const ViewerApi = {
         return backendRequest({ method: 'GET', url: '/api/v1/mode' });
     },
 
+    // The attached captures, anchor first: `[{ id, alias }, ...]`. The N-way
+    // overlay enumerates this to know what to draw. Mirrored in the WASM copy.
+    async getCaptures() {
+        return backendRequest({ method: 'GET', url: '/api/v1/captures' });
+    },
+
     async getMetadata(captureId = 'baseline') {
         return backendRequest({ method: 'GET', url: `/api/v1/metadata${captureQS(captureId)}` });
     },

--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -124,10 +124,7 @@ impl CaptureRegistry {
 
     /// Every attached capture's id, anchor first, in display order.
     ///
-    /// Consumed by the `/api/v1/captures` listing and the N-way frontend (PR 2+
-    /// of the N-way-compare plan); the storage generalization lands first, on
-    /// its own, so it can be reviewed and tested in isolation.
-    #[allow(dead_code)]
+    /// Consumed by the `/api/v1/captures` listing (and the N-way frontend).
     pub fn capture_ids(&self) -> Vec<String> {
         let mut ids = vec![BASELINE_ID.to_string()];
         ids.extend(self.others.read().iter().map(|(id, _)| id.clone()));

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -56,6 +56,7 @@ pub fn app(livereload: LiveReloadLayer, app_state: AppState) -> Router {
         .route("/selection", get(selection_handler))
         .route("/sections", get(sections_handler))
         .route("/file_metadata", get(file_metadata_handler))
+        .route("/captures", get(captures_handler))
         .route("/metrics", get(metrics_handler))
         .route("/timestamps", get(timestamps_handler))
         .route(
@@ -263,6 +264,33 @@ async fn file_metadata_handler(
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/json")],
         body,
+    )
+        .into_response()
+}
+
+/// The attached captures, anchor first, in display order:
+/// `[{ "id": "baseline", "alias": "redis" }, ...]`.
+///
+/// The frontend enumerates this to know what an N-way overlay should draw.
+/// The browser's `WasmCaptureRegistry::captures()` is the same contract; this
+/// is the server side of it.
+async fn captures_handler(State(state): State<Arc<AppState>>) -> Response {
+    let list: Vec<serde_json::Value> = state
+        .captures
+        .capture_ids()
+        .into_iter()
+        .map(|id| {
+            let alias = state
+                .captures
+                .alias_by_id(&id)
+                .unwrap_or_else(|| id.clone());
+            serde_json::json!({ "id": id, "alias": alias })
+        })
+        .collect();
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string()),
     )
         .into_response()
 }

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -126,6 +126,16 @@ eq "file mode loaded"        "$(echo "$mode" | jq -r .loaded)"       "true"     
 mode=$(mode_at $PORT_AB)
 eq "A/B compare_mode"        "$(echo "$mode" | jq -r .compare_mode)" "true"     "$LOGDIR/ab.log"
 
+echo "==> /api/v1/captures lists the attached captures"
+caps=$(curl -fsS "http://127.0.0.1:$PORT_AB/api/v1/captures")
+eq "A/B captures count"      "$(echo "$caps" | jq -r 'length')"        "2"        "$LOGDIR/ab.log"
+eq "A/B first capture id"    "$(echo "$caps" | jq -r '.[0].id')"       "baseline" "$LOGDIR/ab.log"
+eq "A/B second capture id"   "$(echo "$caps" | jq -r '.[1].id')"       "experiment" "$LOGDIR/ab.log"
+# A single-file server lists exactly the baseline.
+caps1=$(curl -fsS "http://127.0.0.1:$PORT_FILE/api/v1/captures")
+eq "single-file captures"    "$(echo "$caps1" | jq -r 'length')"       "1"        "$LOGDIR/file.log"
+eq "single-file id"          "$(echo "$caps1" | jq -r '.[0].id')"      "baseline" "$LOGDIR/file.log"
+
 mode=$(mode_at $PORT_PROXY)
 eq "proxy url_loading"       "$(echo "$mode" | jq -r .url_loading)"  "proxy"    "$LOGDIR/proxy.log"
 


### PR DESCRIPTION
PR 4a of the **N-way compare** arc — the enumeration contract the frontend needs to know what an N-way overlay should draw. Deferred from PR 3, which attached every recording but only the browser (`WasmCaptureRegistry::captures()`) could list them.

## What it adds

- **Server**: `GET /api/v1/captures` → `[{ id, alias }, ...]`, anchor first, in display order. A thin handler over the registry's `capture_ids()` + `alias_by_id()` (both unit-tested in PR 1).
- **`viewer_api.js`** (both hand-maintained copies — the server/WASM adapter seam): `getCaptures()`. The server copy hits the route; the WASM copy calls `registry.captures()`. The two shells must mirror, and do.

No rendering change — `getCaptures` has no caller until PR 4b wires the overlay. The existing two-armed fetch is untouched, so this is additive and low-risk.

## Testing

- The **WASM `captures()` twin** is covered by the CI-run node test (`node --test tests/*.mjs` → `tests/wasm_viewer_rez_archive.test.mjs`).
- The **server route** is asserted by `tests/viewer_smoke.sh` — 2 captures for an A/B server (`baseline`, `experiment`), 1 for a single file — run locally, green.
- The handler is glue over registry methods and the shared id scheme, both already unit-tested, so I didn't add a heavyweight `AppState` router harness for eight lines of it. (`viewer_smoke.sh` is not CI-wired today; the WASM twin gives the CI-enforced coverage of the contract.)

Full viewer suite green (105), clippy clean, fmt clean, 249 node tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)