### PR TITLE
perf(cpu): fentry twin for cpu_usage's cpuacct_account_field hook

### DIFF
--- a/src/agent/samplers/cpu/linux/usage/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/usage/mod.bpf.c
@@ -275,8 +275,14 @@ static __noinline int handle_new_task(struct task_struct* task) {
 // count the CPU usage by tracking the per-task utime/stime. The user time includes both the
 // CPUTIME_NICE and CPUTIME_USER. The system time includes CPUTIME_SYSTEM, CPUTIME_SOFTIRQ and
 // CPUTIME_IRQ.
-SEC("kprobe/cpuacct_account_field")
-int BPF_KPROBE(cpuacct_account_field_kprobe, struct task_struct* task, u32 index, u64 delta) {
+// fentry/kprobe twins share this handler; only the attach mechanism differs.
+// fentry is the cheaper dispatch (see
+// docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md) but needs BTF, so the
+// kprobe twin is the CO-RE-only fallback and one is disabled at load time on
+// kernel_has_btf() (see disabled_programs/required_programs in mod.rs). Only
+// `task` is used -- the kernel bumps task->utime/stime before calling
+// cpuacct_account_field, so we read those rather than the passed index/delta.
+static __always_inline int handle_cpuacct_account_field(struct task_struct* task) {
     u32 cpu, idx;
     u64 curr_utime, curr_stime;
     u64 *last_utime, *last_stime;
@@ -373,6 +379,16 @@ int BPF_KPROBE(cpuacct_account_field_kprobe, struct task_struct* task, u32 index
     }
 
     return 0;
+}
+
+SEC("fentry/cpuacct_account_field")
+int BPF_PROG(cpuacct_account_field_fentry, struct task_struct* task, u32 index, u64 delta) {
+    return handle_cpuacct_account_field(task);
+}
+
+SEC("kprobe/cpuacct_account_field")
+int BPF_KPROBE(cpuacct_account_field_kprobe, struct task_struct* task, u32 index, u64 delta) {
+    return handle_cpuacct_account_field(task);
 }
 
 static __always_inline int account__sched_process_exit(u64* ctx) {

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -174,15 +174,22 @@ fn init(config: Arc<Config>) -> SamplerResult {
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .ringbuf_handler("task_info", handle_task_info)
     .ringbuf_handler("task_exit", handle_task_exit)
+    // BTF present: use the fentry twins (cheaper dispatch), disable the
+    // kprobe/raw fallbacks. Without BTF: the reverse. cpuacct_account_field and
+    // sched_process_exit both switch on the same signal.
     .disabled_programs(if kernel_has_btf() {
-        &["handle__sched_process_exit_raw"]
+        &["handle__sched_process_exit_raw", "cpuacct_account_field_kprobe"]
     } else {
-        &["handle__sched_process_exit_btf"]
+        &["handle__sched_process_exit_btf", "cpuacct_account_field_fentry"]
     })
-    // Losing this kprobe (e.g. CONFIG_TICK_CPU_ACCOUNTING kernels) drops the
+    // Losing this probe (e.g. CONFIG_TICK_CPU_ACCOUNTING kernels) drops the
     // entire CPU-time-by-category breakdown; label it so the health reason is
-    // legible.
-    .required_programs(&[("cpuacct_account_field_kprobe", "CPU time by category")])
+    // legible. Require whichever variant is the active one.
+    .required_programs(if kernel_has_btf() {
+        &[("cpuacct_account_field_fentry", "CPU time by category")]
+    } else {
+        &[("cpuacct_account_field_kprobe", "CPU time by category")]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -216,7 +223,11 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} cpuacct_account_field() BPF instruction count: {}",
+            "{NAME} cpuacct_account_field_fentry() BPF instruction count: {}",
+            self.progs.cpuacct_account_field_fentry.insn_cnt()
+        );
+        debug!(
+            "{NAME} cpuacct_account_field_kprobe() BPF instruction count: {}",
             self.progs.cpuacct_account_field_kprobe.insn_cnt()
         );
         debug!(

--- a/src/agent/samplers/cpu/linux/usage/mod.rs
+++ b/src/agent/samplers/cpu/linux/usage/mod.rs
@@ -178,9 +178,15 @@ fn init(config: Arc<Config>) -> SamplerResult {
     // kprobe/raw fallbacks. Without BTF: the reverse. cpuacct_account_field and
     // sched_process_exit both switch on the same signal.
     .disabled_programs(if kernel_has_btf() {
-        &["handle__sched_process_exit_raw", "cpuacct_account_field_kprobe"]
+        &[
+            "handle__sched_process_exit_raw",
+            "cpuacct_account_field_kprobe",
+        ]
     } else {
-        &["handle__sched_process_exit_btf", "cpuacct_account_field_fentry"]
+        &[
+            "handle__sched_process_exit_btf",
+            "cpuacct_account_field_fentry",
+        ]
     })
     // Losing this probe (e.g. CONFIG_TICK_CPU_ACCOUNTING kernels) drops the
     // entire CPU-time-by-category breakdown; label it so the health reason is


### PR DESCRIPTION
## Summary

Second step of the fentry migration (backlog: *Agent — fentry migration for hot kprobe samplers*), one sampler per PR. `cpu_usage` hooks `cpuacct_account_field` with a kprobe — **per-task-per-tick, one of the hottest hooks in the tree**. Measured dispatch is ~56% cheaper with fentry than a fresh kprobe on a modern `KPROBES_ON_FTRACE` kernel (`docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md`), and the hook is **exclusively owned** by `cpu_usage` (the cross-sampler hook map shows no other sampler touches it), so the standalone win applies with no shared-ftrace penalty.

## Change

- Extract the ~140-line handler into `handle_cpuacct_account_field(task)` shared by both twins. The passed `index`/`delta` were already unused — the kernel bumps `task->utime/stime` before the call, so the handler reads those.
- Add an **fentry twin**; `disabled_programs` picks fentry when BTF is present and the kprobe (CO-RE fallback) otherwise, folded into the existing `sched_process_exit` btf/raw switch.
- **`required_programs` made conditional.** It previously pinned `cpuacct_account_field_kprobe` by name as a health signal — which would fail on a BTF kernel where that variant is disabled. It now names whichever variant is active.
- No metric or output change.

## Validated on Linux (delta, kernel 6.12, BTF present)

- **fentry selected, kprobe disabled**: agent log shows `cpuacct_account_field_fentry() BPF instruction count: 760`; `bpftool prog show` confirms the agent's `cpuacct_account_field_fentry` (production's kprobe-based agent coexists untouched).
- **Sampler healthy** (`1 healthy, 0 failed`) with the required-program label satisfied; `cpu_usage` user/system counters populate under load.

## Test plan

- [x] Both BPF targets compile against the checked-in `vmlinux.h`
- [x] macOS build / `cargo test` (684) / `cargo clippy` clean
- [x] Linux: fentry twin loads on a BTF kernel (kprobe disabled), required-program label intact, metrics populate
- [ ] Follow-on: remaining kprobe samplers, one per PR (tcp_receive next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
