### PR TITLE
feat(viewer): Save-as-Report emits a trimmed .rez (server)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -76,13 +76,26 @@ Source: [retire the `.parquet.ab.tar` container](journal/2026-08-27-retire-ab-ta
   `annotate <file>.rez --event/--add-events/--clear-events` embeds events, and
   both viewer backends read them — the server's `init_file_mode_rez` fills
   `state.selection` from the anchor and events ride `file_metadata`; the WASM
-  `Viewer` already read both from `file_metadata`, so it needed no change.
-  Remaining: a Save-as-Report path that emits a `.rez` (writes `KEY_SELECTION`
-  into the manifest), which is the write half and depends on column trim.
-- **Column-level trim for `.rez`** — Open. `filter` drops whole tables by sampler;
-  Save-as-Report needs per-column projection, which means decode → project →
-  re-encode segments. The one item that breaks the verbatim-BLOB-copy property
-  `rez_v3_rewrite` has held since #1073 — write it knowing that.
+  `Viewer` already read both from `file_metadata`, so it needed no change. The
+  Save-as-Report *writer* now emits a `.rez` on the SERVER (see below).
+- **Column-level trim for `.rez`** — DONE. `rez_v3_rewrite::project_segment_columns`
+  decodes → projects → re-encodes a segment (`rez::segment_writer_props()`,
+  reusing the segment's `SegmentMeta` since a projection changes neither rows
+  nor windows); `CopySpec.keep_metrics` threads it through the single copy path.
+  Exposed as `filter <file>.rez --metrics a,b,c` (composes with `--samplers`),
+  with an empty-archive guard. The one operation that breaks the
+  verbatim-BLOB-copy property, as flagged.
+- **Save-as-Report emits a `.rez` (server)** — DONE for the server; WASM is a
+  follow-up. `save_with_selection` detects a `.rez` source and builds a trimmed
+  `.rez` (`report_save_rez::build_rez_report`): it trims to the union of every
+  attached capture's queried columns, embeds `KEY_SELECTION`/`KEY_EVENTS` and
+  stamps `KEY_REPORT=trimmed` on the anchor manifest, and `init_file_mode_rez`
+  reads that marker back so the report reloads as a report. **WASM follow-up:**
+  the browser viewer cannot build a `.rez` — the trim/assembly path is under
+  `rez`'s `write` feature (it pulls `metriken`, no wasm32), so the WASM
+  Save-as-Report still can't target `.rez`. Closing that needs a metriken-free,
+  reader-available trim+assemble path (the WAL-tail materialization is the one
+  piece that currently needs `metriken`).
 - **Windowless `.rez` tables (non-rezolus sides)** — Open. Ingest is close (the
   recorder already converts Prometheus scrapes to Snapshots; `demote_from_rez`
   documents the refusal as policy, `src/recorder/mod.rs:744-760`). The reader must

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -811,6 +811,61 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
         let experiment_path = state.resolve_experiment_parquet_path();
         let experiment_data = state.captures.get(CaptureId::Experiment);
 
+        // `.rez` source: save a trimmed `.rez` report (single recording or a
+        // 2-recording A/B stay one archive), NOT a parquet or a
+        // `.parquet.ab.tar`. Server-only — the browser viewer can't run the
+        // write-gated trim path yet. This must come before the compare/single
+        // branches below, which assume a parquet source and would fail trying
+        // to reparse the SQLite container as parquet.
+        if crate::recorder::rez::detect_rez_format(&path)
+            .map(|f| f != crate::recorder::rez::RezFormat::NotRez)
+            .unwrap_or(false)
+        {
+            // Union the kept columns across every attached capture — the anchor
+            // as baseline, the rest as experiment — so a 2-recording A/B keeps
+            // both sides' queried metrics. A slightly looser set than a
+            // per-recording trim, but never lossy.
+            let keep: Option<std::collections::BTreeSet<String>> = if trim_columns {
+                let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+                for (i, id) in state.captures.capture_ids().into_iter().enumerate() {
+                    if let Some(source) = state.captures.get_by_id(&id) {
+                        let side = if i == 0 {
+                            ::report_save::Side::Baseline
+                        } else {
+                            ::report_save::Side::Experiment
+                        };
+                        set.extend(::report_save::resolve_kept_columns(
+                            &payload,
+                            source.as_ref(),
+                            side,
+                        ));
+                    }
+                }
+                Some(set)
+            } else {
+                None
+            };
+            let events_json = if payload.events.is_empty() {
+                None
+            } else {
+                serde_json::to_string(&serde_json::json!({ "events": &payload.events })).ok()
+            };
+            let result = tokio::task::spawn_blocking({
+                let source = path.clone();
+                let body = selection_json.clone();
+                move || {
+                    super::report_save_rez::build_rez_report(
+                        &source,
+                        keep.as_ref(),
+                        &body,
+                        events_json.as_deref(),
+                    )
+                }
+            })
+            .await;
+            return finalize_rez_report(result);
+        }
+
         // Compare mode: experiment attached -> tarball with manifest
         // (loaded or synthesized from per-slot runtime state).
         if let (Some(experiment_path), Some(experiment_data)) = (experiment_path, experiment_data) {
@@ -909,6 +964,13 @@ fn finalize_report_attachment_tarball(
     result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
 ) -> Response {
     finalize_attachment(result, "rezolus-report.parquet.ab.tar", tar_attachment)
+}
+
+fn finalize_rez_report(
+    result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
+) -> Response {
+    // A `.rez` is an opaque binary blob, same content-type as the parquet path.
+    finalize_attachment(result, "rezolus-report.rez", parquet_attachment)
 }
 
 /// Convert a `spawn_blocking` outcome into a download Response, logging

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -40,6 +40,7 @@ mod ab_extract;
 mod actions;
 mod metadata;
 mod report_save;
+mod report_save_rez;
 mod routes;
 mod state;
 mod tui;
@@ -858,6 +859,7 @@ fn init_file_mode_rez(
     // reads it per-capture from `file_metadata`; the server keeps one global
     // slot, so the anchor is the one that fills it.
     let b_selection = b_reader.metadata_get(crate::parquet_metadata::KEY_SELECTION);
+    let b_report_marker = b_reader.metadata_get(crate::parquet_metadata::KEY_REPORT);
     // A CLI --baseline-alias still wins over the label-derived one.
     let b_alias = config
         .baseline_alias
@@ -871,6 +873,11 @@ fn init_file_mode_rez(
     );
     *state.parquet_path.write() = Some(path.to_path_buf());
     *state.selection.write() = b_selection;
+    // A `.rez` report stamps `KEY_REPORT=trimmed` on its anchor recording, the
+    // manifest analogue of the parquet footer marker read on the parquet path.
+    // Without this a reloaded `.rez` report would render its (mostly trimmed)
+    // sections instead of going straight to the saved Report view.
+    *state.trimmed_report_marker.write() = b_report_marker;
     state.captures.set_baseline_systeminfo(b_systeminfo);
     state.captures.set_baseline_file_metadata(b_file_meta);
     state.captures.set_baseline_alias(Some(b_alias));
@@ -1317,6 +1324,10 @@ mod tests {
                 crate::parquet_metadata::KEY_EVENTS.to_string(),
                 r#"{"events":[{"timestamp":1000000000,"description":"rollout"}]}"#.to_string(),
             );
+            md.insert(
+                crate::parquet_metadata::KEY_REPORT.to_string(),
+                crate::parquet_metadata::REPORT_VALUE_TRIMMED.to_string(),
+            );
             db.update_recording_metadata(recs[0].id, &md).unwrap();
         }
 
@@ -1334,6 +1345,13 @@ mod tests {
                 .as_deref()
                 .is_some_and(|s| s.contains("cpu_usage")),
             "the baseline recording's selection must fill state.selection"
+        );
+
+        // The report marker on the anchor makes the archive load as a report —
+        // the round trip a `.rez` Save-as-Report depends on.
+        assert!(
+            state.is_trimmed_report(),
+            "KEY_REPORT on the anchor manifest must set the trimmed-report marker"
         );
 
         // Events ride the baseline's file_metadata blob, parsed as JSON.

--- a/src/viewer/report_save_rez.rs
+++ b/src/viewer/report_save_rez.rs
@@ -1,0 +1,183 @@
+//! Save-as-Report for a `.rez` source — the server-side writer.
+//!
+//! A loaded `.rez` (single recording, or a 2-recording A/B) saves to a
+//! trimmed `.rez` rather than a parquet or a `.parquet.ab.tar`: the report is
+//! the same container as the source, which is the point of retiring the
+//! tarball. It reuses the `rez_v3_rewrite` column-trim primitive
+//! (`CopySpec::keep_metrics`) and embeds the selection/events/report marker
+//! into the anchor recording's manifest, the same catalog-`UPDATE` shape
+//! `annotate` established.
+//!
+//! **Server-only.** The trim machinery lives under `rez`'s `write` feature
+//! (it pulls `metriken`, which has no wasm32 build), so the browser viewer
+//! cannot produce a `.rez` report yet — tracked as a follow-up. Everything
+//! here therefore lives in the binary, not in the wasm-safe `report-save`
+//! crate.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::parquet_metadata::{KEY_EVENTS, KEY_REPORT, KEY_SELECTION, REPORT_VALUE_TRIMMED};
+
+/// Build a `.rez` report from `source_path`.
+///
+/// When `keep_metrics` is `Some`, each table's segments are re-encoded down to
+/// those metric columns (plus the structural timestamp/window sidecars) and a
+/// table left with none of them is dropped — this is the trimmed report, and
+/// it stamps `KEY_REPORT=trimmed` so the loader knows to open it straight to
+/// the Report view. When `None`, the archive is copied whole (BLOBs verbatim)
+/// and only the selection is embedded — the untrimmed "save selection" case,
+/// which carries no report marker, exactly as the parquet path behaves.
+///
+/// `selection_json` and `events_json` are written into the ANCHOR recording's
+/// manifest (recordings are numbered in catalog order, so the first is the
+/// anchor the viewer maps onto the baseline slot). Returns the archive bytes.
+pub fn build_rez_report(
+    source_path: &Path,
+    keep_metrics: Option<&BTreeSet<String>>,
+    selection_json: &str,
+    events_json: Option<&str>,
+) -> Result<Vec<u8>, String> {
+    use crate::recorder::rez_sqlite::RezDb;
+    use crate::recorder::rez_v3_rewrite::{copy_recordings_into, CopySpec};
+
+    let src = RezDb::open(source_path)?;
+
+    // Staged in a temp dir; the whole file is read back into memory to stream
+    // as a download attachment, so it never needs a durable path.
+    let staging = tempfile::tempdir().map_err(|e| format!("failed to stage a report: {e}"))?;
+    let staged = staging.path().join("report.rez");
+
+    let mut dst = RezDb::create(&staged)?;
+    dst.transaction(|tx| {
+        src.read_snapshot(|src| {
+            let spec = CopySpec {
+                keep_metrics,
+                ..CopySpec::everything()
+            };
+            copy_recordings_into(src, tx, &spec)?;
+            Ok(())
+        })
+    })?;
+
+    // Embed selection / events / report marker into the anchor recording. The
+    // copy is a catalog write; this is one more `UPDATE` on top of it.
+    let recordings = dst.read_recordings()?;
+    let anchor = recordings.first().ok_or_else(|| {
+        "report has no recordings — the source archive was empty or fully trimmed away".to_string()
+    })?;
+    let mut metadata = anchor.meta.metadata.clone();
+    metadata.insert(KEY_SELECTION.to_string(), selection_json.to_string());
+    if keep_metrics.is_some() {
+        metadata.insert(KEY_REPORT.to_string(), REPORT_VALUE_TRIMMED.to_string());
+    }
+    if let Some(events) = events_json {
+        metadata.insert(KEY_EVENTS.to_string(), events.to_string());
+    } else {
+        // A save carrying no events must not leave a stale payload behind.
+        metadata.remove(KEY_EVENTS);
+    }
+    dst.update_recording_metadata(anchor.id, &metadata)?;
+
+    drop(dst);
+    drop(src);
+
+    std::fs::read(&staged).map_err(|e| format!("failed to read back the report: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recorder::rez::recorder_tests_support::populated_v3_rez;
+    use crate::recorder::rez_sqlite::RezDb;
+    use std::collections::BTreeSet;
+
+    /// A trimmed `.rez` report embeds the selection and stamps the report
+    /// marker on the anchor, and drops tables holding none of the kept metrics
+    /// (this fixture names each sampler's single metric by its index).
+    #[test]
+    fn trimmed_report_embeds_selection_marker_and_drops_unkept_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.rez");
+        populated_v3_rez(&src, "baseline", &["cpu_usage", "scheduler"], 6);
+
+        let keep: BTreeSet<String> = ["0".to_string()].into_iter().collect();
+        let bytes = build_rez_report(&src, Some(&keep), r#"{"entries":[]}"#, None).unwrap();
+
+        let out = dir.path().join("report.rez");
+        std::fs::write(&out, &bytes).unwrap();
+        let db = RezDb::open(&out).unwrap();
+        let recs = db.read_recordings().unwrap();
+        assert_eq!(recs.len(), 1);
+        let md = &recs[0].meta.metadata;
+        assert_eq!(
+            md.get(KEY_SELECTION).map(String::as_str),
+            Some(r#"{"entries":[]}"#)
+        );
+        assert_eq!(
+            md.get(KEY_REPORT).map(String::as_str),
+            Some(REPORT_VALUE_TRIMMED)
+        );
+        assert_eq!(
+            db.all_samplers(recs[0].id).unwrap(),
+            vec!["cpu_usage".to_string()],
+            "only the table holding kept metric \"0\" survives"
+        );
+    }
+
+    /// An untrimmed save (keep_metrics = None) embeds the selection but carries
+    /// no report marker and copies every table — matching the parquet path,
+    /// where only a trim stamps `KEY_REPORT`.
+    #[test]
+    fn untrimmed_report_embeds_selection_without_report_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.rez");
+        populated_v3_rez(&src, "baseline", &["cpu_usage", "scheduler"], 6);
+
+        let bytes = build_rez_report(&src, None, r#"{"entries":[]}"#, None).unwrap();
+        let out = dir.path().join("report.rez");
+        std::fs::write(&out, &bytes).unwrap();
+        let db = RezDb::open(&out).unwrap();
+        let recs = db.read_recordings().unwrap();
+        let md = &recs[0].meta.metadata;
+        assert!(md.contains_key(KEY_SELECTION), "selection embedded");
+        assert!(
+            !md.contains_key(KEY_REPORT),
+            "an untrimmed save carries no report marker"
+        );
+        assert_eq!(
+            db.all_samplers(recs[0].id).unwrap().len(),
+            2,
+            "every table is copied"
+        );
+    }
+
+    /// A save whose payload has no events must clear any events the source
+    /// carried, the same way the parquet footer path (`embed_selection`) does.
+    #[test]
+    fn a_save_with_no_events_clears_a_stale_events_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.rez");
+        populated_v3_rez(&src, "baseline", &["cpu_usage"], 4);
+        {
+            let db = RezDb::open(&src).unwrap();
+            let recs = db.read_recordings().unwrap();
+            let mut md = recs[0].meta.metadata.clone();
+            md.insert(
+                KEY_EVENTS.to_string(),
+                r#"{"events":[{"timestamp":1,"description":"x"}]}"#.to_string(),
+            );
+            db.update_recording_metadata(recs[0].id, &md).unwrap();
+        }
+
+        let bytes = build_rez_report(&src, None, "{}", None).unwrap();
+        let out = dir.path().join("report.rez");
+        std::fs::write(&out, &bytes).unwrap();
+        let db = RezDb::open(&out).unwrap();
+        let md = &db.read_recordings().unwrap()[0].meta.metadata;
+        assert!(
+            !md.contains_key(KEY_EVENTS),
+            "a save with no events drops the stale key"
+        );
+    }
+}


### PR DESCRIPTION
The payoff step of retiring `.parquet.ab.tar`: when the loaded source is a
`.rez`, **Save-as-Report now produces a trimmed `.rez`** — a single recording
or a 2-recording A/B stays one archive — instead of a parquet or a
`.parquet.ab.tar`. Before this, saving a `.rez` was broken outright (the save
path reparsed the SQLite container as parquet and failed).

## Writer
`report_save_rez::build_rez_report` (binary-only, where `rez`'s `write` feature
lives) trims the source with the `CopySpec.keep_metrics` primitive from the
column-trim PR (#1160), then embeds `KEY_SELECTION`/`KEY_EVENTS` and stamps
`KEY_REPORT=trimmed` onto the **anchor** recording's manifest via the #1073
`UPDATE` shape. The kept-column set is the **union** of every attached
capture's queried columns (anchor as baseline, the rest as experiment) —
slightly looser than a per-recording trim, but never lossy.
`save_with_selection` detects a `.rez` source and dispatches before the parquet
compare/single branches.

## Read side
`init_file_mode_rez` now reads `KEY_REPORT` off the anchor manifest into
`state.trimmed_report_marker`, so a reloaded `.rez` report opens straight to the
Report view — the round trip the writer depends on. (Selection was already read
back in #1157.)

## Scope — SERVER ONLY (deliberate)
The trim+assemble path is under `rez`'s `write` feature, which pulls `metriken`
(no wasm32 build), so the **browser viewer can't build a `.rez` yet**. This was
a deliberate call (server-first); the WASM Save-as-Report is a tracked
follow-up needing a metriken-free, reader-available trim path (the WAL-tail
materialization is the one piece that currently needs `metriken`). The WASM
save is no more broken than before — it also couldn't target `.rez`.

## Tests
- `build_rez_report`: embeds selection + report marker and drops tables with no
  kept metric (trimmed); carries no marker and copies every table (untrimmed);
  clears a stale events key when the payload has none.
- `init_file_mode_rez` sets the trimmed-report marker from the anchor manifest
  (the reload round trip), alongside the existing selection/events assertions.
- fmt + clippy clean; all 108 viewer bin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)