### PR TITLE
perf(tcp): fentry twins for tcp_connect_latency's connect hooks

### DIFF
--- a/src/agent/samplers/tcp/linux/connect_latency/mod.bpf.c
+++ b/src/agent/samplers/tcp/linux/connect_latency/mod.bpf.c
@@ -81,18 +81,39 @@ cleanup:
     return 0;
 }
 
+// fentry/kprobe twins share trace_connect()/handle_tcp_rcv_state_process(); only
+// the attach mechanism differs. fentry is the cheaper dispatch (see
+// docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md) but needs BTF, so the
+// kprobe twins are the CO-RE-only fallback and one set is disabled at load time
+// on kernel_has_btf() (see disabled_programs in mod.rs).
+
+SEC("fentry/tcp_v4_connect")
+int BPF_PROG(tcp_v4_connect_fentry, struct sock* sk) {
+    return trace_connect(sk);
+}
+
 SEC("kprobe/tcp_v4_connect")
-int BPF_KPROBE(tcp_v4_connect, struct sock* sk) {
+int BPF_KPROBE(tcp_v4_connect_kprobe, struct sock* sk) {
+    return trace_connect(sk);
+}
+
+SEC("fentry/tcp_v6_connect")
+int BPF_PROG(tcp_v6_connect_fentry, struct sock* sk) {
     return trace_connect(sk);
 }
 
 SEC("kprobe/tcp_v6_connect")
-int BPF_KPROBE(tcp_v6_connect, struct sock* sk) {
+int BPF_KPROBE(tcp_v6_connect_kprobe, struct sock* sk) {
     return trace_connect(sk);
 }
 
+SEC("fentry/tcp_rcv_state_process")
+int BPF_PROG(tcp_rcv_state_process_fentry, struct sock* sk) {
+    return handle_tcp_rcv_state_process(ctx, sk);
+}
+
 SEC("kprobe/tcp_rcv_state_process")
-int BPF_KPROBE(tcp_rcv_state_process, struct sock* sk) {
+int BPF_KPROBE(tcp_rcv_state_process_kprobe, struct sock* sk) {
     return handle_tcp_rcv_state_process(ctx, sk);
 }
 

--- a/src/agent/samplers/tcp/linux/connect_latency/mod.rs
+++ b/src/agent/samplers/tcp/linux/connect_latency/mod.rs
@@ -1,7 +1,6 @@
 //! Collects TCP packet latency stats using BPF and traces:
-//! * `tcp_v4_connect`
-//! * `tcp_v6_connect`
-//! * `tcp_rcv_state_process`
+//! * `tcp_v4_connect`, `tcp_v6_connect`, `tcp_rcv_state_process`
+//!   (fentry when the kernel has BTF, else kprobe)
 //! * `tcp_destroy_sock`
 //!
 //! And produces these stats:
@@ -37,6 +36,20 @@ fn init(config: Arc<Config>) -> SamplerResult {
         ModSkelBuilder::default,
     )
     .histogram("latency", &TCP_CONNECT_LATENCY, &LATENCY_ACQ)
+    // Prefer fentry (cheaper dispatch); fall back to kprobe without BTF.
+    .disabled_programs(if kernel_has_btf() {
+        &[
+            "tcp_v4_connect_kprobe",
+            "tcp_v6_connect_kprobe",
+            "tcp_rcv_state_process_kprobe",
+        ]
+    } else {
+        &[
+            "tcp_v4_connect_fentry",
+            "tcp_v6_connect_fentry",
+            "tcp_rcv_state_process_fentry",
+        ]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -61,12 +74,12 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} tcp_v4_connect() BPF instruction count: {}",
-            self.progs.tcp_v4_connect.insn_cnt()
+            "{NAME} tcp_v4_connect_fentry() BPF instruction count: {}",
+            self.progs.tcp_v4_connect_fentry.insn_cnt()
         );
         debug!(
-            "{NAME} tcp_rcv_state_process() BPF instruction count: {}",
-            self.progs.tcp_rcv_state_process.insn_cnt()
+            "{NAME} tcp_rcv_state_process_fentry() BPF instruction count: {}",
+            self.progs.tcp_rcv_state_process_fentry.insn_cnt()
         );
     }
 }


### PR DESCRIPTION
## Summary

Next step of the fentry migration (one sampler per PR). `tcp_connect_latency` hooks `tcp_v4_connect`, `tcp_v6_connect`, and `tcp_rcv_state_process` with kprobes (connection setup — moderate rate). Measured dispatch ~56% cheaper with fentry than a fresh kprobe on a modern `KPROBES_ON_FTRACE` kernel (`docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md`); all three hooks are exclusively owned by this sampler — no shared-ftrace penalty.

## Change

The three kprobes are already thin wrappers over `trace_connect()` / `handle_tcp_rcv_state_process()`; add **fentry twins** sharing them. `disabled_programs` picks the fentry set when BTF is present, the kprobe set (CO-RE fallback) otherwise. No metric or output change.

## Note on the skipped `cpu_tlb_flush`

Between `tcp_receive` and this one, `cpu_tlb_flush` was next on rate — but its `tlb_finish_mmu` kprobe is **aarch64-only** (x86 uses the `tlb_flush` raw_tp tracepoint for the reason breakdown). An fentry twin there would only affect ARM64, which none of the available x86 test hosts can validate, and the 56% figure is x86-measured. Deferred pending an ARM64 host (tracked in backlog alongside `network_interfaces`).

## Test plan

- [x] Both BPF targets compile against the checked-in `vmlinux.h` (6 programs)
- [x] macOS build / `cargo test` (687) / `cargo clippy` clean
- [ ] Linux: fentry twins load on a BTF kernel (kprobe disabled), connect-latency histogram populates (validating on delta now)
- [ ] Follow-on: `cpu_bandwidth`, `tcp_retransmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
