### PR TITLE
fix(viewer): resolve a named capture id on the server, not just baseline

### DIFF
--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -32,20 +32,6 @@ pub enum CaptureId {
 }
 
 impl CaptureId {
-    pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            BASELINE_ID => Some(CaptureId::Baseline),
-            EXPERIMENT_ID => Some(CaptureId::Experiment),
-            _ => None,
-        }
-    }
-
-    /// Parse an optional `?capture=…` query param. Missing or unknown
-    /// values resolve to the default (Baseline).
-    pub fn parse_opt(s: Option<&str>) -> Self {
-        s.and_then(Self::parse).unwrap_or_default()
-    }
-
     /// The wire id for this capture.
     pub fn id(self) -> &'static str {
         match self {
@@ -161,10 +147,6 @@ impl CaptureRegistry {
             .flatten()
     }
 
-    pub fn file_metadata(&self, id: CaptureId) -> Option<String> {
-        self.file_metadata_by_id(id.id())
-    }
-
     pub fn file_metadata_by_id(&self, id: &str) -> Option<String> {
         self.with_slot(id, |slot| slot.file_metadata.read().clone())
             .flatten()
@@ -272,13 +254,6 @@ mod tests {
 
     fn registry() -> CaptureRegistry {
         CaptureRegistry::new(store("base.parquet"), None, None, Some("base".into()))
-    }
-
-    #[test]
-    fn parse_capture_id() {
-        assert_eq!(CaptureId::parse("baseline"), Some(CaptureId::Baseline));
-        assert_eq!(CaptureId::parse("experiment"), Some(CaptureId::Experiment));
-        assert_eq!(CaptureId::parse("unknown"), None);
     }
 
     #[test]

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1567,11 +1567,11 @@ mod tests {
         // reader landed in each slot.
         let b_meta = state
             .captures
-            .file_metadata(CaptureId::Baseline)
+            .file_metadata_by_id("baseline")
             .unwrap_or_default();
         let e_meta = state
             .captures
-            .file_metadata(CaptureId::Experiment)
+            .file_metadata_by_id("experiment")
             .unwrap_or_default();
         assert!(b_meta.contains("envoy"), "baseline metadata: {b_meta}");
         assert!(e_meta.contains("valkey"), "experiment metadata: {e_meta}");
@@ -1602,7 +1602,7 @@ mod tests {
         assert!(!state.captures.experiment_attached());
         let b_meta = state
             .captures
-            .file_metadata(CaptureId::Baseline)
+            .file_metadata_by_id("baseline")
             .unwrap_or_default();
         assert!(b_meta.contains("valkey"), "baseline metadata: {b_meta}");
         // Named, not "baseline": the window title is the archive's filename,

--- a/src/viewer/routes.rs
+++ b/src/viewer/routes.rs
@@ -32,7 +32,7 @@ use dashboard::display_wire;
 use metriken_query::{QueryError, QueryResult};
 
 use super::actions;
-use super::capture_registry::{self, CaptureId};
+use super::capture_registry::{self};
 use super::state::{self, ApiResponse, AppState, CaptureParam};
 
 #[cfg(not(feature = "developer-mode"))]
@@ -218,7 +218,7 @@ async fn systeminfo_handler(
     State(state): State<Arc<AppState>>,
     Query(p): Query<CaptureParam>,
 ) -> Response {
-    match state.captures.systeminfo(p.capture_id()) {
+    match state.captures.systeminfo_by_id(p.capture_str()) {
         Some(json) => (
             StatusCode::OK,
             [(header::CONTENT_TYPE, "application/json")],
@@ -242,13 +242,10 @@ async fn selection_handler(State(state): State<Arc<AppState>>) -> Response {
 }
 
 /// Navigation list + global capture params; no section bodies.
-async fn sections_handler(
-    State(state): State<Arc<AppState>>,
-    Query(p): Query<CaptureParam>,
-) -> Json<serde_json::Value> {
+async fn sections_handler(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "status": "success",
-        "data": state.sections_metadata(p.capture_id()),
+        "data": state.sections_metadata(),
     }))
 }
 
@@ -258,7 +255,7 @@ async fn file_metadata_handler(
 ) -> Response {
     let body = state
         .captures
-        .file_metadata(p.capture_id())
+        .file_metadata_by_id(p.capture_str())
         .unwrap_or_else(|| "{}".to_string());
     (
         StatusCode::OK,
@@ -309,14 +306,17 @@ async fn metrics_handler(
     State(state): State<Arc<AppState>>,
     Query(p): Query<MetricsParam>,
 ) -> Response {
-    let capture_id = CaptureId::parse_opt(p.capture.as_deref());
-    let Some(data) = state.captures.get(capture_id) else {
+    let capture_id = p
+        .capture
+        .as_deref()
+        .unwrap_or(capture_registry::BASELINE_ID);
+    let Some(data) = state.captures.get_by_id(capture_id) else {
         return StatusCode::NOT_FOUND.into_response();
     };
     let source = p.source.clone().unwrap_or_else(|| data.source());
     let descriptions = state
         .captures
-        .file_metadata(capture_id)
+        .file_metadata_by_id(capture_id)
         .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
         .map(|v| dashboard::metric_catalog::resolve_descriptions(&v, &source))
         .unwrap_or_default();
@@ -346,8 +346,11 @@ async fn timestamps_handler(
     State(state): State<Arc<AppState>>,
     Query(p): Query<MetricsParam>,
 ) -> Response {
-    let capture_id = CaptureId::parse_opt(p.capture.as_deref());
-    let Some(data) = state.captures.get(capture_id) else {
+    let capture_id = p
+        .capture
+        .as_deref()
+        .unwrap_or(capture_registry::BASELINE_ID);
+    let Some(data) = state.captures.get_by_id(capture_id) else {
         return StatusCode::NOT_FOUND.into_response();
     };
     let source = p.source.clone().unwrap_or_else(|| data.source());
@@ -395,10 +398,10 @@ fn run_query<F>(state: &AppState, capture: Option<&str>, f: F) -> Json<ApiRespon
 where
     F: FnOnce(&dyn metriken_query::MetricsSource) -> Result<QueryResult, QueryError>,
 {
-    let capture = CaptureId::parse_opt(capture);
-    let Some(data) = state.captures.get(capture) else {
+    let capture = capture.unwrap_or(capture_registry::BASELINE_ID);
+    let Some(data) = state.captures.get_by_id(capture) else {
         return ApiResponse::err(
-            format!("capture '{capture:?}' not attached"),
+            format!("capture '{capture}' not attached"),
             "capture_not_found",
         );
     };
@@ -438,10 +441,13 @@ async fn range_query(
 /// `dashboard::display_wire` so the WASM viewer produces byte-identical bodies.
 /// Non-`Series` results (scalar/vector) fall back to JSON.
 fn range_query_display(state: &AppState, params: &RangeQueryParams) -> Response {
-    let capture = CaptureId::parse_opt(params.capture.as_deref());
-    let Some(data) = state.captures.get(capture) else {
+    let capture = params
+        .capture
+        .as_deref()
+        .unwrap_or(capture_registry::BASELINE_ID);
+    let Some(data) = state.captures.get_by_id(capture) else {
         return ApiResponse::<serde_json::Value>::err(
-            format!("capture '{capture:?}' not attached"),
+            format!("capture '{capture}' not attached"),
             "capture_not_found",
         )
         .into_response();
@@ -504,10 +510,10 @@ async fn metadata(
     State(state): State<Arc<AppState>>,
     Query(p): Query<CaptureParam>,
 ) -> Json<ApiResponse<serde_json::Value>> {
-    let capture = p.capture_id();
-    let Some(data) = state.captures.get(capture) else {
+    let capture = p.capture_str();
+    let Some(data) = state.captures.get_by_id(capture) else {
         return ApiResponse::err(
-            format!("capture {capture:?} not attached"),
+            format!("capture '{capture}' not attached"),
             "capture_not_found",
         );
     };
@@ -522,17 +528,17 @@ async fn metadata(
     } else {
         0.0
     };
-    let filename = state.captures.filename(capture);
+    let filename = state.captures.filename_by_id(capture);
     let mut meta = serde_json::json!({
         "minTime": min_time,
         "maxTime": max_time,
         "interval": interval,
         "filename": filename,
     });
-    if let Some(alias) = state.captures.alias(capture) {
+    if let Some(alias) = state.captures.alias_by_id(capture) {
         meta["alias"] = serde_json::json!(alias);
     }
-    if matches!(capture, capture_registry::CaptureId::Baseline) {
+    if capture == capture_registry::BASELINE_ID {
         if let Some(checksum) = &*state.file_checksum.read() {
             meta["fileChecksum"] = serde_json::json!(checksum);
         }

--- a/src/viewer/state.rs
+++ b/src/viewer/state.rs
@@ -211,7 +211,7 @@ impl AppState {
     }
 
     /// Build the navigation + global params payload for `/api/v1/sections`.
-    pub fn sections_metadata(&self, _capture: CaptureId) -> serde_json::Value {
+    pub fn sections_metadata(&self) -> serde_json::Value {
         let store = self.sections.read();
         let sections_array: Vec<serde_json::Value> = store
             .sections()
@@ -282,8 +282,16 @@ pub struct CaptureParam {
 }
 
 impl CaptureParam {
-    pub fn capture_id(&self) -> CaptureId {
-        CaptureId::parse_opt(self.capture.as_deref())
+    /// The raw wire id, defaulting to the anchor when absent.
+    ///
+    /// A string, never the `CaptureId` enum: an archive attaches captures
+    /// under named ids (`envoy`), so a request for `capture=envoy` must
+    /// resolve the `envoy` recording, not collapse an unknown id to the
+    /// baseline. The registry's `*_by_id` accessors take this string.
+    pub fn capture_str(&self) -> &str {
+        self.capture
+            .as_deref()
+            .unwrap_or(super::capture_registry::BASELINE_ID)
     }
 }
 

--- a/tests/viewer_smoke.sh
+++ b/tests/viewer_smoke.sh
@@ -136,6 +136,15 @@ caps1=$(curl -fsS "http://127.0.0.1:$PORT_FILE/api/v1/captures")
 eq "single-file captures"    "$(echo "$caps1" | jq -r 'length')"       "1"        "$LOGDIR/file.log"
 eq "single-file id"          "$(echo "$caps1" | jq -r '.[0].id')"      "baseline" "$LOGDIR/file.log"
 
+# Named-id resolution: `?capture=experiment` must answer about the experiment,
+# and an UNKNOWN id must error rather than silently returning the baseline
+# (the pre-fix behavior, when CaptureId::parse_opt collapsed unknowns).
+expmeta=$(curl -fsS "http://127.0.0.1:$PORT_AB/api/v1/metadata?capture=experiment")
+eq "experiment metadata status" "$(echo "$expmeta" | jq -r .status)" "success" "$LOGDIR/ab.log"
+unknown=$(curl -fsS "http://127.0.0.1:$PORT_AB/api/v1/metadata?capture=nope")
+eq "unknown capture errors"  "$(echo "$unknown" | jq -r .status)"     "error"    "$LOGDIR/ab.log"
+eq "unknown capture type"    "$(echo "$unknown" | jq -r .errorType)"  "capture_not_found" "$LOGDIR/ab.log"
+
 mode=$(mode_at $PORT_PROXY)
 eq "proxy url_loading"       "$(echo "$mode" | jq -r .url_loading)"  "proxy"    "$LOGDIR/proxy.log"
 


### PR DESCRIPTION
PR 6 of the **N-way compare** arc — and it turned out to be a correctness **fix**, not cosmetic URL polish.

## The bug

After the N-way work the server attaches captures under named ids (`envoy`), but its HTTP handlers still resolved `?capture=` through `CaptureId::parse_opt` — a **two-variant enum** that cannot represent `envoy`, so an unknown id collapsed to `Baseline`. `?capture=envoy` therefore returned the **baseline's data**, and the server viewer's N-way overlay (the fetch added in #1153) drew **every extra arm as a duplicate of baseline**.

The WASM registry was already correct — its `slot(&str)` resolves by string id (PR 2) — so this was **server-only**. The overlay works in the browser and was broken on `rezolus view`.

## The fix

Every handler now resolves the raw id string through the registry's `*_by_id` accessors (already unit-tested in PR 1), defaulting a missing param to the baseline anchor. An **unknown id errors** (`capture_not_found`) rather than silently answering baseline — correct, and the honest failure.

This is what makes `?capture=<named>` **round-trip**: a `.rez` loaded by URL reproduces its full N-way view, and each arm is addressable — the "shareable N-way URLs" goal.

## Cleanup

The two-variant `CaptureId` enum **stays** — `actions.rs`'s A/B save and combine address the two slots directly with it — but the string bridges it no longer needs (`parse`, `parse_opt`, `CaptureParam::capture_id`, and the orphaned `file_metadata(CaptureId)`) are removed.

## Tests

`viewer_smoke.sh` gains: `?capture=experiment` answers about the experiment; an unknown id returns `capture_not_found` (before the fix it returned baseline data with 200). The registry accessors this routes through are unit-tested; the handler glue is smoke-covered — that script isn't CI-wired, the same coverage shape as `/api/v1/captures`. Full workspace green, clippy clean, fmt clean.

## Arc status

Functionally complete: registries hold N (#1140, #1146), `.rez` attaches all (#1149), the list is enumerable (#1150), the overlay draws N (#1152), the frontend fetches N (#1153), named ids resolve (this). Remaining is UI polish (the compare strip listing N — cosmetic; the chart legend already names all series) and browser verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)