### PR TITLE
feat(agent): opt-in host-wide BPF run-time stats via config flag + held fd

### DIFF
--- a/config/agent.toml
+++ b/config/agent.toml
@@ -86,6 +86,22 @@ ttl = "10ms"
 # rank behind the ones named, so a partial list cannot silently drop one.
 # pmu_priority = ["cpu_perf", "cpu_branch", "cpu_dtlb", "cpu_l3", "cpu_frequency"]
 
+# Enable host-wide BPF run-time statistics so `rezolus_bpf_run_time` and
+# `rezolus_bpf_run_count` populate (mean ns/call per sampler — the principle-16
+# self-telemetry used to size sampler overhead).
+#
+# OFF by default, and deliberately. The kernel has a single global switch for
+# run-time accounting; turning it on adds two clock reads to EVERY BPF program
+# run on the host, not just Rezolus's. On a box running XDP at line rate,
+# cilium, or other heavy BPF, that is a real per-event tax on programs the agent
+# does not own. Rezolus enables it through a BPF_ENABLE_STATS fd held for its
+# lifetime, so it turns back off when the agent exits (no lingering
+# `kernel.bpf_stats_enabled` sysctl) — but while on it is still host-wide.
+#
+# Leave it off in normal operation; turn it on only while actively investigating
+# sampler overhead, and prefer a host that is not saturating other BPF programs.
+# bpf_stats = false
+
 [scheduler]
 # By default, Rezolus will use the SCHED_RR realtime scheduling policy to ensure
 # collection happens with minimal delay. Other policies are: `normal` and `fifo`

--- a/src/agent/config/general.rs
+++ b/src/agent/config/general.rs
@@ -63,6 +63,13 @@ pub struct General {
     // CPUs the reservation applies to (see `reserved_pmu_cpus`)
     #[serde(default)]
     reserved_pmu_cpus: Option<String>,
+
+    // enable host-wide BPF run-time statistics (see `bpf_stats`)
+    // Only consulted on Linux, where BPF runs; the field exists on every
+    // platform so the config shape is identical.
+    #[serde(default)]
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    bpf_stats: bool,
 }
 
 /// Written out rather than derived, because a derived `Default` would ignore
@@ -85,6 +92,7 @@ impl Default for General {
             reserved_pmu_counters: 0,
             pmu_priority: Vec::new(),
             reserved_pmu_cpus: None,
+            bpf_stats: false,
         }
     }
 }
