### PR TITLE
perf(tcp): fentry twin for tcp_receive's tcp_rcv_established hook

### DIFF
--- a/src/agent/samplers/tcp/linux/receive/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/receive/mod.bpf.c
@@ -35,8 +35,12 @@ struct {
     __uint(max_entries, HISTOGRAM_BUCKETS);
 } srtt SEC(".maps");
 
-SEC("kprobe/tcp_rcv_established")
-int BPF_KPROBE(tcp_rcv_kprobe, struct sock* sk) {
+// fentry/kprobe twins share this handler; only the attach mechanism differs.
+// fentry is the cheaper dispatch (see
+// docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md) but needs BTF, so the
+// kprobe twin is the CO-RE-only fallback and one is disabled at load time on
+// kernel_has_btf() (see disabled_programs in mod.rs).
+static __always_inline int handle_tcp_rcv_established(struct sock* sk) {
     struct tcp_sock* ts;
     u32 mdev_us, srtt_us;
     u64 mdev_ns, srtt_ns;
@@ -58,6 +62,16 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock* sk) {
     histogram_incr(&jitter, HISTOGRAM_POWER, mdev_ns);
 
     return 0;
+}
+
+SEC("fentry/tcp_rcv_established")
+int BPF_PROG(tcp_rcv_fentry, struct sock* sk) {
+    return handle_tcp_rcv_established(sk);
+}
+
+SEC("kprobe/tcp_rcv_established")
+int BPF_KPROBE(tcp_rcv_kprobe, struct sock* sk) {
+    return handle_tcp_rcv_established(sk);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/tcp/linux/receive/mod.rs
+++ b/src/agent/samplers/tcp/linux/receive/mod.rs
@@ -1,5 +1,5 @@
 //! Collects TCP Receive stats using BPF and traces:
-//! * `tcp_rcv_established`
+//! * `tcp_rcv_established` (fentry when the kernel has BTF, else kprobe)
 //!
 //! And produces these stats:
 //! * `tcp/receive/jitter`
@@ -36,6 +36,12 @@ fn init(config: Arc<Config>) -> SamplerResult {
     )
     .histogram("srtt", &TCP_SRTT, &SRTT_ACQ)
     .histogram("jitter", &TCP_JITTER, &JITTER_ACQ)
+    // Prefer fentry (cheaper dispatch); fall back to kprobe without BTF.
+    .disabled_programs(if kernel_has_btf() {
+        &["tcp_rcv_kprobe"]
+    } else {
+        &["tcp_rcv_fentry"]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -61,8 +67,8 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} tcp_rcv() BPF instruction count: {}",
-            self.progs.tcp_rcv_kprobe.insn_cnt()
+            "{NAME} tcp_rcv_established_fentry() BPF instruction count: {}",
+            self.progs.tcp_rcv_fentry.insn_cnt()
         );
     }
 }


### PR DESCRIPTION
## Summary

Third step of the fentry migration (one sampler per PR). `tcp_receive` hooks `tcp_rcv_established` with a kprobe — **per-packet on established connections**, a hot hook. Measured dispatch ~56% cheaper with fentry than a fresh kprobe on a modern `KPROBES_ON_FTRACE` kernel (`docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md`); the hook is exclusively owned by `tcp_receive`, so no shared-ftrace penalty.

## Change

- Extract the handler into `handle_tcp_rcv_established(sk)` shared by both twins.
- Add an **fentry twin**; `disabled_programs` picks fentry when BTF is present, kprobe (CO-RE fallback) otherwise. No metric or output change.

## Validated on Linux (delta, kernel 6.12, BTF present)

- **fentry selected, kprobe disabled**: `tcp_rcv_established_fentry() BPF instruction count: 205`; `bpftool prog show` confirms the agent's `tcp_rcv_fentry` (production's kprobe-based agent coexists).
- **Sampler healthy**; `tcp_srtt` and `tcp_jitter` histograms populate (~3.6M samples each) under established-connection traffic.

## Test plan

- [x] Both BPF targets compile against the checked-in `vmlinux.h`
- [x] macOS build / `cargo test` (684) / `cargo clippy` clean
- [x] Linux: fentry twin loads (kprobe disabled), metrics populate
- [ ] Follow-on: remaining kprobe samplers, one per PR (cpu_tlb_flush next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
