### PR TITLE
feat(viewer): both viewers save a compare as a .rez, retire the tarball writers

### DIFF
--- a/crates/viewer/src/lib.rs
+++ b/crates/viewer/src/lib.rs
@@ -122,34 +122,6 @@ fn incomplete_notice(
     ))
 }
 
-/// Build a synthetic `AbContainers` manifest from two attached viewers
-/// at Save-as-Report time. The WASM viewer's compare mode loads two
-/// independent parquets (no real tar manifest involved), so we
-/// reconstruct one from each slot's alias + source field.
-fn synthesize_manifest(baseline: &Viewer, experiment: &Viewer) -> report_save::AbContainers {
-    let to_sources = |raw: &str| -> Vec<String> {
-        serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|_| vec![raw.to_string()])
-    };
-    report_save::AbContainers {
-        version: report_save::AbContainers::SCHEMA_VERSION,
-        baseline: report_save::AbSide {
-            alias: baseline
-                .alias
-                .clone()
-                .unwrap_or_else(|| "baseline".to_string()),
-            sources: to_sources(&baseline.reader.source()),
-        },
-        experiment: report_save::AbSide {
-            alias: experiment
-                .alias
-                .clone()
-                .unwrap_or_else(|| "experiment".to_string()),
-            sources: to_sources(&experiment.reader.source()),
-        },
-        category: None,
-    }
-}
-
 #[wasm_bindgen]
 pub struct Viewer {
     /// The loaded capture. Type-erased because a capture is a parquet file or
@@ -697,6 +669,12 @@ pub struct WasmCaptureRegistry {
     /// browser, so it is returned instead of dropped: an archive whose third
     /// arm is silently missing looks exactly like an archive with two arms.
     notices: Vec<String>,
+    /// The uploaded `.rez` archive's own bytes, when the loaded dataset is a
+    /// `.rez` (single or multi-recording). Retained because a Save-as-Report
+    /// from a `.rez` source builds its report by trimming THIS archive — the
+    /// per-capture `Viewer`s hold no source bytes for a `.rez`. `None` for a
+    /// parquet dataset, where each capture carries its own parquet bytes.
+    rez_source: Option<Bytes>,
 }
 
 #[wasm_bindgen]
@@ -707,6 +685,7 @@ impl WasmCaptureRegistry {
             baseline: None,
             others: Vec::new(),
             notices: Vec::new(),
+            rez_source: None,
         }
     }
 
