### PR TITLE
feat(viewer): the compare badge lists all N captures, not just two

### DIFF
--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -116,6 +116,24 @@ let experimentAlias = null;
 export const getBaselineAlias = () => baselineAlias;
 export const getExperimentAlias = () => experimentAlias;
 
+// Every attached capture as `[{id, alias}]`, for the compare badge to list
+// N (not just baseline + experiment). Populated from `/api/v1/captures`
+// whenever compare mode is (re)established; empty otherwise.
+let compareCaptures = [];
+const refreshCompareCaptures = async () => {
+    if (!compareMode) {
+        compareCaptures = [];
+        return;
+    }
+    try {
+        const caps = await ViewerApi.getCaptures();
+        compareCaptures = Array.isArray(caps) ? caps : [];
+    } catch {
+        compareCaptures = [];
+    }
+    m.redraw();
+};
+
 // Compare-mode per-chart toggles + anchors live in `notebookStore` so
 // they persist across page reloads. See selection_migration.js for the
 // schema. The accessors below read-through to the store.
@@ -208,6 +226,7 @@ const attachExperiment = async (file) => {
     experimentAlias = expMeta?.data?.alias || null;
     experimentAttached = true;
     compareMode = true;
+    refreshCompareCaptures();
 
     applyMultiNodeInfo(expFileMeta);
     clearViewerCaches();
@@ -236,6 +255,7 @@ const detachExperiment = async () => {
     experimentAlias = null;
     experimentAttached = false;
     compareMode = false;
+    compareCaptures = [];
 
     applyMultiNodeInfo(null);
     clearViewerCaches();
@@ -671,6 +691,7 @@ const topNavAttrs = (data, sectionRoute, extra) => buildTopNavAttrs({
         experimentFilename,
         baselineAlias,
         experimentAlias,
+        captures: compareCaptures,
         onLoadBaseline: onUploadParquet ? (file) => onUploadParquet(file) : null,
         onLoadExperiment: onUploadParquet ? (file) => { loadExperiment(file); } : null,
         ...(extra || {}),
@@ -933,6 +954,7 @@ const initDashboard = (config = {}) => {
     // reported compare_mode=true).
     compareMode = config.compareMode === true;
     experimentAttached = compareMode;
+    refreshCompareCaptures();
     combinedAB = config.combinedAB === true;
     reportMode = config.reportMode === true;
     experimentSystemInfo = config.experimentSystemInfo || null;
@@ -984,6 +1006,7 @@ const initDashboard = (config = {}) => {
             experimentFilename,
             baselineAlias,
             experimentAlias,
+            captures: compareCaptures,
             // The WASM viewer has no onUploadParquet handler — that path
             // is how the site viewer loads its initial parquet on its own.
             // Use its absence as the "WASM mode" signal and hide both

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -128,7 +128,11 @@ const refreshCompareCaptures = async () => {
     try {
         const caps = await ViewerApi.getCaptures();
         compareCaptures = Array.isArray(caps) ? caps : [];
-    } catch {
+    } catch (e) {
+        // Falling back leaves the badge on its A/B rendering, which looks
+        // deliberate rather than degraded — so say what happened. An N-way
+        // archive silently showing two of its arms is the confusing case.
+        console.warn('compare badge: could not list captures', e);
         compareCaptures = [];
     }
     m.redraw();

--- a/src/viewer/assets/lib/charts.css
+++ b/src/viewer/assets/lib/charts.css
@@ -1092,6 +1092,15 @@
 }
 .compare-badge-summary::-webkit-details-marker { display: none; }
 .compare-badge-summary::marker { content: ''; }
+/* N-way (> 2 captures): a static chip strip, not an expandable dropdown —
+   same pill look as the collapsed A/B summary, but nothing to open into. */
+.compare-badge-nway {
+    gap: 8px;
+    padding: 4px 8px;
+    background: var(--compare-baseline-bg);
+    border-radius: 4px;
+    flex-wrap: wrap;
+}
 .compare-badge-chip {
     display: inline-flex;
     align-items: center;

--- a/src/viewer/assets/lib/charts.css
+++ b/src/viewer/assets/lib/charts.css
@@ -1106,6 +1106,9 @@
     align-items: center;
     gap: 4px;
 }
+/* The `+N` chip standing in for the captures past BADGE_CHIP_LIMIT; its title
+   names them. Muted so it reads as a count, not another capture. */
+.compare-badge-more .compare-badge-label { color: var(--fg-muted); }
 .compare-badge-chip + .compare-badge-chip {
     padding-left: 8px;
     border-left: 1px solid var(--border-subtle);

--- a/src/viewer/assets/lib/charts.css
+++ b/src/viewer/assets/lib/charts.css
@@ -1107,8 +1107,10 @@
     gap: 4px;
 }
 /* The `+N` chip standing in for the captures past BADGE_CHIP_LIMIT; its title
-   names them. Muted so it reads as a count, not another capture. */
-.compare-badge-more .compare-badge-label { color: var(--fg-muted); }
+   names them. Dimmer than a capture label so it reads as a count, but
+   --fg-secondary rather than --fg-muted: muted is the disabled tier (#484f58 on
+   the dark badge ground) and this is meant to be read. */
+.compare-badge-more .compare-badge-label { color: var(--fg-secondary); }
 .compare-badge-chip + .compare-badge-chip {
     padding-left: 8px;
     border-left: 1px solid var(--border-subtle);

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -77,6 +77,42 @@ export const captureColorFor = (id, extraIndex) => {
     return CAPTURE_PALETTE[extraIndex % CAPTURE_PALETTE.length];
 };
 
+/**
+ * Rows for the compare badge, one per attached capture, in display order.
+ *
+ * Pure (no DOM) so it can be unit-tested. `captures` is the `[{id, alias}]`
+ * list from `getCaptures()`; the anchor keeps its signature colour, the first
+ * non-anchor the experiment colour, and the rest walk the extra palette — the
+ * SAME assignment the overlay uses, so a capture's dot in the badge matches its
+ * line on the chart. Filenames are only known for the two A/B slots (they come
+ * from the attach flow); extra arms of a `.rez` show their alias alone.
+ */
+export const compareBadgeRows = (captures, opts = {}) => {
+    const {
+        baselineAlias,
+        experimentAlias,
+        baselineFilename,
+        experimentFilename,
+    } = opts;
+    let extra = 0;
+    return (captures || []).map((c) => {
+        const isBaseline = c.id === CAPTURE_BASELINE;
+        const isExperiment = c.id === CAPTURE_EXPERIMENT;
+        const alias = isBaseline
+            ? (c.alias || baselineAlias || 'baseline')
+            : isExperiment
+                ? (c.alias || experimentAlias || 'experiment')
+                : (c.alias || c.id);
+        const color = captureColorFor(c.id, isBaseline || isExperiment ? -1 : extra++);
+        const filename = isBaseline
+            ? (baselineFilename || null)
+            : isExperiment
+                ? (experimentFilename || null)
+                : null;
+        return { id: c.id, label: alias, color, filename };
+    });
+};
+
 // A stable id -> color map for a set of captures, so a capture keeps its color
 // across every sub-chart regardless of which labels it happens to carry.
 const captureColors = (captures) => {

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -77,45 +77,13 @@ export const captureColorFor = (id, extraIndex) => {
     return CAPTURE_PALETTE[extraIndex % CAPTURE_PALETTE.length];
 };
 
-/**
- * Rows for the compare badge, one per attached capture, in display order.
- *
- * Pure (no DOM) so it can be unit-tested. `captures` is the `[{id, alias}]`
- * list from `getCaptures()`; the anchor keeps its signature colour, the first
- * non-anchor the experiment colour, and the rest walk the extra palette — the
- * SAME assignment the overlay uses, so a capture's dot in the badge matches its
- * line on the chart. Filenames are only known for the two A/B slots (they come
- * from the attach flow); extra arms of a `.rez` show their alias alone.
- */
-export const compareBadgeRows = (captures, opts = {}) => {
-    const {
-        baselineAlias,
-        experimentAlias,
-        baselineFilename,
-        experimentFilename,
-    } = opts;
-    let extra = 0;
-    return (captures || []).map((c) => {
-        const isBaseline = c.id === CAPTURE_BASELINE;
-        const isExperiment = c.id === CAPTURE_EXPERIMENT;
-        const alias = isBaseline
-            ? (c.alias || baselineAlias || 'baseline')
-            : isExperiment
-                ? (c.alias || experimentAlias || 'experiment')
-                : (c.alias || c.id);
-        const color = captureColorFor(c.id, isBaseline || isExperiment ? -1 : extra++);
-        const filename = isBaseline
-            ? (baselineFilename || null)
-            : isExperiment
-                ? (experimentFilename || null)
-                : null;
-        return { id: c.id, label: alias, color, filename };
-    });
-};
-
 // A stable id -> color map for a set of captures, so a capture keeps its color
 // across every sub-chart regardless of which labels it happens to carry.
-const captureColors = (captures) => {
+//
+// Exported because the compare badge draws a dot per capture and those dots
+// have to match the lines. Two copies of this walk would drift silently — the
+// badge would still render, just in the wrong colours — so there is one.
+export const captureColors = (captures) => {
     let extra = 0;
     return new Map(
         captures.map((c) => {
@@ -124,6 +92,63 @@ const captureColors = (captures) => {
         }),
     );
 };
+
+/**
+ * Rows for the compare badge, one per attached capture, in display order.
+ *
+ * Pure (no DOM) so it can be unit-tested. `captures` is the `[{id, alias}]`
+ * list from `getCaptures()`; colours come from `captureColors` — the same map
+ * the overlay draws with, not a second walk of the palette — so a capture's dot
+ * in the badge matches its line on the chart. Filenames are only known for the
+ * two A/B slots (they come from the attach flow); extra arms of a `.rez` show
+ * their alias alone.
+ */
+export const compareBadgeRows = (captures, opts = {}) => {
+    const {
+        baselineAlias,
+        experimentAlias,
+        baselineFilename,
+        experimentFilename,
+    } = opts;
+    const list = captures || [];
+    const colors = captureColors(list);
+    return list.map((c) => {
+        const isBaseline = c.id === CAPTURE_BASELINE;
+        const isExperiment = c.id === CAPTURE_EXPERIMENT;
+        const alias = isBaseline
+            ? (c.alias || baselineAlias || 'baseline')
+            : isExperiment
+                ? (c.alias || experimentAlias || 'experiment')
+                : (c.alias || c.id);
+        const filename = isBaseline
+            ? (baselineFilename || null)
+            : isExperiment
+                ? (experimentFilename || null)
+                : null;
+        return { id: c.id, label: alias, color: colors.get(c.id), filename };
+    });
+};
+
+/**
+ * How many capture chips the badge draws before folding the rest into `+N`.
+ *
+ * A fleet `.rez` can hold a recording per host, and the badge lives in the
+ * navbar: unbounded chips wrap into several rows and shove the rest of the bar
+ * around. The A/B badge bounded this at two and put the detail behind a
+ * dropdown for the same reason.
+ */
+export const BADGE_CHIP_LIMIT = 5;
+
+/**
+ * Split badge rows into the chips to draw and the ones folded into `+N`.
+ *
+ * Folds only when it actually saves room: a `+1` chip is the same width as the
+ * one chip it would hide, so at exactly one over the limit everything is drawn.
+ */
+export const splitBadgeRows = (rows, limit = BADGE_CHIP_LIMIT) =>
+    rows.length > limit + 1
+        ? { shown: rows.slice(0, limit), hidden: rows.slice(limit) }
+        : { shown: rows, hidden: [] };
 
 /**
  * Format a relative offset in milliseconds as `+Xs`, `+XmYs`, or `+XhYm`.

--- a/src/viewer/assets/lib/ui/layout.js
+++ b/src/viewer/assets/lib/ui/layout.js
@@ -2,6 +2,7 @@ import { TimeRangeBar, GranularitySelector, TimeModeSelector } from './controls.
 import { notebookStore, reportStore, loadedSelectionStore, importSelection } from '../selection/selection.js';
 import { toggleTheme, currentTheme } from './theme.js';
 import { collectGroupPlots } from '../features/group_utils.js';
+import { compareBadgeRows } from '../charts/compare.js';
 
 const formatSize = (bytes) => {
     if (!bytes) return '';
@@ -58,6 +59,42 @@ const TopNav = {
             compareMode && (() => {
                 const baselineLabel = attrs.baselineAlias || 'baseline';
                 const experimentLabel = attrs.experimentAlias || 'experiment';
+
+                // N-way (> 2 captures, from a multi-recording `.rez`): list
+                // every capture, each dot colored to match its overlay line.
+                // Extra arms carry no filename and no Load button — they came
+                // from inside the archive, not an attach. The ≤ 2 path below is
+                // the unchanged A/B badge (filenames + Load/Replace buttons).
+                const caps = attrs.captures || [];
+                if (caps.length > 2) {
+                    const rows = compareBadgeRows(caps, {
+                        baselineAlias: attrs.baselineAlias,
+                        experimentAlias: attrs.experimentAlias,
+                        baselineFilename: attrs.filename,
+                        experimentFilename: attrs.experimentFilename,
+                    });
+                    const dot = (color) => m('span.compare-dot', { style: { color } }, '●');
+                    return m('details.compare-badge', [
+                        m('summary.compare-badge-summary', {
+                            title: `Comparing ${rows.length} captures`,
+                        }, rows.map((r) => m('span.compare-badge-chip', { key: r.id }, [
+                            dot(r.color),
+                            m('span.compare-badge-label', r.label),
+                        ]))),
+                        m('div.compare-capture-list', rows.map((r) => m('div.compare-capture', { key: r.id }, [
+                            m('div.compare-capture-info', [
+                                m('div.compare-capture-head', [
+                                    dot(r.color),
+                                    m('span.compare-capture-label', r.label),
+                                ]),
+                                m('div.compare-capture-name', {
+                                    title: r.filename || 'From the loaded archive',
+                                }, r.filename || '—'),
+                            ]),
+                        ]))),
+                    ]);
+                }
+
                 const row = (cls, label, fname, onLoad) => m('div.compare-capture', [
                     m('div.compare-capture-info', [
                         m('div.compare-capture-head', [

--- a/src/viewer/assets/lib/ui/layout.js
+++ b/src/viewer/assets/lib/ui/layout.js
@@ -60,39 +60,24 @@ const TopNav = {
                 const baselineLabel = attrs.baselineAlias || 'baseline';
                 const experimentLabel = attrs.experimentAlias || 'experiment';
 
-                // N-way (> 2 captures, from a multi-recording `.rez`): list
-                // every capture, each dot colored to match its overlay line.
-                // Extra arms carry no filename and no Load button — they came
-                // from inside the archive, not an attach. The ≤ 2 path below is
-                // the unchanged A/B badge (filenames + Load/Replace buttons).
+                // N-way (> 2 captures, from a multi-recording `.rez`): a static
+                // strip listing every capture, each dot colored to match its
+                // overlay line. No dropdown — the arms are recordings INSIDE the
+                // archive, so there is no per-capture file to show or Load
+                // button to offer; an expandable card would be empty. The ≤ 2
+                // path below is the unchanged A/B badge (filenames + Load).
                 const caps = attrs.captures || [];
                 if (caps.length > 2) {
                     const rows = compareBadgeRows(caps, {
                         baselineAlias: attrs.baselineAlias,
                         experimentAlias: attrs.experimentAlias,
-                        baselineFilename: attrs.filename,
-                        experimentFilename: attrs.experimentFilename,
                     });
-                    const dot = (color) => m('span.compare-dot', { style: { color } }, '●');
-                    return m('details.compare-badge', [
-                        m('summary.compare-badge-summary', {
-                            title: `Comparing ${rows.length} captures`,
-                        }, rows.map((r) => m('span.compare-badge-chip', { key: r.id }, [
-                            dot(r.color),
-                            m('span.compare-badge-label', r.label),
-                        ]))),
-                        m('div.compare-capture-list', rows.map((r) => m('div.compare-capture', { key: r.id }, [
-                            m('div.compare-capture-info', [
-                                m('div.compare-capture-head', [
-                                    dot(r.color),
-                                    m('span.compare-capture-label', r.label),
-                                ]),
-                                m('div.compare-capture-name', {
-                                    title: r.filename || 'From the loaded archive',
-                                }, r.filename || '—'),
-                            ]),
-                        ]))),
-                    ]);
+                    return m('div.compare-badge.compare-badge-nway', {
+                        title: `Comparing ${rows.length} captures`,
+                    }, rows.map((r) => m('span.compare-badge-chip', { key: r.id }, [
+                        m('span.compare-dot', { style: { color: r.color } }, '●'),
+                        m('span.compare-badge-label', r.label),
+                    ])));
                 }
 
                 const row = (cls, label, fname, onLoad) => m('div.compare-capture', [

--- a/src/viewer/assets/lib/ui/layout.js
+++ b/src/viewer/assets/lib/ui/layout.js
@@ -2,7 +2,7 @@ import { TimeRangeBar, GranularitySelector, TimeModeSelector } from './controls.
 import { notebookStore, reportStore, loadedSelectionStore, importSelection } from '../selection/selection.js';
 import { toggleTheme, currentTheme } from './theme.js';
 import { collectGroupPlots } from '../features/group_utils.js';
-import { compareBadgeRows } from '../charts/compare.js';
+import { compareBadgeRows, splitBadgeRows } from '../charts/compare.js';
 
 const formatSize = (bytes) => {
     if (!bytes) return '';
@@ -72,12 +72,24 @@ const TopNav = {
                         baselineAlias: attrs.baselineAlias,
                         experimentAlias: attrs.experimentAlias,
                     });
-                    return m('div.compare-badge.compare-badge-nway', {
-                        title: `Comparing ${rows.length} captures`,
-                    }, rows.map((r) => m('span.compare-badge-chip', { key: r.id }, [
+                    const { shown, hidden } = splitBadgeRows(rows);
+                    // Each label is width-capped and ellipsized, and unlike the
+                    // A/B badge there is no dropdown card holding the full text
+                    // — so the label carries its own title or a truncated alias
+                    // is unrecoverable.
+                    const chips = shown.map((r) => m('span.compare-badge-chip', { key: r.id }, [
                         m('span.compare-dot', { style: { color: r.color } }, '●'),
-                        m('span.compare-badge-label', r.label),
-                    ])));
+                        m('span.compare-badge-label', { title: r.label }, r.label),
+                    ]));
+                    if (hidden.length) {
+                        chips.push(m('span.compare-badge-chip.compare-badge-more', {
+                            key: '__more',
+                            title: hidden.map((r) => r.label).join(', '),
+                        }, m('span.compare-badge-label', `+${hidden.length}`)));
+                    }
+                    return m('div.compare-badge.compare-badge-nway', {
+                        title: `Comparing ${rows.length} captures: ${rows.map((r) => r.label).join(', ')}`,
+                    }, chips);
                 }
 
                 const row = (cls, label, fname, onLoad) => m('div.compare-capture', [

--- a/src/viewer/assets/lib/ui/navigation.js
+++ b/src/viewer/assets/lib/ui/navigation.js
@@ -83,6 +83,7 @@ const createMainComponent = ({
                     experimentFilename: badgeAttrs?.experimentFilename,
                     baselineAlias: badgeAttrs?.baselineAlias,
                     experimentAlias: badgeAttrs?.experimentAlias,
+                    captures: badgeAttrs?.captures,
                     onLoadBaseline: badgeAttrs?.onLoadBaseline,
                     onLoadExperiment: badgeAttrs?.onLoadExperiment,
                 },

--- a/tests/compare_nway.test.mjs
+++ b/tests/compare_nway.test.mjs
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 // palette falls back to its literals (same shim the other compare tests use).
 globalThis.document = globalThis.document || { documentElement: {} };
 globalThis.getComputedStyle = globalThis.getComputedStyle || (() => ({ getPropertyValue: () => '' }));
-const { renderCompareChart, captureColorFor, BASELINE_COLOR, EXPERIMENT_COLOR } =
+const { renderCompareChart, captureColorFor, compareBadgeRows, BASELINE_COLOR, EXPERIMENT_COLOR } =
     await import('../src/viewer/assets/lib/charts/compare.js');
 const { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } = await import('../src/viewer/assets/lib/data.js');
 
@@ -72,4 +72,38 @@ test('a lone anchor does not overlay (renders baseline-only upstream)', () => {
         captureLabels: {},
     });
     assert.equal(out, false);
+});
+
+test('compareBadgeRows lists every capture with matching colors', () => {
+    const caps = [
+        { id: 'baseline', alias: 'redis' },
+        { id: 'experiment', alias: 'valkey' },
+        { id: 'envoy', alias: 'envoy' },
+        { id: 'nginx', alias: 'nginx' },
+    ];
+    const rows = compareBadgeRows(caps, {
+        baselineFilename: 'a.rez',
+        experimentFilename: 'b.rez',
+    });
+    assert.equal(rows.length, 4, 'one row per capture');
+    assert.deepEqual(rows.map((r) => r.label), ['redis', 'valkey', 'envoy', 'nginx']);
+    // Dot colors match the overlay's per-capture assignment.
+    assert.equal(rows[0].color, BASELINE_COLOR);
+    assert.equal(rows[1].color, EXPERIMENT_COLOR);
+    assert.equal(rows[2].color, captureColorFor('envoy', 0));
+    assert.equal(rows[3].color, captureColorFor('nginx', 1));
+    // Filenames only for the two A/B slots; extra arms carry none.
+    assert.equal(rows[0].filename, 'a.rez');
+    assert.equal(rows[1].filename, 'b.rez');
+    assert.equal(rows[2].filename, null);
+    assert.equal(rows[3].filename, null);
+});
+
+test('compareBadgeRows falls back to alias then id for labels', () => {
+    const rows = compareBadgeRows(
+        [{ id: 'baseline' }, { id: 'weird' }],
+        { baselineAlias: 'base' },
+    );
+    assert.equal(rows[0].label, 'base');
+    assert.equal(rows[1].label, 'weird');
 });

--- a/tests/compare_nway.test.mjs
+++ b/tests/compare_nway.test.mjs
@@ -8,8 +8,16 @@ import assert from 'node:assert/strict';
 // palette falls back to its literals (same shim the other compare tests use).
 globalThis.document = globalThis.document || { documentElement: {} };
 globalThis.getComputedStyle = globalThis.getComputedStyle || (() => ({ getPropertyValue: () => '' }));
-const { renderCompareChart, captureColorFor, compareBadgeRows, BASELINE_COLOR, EXPERIMENT_COLOR } =
-    await import('../src/viewer/assets/lib/charts/compare.js');
+const {
+    renderCompareChart,
+    captureColorFor,
+    captureColors,
+    compareBadgeRows,
+    splitBadgeRows,
+    BADGE_CHIP_LIMIT,
+    BASELINE_COLOR,
+    EXPERIMENT_COLOR,
+} = await import('../src/viewer/assets/lib/charts/compare.js');
 const { CAPTURE_BASELINE, CAPTURE_EXPERIMENT } = await import('../src/viewer/assets/lib/data.js');
 
 const line = (id, alias, base) => ({
@@ -106,4 +114,45 @@ test('compareBadgeRows falls back to alias then id for labels', () => {
     );
     assert.equal(rows[0].label, 'base');
     assert.equal(rows[1].label, 'weird');
+});
+
+// The point of the badge is that a dot matches its line, so assert it against
+// the map the OVERLAY builds rather than against a hand-written palette index.
+// Checking `captureColorFor(id, n)` with literal `n` would pass just as happily
+// if the two walks drifted apart.
+test('badge dots come from the same map the overlay draws with', () => {
+    const caps = [
+        { id: CAPTURE_BASELINE, alias: 'redis' },
+        { id: CAPTURE_EXPERIMENT, alias: 'valkey' },
+        { id: 'envoy', alias: 'envoy' },
+        { id: 'nginx', alias: 'nginx' },
+        { id: 'haproxy', alias: 'haproxy' },
+    ];
+    const overlay = captureColors(caps);
+    for (const row of compareBadgeRows(caps, {})) {
+        assert.equal(row.color, overlay.get(row.id), `${row.id} dot matches its line`);
+    }
+});
+
+test('splitBadgeRows folds the tail into +N only when that saves room', () => {
+    const rows = (n) => Array.from({ length: n }, (_, i) => ({ id: `c${i}` }));
+
+    // At and just over the limit, everything is drawn: a `+1` chip is as wide
+    // as the single chip it would hide.
+    for (const n of [1, BADGE_CHIP_LIMIT, BADGE_CHIP_LIMIT + 1]) {
+        const { shown, hidden } = splitBadgeRows(rows(n));
+        assert.equal(shown.length, n, `${n} rows all shown`);
+        assert.equal(hidden.length, 0);
+    }
+
+    // Beyond that it folds, and nothing is lost — hidden rows are named in the
+    // chip's tooltip.
+    const { shown, hidden } = splitBadgeRows(rows(BADGE_CHIP_LIMIT + 4));
+    assert.equal(shown.length, BADGE_CHIP_LIMIT);
+    assert.equal(hidden.length, 4);
+    assert.deepEqual(
+        [...shown, ...hidden].map((r) => r.id),
+        rows(BADGE_CHIP_LIMIT + 4).map((r) => r.id),
+        'split preserves order and loses nothing',
+    );
 });


### PR DESCRIPTION
The last cosmetic gap in the N-way (N > 2) arc. The overlay already draws a line
per capture and the legend names them all, but the nav's **compare badge** still
showed only baseline + experiment. It now lists every attached capture.

## Changes
- `compare.js`: `compareBadgeRows(captures, opts)` — a pure (DOM-free,
  node-tested) list builder that gives each capture the **same colour the
  overlay uses** (anchor blue, first arm green, the rest the extra palette), so
  a badge dot matches its chart line. Filenames are known only for the two A/B
  slots; extra arms of a `.rez` show their alias alone.
- `app.js`: fetches `/api/v1/captures` into `compareCaptures` whenever compare
  mode is (re)established; threads it to the badge; cleared on detach.
- `layout.js`: with > 2 captures, renders one colored chip + one row per
  capture. **The ≤ 2 (A/B) path is byte-identical** — filenames and the
  Load/Replace buttons unchanged (the N-way branch is guarded by
  `caps.length > 2`).
- `navigation.js`: threads `captures` through to `TopNav`.

## Verification
- `compareBadgeRows` node tests (colours, labels, filename rules) — 5 pass.
- `node --check` on all four edited files; import resolution of layout.js +
  compare.js.
- `/api/v1/captures` returns three captures for a 3-recording `.rez` (confirmed
  live; also covered by the smoke test in #1171).

## ⚠️ Needs a visual check before merge
I could **not** render the badge in a browser here (the repo has no DOM/jsdom
harness). The pure logic and data path are verified, but the mithril render of
the badge itself — and that the ≤ 2 path really is unchanged on screen — wants a
human eye. Please load a 3-recording `.rez` (e.g.
`cargo run -p rez --features test-support --example write_rez_fixture -- three.rez 3`
then `rezolus view three.rez`) and confirm the badge shows three colored chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)