### PR TITLE
perf(tcp): fentry twins for tcp_traffic, kprobe as the CO-RE fallback

### DIFF
--- a/src/agent/samplers/tcp/linux/traffic/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/traffic/mod.bpf.c
@@ -91,8 +91,20 @@ static int probe_ip(bool receiving, struct sock* sk, size_t size) {
     return 0;
 }
 
+// fentry/kprobe twins share probe_ip(); only the attach mechanism differs.
+// fentry is the cheaper dispatch (measured ~56% less than kprobe on a modern
+// KPROBES_ON_FTRACE kernel -- see
+// docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md), but it needs BTF, so
+// the kprobe twin is kept as the CO-RE-only fallback and one is disabled at load
+// time based on kernel_has_btf() (see disabled_programs in mod.rs).
+
+SEC("fentry/tcp_sendmsg")
+int BPF_PROG(tcp_sendmsg_fentry, struct sock* sk, struct msghdr* msg, size_t size) {
+    return probe_ip(false, sk, size);
+}
+
 SEC("kprobe/tcp_sendmsg")
-int BPF_KPROBE(tcp_sendmsg, struct sock* sk, struct msghdr* msg, size_t size) {
+int BPF_KPROBE(tcp_sendmsg_kprobe, struct sock* sk, struct msghdr* msg, size_t size) {
     return probe_ip(false, sk, size);
 }
 
@@ -102,8 +114,17 @@ int BPF_KPROBE(tcp_sendmsg, struct sock* sk, struct msghdr* msg, size_t size) {
  * - misses tcp_read_sock() traffic
  * we'd much prefer tracepoints once they are available.
  */
+SEC("fentry/tcp_cleanup_rbuf")
+int BPF_PROG(tcp_cleanup_rbuf_fentry, struct sock* sk, int copied) {
+    if (copied <= 0) {
+        return 0;
+    }
+
+    return probe_ip(true, sk, copied);
+}
+
 SEC("kprobe/tcp_cleanup_rbuf")
-int BPF_KPROBE(tcp_cleanup_rbuf, struct sock* sk, int copied) {
+int BPF_KPROBE(tcp_cleanup_rbuf_kprobe, struct sock* sk, int copied) {
     if (copied <= 0) {
         return 0;
     }

--- a/src/agent/samplers/tcp/linux/traffic/mod.rs
+++ b/src/agent/samplers/tcp/linux/traffic/mod.rs
@@ -1,6 +1,6 @@
-//! Collects TCP stats using BPF and traces:
-//! * `tcp_sendmsg`
-//! * `tcp_cleanup_rbuf`
+//! Collects TCP stats using BPF and traces `tcp_sendmsg` and `tcp_cleanup_rbuf`,
+//! via fentry when the kernel has BTF (cheaper dispatch) and kprobe otherwise
+//! (the CO-RE-only fallback).
 //!
 //! And produces these stats:
 //! * `tcp/receive/bytes`
@@ -51,6 +51,12 @@ fn init(config: Arc<Config>) -> SamplerResult {
     // doc comment.
     .histogram("rx_size", &TCP_RX_SIZE, &SIZES_ACQ)
     .histogram("tx_size", &TCP_TX_SIZE, &SIZES_ACQ)
+    // Prefer fentry (cheaper dispatch); fall back to kprobe without BTF.
+    .disabled_programs(if kernel_has_btf() {
+        &["tcp_sendmsg_kprobe", "tcp_cleanup_rbuf_kprobe"]
+    } else {
+        &["tcp_sendmsg_fentry", "tcp_cleanup_rbuf_fentry"]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -77,12 +83,12 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} tcp_sendmsg() BPF instruction count: {}",
-            self.progs.tcp_sendmsg.insn_cnt()
+            "{NAME} tcp_sendmsg_fentry() BPF instruction count: {}",
+            self.progs.tcp_sendmsg_fentry.insn_cnt()
         );
         debug!(
-            "{NAME} tcp_cleanup_rbuf() BPF instruction count: {}",
-            self.progs.tcp_cleanup_rbuf.insn_cnt()
+            "{NAME} tcp_cleanup_rbuf_fentry() BPF instruction count: {}",
+            self.progs.tcp_cleanup_rbuf_fentry.insn_cnt()
         );
     }
 }


### PR DESCRIPTION
## Summary

First step of the fentry migration (backlog: *Agent — fentry migration for hot kprobe samplers*). `tcp_traffic` hooks `tcp_sendmsg` (per-message — the highest-rate kprobe hook in the tree) and `tcp_cleanup_rbuf` with kprobes. The matched-twin dispatch measurement (`docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md`) found **fentry ~56% cheaper per call** than a fresh kprobe on `tcp_sendmsg` (kernel 6.12) — a fresh kprobe still routes through the kprobe framework on top of ftrace, while fentry is a lean BPF trampoline.

## Change

- **fentry twins** (`tcp_sendmsg_fentry`, `tcp_cleanup_rbuf_fentry`) sharing the existing `probe_ip()` body; only the attach mechanism differs.
- **`disabled_programs(if kernel_has_btf() { …kprobe } else { …fentry })`** — prefers fentry when BTF is present, keeps the kprobe twin as the CO-RE-only fallback (principle 2). Same pattern the existing tp_btf/raw_tp twins use.
- No metric or output change — a pure dispatch swap for the common (BTF-present) case.

## Validated on Linux (delta, kernel 6.12, BTF present)

- **fentry selected, kprobe disabled**: agent log shows `tcp_sendmsg_fentry() BPF instruction count: 302`, `tcp_cleanup_rbuf_fentry() BPF instruction count: 306` — the fentry variants are what loaded. `bpftool prog show` confirms the agent's `*_fentry` programs (the host's production kprobe-based agent coexists untouched).
- **Agent healthy** (`1 healthy, 0 failed`); tcp bytes/packets metrics populate correctly in both directions under loopback traffic.

## Test plan

- [x] Both BPF targets compile against the checked-in `vmlinux.h` (4 programs)
- [x] macOS build / `cargo test` (681) / `cargo clippy` clean
- [x] Linux: agent loads the fentry twins on a BTF kernel, kprobe disabled; metrics populate
- [ ] Follow-on: the other 7 kprobe samplers, each re-measured on a clean function first (tracked in backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
