### PR TITLE
feat(viewer): overlay N captures on a compare chart

### DIFF
--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -38,7 +38,7 @@
 //   anchors: { baseline: ms, experiment: ms }  — subtracted from each
 //            capture's timestamps to produce a relative (`+Xs`) x-axis.
 
-import { nullDiff, intersectLabels, canonicalQuantileLabel, unifyHistogramRange, buildDeltaSpectrum } from './util/compare_math.js';
+import { nullDiff, canonicalQuantileLabel, unifyHistogramRange, buildDeltaSpectrum } from './util/compare_math.js';
 import { DIVERGING_BLUE_GREEN, DIVERGING_BLUE_GREEN_DARK, nullCellColor, resampleDivergingForRange } from './util/colormap.js';
 import { ensureHeatmapMatrix } from './util/heatmap_data.js';
 import { resolvedStyle } from './metric_types.js';
@@ -55,6 +55,39 @@ const cssColor = (name, fallback) => {
 };
 export const BASELINE_COLOR = cssColor('--compare-baseline', '#2E5BFF');
 export const EXPERIMENT_COLOR = cssColor('--compare-experiment', '#00C46A');
+
+// Colors for a 3rd-and-beyond capture in an N-way overlay. baseline and
+// experiment keep their signature blue/green (so a plain A/B looks exactly as
+// before); every extra draws from this categorical sequence, by the order it
+// was attached. Chosen for contrast against each other and the two fixed hues.
+const CAPTURE_PALETTE = [
+    cssColor('--compare-capture-3', '#FF8A00'), // orange
+    cssColor('--compare-capture-4', '#B45BFF'), // violet
+    cssColor('--compare-capture-5', '#FF4D6D'), // rose
+    cssColor('--compare-capture-6', '#00B8D9'), // cyan
+    cssColor('--compare-capture-7', '#F5C518'), // amber
+    cssColor('--compare-capture-8', '#8C6E5D'), // brown
+];
+
+// The overlay color for a capture. baseline/experiment are fixed by id;
+// `extraIndex` is the capture's 0-based position among the NON-fixed ones.
+export const captureColorFor = (id, extraIndex) => {
+    if (id === CAPTURE_BASELINE) return BASELINE_COLOR;
+    if (id === CAPTURE_EXPERIMENT) return EXPERIMENT_COLOR;
+    return CAPTURE_PALETTE[extraIndex % CAPTURE_PALETTE.length];
+};
+
+// A stable id -> color map for a set of captures, so a capture keeps its color
+// across every sub-chart regardless of which labels it happens to carry.
+const captureColors = (captures) => {
+    let extra = 0;
+    return new Map(
+        captures.map((c) => {
+            const isFixed = c.id === CAPTURE_BASELINE || c.id === CAPTURE_EXPERIMENT;
+            return [c.id, captureColorFor(c.id, isFixed ? -1 : extra++)];
+        }),
+    );
+};
 
 /**
  * Format a relative offset in milliseconds as `+Xs`, `+XmYs`, or `+XhYm`.
@@ -152,9 +185,9 @@ const anchorSecondsFor = (anchors, id, timeDataSec) => {
  * capture is unusable — the caller can then render baseline-only.
  */
 const overlayLine = ({ spec, captures, anchors, captureLabels }) => {
-    const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
-    const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
-    if (!baseline || !experiment) return false;
+    // Overlay needs at least two captures; with only the anchor, the caller
+    // renders the baseline single-chart instead.
+    if (!captures || captures.length < 2) return false;
 
     // Build one overlay entry per capture. When the capture carries a decimated
     // boxplot (min/max envelope), the entry is drawn ENTIRELY from it — median +
@@ -197,10 +230,14 @@ const overlayLine = ({ spec, captures, anchors, captureLabels }) => {
         return null;
     };
 
-    const seriesList = [
-        entryFor(baseline, labelFor(captureLabels, CAPTURE_BASELINE), BASELINE_COLOR),
-        entryFor(experiment, labelFor(captureLabels, CAPTURE_EXPERIMENT), EXPERIMENT_COLOR),
-    ].filter(Boolean);
+    // One overlay entry per capture, in the order given (anchor first). A plain
+    // A/B is baseline+experiment with their signature colors; extras follow
+    // from the palette. `divergenceBand` shades the gap only for exactly two
+    // (`divergenceBandFor` returns null otherwise), so it is a no-op for N > 2.
+    const colors = captureColors(captures);
+    const seriesList = captures
+        .map((cap) => entryFor(cap, cap.alias || labelFor(captureLabels, cap.id), colors.get(cap.id)))
+        .filter(Boolean);
     if (seriesList.length === 0) return FALLBACK;
 
     return {
@@ -454,40 +491,36 @@ const splitScatterToSubgroup = ({ spec, captures, anchors, captureLabels }) =>
     });
 
 const splitIntoOverlayLines = ({ spec, captures, anchors, captureLabels, labelFor: _labelFor, seriesType = 'line' }) => {
-    const baseline = captures.find((c) => c.id === CAPTURE_BASELINE);
-    const experiment = captures.find((c) => c.id === CAPTURE_EXPERIMENT);
-    if (!baseline || !experiment) return FALLBACK;
-
-    const mapA = baseline.seriesMap || new Map();
-    const mapB = experiment.seriesMap || new Map();
-    const labelsA = new Set(mapA.keys());
-    const labelsB = new Set(mapB.keys());
-    const shared = [...intersectLabels(labelsA, labelsB)].sort();
+    if (!captures || captures.length < 2) return FALLBACK;
     const asScatter = seriesType === 'scatter';
+    const colors = captureColors(captures);
+
+    // Every series label present in ANY capture (a union, not the pairwise
+    // intersection the two-capture path used): a per-CPU or per-cgroup label
+    // present in three of four arms should still draw those three, overlaid,
+    // rather than vanish because one arm lacks it.
+    const allLabels = new Set();
+    for (const cap of captures) {
+        for (const k of (cap.seriesMap || new Map()).keys()) allLabels.add(k);
+    }
+    const shared = [...allLabels].sort();
 
     const specs = shared.map((label) => {
-        const a = mapA.get(label);
-        const b = mapB.get(label);
-        const baseSec = anchorSecondsFor(anchors, CAPTURE_BASELINE, a.timeData);
-        const expSec = anchorSecondsFor(anchors, CAPTURE_EXPERIMENT, b.timeData);
-        const multiSeries = [
-            {
-                name: labelFor(captureLabels, CAPTURE_BASELINE),
-                color: BASELINE_COLOR,
-                timeData: rebase(a.timeData, baseSec),
-                valueData: a.valueData,
-                fill: false,
-                scatter: asScatter,
-            },
-            {
-                name: labelFor(captureLabels, CAPTURE_EXPERIMENT),
-                color: EXPERIMENT_COLOR,
-                timeData: rebase(b.timeData, expSec),
-                valueData: b.valueData,
-                fill: false,
-                scatter: asScatter,
-            },
-        ];
+        const multiSeries = captures
+            .map((cap) => {
+                const r = (cap.seriesMap || new Map()).get(label);
+                if (!r) return null;
+                const sec = anchorSecondsFor(anchors, cap.id, r.timeData);
+                return {
+                    name: cap.alias || labelFor(captureLabels, cap.id),
+                    color: colors.get(cap.id),
+                    timeData: rebase(r.timeData, sec),
+                    valueData: r.valueData,
+                    fill: false,
+                    scatter: asScatter,
+                };
+            })
+            .filter(Boolean);
         return {
             ...stripDisplay(spec),
             opts: {

--- a/src/viewer/assets/lib/style.css
+++ b/src/viewer/assets/lib/style.css
@@ -52,6 +52,14 @@
     --compare-baseline-bg: rgba(46, 91, 255, 0.08);
     --compare-experiment: #00C46A;
     --compare-experiment-bg: rgba(0, 196, 106, 0.08);
+    /* N-way overlay: colors for a 3rd-and-beyond capture (baseline/experiment
+       keep the two above). Match charts/compare.js CAPTURE_PALETTE. */
+    --compare-capture-3: #FF8A00;
+    --compare-capture-4: #B45BFF;
+    --compare-capture-5: #FF4D6D;
+    --compare-capture-6: #00B8D9;
+    --compare-capture-7: #F5C518;
+    --compare-capture-8: #8C6E5D;
 
     /* Status colors */
     --success: #3fb950;

--- a/tests/compare_nway.test.mjs
+++ b/tests/compare_nway.test.mjs
@@ -1,0 +1,75 @@
+// N-way overlay: a compare-line chart draws one series per capture, each with a
+// distinct color, not just baseline+experiment. Scope of the N-way arc is
+// overlay charts; diff/side-by-side stay 2-only (covered elsewhere).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// compare.js reads CSS custom properties at module load; stub the DOM so the
+// palette falls back to its literals (same shim the other compare tests use).
+globalThis.document = globalThis.document || { documentElement: {} };
+globalThis.getComputedStyle = globalThis.getComputedStyle || (() => ({ getPropertyValue: () => '' }));
+const { renderCompareChart, captureColorFor, BASELINE_COLOR, EXPERIMENT_COLOR } =
+    await import('../src/viewer/assets/lib/charts/compare.js');
+const { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } = await import('../src/viewer/assets/lib/data.js');
+
+const line = (id, alias, base) => ({
+    id, alias,
+    timeData: [100, 101, 102],
+    valueData: [base, base + 1, base + 2],
+});
+
+test('a compare-line overlay draws one series per capture, N > 2', () => {
+    const captures = [
+        line(CAPTURE_BASELINE, 'redis', 10),
+        line(CAPTURE_EXPERIMENT, 'valkey', 20),
+        line('envoy', 'envoy', 30),
+        line('nginx', 'nginx', 40),
+    ];
+    const out = renderCompareChart({
+        spec: { opts: { style: 'line' } },
+        captures,
+        anchors: {},
+        captureLabels: {},
+    });
+    assert.equal(out.kind, 'spec');
+    const ms = out.spec.multiSeries;
+    assert.equal(ms.length, 4, 'all four captures overlaid');
+    assert.deepEqual(ms.map((s) => s.name), ['redis', 'valkey', 'envoy', 'nginx']);
+
+    // baseline/experiment keep their signature colors; extras come from the
+    // palette; every color is distinct so the arms are tellable apart.
+    assert.equal(ms[0].color, BASELINE_COLOR);
+    assert.equal(ms[1].color, EXPERIMENT_COLOR);
+    assert.equal(ms[2].color, captureColorFor('envoy', 0));
+    assert.equal(ms[3].color, captureColorFor('nginx', 1));
+    assert.equal(new Set(ms.map((s) => s.color)).size, 4, 'distinct colors');
+
+    // No divergence band for N > 2 (it is a two-capture concept).
+    assert.equal(out.spec.divergenceBand, null);
+});
+
+test('the two-capture overlay is unchanged: signature colors, divergence band', () => {
+    const captures = [line(CAPTURE_BASELINE, 'redis', 10), line(CAPTURE_EXPERIMENT, 'valkey', 20)];
+    const out = renderCompareChart({
+        spec: { opts: { style: 'line' } },
+        captures,
+        anchors: {},
+        captureLabels: {},
+    });
+    const ms = out.spec.multiSeries;
+    assert.equal(ms.length, 2);
+    assert.equal(ms[0].color, BASELINE_COLOR);
+    assert.equal(ms[1].color, EXPERIMENT_COLOR);
+    // The two medians sit on a coincident grid → a divergence band is present.
+    assert.ok(out.spec.divergenceBand, 'two captures get a divergence band');
+});
+
+test('a lone anchor does not overlay (renders baseline-only upstream)', () => {
+    const out = renderCompareChart({
+        spec: { opts: { style: 'line' } },
+        captures: [line(CAPTURE_BASELINE, 'redis', 10)],
+        anchors: {},
+        captureLabels: {},
+    });
+    assert.equal(out, false);
+});


### PR DESCRIPTION
PR 4b of the **N-way compare** arc: the overlay renderer draws one series per capture, not just baseline + experiment.

The ECharts layer (`charts/line.js` `multiSeries`) already draws N named, colored series — this generalizes the two producers that feed it.

## What changed

- **`overlayLine`** (the `line` style) and **`splitIntoOverlayLines`** (the `multi` per-CPU/per-cgroup and `scatter` percentile splits) now **iterate the captures** instead of finding two fixed ids.
- Color comes from a **stable per-capture map**: baseline and experiment keep their signature blue/green, so a plain A/B looks exactly as before; extras draw from a categorical palette (also exposed as `--compare-capture-3..8` CSS vars for theming).
- The split charts **union** their series labels rather than intersect — a per-CPU label present in three of four arms should draw those three overlaid, not vanish because the fourth lacks it.

## Deliberately unchanged (the scope decision)

Diff and side-by-side heatmaps and the scatter spectrum stay **two-capture** — they're intrinsically pairwise. `divergenceBand` was already null for anything but two captures, so it's a no-op for N > 2.

## Split from the fetch

Nothing feeds these producers more than two captures **yet** — the `viewer_core` `CompareChartWrapper` fetch that holds N lands in **PR 4c**. This is the pure-function rendering half, split from the stateful/async fetch so each is reviewable on its own (and the risky part is isolated).

## Tests

New `tests/compare_nway.test.mjs` proves a 4-capture overlay draws four distinctly-colored series (baseline/experiment signature colors, extras from the palette) with no divergence band, and that the **two-capture path is unchanged** (signature colors, divergence band present). A lone anchor returns `false` (baseline-only upstream). All 252 node tests pass; symlink parity holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)