### PR TITLE
fix(cpu)!: correct cpu_bandwidth quota/period, add fentry twins

### DIFF
--- a/src/agent/bpf/builder.rs
+++ b/src/agent/bpf/builder.rs
@@ -593,14 +593,37 @@ where
             // (leaving all others at their default). Used to drop the unused
             // tp_btf/raw_tp variant based on in-kernel BTF availability.
             if let Some(ref disabled) = self.disabled_programs {
+                let mut matched: HashSet<String> = HashSet::new();
+
                 for mut prog in open_skel.open_object_mut().progs_mut() {
-                    let prog_name = prog.name().to_string_lossy();
-                    if disabled.contains(prog_name.as_ref()) {
+                    let prog_name = prog.name().to_string_lossy().to_string();
+                    if disabled.contains(prog_name.as_str()) {
                         debug!(
                             "{} disabling autoload for program: {}",
                             self.name, prog_name
                         );
                         prog.set_autoload(false);
+                        matched.insert(prog_name);
+                    }
+                }
+
+                // Guard against typos, the same way declared probe intents and
+                // labels are guarded below — but the consequence here is worse
+                // than a no-op override. A name matching no program leaves BOTH
+                // twins of that hook autoloaded, and two attached twins each run
+                // the shared handler: every `array_add` in it is applied twice,
+                // silently doubling the counter. Debug-only; names are
+                // stringly-typed.
+                #[cfg(debug_assertions)]
+                {
+                    for declared in disabled.iter() {
+                        debug_assert!(
+                            matched.contains(*declared),
+                            "{}: disabled_programs names '{}', which is not a program in this \
+                             skeleton — its twin would stay autoloaded and double-count",
+                            self.name,
+                            declared,
+                        );
                     }
                 }
             }

--- a/src/agent/bpf/mod.rs
+++ b/src/agent/bpf/mod.rs
@@ -24,6 +24,52 @@ pub fn kernel_has_btf() -> bool {
     *HAS_BTF.get_or_init(|| Path::new("/sys/kernel/btf/vmlinux").exists())
 }
 
+/// Returns true if the running kernel's BTF describes every one of `names` as a
+/// function — i.e. an `fentry`/`fexit` program may name it as an attach target.
+///
+/// [`kernel_has_btf`] answers a different, weaker question: "is there a vmlinux
+/// BTF at all". A trampoline program additionally needs ITS OWN target in that
+/// BTF, and libbpf resolves `attach_btf_id` at LOAD time — so a missing target
+/// is a load failure, which [`BpfBuilder`] treats as fatal for the whole
+/// skeleton (`set_failed`, and `rezolus status` then exits non-zero). A kprobe's
+/// equivalent miss is an ENOENT at ATTACH, which is tolerated and reported as
+/// unsupported.
+///
+/// That difference matters for any hook sitting behind a kernel config option:
+/// `cpu_bandwidth`'s three targets are all inside `CONFIG_CFS_BANDWIDTH`, so
+/// choosing its trampoline twins on `kernel_has_btf()` alone would turn "this
+/// kernel does not implement CFS bandwidth control" into a failed sampler.
+/// Selecting on this function instead falls back to the kprobe twins, which miss
+/// gracefully.
+///
+/// Not cached: callers ask once, at sampler init, and each call parses vmlinux
+/// BTF. Returns false when there is no kernel BTF to consult.
+pub fn kernel_btf_has_funcs(names: &[&str]) -> bool {
+    if !kernel_has_btf() {
+        return false;
+    }
+
+    let Ok(btf) = libbpf_rs::btf::Btf::from_vmlinux() else {
+        return false;
+    };
+
+    // Every name is checked, not just up to the first miss: when a sampler is
+    // about to fall back, the useful debug output names all of what is absent.
+    let mut all = true;
+
+    for name in names {
+        if btf
+            .type_by_name::<libbpf_rs::btf::types::Func<'_>>(name)
+            .is_none()
+        {
+            debug!("kernel BTF has no function `{name}`");
+            all = false;
+        }
+    }
+
+    all
+}
+
 pub trait OpenSkelExt {
     /// When called, the SkelBuilder should log instruction counts for each of
     /// the programs within the skeleton. Log level should be debug.

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
@@ -103,12 +103,15 @@ struct {
     __uint(max_entries, MAX_CGROUPS);
 } bandwidth_throttled_time SEC(".maps");
 
-SEC("kprobe/tg_set_cfs_bandwidth")
-int tg_set_cfs_bandwidth(struct pt_regs* ctx) {
-    struct task_group* tg = (struct task_group*)PT_REGS_PARM1(ctx);
-    struct cfs_bandwidth* cfs_b = (struct cfs_bandwidth*)PT_REGS_PARM2(ctx);
+// fentry/kprobe twins share these handlers; only the attach mechanism differs.
+// fentry is the cheaper dispatch (see
+// docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md) but needs BTF, so the
+// kprobe twins are the CO-RE-only fallback and one set is disabled at load time
+// on kernel_has_btf() (see disabled_programs in mod.rs).
 
-    if (!tg || !cfs_b)
+static __always_inline int handle_tg_set_cfs_bandwidth(struct task_group* tg, u64 period,
+                                                       u64 quota) {
+    if (!tg)
         return 0;
 
     // get the cgroup id and serial number
@@ -137,17 +140,20 @@ int tg_set_cfs_bandwidth(struct pt_regs* ctx) {
         bpf_ringbuf_reserve(&bandwidth_info, sizeof(struct bandwidth_info), 0);
     if (bw_info) {
         bw_info->id = cgroup_id;
-        bw_info->quota = BPF_CORE_READ(cfs_b, quota);
-        bw_info->period = BPF_CORE_READ(cfs_b, period);
+        // period/quota come straight from the args. The kernel signature is
+        // tg_set_cfs_bandwidth(tg, period, quota, burst); the old code cast
+        // arg1 (the period) to a pointer and dereferenced it, reading 0
+        // (issue #1166). fentry receives these typed; the kprobe reads
+        // PARM2/PARM3.
+        bw_info->quota = quota;
+        bw_info->period = period;
         bpf_ringbuf_submit(bw_info, 0);
     }
 
     return 0;
 }
 
-SEC("kprobe/throttle_cfs_rq")
-int throttle_cfs_rq(struct pt_regs* ctx) {
-    struct cfs_rq* cfs_rq = (struct cfs_rq*)PT_REGS_PARM1(ctx);
+static __always_inline int handle_throttle_cfs_rq(struct cfs_rq* cfs_rq) {
     int cpu = BPF_CORE_READ(cfs_rq, rq, cpu);
 
     // get the cgroup id and serial number
@@ -191,9 +197,7 @@ int throttle_cfs_rq(struct pt_regs* ctx) {
     return 0;
 }
 
-SEC("kprobe/unthrottle_cfs_rq")
-int unthrottle_cfs_rq(struct pt_regs* ctx) {
-    struct cfs_rq* cfs_rq = (struct cfs_rq*)PT_REGS_PARM1(ctx);
+static __always_inline int handle_unthrottle_cfs_rq(struct cfs_rq* cfs_rq) {
     int cpu = BPF_CORE_READ(cfs_rq, rq, cpu);
 
     // get the cgroup id
@@ -240,6 +244,36 @@ int unthrottle_cfs_rq(struct pt_regs* ctx) {
     bpf_map_update_elem(&throttle_start, &cgroup_runqueue_idx, &zero, BPF_ANY);
 
     return 0;
+}
+
+SEC("fentry/tg_set_cfs_bandwidth")
+int BPF_PROG(tg_set_cfs_bandwidth_fentry, struct task_group* tg, u64 period, u64 quota, u64 burst) {
+    return handle_tg_set_cfs_bandwidth(tg, period, quota);
+}
+
+SEC("kprobe/tg_set_cfs_bandwidth")
+int BPF_KPROBE(tg_set_cfs_bandwidth_kprobe, struct task_group* tg, u64 period, u64 quota) {
+    return handle_tg_set_cfs_bandwidth(tg, period, quota);
+}
+
+SEC("fentry/throttle_cfs_rq")
+int BPF_PROG(throttle_cfs_rq_fentry, struct cfs_rq* cfs_rq) {
+    return handle_throttle_cfs_rq(cfs_rq);
+}
+
+SEC("kprobe/throttle_cfs_rq")
+int BPF_KPROBE(throttle_cfs_rq_kprobe, struct cfs_rq* cfs_rq) {
+    return handle_throttle_cfs_rq(cfs_rq);
+}
+
+SEC("fentry/unthrottle_cfs_rq")
+int BPF_PROG(unthrottle_cfs_rq_fentry, struct cfs_rq* cfs_rq) {
+    return handle_unthrottle_cfs_rq(cfs_rq);
+}
+
+SEC("kprobe/unthrottle_cfs_rq")
+int BPF_KPROBE(unthrottle_cfs_rq_kprobe, struct cfs_rq* cfs_rq) {
+    return handle_unthrottle_cfs_rq(cfs_rq);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.bpf.c
@@ -105,9 +105,10 @@ struct {
 
 // fentry/kprobe twins share these handlers; only the attach mechanism differs.
 // fentry is the cheaper dispatch (see
-// docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md) but needs BTF, so the
-// kprobe twins are the CO-RE-only fallback and one set is disabled at load time
-// on kernel_has_btf() (see disabled_programs in mod.rs).
+// docs/journal/2026-09-04-fentry-vs-kprobe-dispatch.md) but needs the target in
+// the kernel's own BTF -- not merely a kernel that has BTF -- so the kprobe
+// twins are the CO-RE-only fallback and one set is disabled at load time (see
+// disabled_programs in mod.rs).
 
 static __always_inline int handle_tg_set_cfs_bandwidth(struct task_group* tg, u64 period,
                                                        u64 quota) {
@@ -145,6 +146,10 @@ static __always_inline int handle_tg_set_cfs_bandwidth(struct task_group* tg, u6
         // arg1 (the period) to a pointer and dereferenced it, reading 0
         // (issue #1166). fentry receives these typed; the kprobe reads
         // PARM2/PARM3.
+        //
+        // quota is passed through as-is, RUNTIME_INF (u64 ~0) included -- that
+        // is how the kernel spells "no limit", and userspace maps it to a
+        // sentinel rather than to a nanosecond count. See handle_bandwidth_info.
         bw_info->quota = quota;
         bw_info->period = period;
         bpf_ringbuf_submit(bw_info, 0);
@@ -246,6 +251,26 @@ static __always_inline int handle_unthrottle_cfs_rq(struct cfs_rq* cfs_rq) {
     return 0;
 }
 
+// Entry, not exit, and deliberately so.
+//
+// tg_set_cfs_bandwidth VALIDATES what it is handed -- it returns -EINVAL for the
+// root task group, for an out-of-range period or quota, and when the
+// __cfs_schedulable hierarchy check rejects the request. Reading the args at
+// entry therefore records what userspace ASKED for, where an fexit twin could
+// check the return value and record only what was applied.
+//
+// fexit is not usable here. Its return value sits at arg slot `nr_args`, so a
+// program declaring the modern 4-arg signature reads slot 4 -- and `burst` was
+// only added to this function in 5.14 (f4183717b370). On a 3-arg kernel, which
+// includes 5.10 LTS and so a large part of any real fleet, slot 4 is past the
+// end and the verifier rejects the program at LOAD. That is fatal for the whole
+// skeleton, costing the throttling counters too, to avoid recording the rare
+// rejected cpu.max write. Not a trade worth making.
+//
+// The unused `burst` below is safe for the opposite reason: nothing reads it, so
+// clang emits no load for that slot and the verifier never checks it against the
+// target's arity. Naming it keeps the prototype honest against the kernel
+// signature without depending on it.
 SEC("fentry/tg_set_cfs_bandwidth")
 int BPF_PROG(tg_set_cfs_bandwidth_fentry, struct task_group* tg, u64 period, u64 quota, u64 burst) {
     return handle_tg_set_cfs_bandwidth(tg, period, quota);

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.rs
@@ -1,5 +1,5 @@
 //! Collects CPU CFS bandwidth control and throttling stats using BPF and traces:
-//! * `tg_set_cfs_bandwidth`
+//! * `tg_set_cfs_bandwidth` (fentry when the kernel has BTF, else kprobe)
 //! * `throttle_cfs_rq`
 //! * `unthrottle_cfs_rq`
 //!
@@ -101,6 +101,20 @@ fn init(config: Arc<Config>) -> SamplerResult {
     )
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .ringbuf_handler("bandwidth_info", handle_bandwidth_info)
+    // Prefer fentry (cheaper dispatch); fall back to kprobe without BTF.
+    .disabled_programs(if kernel_has_btf() {
+        &[
+            "tg_set_cfs_bandwidth_kprobe",
+            "throttle_cfs_rq_kprobe",
+            "unthrottle_cfs_rq_kprobe",
+        ]
+    } else {
+        &[
+            "tg_set_cfs_bandwidth_fentry",
+            "throttle_cfs_rq_fentry",
+            "unthrottle_cfs_rq_fentry",
+        ]
+    })
     .build()?;
 
     Ok(Some(Box::new(bpf)))
@@ -131,16 +145,16 @@ impl SkelExt for ModSkel<'_> {
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
         debug!(
-            "{NAME} tg_set_cfs_bandwidth() BPF instruction count: {}",
-            self.progs.tg_set_cfs_bandwidth.insn_cnt()
+            "{NAME} tg_set_cfs_bandwidth_fentry() BPF instruction count: {}",
+            self.progs.tg_set_cfs_bandwidth_fentry.insn_cnt()
         );
         debug!(
-            "{NAME} throttle_cfs_rq() BPF instruction count: {}",
-            self.progs.throttle_cfs_rq.insn_cnt()
+            "{NAME} throttle_cfs_rq_fentry() BPF instruction count: {}",
+            self.progs.throttle_cfs_rq_fentry.insn_cnt()
         );
         debug!(
-            "{NAME} unthrottle_cfs_rq() BPF instruction count: {}",
-            self.progs.unthrottle_cfs_rq.insn_cnt()
+            "{NAME} unthrottle_cfs_rq_fentry() BPF instruction count: {}",
+            self.progs.unthrottle_cfs_rq_fentry.insn_cnt()
         );
     }
 }

--- a/src/agent/samplers/cpu/linux/bandwidth/mod.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/mod.rs
@@ -1,7 +1,7 @@
 //! Collects CPU CFS bandwidth control and throttling stats using BPF and traces:
-//! * `tg_set_cfs_bandwidth` (fentry when the kernel has BTF, else kprobe)
-//! * `throttle_cfs_rq`
-//! * `unthrottle_cfs_rq`
+//! * `tg_set_cfs_bandwidth` (fentry when the kernel's BTF has it, else kprobe)
+//! * `throttle_cfs_rq` (fentry when the kernel's BTF has it, else kprobe)
+//! * `unthrottle_cfs_rq` (fentry when the kernel's BTF has it, else kprobe)
 //!
 //! And produces these stats:
 //! * `cgroup_cpu_bandwidth_quota`
@@ -43,6 +43,31 @@ fn handle_cgroup_info(data: &[u8]) -> i32 {
     process_cgroup_info::<bpf::types::cgroup_info>(data, CGROUP_METRICS)
 }
 
+/// The kernel's "no quota" spelling: `RUNTIME_INF`, defined as `(u64)~0ULL`.
+const RUNTIME_INF: u64 = u64::MAX;
+
+/// What `cgroup_cpu_bandwidth_quota` reports for an unquota'd cgroup.
+///
+/// Negative, so it cannot be read as a nanosecond count, and distinct from `0`
+/// — which is what an unwritten gauge slot reads as, and so cannot mean
+/// "unlimited" without colliding with "never observed".
+const QUOTA_UNLIMITED: i64 = -1;
+
+/// Map a raw `tg_set_cfs_bandwidth` quota onto the gauge.
+///
+/// Every cgroup written as `cpu.max = "max <period>"` arrives here as
+/// `RUNTIME_INF`, which is the common case rather than an edge one: that is what
+/// a Kubernetes pod with no CPU limit gets. Left to the plain `as i64` cast it
+/// would land on `-1` anyway, but by accident of two's complement rather than by
+/// decision — so name the sentinel and document it on the metric.
+fn quota_gauge(quota: u64) -> i64 {
+    if quota == RUNTIME_INF {
+        QUOTA_UNLIMITED
+    } else {
+        quota as i64
+    }
+}
+
 fn handle_bandwidth_info(data: &[u8]) -> i32 {
     let mut bandwidth_info = bpf::types::bandwidth_info::default();
 
@@ -52,7 +77,7 @@ fn handle_bandwidth_info(data: &[u8]) -> i32 {
         let period = bandwidth_info.period;
 
         if id < MAX_CGROUPS as u32 {
-            let _ = CGROUP_CPU_BANDWIDTH_QUOTA.set(id as usize, quota as i64);
+            let _ = CGROUP_CPU_BANDWIDTH_QUOTA.set(id as usize, quota_gauge(quota));
             let _ = CGROUP_CPU_BANDWIDTH_PERIOD_DURATION.set(id as usize, period as i64);
         }
     }
@@ -60,9 +85,30 @@ fn handle_bandwidth_info(data: &[u8]) -> i32 {
     0
 }
 
+/// The functions the fentry twins name as attach targets. All three live behind
+/// `CONFIG_CFS_BANDWIDTH`, so on a kernel built without it none of them exists —
+/// and an fentry program naming a target the kernel's BTF does not have fails to
+/// LOAD, which takes the whole sampler down with it. The kprobe twins miss at
+/// attach instead, which is tolerated and reported as unsupported. Hence the
+/// selection below asks whether these specific functions are in BTF, not merely
+/// whether BTF exists. See `kernel_btf_has_funcs`.
+const FENTRY_TARGETS: &[&str] = &[
+    "tg_set_cfs_bandwidth",
+    "throttle_cfs_rq",
+    "unthrottle_cfs_rq",
+];
+
 fn init(config: Arc<Config>) -> SamplerResult {
     if !config.enabled(NAME) {
         return Ok(None);
+    }
+
+    // Prefer the fentry twins (cheaper dispatch); fall back to kprobe when this
+    // kernel's BTF cannot name the targets.
+    let fentry = kernel_btf_has_funcs(FENTRY_TARGETS);
+
+    if !fentry {
+        debug!("{NAME}: no kernel BTF for the CFS bandwidth hooks, using kprobes");
     }
 
     let bpf = BpfBuilder::new(
@@ -101,8 +147,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
     )
     .ringbuf_handler("cgroup_info", handle_cgroup_info)
     .ringbuf_handler("bandwidth_info", handle_bandwidth_info)
-    // Prefer fentry (cheaper dispatch); fall back to kprobe without BTF.
-    .disabled_programs(if kernel_has_btf() {
+    .disabled_programs(if fentry {
         &[
             "tg_set_cfs_bandwidth_kprobe",
             "throttle_cfs_rq_kprobe",
@@ -144,17 +189,52 @@ impl SkelExt for ModSkel<'_> {
 
 impl OpenSkelExt for ModSkel<'_> {
     fn log_prog_instructions(&self) {
+        // Both twins of each hook: only one set is autoloaded, and which one is
+        // a runtime decision, so logging just the fentry names would report
+        // programs that are not running on a kernel that took the kprobe path.
         debug!(
             "{NAME} tg_set_cfs_bandwidth_fentry() BPF instruction count: {}",
             self.progs.tg_set_cfs_bandwidth_fentry.insn_cnt()
+        );
+        debug!(
+            "{NAME} tg_set_cfs_bandwidth_kprobe() BPF instruction count: {}",
+            self.progs.tg_set_cfs_bandwidth_kprobe.insn_cnt()
         );
         debug!(
             "{NAME} throttle_cfs_rq_fentry() BPF instruction count: {}",
             self.progs.throttle_cfs_rq_fentry.insn_cnt()
         );
         debug!(
+            "{NAME} throttle_cfs_rq_kprobe() BPF instruction count: {}",
+            self.progs.throttle_cfs_rq_kprobe.insn_cnt()
+        );
+        debug!(
             "{NAME} unthrottle_cfs_rq_fentry() BPF instruction count: {}",
             self.progs.unthrottle_cfs_rq_fentry.insn_cnt()
         );
+        debug!(
+            "{NAME} unthrottle_cfs_rq_kprobe() BPF instruction count: {}",
+            self.progs.unthrottle_cfs_rq_kprobe.insn_cnt()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{quota_gauge, QUOTA_UNLIMITED, RUNTIME_INF};
+
+    #[test]
+    fn an_unlimited_quota_maps_to_the_sentinel() {
+        // `cpu.max = "max <period>"` reaches tg_set_cfs_bandwidth as
+        // RUNTIME_INF. Pinning this is the point of naming the sentinel: the
+        // plain cast lands on -1 by two's-complement accident, and a later
+        // refactor could just as easily land on i64::MAX.
+        assert_eq!(quota_gauge(RUNTIME_INF), QUOTA_UNLIMITED);
+    }
+
+    #[test]
+    fn a_real_quota_passes_through_as_nanoseconds() {
+        // `cpu.max = "50000 100000"` — 50ms of quota, in nanoseconds.
+        assert_eq!(quota_gauge(50_000_000), 50_000_000);
     }
 }

--- a/src/agent/samplers/cpu/linux/bandwidth/stats.rs
+++ b/src/agent/samplers/cpu/linux/bandwidth/stats.rs
@@ -70,7 +70,7 @@ pub static BPF_RUN_TIME: LazyCounter = LazyCounter::new(Counter::default);
 
 #[metric(
     name = "cgroup_cpu_bandwidth_quota",
-    description = "The CPU bandwidth quota assigned to the cgroup in nanoseconds",
+    description = "The CPU bandwidth quota assigned to the cgroup in nanoseconds, or -1 when the cgroup has no quota (cpu.max = max)",
     metadata = { unit = "nanoseconds" }
 )]
 pub static CGROUP_CPU_BANDWIDTH_QUOTA: GaugeGroup = GaugeGroup::new(MAX_CGROUPS);


### PR DESCRIPTION
## Summary

Fixes #1166 **and** migrates `cpu_bandwidth` to fentry in one change — the two are entangled: the correctness bug only becomes visible (and trivially fixable) once you read the typed args, which is exactly what fentry gives you.

## The bug

The `tg_set_cfs_bandwidth` kprobe read `PARM2` as `struct cfs_bandwidth*` and dereferenced it. But the kernel signature is `tg_set_cfs_bandwidth(struct task_group *tg, u64 period, u64 quota, u64 burst)` — **`PARM2` is `period` (a u64), not a pointer**. On modern kernels that dereferences the period *value* as an address, faults, and reads 0, so `cgroup_cpu_bandwidth_quota`/`period` were wrong.

**Verified on delta (6.12)** — setting `cpu.max="50000 100000"`:
```
KPROBE: arg1(cast to cfs_bandwidth*)=0x5f5e100   arg2=50000000
FENTRY: period=100000000 quota=50000000 burst=0
```
`arg1` = 0x5f5e100 = 100000000 = the period *value*; the real period/quota sit in arg1/arg2 as plain u64s.

## The fix + migration

- Read `period`/`quota` **directly from the args** in both paths — fentry gets them typed, the kprobe reads `PARM2`/`PARM3`.
- Extract shared handlers for all three functions and add **fentry twins**. `throttle_cfs_rq`/`unthrottle_cfs_rq` were already correct (single `cfs_rq*` arg); they gain fentry twins too.
- `disabled_programs` picks the fentry set on BTF, kprobe (CO-RE fallback) otherwise.

The `!` in the title/commit marks the metric-value change: `cgroup_cpu_bandwidth_quota`/`period` go from 0 to their real values where the old read faulted.

## Test plan

- [x] Both BPF targets compile against the checked-in `vmlinux.h` (6 programs)
- [x] macOS build / `cargo test` (687) / `cargo clippy` clean
- [ ] Linux: fentry twins load (kprobe disabled); `cgroup_cpu_bandwidth_quota`/`period` read the correct values (not 0) after a `cpu.max` write (validating on delta now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016x17dLjVUrB6fpksxQ533r