@@ -720,6 +699,10 @@ impl WasmCaptureRegistry {
     pub fn attach(&mut self, capture: &str, data: &[u8], filename: &str) -> Result<(), JsValue> {
         self.notices.clear();
         if rez::rez::detect_rez_format_bytes(data) != rez::rez::RezFormat::NotRez {
+            // Retain the archive bytes: a Save-as-Report from a `.rez` source
+            // trims THIS archive rather than reassembling from per-capture
+            // parquet bytes (which a `.rez` capture does not have).
+            self.rez_source = Some(Bytes::copy_from_slice(data));
             let pool = BufferPool::new(WASM_CACHE_SIZE_BYTES);
             let recordings = open_rez(data, Arc::clone(&pool))?;
             self.notices
@@ -737,6 +720,9 @@ impl WasmCaptureRegistry {
             self.set_capture(capture, viewer);
             return Ok(());
         }
+        // A parquet capture: the dataset is parquet-backed, so a report is
+        // assembled from per-capture parquet bytes, not a `.rez` source.
+        self.rez_source = None;
         let viewer = Viewer::new(data, filename)?;
         self.set_capture(capture, viewer);
         Ok(())
@@ -1028,6 +1014,7 @@ impl WasmCaptureRegistry {
     /// each side trimmed independently. The JS caller wraps the bytes
     /// in a Blob and triggers a download — no HTTP needed.
     pub fn save_with_selection(&self, payload_json: &str) -> Result<Vec<u8>, JsValue> {
+        use std::collections::BTreeSet;
         let payload: report_save::ReportPayload = serde_json::from_str(payload_json)
             .map_err(|e| JsValue::from_str(&format!("invalid selection payload: {e}")))?;
 
@@ -1036,21 +1023,74 @@ impl WasmCaptureRegistry {
             .as_ref()
             .ok_or_else(|| JsValue::from_str("no baseline capture attached"))?;
 
-        match self.experiment() {
-            Some(experiment) => {
-                let manifest = synthesize_manifest(baseline, experiment);
-                report_save::save_combined_ab_tarball(
-                    baseline.source_bytes.clone(),
-                    experiment.source_bytes.clone(),
+        let events_json = if payload.events.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&serde_json::json!({ "events": &payload.events })).ok()
+        };
+
+        // `.rez` source (single or A/B): trim the archive itself and embed the
+        // selection — the same output the server produces for a `.rez` source.
+        if let Some(rez_bytes) = &self.rez_source {
+            let keep: Option<BTreeSet<String>> = payload.trim_columns.then(|| {
+                let mut set: BTreeSet<String> = ::report_save::resolve_kept_columns(
                     &payload,
-                    payload_json,
                     baseline.reader.as_ref(),
-                    experiment.reader.as_ref(),
-                    &manifest,
+                    ::report_save::Side::Baseline,
+                )
+                .into_iter()
+                .collect();
+                for (_, viewer) in &self.others {
+                    set.extend(::report_save::resolve_kept_columns(
+                        &payload,
+                        viewer.reader.as_ref(),
+                        ::report_save::Side::Experiment,
+                    ));
+                }
+                set
+            });
+            return ::report_save::build_rez_report_from_rez(
+                rez_bytes,
+                keep.as_ref(),
+                payload_json,
+                events_json.as_deref(),
+            )
+            .map_err(|e| JsValue::from_str(&e));
+        }
+
+        match self.experiment() {
+            // Parquet compare: assemble a 2-recording `.rez` report (one
+            // recording per side), replacing the `.parquet.ab.tar`.
+            Some(experiment) => {
+                let resolve = |viewer: &Viewer, side| -> Option<BTreeSet<String>> {
+                    payload.trim_columns.then(|| {
+                        ::report_save::resolve_kept_columns(&payload, viewer.reader.as_ref(), side)
+                            .into_iter()
+                            .collect()
+                    })
+                };
+                let baseline_keep = resolve(baseline, ::report_save::Side::Baseline);
+                let experiment_keep = resolve(experiment, ::report_save::Side::Experiment);
+                let sides = [
+                    ::report_save::ParquetReportSide {
+                        bytes: &baseline.source_bytes,
+                        keep_metrics: baseline_keep.as_ref(),
+                    },
+                    ::report_save::ParquetReportSide {
+                        bytes: &experiment.source_bytes,
+                        keep_metrics: experiment_keep.as_ref(),
+                    },
+                ];
+                ::report_save::build_rez_report_from_parquets(
+                    &sides,
                     payload.trim_columns,
+                    payload_json,
+                    events_json.as_deref(),
                 )
                 .map_err(|e| JsValue::from_str(&e))
             }
+            // A single parquet stays a parquet report — the tarball only ever
+            // existed for the compare case.
             None => report_save::save_single_parquet(
                 baseline.source_bytes.clone(),
                 &payload,
@@ -1059,6 +1099,17 @@ impl WasmCaptureRegistry {
                 payload.trim_columns,
             )
             .map_err(|e| JsValue::from_str(&e)),
+        }
+    }
+
+    /// The download extension a Save-as-Report produces for the loaded dataset:
+    /// `.rez` for a `.rez` source or a parquet compare, `.parquet` for a single
+    /// parquet. The JS adapter uses it to name the download.
+    pub fn report_extension(&self) -> String {
+        if self.rez_source.is_some() || !self.others.is_empty() {
+            ".rez".to_string()
+        } else {
+            ".parquet".to_string()
         }
     }
 
@@ -1639,5 +1690,44 @@ mod tests {
         let ctx: dashboard::dashboard::DashboardContext = Default::default();
         let json = serde_json::to_string(&ctx.sections).unwrap();
         assert_eq!(json, "[]");
+    }
+
+    /// A `.rez` source saves a `.rez` report: the archive is trimmed/copied in
+    /// the browser (no filesystem) and the selection is embedded. This is the
+    /// browser half of the server's `.rez` Save-as-Report.
+    #[test]
+    fn a_rez_source_saves_a_rez_report() {
+        let mut reg = WasmCaptureRegistry::new();
+        reg.attach(
+            "baseline",
+            &rez_bytes(&[("redis", "web-01"), ("valkey", "web-01")]),
+            "fleet.rez",
+        )
+        .unwrap();
+        assert_eq!(reg.report_extension(), ".rez");
+
+        // trim_columns=false keeps every column, so the report is a full copy
+        // with the selection embedded — no query engine needed for the test.
+        let out = reg
+            .save_with_selection(r#"{"entries":[],"trim_columns":false}"#)
+            .unwrap();
+        let db = rez::rez_sqlite::RezDb::open_bytes(out).unwrap();
+        let recs = db.read_recordings().unwrap();
+        assert_eq!(recs.len(), 2, "the report keeps both recordings");
+        assert!(
+            recs[0].meta.metadata.contains_key("selection"),
+            "the selection is embedded on the anchor"
+        );
+    }
+
+    /// A single parquet still reports `.parquet`; only a `.rez` source or a
+    /// compare produces `.rez`.
+    #[test]
+    fn report_extension_tracks_the_source_kind() {
+        // A 1-recording `.rez` is still a `.rez` source.
+        let mut reg = WasmCaptureRegistry::new();
+        reg.attach("baseline", &rez_bytes(&[("redis", "web-01")]), "one.rez")
+            .unwrap();
+        assert_eq!(reg.report_extension(), ".rez");
     }
 }

--- a/crates/viewer/src/report_save.rs
+++ b/crates/viewer/src/report_save.rs
@@ -1,38 +1,14 @@
-//! WASM-side adapter over the shared `report-save` crate. The shared
-//! crate handles parquet projection + tar repack against `Bytes`; this
-//! thin wrapper synthesizes an `AbContainers` manifest from the two
-//! attached viewers (compare mode loads two separate parquets, never
-//! a real tar manifest) and serializes it for the shared crate.
+//! WASM-side adapter over the shared `report-save` crate.
+//!
+//! The single-parquet save still goes through here (a thin pass-through);
+//! compare and `.rez`-source saves call the shared crate's `.rez` report
+//! builders directly from `lib.rs`. The tarball repack (and its synthetic
+//! `AbContainers` manifest) is gone — a compare now saves a `.rez`.
 
 use bytes::Bytes;
 use metriken_query::MetricsSource;
-use serde::Serialize;
 
 pub use report_save::ReportPayload;
-
-/// Wire shape of the AB tarball manifest. Defined here rather than
-/// pulled from `crate::parquet_metadata` because the WASM crate
-/// doesn't depend on the rezolus binary. The shared `report-save`
-/// crate is intentionally manifest-agnostic — it takes pre-serialized
-/// bytes — so this struct never crosses a boundary.
-#[derive(Debug, Clone, Serialize, serde::Deserialize)]
-pub struct AbContainers {
-    pub version: u32,
-    pub baseline: AbSide,
-    pub experiment: AbSide,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub category: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, serde::Deserialize)]
-pub struct AbSide {
-    pub alias: String,
-    pub sources: Vec<String>,
-}
-
-impl AbContainers {
-    pub const SCHEMA_VERSION: u32 = 1;
-}
 
 /// Trim or embed-only single-parquet save.
 pub fn save_single_parquet(
@@ -43,29 +19,4 @@ pub fn save_single_parquet(
     trim_columns: bool,
 ) -> Result<Vec<u8>, String> {
     report_save::save_single_parquet(source_bytes, payload, selection_json, source, trim_columns)
-}
-
-/// Trim or embed-only combined-A/B repack.
-#[allow(clippy::too_many_arguments)]
-pub fn save_combined_ab_tarball(
-    baseline_bytes: Bytes,
-    experiment_bytes: Bytes,
-    payload: &ReportPayload,
-    selection_json: &str,
-    baseline_source: &dyn MetricsSource,
-    experiment_source: &dyn MetricsSource,
-    manifest: &AbContainers,
-    trim_columns: bool,
-) -> Result<Vec<u8>, String> {
-    let manifest_bytes = serde_json::to_vec_pretty(manifest).map_err(|e| e.to_string())?;
-    report_save::save_combined_ab_tarball(
-        baseline_bytes,
-        experiment_bytes,
-        payload,
-        selection_json,
-        baseline_source,
-        experiment_source,
-        &manifest_bytes,
-        trim_columns,
-    )
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -85,17 +85,19 @@ Source: [retire the `.parquet.ab.tar` container](journal/2026-08-27-retire-ab-ta
   Exposed as `filter <file>.rez --metrics a,b,c` (composes with `--samplers`),
   with an empty-archive guard. The one operation that breaks the
   verbatim-BLOB-copy property, as flagged.
-- **Save-as-Report emits a `.rez` (server)** — DONE for the server; WASM is a
-  follow-up. `save_with_selection` detects a `.rez` source and builds a trimmed
-  `.rez` (`report_save_rez::build_rez_report`): it trims to the union of every
-  attached capture's queried columns, embeds `KEY_SELECTION`/`KEY_EVENTS` and
-  stamps `KEY_REPORT=trimmed` on the anchor manifest, and `init_file_mode_rez`
-  reads that marker back so the report reloads as a report. **WASM follow-up:**
-  the browser viewer cannot build a `.rez` — the trim/assembly path is under
-  `rez`'s `write` feature (it pulls `metriken`, no wasm32), so the WASM
-  Save-as-Report still can't target `.rez`. Closing that needs a metriken-free,
-  reader-available trim+assemble path (the WAL-tail materialization is the one
-  piece that currently needs `metriken`).
+- **Save-as-Report emits a `.rez` (both backends)** — DONE. A `.rez` source and
+  a parquet **compare** now save a `.rez` on the server AND in the browser; only
+  a single parquet still saves a parquet (the tarball only ever existed for the
+  compare case). The trim/assemble path was made reader-available and shared
+  (`report_save::build_rez_report_from_rez` / `build_rez_report_from_parquets`,
+  in-memory via `RezDb::create_in_memory`/`serialize`; `rez_v3_rewrite` was
+  metriken-free all along, its `write` gate lifted). Both viewer backends embed
+  `KEY_SELECTION`/`KEY_EVENTS` and stamp `KEY_REPORT=trimmed` on the anchor, and
+  `init_file_mode_rez` reads the marker back. The viewer-side `.parquet.ab.tar`
+  **writers** are retired (server `save_combined_ab_tarball` glue + the WASM
+  equivalent gone). Read compat (`ab_extract`) and the CLI `combine --ab` stay
+  for a later cleanup; the shared crate's now-unused `save_combined_ab_tarball`
+  is a small follow-up removal.
 - **Windowless `.rez` tables (non-rezolus sides)** — Open. Ingest is close (the
   recorder already converts Prometheus scrapes to Snapshots; `demote_from_rez`
   documents the refusal as policy, `src/recorder/mod.rs:744-760`). The reader must

--- a/site/viewer/lib/viewer_api.js
+++ b/site/viewer/lib/viewer_api.js
@@ -176,12 +176,10 @@ const ViewerApi = {
     async saveWithSelection(payload) {
         ensureAttached('baseline');
         const bytes = registry.save_with_selection(JSON.stringify(payload));
-        const hasExperiment = registry.has('experiment');
-        return {
-            bytes,
-            mime: hasExperiment ? 'application/x-tar' : 'application/octet-stream',
-            extension: hasExperiment ? '.parquet.ab.tar' : '.parquet',
-        };
+        // The registry decides the output shape: `.rez` for a `.rez` source or
+        // a parquet compare, `.parquet` for a single parquet.
+        const extension = registry.report_extension();
+        return { bytes, mime: 'application/octet-stream', extension };
     },
 };
 

--- a/src/viewer/actions.rs
+++ b/src/viewer/actions.rs
@@ -28,11 +28,6 @@ use super::report_save;
 use super::state::{ApiResponse, AppState, LazySectionStore};
 use ::dashboard;
 
-// MetricsSource::source() may be a JSON array (multi-source) or a single label.
-fn parse_source_field(raw: &str) -> Vec<String> {
-    serde_json::from_str::<Vec<String>>(raw).unwrap_or_else(|_| vec![raw.to_string()])
-}
-
 // ── Snapshot ingest (live mode) ───────────────────────────────────────
 
 /// Background task that polls a live agent and ingests snapshots.
@@ -805,9 +800,6 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
         };
         let baseline_data = state.baseline_data();
         let trim_columns = payload.trim_columns;
-        // Bind to a local so the temporary read guard from .read() doesn't
-        // extend through the `if let` body and trip Send across the await.
-        let ab_manifest_runtime = state.combined_ab_marker.read().clone();
         let experiment_path = state.resolve_experiment_parquet_path();
         let experiment_data = state.captures.get(CaptureId::Experiment);
 
@@ -866,46 +858,65 @@ pub async fn save_with_selection(State(state): State<Arc<AppState>>, body: Strin
             return finalize_rez_report(result);
         }
 
-        // Compare mode: experiment attached -> tarball with manifest
-        // (loaded or synthesized from per-slot runtime state).
+        // Compare mode (two parquet sources): assemble a 2-recording `.rez`
+        // report, one recording per side, instead of a `.parquet.ab.tar`. A
+        // `.rez` source never reaches here — it returned above. Labels come
+        // from each parquet's own source metadata, so there is no manifest to
+        // synthesize.
         if let (Some(experiment_path), Some(experiment_data)) = (experiment_path, experiment_data) {
-            let manifest = ab_manifest_runtime.unwrap_or_else(|| {
-                let baseline_alias = state.captures.alias(CaptureId::Baseline);
-                let experiment_alias = state.captures.alias(CaptureId::Experiment);
-                let baseline_filename = state.captures.filename(CaptureId::Baseline);
-                let experiment_filename = state.captures.filename(CaptureId::Experiment);
-                let baseline_sources = parse_source_field(&baseline_data.source());
-                let experiment_sources = parse_source_field(&experiment_data.source());
-                let category = state.category_name.read().clone();
-                crate::parquet_metadata::synthesize_ab_manifest(
-                    baseline_alias.as_deref(),
-                    &baseline_filename,
-                    &baseline_sources,
-                    experiment_alias.as_deref(),
-                    &experiment_filename,
-                    &experiment_sources,
-                    category.as_deref(),
-                )
-            });
+            let baseline_keep: Option<std::collections::BTreeSet<String>> =
+                trim_columns.then(|| {
+                    ::report_save::resolve_kept_columns(
+                        &payload,
+                        baseline_data.as_ref(),
+                        ::report_save::Side::Baseline,
+                    )
+                    .into_iter()
+                    .collect()
+                });
+            let experiment_keep: Option<std::collections::BTreeSet<String>> =
+                trim_columns.then(|| {
+                    ::report_save::resolve_kept_columns(
+                        &payload,
+                        experiment_data.as_ref(),
+                        ::report_save::Side::Experiment,
+                    )
+                    .into_iter()
+                    .collect()
+                });
+            let events_json = if payload.events.is_empty() {
+                None
+            } else {
+                serde_json::to_string(&serde_json::json!({ "events": &payload.events })).ok()
+            };
             let result = tokio::task::spawn_blocking({
                 let baseline_path = path.clone();
                 let body = selection_json.clone();
-                move || {
-                    report_save::save_combined_ab_tarball(
-                        &baseline_path,
-                        &experiment_path,
-                        &payload,
-                        &body,
-                        &manifest,
+                move || -> Result<Vec<u8>, String> {
+                    let baseline_bytes = std::fs::read(&baseline_path)
+                        .map_err(|e| format!("failed to read baseline: {e}"))?;
+                    let experiment_bytes = std::fs::read(&experiment_path)
+                        .map_err(|e| format!("failed to read experiment: {e}"))?;
+                    let sides = [
+                        ::report_save::ParquetReportSide {
+                            bytes: &baseline_bytes,
+                            keep_metrics: baseline_keep.as_ref(),
+                        },
+                        ::report_save::ParquetReportSide {
+                            bytes: &experiment_bytes,
+                            keep_metrics: experiment_keep.as_ref(),
+                        },
+                    ];
+                    ::report_save::build_rez_report_from_parquets(
+                        &sides,
                         trim_columns,
-                        baseline_data.as_ref(),
-                        experiment_data.as_ref(),
+                        &body,
+                        events_json.as_deref(),
                     )
-                    .map_err(|e| e.to_string())
                 }
             })
             .await;
-            return finalize_report_attachment_tarball(result);
+            return finalize_rez_report(result);
         }
 
         // Single-capture save.
@@ -960,12 +971,6 @@ fn finalize_report_attachment(
     finalize_attachment(result, "rezolus-report.parquet", parquet_attachment)
 }
 
-fn finalize_report_attachment_tarball(
-    result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
-) -> Response {
-    finalize_attachment(result, "rezolus-report.parquet.ab.tar", tar_attachment)
-}
-
 fn finalize_rez_report(
     result: Result<Result<Vec<u8>, String>, tokio::task::JoinError>,
 ) -> Response {
@@ -994,18 +999,6 @@ fn finalize_attachment(
             server_error("internal error")
         }
     }
-}
-
-fn tar_attachment(filename: &str, body: Vec<u8>) -> Response {
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "application/x-tar")
-        .header(
-            header::CONTENT_DISPOSITION,
-            format!("attachment; filename=\"{filename}\""),
-        )
-        .body(Body::from(body))
-        .unwrap()
 }
 
 #[cfg(test)]

--- a/src/viewer/assets/lib/selection/selection.js
+++ b/src/viewer/assets/lib/selection/selection.js
@@ -770,7 +770,7 @@ const saveToParquet = async (store, attrs) => {
         // actually produced (handles users keeping the default in either
         // mode + handles users editing the prefix without re-typing the
         // extension). Skips swap if the user typed a custom extension.
-        const knownExts = ['.parquet.ab.tar', '.ab.tar', '.parquet'];
+        const knownExts = ['.rez', '.parquet.ab.tar', '.ab.tar', '.parquet'];
         let finalName = filename;
         if (extension) {
             for (const ext of knownExts) {

--- a/src/viewer/assets/lib/viewer_api.js
+++ b/src/viewer/assets/lib/viewer_api.js
@@ -256,7 +256,12 @@ const ViewerApi = {
             throw new Error(`save failed (HTTP ${resp.status})${detail ? `: ${detail}` : ''}`);
         }
         const mime = resp.headers.get('content-type') || 'application/octet-stream';
-        const extension = mime.includes('x-tar') ? '.parquet.ab.tar' : '.parquet';
+        // The server names the download (rezolus-report.rez for a .rez source
+        // or a compare, .parquet for a single parquet); trust its extension
+        // rather than guessing from the MIME, which is octet-stream for both.
+        const disposition = resp.headers.get('content-disposition') || '';
+        const named = /filename="?([^"]+)"?/.exec(disposition)?.[1] || '';
+        const extension = named.endsWith('.rez') ? '.rez' : '.parquet';
         const bytes = new Uint8Array(await resp.arrayBuffer());
         return { bytes, mime, extension };
     },

--- a/src/viewer/capture_registry.rs
+++ b/src/viewer/capture_registry.rs
@@ -125,13 +125,6 @@ impl CaptureRegistry {
         self.get_by_id(id.id())
     }
 
-    /// Returns the display filename for the given capture.
-    /// Reads it from the data source's `filename()` method — no separate
-    /// storage needed since the reader/store carries the name.
-    pub fn filename(&self, id: CaptureId) -> String {
-        self.filename_by_id(id.id())
-    }
-
     pub fn filename_by_id(&self, id: &str) -> String {
         self.with_slot(id, |slot| slot.data.read().filename())
             .flatten()
@@ -150,13 +143,6 @@ impl CaptureRegistry {
     pub fn file_metadata_by_id(&self, id: &str) -> Option<String> {
         self.with_slot(id, |slot| slot.file_metadata.read().clone())
             .flatten()
-    }
-
-    /// Display alias for the given capture, when one was provided on the
-    /// command line (or via attach). None = fall back to the identifier
-    /// name on the UI side.
-    pub fn alias(&self, id: CaptureId) -> Option<String> {
-        self.alias_by_id(id.id())
     }
 
     pub fn alias_by_id(&self, id: &str) -> Option<String> {
@@ -277,9 +263,8 @@ mod tests {
     fn the_experiment_id_and_enum_resolve_to_one_slot() {
         let reg = registry();
         reg.attach_experiment(store("exp.parquet"), None, None, Some("valkey".into()));
-        assert_eq!(reg.alias(CaptureId::Experiment).as_deref(), Some("valkey"));
         assert_eq!(reg.alias_by_id(EXPERIMENT_ID).as_deref(), Some("valkey"));
-        assert_eq!(reg.filename(CaptureId::Experiment), "exp.parquet");
+        assert_eq!(reg.filename_by_id(EXPERIMENT_ID), "exp.parquet");
         assert!(reg.get(CaptureId::Experiment).is_some());
     }
 

--- a/src/viewer/mod.rs
+++ b/src/viewer/mod.rs
@@ -1285,7 +1285,7 @@ mod tests {
         assert_eq!(
             state
                 .captures
-                .alias(crate::viewer::capture_registry::CaptureId::Baseline)
+                .alias_by_id(crate::viewer::capture_registry::BASELINE_ID)
                 .as_deref(),
             Some("baseline"),
         );
@@ -1614,7 +1614,6 @@ mod tests {
     /// regardless would still produce two populated dashboards.
     #[test]
     fn selected_recordings_fill_the_ab_slots() {
-        use crate::viewer::capture_registry::CaptureId;
         let dir = tempfile::tempdir().unwrap();
         let rez_path = dir.path().join("fleet.rez");
         crate::recorder::rez::recorder_tests_support::multi_recording_v3_rez(
@@ -1643,11 +1642,17 @@ mod tests {
 
         assert!(state.captures.experiment_attached());
         assert_eq!(
-            state.captures.alias(CaptureId::Baseline).as_deref(),
+            state
+                .captures
+                .alias_by_id(crate::viewer::capture_registry::BASELINE_ID)
+                .as_deref(),
             Some("envoy"),
         );
         assert_eq!(
-            state.captures.alias(CaptureId::Experiment).as_deref(),
+            state
+                .captures
+                .alias_by_id(crate::viewer::capture_registry::EXPERIMENT_ID)
+                .as_deref(),
             Some("valkey"),
         );
         // Aliases come from the labels; the per-recording metadata is written
@@ -1668,7 +1673,6 @@ mod tests {
     /// A baseline selector alone loads one capture and attaches no experiment.
     #[test]
     fn a_baseline_selector_alone_leaves_the_experiment_slot_empty() {
-        use crate::viewer::capture_registry::CaptureId;
         let dir = tempfile::tempdir().unwrap();
         let rez_path = dir.path().join("fleet.rez");
         crate::recorder::rez::recorder_tests_support::multi_recording_v3_rez(
@@ -1697,7 +1701,10 @@ mod tests {
         // so a generic alias would leave nothing on screen saying which of the
         // archive's recordings is being read.
         assert_eq!(
-            state.captures.alias(CaptureId::Baseline).as_deref(),
+            state
+                .captures
+                .alias_by_id(crate::viewer::capture_registry::BASELINE_ID)
+                .as_deref(),
             Some("valkey"),
         );
     }
@@ -1707,7 +1714,6 @@ mod tests {
     /// the archive, which only runs on this path.
     #[test]
     fn without_flags_a_three_recording_archive_attaches_every_recording() {
-        use crate::viewer::capture_registry::CaptureId;
         let dir = tempfile::tempdir().unwrap();
         let rez_path = dir.path().join("fleet.rez");
         crate::recorder::rez::recorder_tests_support::multi_recording_v3_rez(
@@ -1727,11 +1733,17 @@ mod tests {
 
         assert!(state.captures.experiment_attached());
         assert_eq!(
-            state.captures.alias(CaptureId::Baseline).as_deref(),
+            state
+                .captures
+                .alias_by_id(crate::viewer::capture_registry::BASELINE_ID)
+                .as_deref(),
             Some("redis"),
         );
         assert_eq!(
-            state.captures.alias(CaptureId::Experiment).as_deref(),
+            state
+                .captures
+                .alias_by_id(crate::viewer::capture_registry::EXPERIMENT_ID)
+                .as_deref(),
             Some("valkey"),
         );
         // The third recording is no longer dropped: it attaches under its own
@@ -1757,7 +1769,6 @@ mod tests {
     /// this pair "baseline"/"experiment" despite `host` naming them exactly.
     #[test]
     fn aliases_come_from_the_recordings_shown_not_the_whole_archive() {
-        use crate::viewer::capture_registry::CaptureId;
         let dir = tempfile::tempdir().unwrap();
         let rez_path = dir.path().join("fleet.rez");
         crate::recorder::rez::recorder_tests_support::multi_recording_v3_rez(
@@ -1790,11 +1801,17 @@ mod tests {
         let state = super::init_file_mode(&config, &rez_path, &registry, pool);
 
         assert_eq!(
-            state.captures.alias(CaptureId::Baseline).as_deref(),
+            state
+                .captures
+                .alias_by_id(crate::viewer::capture_registry::BASELINE_ID)
+                .as_deref(),
             Some("web-01"),
         );
         assert_eq!(
-            state.captures.alias(CaptureId::Experiment).as_deref(),
+            state
+                .captures
+                .alias_by_id(crate::viewer::capture_registry::EXPERIMENT_ID)
+                .as_deref(),
             Some("web-02"),
         );
     }

--- a/src/viewer/report_save.rs
+++ b/src/viewer/report_save.rs
@@ -1,15 +1,14 @@
 //! Path-shaped adapter over the shared `report-save` crate. The
 //! server's `save_with_selection` handler receives a `PathBuf` (the
 //! loaded parquet on disk) and a MetricsSource; this module reads
-//! the path into bytes once and delegates the trim/embed/tarball logic
-//! to the shared crate so the WASM static-site viewer can share it.
+//! the path into bytes once and delegates the trim/embed logic to the
+//! shared crate so the WASM static-site viewer can share it. Compare and
+//! `.rez`-source saves call the shared `.rez` builders directly.
 
 use std::path::Path;
 
 use bytes::Bytes;
 use metriken_query::MetricsSource;
-
-use crate::parquet_metadata::AbContainers;
 
 pub use report_save::ReportPayload;
 
@@ -29,32 +28,4 @@ pub fn save_single_parquet(
     let bytes = read_path_to_bytes(source_path)?;
     report_save::save_single_parquet(bytes, payload, selection_json, source, trim_columns)
         .map_err(Into::into)
-}
-
-/// Combined-A/B equivalent.
-#[allow(clippy::too_many_arguments)]
-pub fn save_combined_ab_tarball(
-    baseline_path: &Path,
-    experiment_path: &Path,
-    payload: &ReportPayload,
-    selection_json: &str,
-    manifest: &AbContainers,
-    trim_columns: bool,
-    baseline_source: &dyn MetricsSource,
-    experiment_source: &dyn MetricsSource,
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let baseline_bytes = read_path_to_bytes(baseline_path)?;
-    let experiment_bytes = read_path_to_bytes(experiment_path)?;
-    let manifest_bytes = serde_json::to_vec_pretty(manifest)?;
-    report_save::save_combined_ab_tarball(
-        baseline_bytes,
-        experiment_bytes,
-        payload,
-        selection_json,
-        baseline_source,
-        experiment_source,
-        &manifest_bytes,
-        trim_columns,
-    )
-    .map_err(Into::into)
 }


### PR DESCRIPTION
**PR2 of 2** — the behavior change on the PR1 (#1169) foundation, and the last
step of retiring the `.parquet.ab.tar` **write** path.

A `.rez` source and a parquet **compare** now save a `.rez` report on the
**server AND in the browser (WASM)**, instead of a `.parquet.ab.tar`. A single
parquet still saves a parquet — the tarball only ever existed for the compare
case.

## Server (`save_with_selection`)
The compare branch assembles a 2-recording `.rez` via
`report_save::build_rez_report_from_parquets` (per-side column trim, selection
embedded), returned as `rezolus-report.rez`. The tarball glue
(`save_combined_ab_tarball` wrapper, `finalize_report_attachment_tarball`,
`tar_attachment`, the synthesized manifest) is gone.

## WASM (`WasmCaptureRegistry`)
Retains the uploaded `.rez` bytes (`rez_source`) so a `.rez`-source save trims
THAT archive; a parquet compare assembles a `.rez` from the two capture
byte-blobs (the per-capture `Viewer`s hold no source bytes for a `.rez`, so the
registry must). Single parquet still uses `save_single_parquet`. New
`report_extension()` tells the JS adapter which extension to name the download.

## Frontend
The server adapter takes the extension from the response's Content-Disposition
(octet-stream can't distinguish `.rez` from `.parquet`); the WASM adapter uses
`registry.report_extension()`; `.rez` is added to the download-rename
known-extensions.

## Cleanup
Removed the now-dead `CaptureRegistry::{filename,alias}(CaptureId)` enum
accessors (their only non-test caller was the deleted manifest synthesis).
**Kept for a later small cleanup:** `ab_extract` (read compat), the CLI
`combine --ab`, and the shared crate's now-unused `save_combined_ab_tarball`.

## Tests
- WASM: a `.rez`-source save produces a 2-recording `.rez` with the selection
  embedded; `report_extension` tracks the source kind.
- Server compare is covered by report-save's `build_rez_report_from_parquets`
  tests (#1169).
- All viewer tests (108 bin / 14 native), report-save (17), rez, the pure-JS
  node suite (252), the viewer symlink check, fmt, clippy, and both
  `wasm32-unknown-unknown` checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)