@@ -150,6 +158,24 @@ impl General {
     /// wanted them.
     pub fn reserved_pmu_cpus(&self) -> Option<&str> {
         self.reserved_pmu_cpus.as_deref()
+    }
+
+    /// Whether to enable host-wide BPF run-time statistics so
+    /// `rezolus_bpf_run_time` / `rezolus_bpf_run_count` populate.
+    ///
+    /// Off by default, and deliberately. The kernel exposes run-time stats
+    /// through a single global switch (`bpf_stats_enabled_key`): turning it on
+    /// -- whether via the `kernel.bpf_stats_enabled` sysctl or the
+    /// `BPF_ENABLE_STATS` fd this agent uses -- adds two `ktime` reads to
+    /// EVERY BPF program run on the host, not just Rezolus's. On a box running
+    /// XDP at line rate, cilium, or other heavy BPF, that is a real per-event
+    /// tax on programs the agent does not own. The fd form scopes the *when*
+    /// (it is released on agent exit, leaving no persistent setting) but not
+    /// the *whom*, so enabling stays opt-in. Leave it off unless you are
+    /// actively investigating sampler overhead. (See issue #1047.)
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn bpf_stats(&self) -> bool {
+        self.bpf_stats
     }
 
     pub fn listen(&self) -> SocketAddr {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -61,6 +61,27 @@ pub const MAX_PID: usize = 4194304;
 /// Rezolus-specific msgpack endpoint.
 ///
 /// This is the default mode for running Rezolus.
+/// Turn on host-wide BPF run-time statistics and return the fd that keeps them
+/// on. The kernel refcounts this: statistics stay enabled while any process
+/// holds such an fd and turn off when the last one closes, so holding it for
+/// the agent's lifetime (and closing it on exit) is what makes the setting
+/// self-scoped rather than a persistent sysctl. `BPF_ENABLE_STATS` is a
+/// bpf(2) command since Linux 5.8, matching the CO-RE baseline (principle 2);
+/// on an older or restrictive kernel the call fails and the caller degrades to
+/// stats-absent.
+#[cfg(target_os = "linux")]
+fn enable_bpf_run_stats() -> std::io::Result<std::os::fd::OwnedFd> {
+    use std::os::fd::FromRawFd;
+    // Safety: FFI call with a plain enum arg; returns a new fd or -1/errno.
+    let fd = unsafe { libbpf_sys::bpf_enable_stats(libbpf_sys::BPF_STATS_RUN_TIME) };
+    if fd < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        // Safety: `fd` is a fresh, owned fd returned by the kernel.
+        Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(fd) })
+    }
+}
+
 pub fn run(config: PathBuf) {
     record_agent_start();
 
@@ -77,6 +98,33 @@ pub fn run(config: PathBuf) {
 
     #[cfg(target_os = "linux")]
     config.scheduler().apply();
+
+    // BPF run-time stats are host-wide (one global kernel switch), so they are
+    // opt-in. When enabled, acquire a BPF_ENABLE_STATS fd and hold it for the
+    // agent's lifetime: while any process holds such an fd the kernel keeps
+    // run-time accounting on, and dropping it on exit turns it back off,
+    // leaving no persistent `kernel.bpf_stats_enabled` sysctl behind. The
+    // binding lives to the end of `run()` (which never returns), so the fd
+    // stays open for the whole process. See `General::bpf_stats`.
+    #[cfg(target_os = "linux")]
+    let _bpf_stats_fd = if config.general().bpf_stats() {
+        match enable_bpf_run_stats() {
+            Ok(fd) => {
+                info!(
+                    "bpf_stats=true: enabled host-wide BPF run-time statistics;                      rezolus_bpf_run_time/count will populate. This taxes EVERY BPF                      program on the host, not just Rezolus's."
+                );
+                Some(fd)
+            }
+            Err(e) => {
+                warn!(
+                    "bpf_stats=true but BPF_ENABLE_STATS failed ({e});                      rezolus_bpf_run_time/count will be absent"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     let _log_drain = configure_logging(config.log().level().to_tracing_level());
 


### PR DESCRIPTION
## Summary

`rezolus_bpf_run_time` / `rezolus_bpf_run_count` — the principle-16 self-telemetry used to size sampler overhead — only populate when the kernel's BPF run-time accounting is on. Previously that meant the global `kernel.bpf_stats_enabled` sysctl, which most hosts leave off, so the numbers were **silently absent** (I hit this repeatedly measuring on delta and hv01 this cycle — both had it at `0`).

This adds an opt-in config flag that enables accounting through a **`BPF_ENABLE_STATS` fd held for the agent's lifetime**, instead of the sysctl.

## The design, and why it's a flag not just an fd

The fd is better than the sysctl for *lifecycle*: the kernel refcounts accounting on it, so it turns off when the agent exits — no persistent setting left behind. But accounting is a **single global kernel switch**: while on, it adds two clock reads to **every** BPF program run on the host — XDP, cilium, other tracers — not just Rezolus's. The fd scopes the *when*, not the *whom*.

So it must be opt-in. **`[general] bpf_stats = false` by default** (no behavior change). Turn it on only to investigate overhead, and prefer a host that isn't saturating other BPF. `config/agent.toml` documents the host-wide caveat in full.

Graceful: `BPF_ENABLE_STATS` is 5.8+ (CO-RE baseline); on an older/restrictive kernel it fails, the agent logs and continues with stats absent, as before.

## Refines #1047

That issue proposes the fd, fixing the sysctl's *persistent* and *invisible* problems. The config flag is the missing piece for its *global-impact* problem, which the fd alone doesn't solve. (Issue updated with this.)

## Validated on Linux (delta, kernel 6.12, production agent running alongside)

| | `run_time` populates | `kernel.bpf_stats_enabled` |
|---|---|---|
| `bpf_stats = true` | **YES** (`blockio_latency run_time = 179872`) | stays `0` (fd path, not the sysctl) |
| `bpf_stats = false` | no | `0` |
| after agent exit | — | `0` (fd released → auto-off) |

Confirms: the fd enables the metrics **without** the sysctl, default-off means no stats, and it leaves **no persistent global setting** behind.

## Test plan

- [x] macOS build / `cargo test` (676) / `cargo clippy --all-targets` clean; field & accessor `#[cfg]`-guarded so non-Linux doesn't warn
- [x] Linux: release build, agent loads with the flag
- [x] `bpf_stats=true` populates `run_time`/`run_count` without the sysctl; `=false` doesn't; sysctl untouched throughout and stats off after exit
- [x] `config/agent.toml` documents the host-wide XDP/cilium caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
