### PR TITLE
feat: Intel GPU sampler, and per-GPU charts that tell two vendors apart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,6 +3669,7 @@ dependencies = [
 name = "systeminfo"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "libloading",
  "log",
  "serde",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Rezolus effortlessly tracks the details you need to understand production so you
 - **GPU telemetry** — NVIDIA via NVML and GPM, including per-tensor-pipe
   utilization, plus SM utilization/occupancy, DRAM bandwidth, PCIe throughput, power,
   energy, clocks, and temperature. AMD via ROCm SMI and rocprofiler hardware
-  counters. Intel integrated and Arc GPUs via the i915/xe PMU, with per-engine
+  counters. Intel integrated and Arc GPUs via the i915 PMU, with per-engine
   (render/copy/video/compute) busy time and frequency, plus VRAM usage. Apple GPU
   metrics on macOS.
 - **Container-aware** — per-cgroup CPU cycles/instructions, migrations, syscalls,

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ Rezolus effortlessly tracks the details you need to understand production so you
   frequency, per core and per cgroup.
 - **GPU telemetry** — NVIDIA via NVML and GPM, including per-tensor-pipe
   utilization, plus SM utilization/occupancy, DRAM bandwidth, PCIe throughput, power,
-  energy, clocks, and temperature. Apple GPU metrics on macOS.
+  energy, clocks, and temperature. AMD via ROCm SMI and rocprofiler hardware
+  counters. Intel integrated and Arc GPUs via the i915/xe PMU, with per-engine
+  (render/copy/video/compute) busy time and frequency, plus VRAM usage. Apple GPU
+  metrics on macOS.
 - **Container-aware** — per-cgroup CPU cycles/instructions, migrations, syscalls,
   and CFS bandwidth/throttling, so you can attribute behavior per container.
 - **Service & inference telemetry** — runtime-loaded templates that turn

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -216,6 +216,29 @@ enabled = false
 # workloads, so use with care on production hosts.
 # gpu_perf_level = "stable_std"
 
+# Produces Intel GPU metrics from the i915/xe PMU via perf_event_open: per-engine
+# busy time and actual/requested frequency, plus VRAM usage via the DRM query
+# ioctl. Covers both integrated GPUs and discrete Arc cards, which register as
+# separate PMUs; each is discovered from sysfs along with its engine set, so no
+# per-model configuration is needed. This is the same data source intel_gpu_top
+# reads. Requires CAP_PERFMON (or kernel.perf_event_paranoid <= 2); disabled
+# automatically on hosts with no Intel GPU or insufficient permissions.
+#
+# VRAM is discrete-only: an integrated GPU has no device-local memory region, so
+# it publishes no gpu_memory series.
+#
+# Note: the PMU values are cumulative counters, so both are consumed as rates —
+# `rate(gpu_engine_busy_time) * 100` is engine utilization in percent, and
+# `rate(gpu_frequency_sample)` is average MHz. Pair them: the PMU reports
+# occupancy, not efficiency, so frequency is what separates "busy but
+# downclocked" from genuinely saturated.
+[samplers.gpu_intel_pmu]
+# Reads touch the driver (a perf group read takes a driver lock; VRAM is an
+# ioctl), so they run on their own cadence rather than at the scrape rate, and
+# are dispatched off the async worker. Default 1s, matching intel_gpu_top's own
+# sampling period. Cached values are served between reads.
+# interval = "1s"
+
 # Memory utilization from /proc/meminfo
 [samplers.memory_meminfo]
 

--- a/config/agent.toml
+++ b/config/agent.toml
@@ -216,7 +216,7 @@ enabled = false
 # workloads, so use with care on production hosts.
 # gpu_perf_level = "stable_std"
 
-# Produces Intel GPU metrics from the i915/xe PMU via perf_event_open: per-engine
+# Produces Intel GPU metrics from the i915 PMU via perf_event_open: per-engine
 # busy time and actual/requested frequency, plus VRAM usage via the DRM query
 # ioctl. Covers both integrated GPUs and discrete Arc cards, which register as
 # separate PMUs; each is discovered from sysfs along with its engine set, so no

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -114,7 +114,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage)
                 .percentage_range()
                 .with_row_label("GPU"),
-            "sum by (id) (gpu_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_utilization) / 100".to_string(),
         );
     } else {
         gpu.plot_promql_full(
@@ -139,7 +139,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id) (gpu_memory_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_memory_utilization) / 100".to_string(),
         );
     } else {
         mem_ctrl.plot_promql_full(
@@ -169,7 +169,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id) (gpu_tensor_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_tensor_utilization) / 100".to_string(),
         );
     } else {
         tensor.plot_promql_full(
@@ -194,7 +194,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id) (gpu_sm_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_sm_utilization) / 100".to_string(),
         );
         sm.plot_promql(
             PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage)
@@ -209,7 +209,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id) (gpu_sm_occupancy) / 100".to_string(),
+            "sum by (id, vendor) (gpu_sm_occupancy) / 100".to_string(),
         );
     } else {
         sm.plot_promql_full(
@@ -249,12 +249,12 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         per_device.plot_promql(
             PlotOpts::gauge("Used (Per-GPU)", "mem-used-per-gpu", Unit::Bytes)
                 .with_row_label("GPU"),
-            "sum by (id) (gpu_memory{state=\"used\"})".to_string(),
+            "sum by (id, vendor) (gpu_memory{state=\"used\"})".to_string(),
         );
         per_device.plot_promql(
             PlotOpts::gauge("Free (Per-GPU)", "mem-free-per-gpu", Unit::Bytes)
                 .with_row_label("GPU"),
-            "sum by (id) (gpu_memory{state=\"free\"})".to_string(),
+            "sum by (id, vendor) (gpu_memory{state=\"free\"})".to_string(),
         );
     }
 
@@ -278,7 +278,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id) (gpu_dram_bandwidth_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_dram_bandwidth_utilization) / 100".to_string(),
         );
     } else {
         dram_bw.plot_promql_full(
@@ -352,7 +352,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             PlotOpts::gauge("Power (Per-GPU)", "power-watts-per-gpu", Unit::Count)
                 .with_axis_label("Watts")
                 .with_row_label("GPU"),
-            "sum by (id) (gpu_power_usage) / 1000".to_string(),
+            "sum by (id, vendor) (gpu_power_usage) / 1000".to_string(),
         );
     } else {
         draw.plot_promql_full(
@@ -383,7 +383,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             PlotOpts::gauge("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count)
                 .with_axis_label("°C")
                 .with_row_label("GPU"),
-            "max by (id) (gpu_temperature)".to_string(),
+            "max by (id, vendor) (gpu_temperature)".to_string(),
         );
         temps.plot_promql(
             PlotOpts::gauge("Max (°C)", "temp-max", Unit::Count).with_axis_label("°C"),
@@ -404,19 +404,19 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     freqs.describe("Per-device clock speeds for graphics, memory, compute, and video engines.");
     freqs.plot_promql(
         PlotOpts::gauge("Graphics", "clock-graphics", Unit::Frequency),
-        "sum by (id) (gpu_clock{clock=\"graphics\"})".to_string(),
+        "sum by (id, vendor) (gpu_clock{clock=\"graphics\"})".to_string(),
     );
     freqs.plot_promql(
         PlotOpts::gauge("Memory", "clock-memory", Unit::Frequency),
-        "sum by (id) (gpu_clock{clock=\"memory\"})".to_string(),
+        "sum by (id, vendor) (gpu_clock{clock=\"memory\"})".to_string(),
     );
     freqs.plot_promql(
         PlotOpts::gauge("Compute", "clock-compute", Unit::Frequency),
-        "sum by (id) (gpu_clock{clock=\"compute\"})".to_string(),
+        "sum by (id, vendor) (gpu_clock{clock=\"compute\"})".to_string(),
     );
     freqs.plot_promql(
         PlotOpts::gauge("Video", "clock-video", Unit::Frequency),
-        "sum by (id) (gpu_clock{clock=\"video\"})".to_string(),
+        "sum by (id, vendor) (gpu_clock{clock=\"video\"})".to_string(),
     );
 
     view.group(clocks);
@@ -676,7 +676,7 @@ fn intel_pmu(view: &mut View, multi_gpu: bool) {
                 Unit::Percentage,
             )
             .with_row_label("GPU"),
-            "sum by (id) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
+            "sum by (id, vendor) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
         );
     }
 
@@ -691,11 +691,12 @@ fn intel_pmu(view: &mut View, multi_gpu: bool) {
     );
     freq.plot_promql(
         PlotOpts::gauge("Actual", "intel-freq-actual", Unit::Frequency),
-        "sum by (id) (rate(gpu_frequency_sample{frequency=\"actual\"}[5m])) * 1000000".to_string(),
+        "sum by (id, vendor) (rate(gpu_frequency_sample{frequency=\"actual\"}[5m])) * 1000000"
+            .to_string(),
     );
     freq.plot_promql(
         PlotOpts::gauge("Requested", "intel-freq-requested", Unit::Frequency),
-        "sum by (id) (rate(gpu_frequency_sample{frequency=\"requested\"}[5m])) * 1000000"
+        "sum by (id, vendor) (rate(gpu_frequency_sample{frequency=\"requested\"}[5m])) * 1000000"
             .to_string(),
     );
 

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -2,6 +2,11 @@ use crate::MetricsSource;
 use crate::plot::*;
 
 /// The metrics we probe for GPU presence / id enumeration.
+///
+/// `gpu_engine_busy_time` and `gpu_frequency_sample` are Intel's — an Intel host
+/// publishes neither `gpu_utilization` nor (on an integrated GPU) `gpu_memory`,
+/// so without them such a host would enumerate no GPUs at all and the per-device
+/// charts and selector would never appear.
 const GPU_PROBE_METRICS: &[&str] = &[
     "gpu_utilization",
     "gpu_memory",
@@ -10,6 +15,8 @@ const GPU_PROBE_METRICS: &[&str] = &[
     "gpu_clock",
     "gpu_memory_utilization",
     "gpmu_clock",
+    "gpu_engine_busy_time",
+    "gpu_frequency_sample",
 ];
 
 /// True iff the recording has more than one GPU. Per-device charts are
@@ -368,6 +375,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     view.group(clocks);
 
     amd_pmu(&mut view);
+    intel_pmu(&mut view, multi_gpu);
 
     view
 }
@@ -533,6 +541,115 @@ fn amd_pmu(view: &mut View) {
         PlotOpts::counter("VRAM Write Requests", "amd-vram-write-req", Unit::Count)
             .with_axis_label("requests/s"),
         "sum(rate(gpmu_vram_write_requests[5m]))".to_string(),
+    );
+
+    view.group(pmu);
+}
+
+/// Intel GPU metrics from the i915/xe PMU (the `gpu_intel_pmu` sampler).
+///
+/// Only populated on Intel hosts; the charts are empty otherwise. See
+/// `docs/metrics.md#gpu_intel_pmu`.
+///
+/// Both PMU families are **cumulative counters**, so everything here is a
+/// `rate()`. Two consequences shape the queries below:
+///
+/// - Engine busy is cumulative nanoseconds, so `rate()` yields nanoseconds of
+///   busy time per second — dividing by 1e9 gives the busy fraction, which is
+///   what the percentage charts plot.
+/// - The frequency events are a running sum of one MHz sample per driver tick,
+///   accumulated only while the GT is awake. `rate()` recovers average MHz over
+///   the interval; a raw reading carries no meaning without its predecessor.
+///   The GT parking while idle is why these drop to zero rather than to an idle
+///   clock.
+///
+/// `gpu_memory` is deliberately absent here: the Intel sampler publishes it
+/// under the same vendor-neutral name and labels the AMD and NVIDIA samplers
+/// use, so it already appears in the shared Memory group above. VRAM is
+/// discrete-only — an integrated GPU has no device-local memory region and
+/// publishes no such series.
+fn intel_pmu(view: &mut View, multi_gpu: bool) {
+    let mut pmu = Group::new("Intel GPU Performance Counters", "intel-pmu");
+
+    // ----- Engine occupancy -----
+    let engines = pmu.subgroup("Engine Busy");
+    engines.describe(
+        "Fraction of wall time each GPU engine spent executing work, from the i915/xe PMU. \
+         This is occupancy, not efficiency: an engine at 100% had work queued, which does not \
+         mean the execution units were saturated — read it alongside the frequency charts.",
+    );
+
+    // Aggregate across engines of a class. Summing the busy time of several
+    // engines can exceed one device-second (they run concurrently), which is
+    // correct and why this is not clamped to 100%.
+    engines.plot_promql(
+        PlotOpts::gauge(
+            "Busy % by Engine Class",
+            "intel-engine-class-pct",
+            Unit::Percentage,
+        )
+        .with_row_label("Class"),
+        "sum by (engine_class) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
+    );
+    engines.plot_promql(
+        PlotOpts::gauge("Busy % by Engine", "intel-engine-pct", Unit::Percentage)
+            .with_row_label("Engine"),
+        "sum by (engine) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
+    );
+
+    // The engine that carries the compute workload, called out on its own
+    // because it is the one to watch on a GPGPU host. A discrete Arc exposes a
+    // compute engine; an integrated GPU generally does not, and this chart is
+    // then empty while the render one below carries the load.
+    engines.plot_promql(
+        PlotOpts::gauge(
+            "Compute Engine Busy %",
+            "intel-compute-pct",
+            Unit::Percentage,
+        )
+        .percentage_range(),
+        "sum(rate(gpu_engine_busy_time{engine_class=\"compute\"}[5m])) / 1000000000".to_string(),
+    );
+    engines.plot_promql(
+        PlotOpts::gauge("Render Engine Busy %", "intel-render-pct", Unit::Percentage)
+            .percentage_range(),
+        "sum(rate(gpu_engine_busy_time{engine_class=\"render\"}[5m])) / 1000000000".to_string(),
+    );
+
+    if multi_gpu {
+        let per_device = pmu.subgroup("Per-Device Engine Busy");
+        per_device.describe(
+            "Engine busy time broken out by GPU id — on a host with both an integrated GPU and \
+             a discrete Arc card, this is what separates them.",
+        );
+        per_device.plot_promql(
+            PlotOpts::gauge(
+                "Busy % (Per-GPU)",
+                "intel-engine-pct-per-gpu",
+                Unit::Percentage,
+            )
+            .with_row_label("GPU"),
+            "sum by (id) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
+        );
+    }
+
+    // ----- Frequency -----
+    let freq = pmu.subgroup("Frequency");
+    freq.describe(
+        "Average GPU frequency over each interval, recovered from the PMU's cumulative sum of \
+         per-tick MHz samples. Requested is what the driver asked for; actual is what the \
+         hardware delivered — a persistent gap between them means the GPU is being held back \
+         (thermal, power or voltage limits). Both fall to zero when the GT parks, because the \
+         driver stops sampling rather than because the clock reached zero.",
+    );
+    freq.plot_promql(
+        PlotOpts::gauge("Actual", "intel-freq-actual", Unit::Frequency),
+        "sum by (id) (rate(gpu_frequency_sample{frequency=\"actual\"}[5m])) * 1000000".to_string(),
+    );
+    freq.plot_promql(
+        PlotOpts::gauge("Requested", "intel-freq-requested", Unit::Frequency),
+        "sum by (id) (rate(gpu_frequency_sample{frequency=\"requested\"}[5m])) * 1000000"
+            .to_string(),
     );
 
     view.group(pmu);

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -21,36 +21,83 @@ const GPU_PROBE_METRICS: &[&str] = &[
 
 /// True iff the recording has more than one GPU. Per-device charts are
 /// suppressed when this is false because they degenerate to the aggregate.
+///
+/// Counts distinct `(vendor, id)` pairs, not distinct ids: a host with an
+/// NVIDIA card and an Intel iGPU has two GPUs that are both `id="0"`, and
+/// counting ids alone would call that a single-GPU host and hide the
+/// per-device charts that separate them.
 fn has_multiple_gpus(data: &dyn MetricsSource) -> bool {
-    GPU_PROBE_METRICS
-        .iter()
-        .any(|m| metric_unique_label_count(data, m, "id") > 1)
+    gpu_entries(data).len() > 1
 }
 
-/// The distinct GPU `id` values present in the recording, sorted numerically.
-fn gpu_ids(data: &dyn MetricsSource) -> Vec<i64> {
-    let mut ids: Vec<i64> = GPU_PROBE_METRICS
-        .iter()
-        .flat_map(|m| data.label_values(m, "id"))
-        .filter_map(|v| v.parse::<i64>().ok())
-        .collect();
-    ids.sort_unstable();
-    ids.dedup();
-    ids
+/// One GPU present in the recording, as the selector needs to address it.
+///
+/// `id` alone does not identify a GPU. Every vendor's sampler numbers its own
+/// devices from 0 (NVML's device index, ROCm's, and for Intel the PMU discovery
+/// order), so on a host with an NVIDIA card and an Intel iGPU there are two
+/// distinct GPUs both labelled `id="0"`. Selecting on `id` alone matches both.
+struct GpuEntry {
+    id: i64,
+    /// The `vendor` label, absent on samplers that do not set one (the Apple
+    /// GPU sampler declares no vendor). `None` means "match on id alone",
+    /// which is the pre-existing behaviour and correct when nothing else
+    /// disambiguates.
+    vendor: Option<String>,
+}
+
+/// The distinct GPUs present in the recording, sorted by vendor then id so the
+/// selector's order is stable across runs.
+fn gpu_entries(data: &dyn MetricsSource) -> Vec<GpuEntry> {
+    let mut seen: std::collections::BTreeSet<(Option<String>, i64)> =
+        std::collections::BTreeSet::new();
+
+    for metric in GPU_PROBE_METRICS {
+        // Read whole label sets rather than one key at a time: pairing a
+        // vendor with an id requires seeing them on the same series.
+        for labels in data
+            .counter_labels(metric)
+            .into_iter()
+            .chain(data.gauge_labels(metric))
+        {
+            let Some(id) = labels.get("id").and_then(|v| v.parse::<i64>().ok()) else {
+                continue;
+            };
+            seen.insert((labels.get("vendor").cloned(), id));
+        }
+    }
+
+    seen.into_iter()
+        .map(|(vendor, id)| GpuEntry { id, vendor })
+        .collect()
 }
 
 pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     let mut view = View::new(data, sections);
     let multi_gpu = has_multiple_gpus(data);
 
-    // Tell the frontend which GPU ids exist so it can render the GPU selector
-    // (a dropdown to view the non-per-GPU charts for a single GPU or the
+    // Tell the frontend which GPUs exist so it can render the GPU selector
+    // (a picker that filters the non-per-GPU charts to a subset, or the
     // aggregate). Only meaningful with more than one GPU.
-    let ids = gpu_ids(data);
-    if ids.len() > 1 {
+    //
+    // `gpus` carries the (vendor, id) pairs the selector must filter on; `ids`
+    // is kept alongside it for older frontends, which read only that field.
+    let entries = gpu_entries(data);
+    if entries.len() > 1 {
+        let mut ids: Vec<i64> = entries.iter().map(|g| g.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+
+        let gpus: Vec<serde_json::Value> = entries
+            .iter()
+            .map(|g| match &g.vendor {
+                Some(v) => serde_json::json!({ "id": g.id, "vendor": v }),
+                None => serde_json::json!({ "id": g.id }),
+            })
+            .collect();
+
         view.metadata.insert(
             "gpu_selector".to_string(),
-            serde_json::json!({ "enabled": true, "ids": ids }),
+            serde_json::json!({ "enabled": true, "ids": ids, "gpus": gpus }),
         );
     }
 

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -113,7 +113,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         gpu.plot_promql(
             PlotOpts::gauge("GPU % (Per-GPU)", "gpu-pct-per-gpu", Unit::Percentage)
                 .percentage_range()
-                .with_row_label("GPU"),
+                .with_row_label("GPU")
+                .with_style("heatmap"),
             "sum by (id, vendor) (gpu_utilization) / 100".to_string(),
         );
     } else {
@@ -138,7 +139,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 Unit::Percentage,
             )
             .percentage_range()
-            .with_row_label("GPU"),
+            .with_row_label("GPU")
+            .with_style("heatmap"),
             "sum by (id, vendor) (gpu_memory_utilization) / 100".to_string(),
         );
     } else {
@@ -168,7 +170,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 Unit::Percentage,
             )
             .percentage_range()
-            .with_row_label("GPU"),
+            .with_row_label("GPU")
+            .with_style("heatmap"),
             "sum by (id, vendor) (gpu_tensor_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
     } else {
@@ -193,7 +196,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 Unit::Percentage,
             )
             .percentage_range()
-            .with_row_label("GPU"),
+            .with_row_label("GPU")
+            .with_style("heatmap"),
             "sum by (id, vendor) (gpu_sm_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
         sm.plot_promql(
@@ -208,7 +212,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 Unit::Percentage,
             )
             .percentage_range()
-            .with_row_label("GPU"),
+            .with_row_label("GPU")
+            .with_style("heatmap"),
             "sum by (id, vendor) (gpu_sm_occupancy{vendor=\"nvidia\"}) / 100".to_string(),
         );
     } else {
@@ -248,12 +253,14 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         per_device.describe("Memory used and free broken out by GPU id.");
         per_device.plot_promql(
             PlotOpts::gauge("Used (Per-GPU)", "mem-used-per-gpu", Unit::Bytes)
-                .with_row_label("GPU"),
+                .with_row_label("GPU")
+                .with_style("heatmap"),
             "sum by (id, vendor) (gpu_memory{state=\"used\"})".to_string(),
         );
         per_device.plot_promql(
             PlotOpts::gauge("Free (Per-GPU)", "mem-free-per-gpu", Unit::Bytes)
-                .with_row_label("GPU"),
+                .with_row_label("GPU")
+                .with_style("heatmap"),
             "sum by (id, vendor) (gpu_memory{state=\"free\"})".to_string(),
         );
     }
@@ -277,7 +284,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 Unit::Percentage,
             )
             .percentage_range()
-            .with_row_label("GPU"),
+            .with_row_label("GPU")
+            .with_style("heatmap"),
             "sum by (id, vendor) (gpu_dram_bandwidth_utilization{vendor=\"nvidia\"}) / 100"
                 .to_string(),
         );
@@ -352,7 +360,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         draw.plot_promql(
             PlotOpts::gauge("Power (Per-GPU)", "power-watts-per-gpu", Unit::Count)
                 .with_axis_label("Watts")
-                .with_row_label("GPU"),
+                .with_row_label("GPU")
+                .with_style("heatmap"),
             "sum by (id, vendor) (gpu_power_usage) / 1000".to_string(),
         );
     } else {
@@ -383,7 +392,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         temps.plot_promql(
             PlotOpts::gauge("Temperature (Per-GPU)", "temp-per-gpu", Unit::Count)
                 .with_axis_label("°C")
-                .with_row_label("GPU"),
+                .with_row_label("GPU")
+                .with_style("heatmap"),
             "max by (id, vendor) (gpu_temperature)".to_string(),
         );
         temps.plot_promql(
@@ -630,6 +640,21 @@ const ENGINE_CLASSES: [(&str, &str); 6] = [
 ];
 
 fn intel_pmu(view: &mut View, data: &dyn MetricsSource) {
+    // Nothing to show without the sampler's own metrics. The per-class
+    // subgroups are each gated on the classes present, but the Frequency
+    // subgroup and the group itself were not — so an NVIDIA- or AMD-only
+    // recording rendered an empty "Intel GPU Performance Counters" section.
+    let has_intel = !data
+        .label_values("gpu_engine_busy_time", "engine_class")
+        .is_empty()
+        || !data
+            .label_values("gpu_frequency_sample", "frequency")
+            .is_empty();
+
+    if !has_intel {
+        return;
+    }
+
     let mut pmu = Group::new("Intel GPU Performance Counters", "intel-pmu");
 
     // ----- Engine occupancy, one subgroup per engine class -----
@@ -680,7 +705,8 @@ fn intel_pmu(view: &mut View, data: &dyn MetricsSource) {
                 format!("intel-{class_name}-pct-per-gpu"),
                 Unit::Percentage,
             )
-            .with_row_label("GPU"),
+            .with_row_label("GPU")
+            .with_style("heatmap"),
             format!(
                 "sum by (id, vendor) (rate(gpu_engine_busy_time{{engine_class=\"{class_name}\", \
                  vendor=\"intel\"}}[5m])) / 1000000000"

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -423,7 +423,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     view.group(clocks);
 
     amd_pmu(&mut view);
-    intel_pmu(&mut view, multi_gpu);
+    intel_pmu(&mut view, data);
 
     view
 }
@@ -616,71 +616,75 @@ fn amd_pmu(view: &mut View) {
 /// use, so it already appears in the shared Memory group above. VRAM is
 /// discrete-only — an integrated GPU has no device-local memory region and
 /// publishes no such series.
-fn intel_pmu(view: &mut View, multi_gpu: bool) {
+/// The engine classes the Intel sampler labels, in the order they are shown.
+///
+/// These are the `engine_class` values `gpu/linux/intel/mod.rs` maps sysfs
+/// engine names onto; `other` is its fallback for an unrecognised prefix.
+const ENGINE_CLASSES: [(&str, &str); 6] = [
+    ("compute", "Compute"),
+    ("render", "Render"),
+    ("copy", "Copy"),
+    ("video", "Video"),
+    ("video-enhance", "Video Enhance"),
+    ("other", "Other"),
+];
+
+fn intel_pmu(view: &mut View, data: &dyn MetricsSource) {
     let mut pmu = Group::new("Intel GPU Performance Counters", "intel-pmu");
 
-    // ----- Engine occupancy -----
-    let engines = pmu.subgroup("Engine Busy");
-    engines.describe(
-        "Fraction of wall time each GPU engine spent executing work, from the i915/xe PMU. \
-         This is occupancy, not efficiency: an engine at 100% had work queued, which does not \
-         mean the execution units were saturated — read it alongside the frequency charts.",
-    );
-
-    // Aggregate across engines of a class. Summing the busy time of several
-    // engines can exceed one device-second (they run concurrently), which is
-    // correct and why this is not clamped to 100%.
-    engines.plot_promql(
-        PlotOpts::gauge(
-            "Busy % by Engine Class",
-            "intel-engine-class-pct",
-            Unit::Percentage,
-        )
-        .with_row_label("Class"),
-        "sum by (engine_class) (rate(gpu_engine_busy_time{vendor=\"intel\"}[5m])) / 1000000000"
-            .to_string(),
-    );
-    engines.plot_promql(
-        PlotOpts::gauge("Busy % by Engine", "intel-engine-pct", Unit::Percentage)
-            .with_row_label("Engine"),
-        "sum by (engine) (rate(gpu_engine_busy_time{vendor=\"intel\"}[5m])) / 1000000000"
-            .to_string(),
-    );
-
-    // The engine that carries the compute workload, called out on its own
-    // because it is the one to watch on a GPGPU host. A discrete Arc exposes a
-    // compute engine; an integrated GPU generally does not, and this chart is
-    // then empty while the render one below carries the load.
-    engines.plot_promql(
-        PlotOpts::gauge(
-            "Compute Engine Busy %",
-            "intel-compute-pct",
-            Unit::Percentage,
-        )
-        .percentage_range(),
-        "sum(rate(gpu_engine_busy_time{engine_class=\"compute\", vendor=\"intel\"}[5m])) / 1000000000".to_string(),
-    );
-    engines.plot_promql(
-        PlotOpts::gauge("Render Engine Busy %", "intel-render-pct", Unit::Percentage)
-            .percentage_range(),
-        "sum(rate(gpu_engine_busy_time{engine_class=\"render\", vendor=\"intel\"}[5m])) / 1000000000".to_string(),
-    );
-
-    if multi_gpu {
-        let per_device = pmu.subgroup("Per-Device Engine Busy");
-        per_device.describe(
-            "Engine busy time broken out by GPU id — on a host with both an integrated GPU and \
-             a discrete Arc card, this is what separates them.",
+    // ----- Engine occupancy, one subgroup per engine class -----
+    //
+    // The i915/xe PMU counts busy time per engine, and the engine classes do
+    // very different jobs — a compute kernel, a blit, a video decode. Stacking
+    // every class into one chart made them hard to read against each other and
+    // buried the one that mattered for a given workload. Each class now gets
+    // its own subgroup with two plots: the aggregate across the host, and the
+    // same broken out per GPU.
+    //
+    // Only classes the recording actually contains are emitted, so an
+    // integrated GPU (no compute engine) shows no empty compute section.
+    for (class_name, title) in ENGINE_CLASSES {
+        let query_all = format!(
+            "sum(rate(gpu_engine_busy_time{{engine_class=\"{class_name}\", \
+             vendor=\"intel\"}}[5m])) / 1000000000"
         );
-        per_device.plot_promql(
+
+        if !data
+            .label_values("gpu_engine_busy_time", "engine_class")
+            .contains(class_name)
+        {
+            continue;
+        }
+
+        let engines = pmu.subgroup(title);
+        engines.describe(format!(
+            "Fraction of wall time the {class_name} engine(s) spent executing work, from the \
+             i915/xe PMU. This is occupancy, not efficiency: an engine at 100% had work queued, \
+             which does not mean the execution units were saturated — read it alongside the \
+             frequency charts. Summing several engines of one class can exceed 100%, since they \
+             run concurrently."
+        ));
+
+        engines.plot_promql(
             PlotOpts::gauge(
-                "Busy % (Per-GPU)",
-                "intel-engine-pct-per-gpu",
+                format!("{title} Busy %"),
+                format!("intel-{class_name}-pct"),
+                Unit::Percentage,
+            ),
+            query_all,
+        );
+
+        engines.plot_promql(
+            PlotOpts::gauge(
+                format!("{title} Busy % (Per-GPU)"),
+                format!("intel-{class_name}-pct-per-gpu"),
                 Unit::Percentage,
             )
             .with_row_label("GPU"),
-            "sum by (id, vendor) (rate(gpu_engine_busy_time{vendor=\"intel\"}[5m])) / 1000000000"
-                .to_string(),
+            format!(
+                "sum by (id, vendor) (rate(gpu_engine_busy_time{{engine_class=\"{class_name}\", \
+                 vendor=\"intel\"}}[5m])) / 1000000000"
+            ),
         );
     }
 

--- a/crates/dashboard/src/dashboard/gpu.rs
+++ b/crates/dashboard/src/dashboard/gpu.rs
@@ -159,7 +159,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
         tensor.plot_promql(
             PlotOpts::gauge("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage)
                 .percentage_range(),
-            "avg(gpu_tensor_utilization) / 100".to_string(),
+            "avg(gpu_tensor_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
         tensor.plot_promql(
             PlotOpts::gauge(
@@ -169,13 +169,13 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id, vendor) (gpu_tensor_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_tensor_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
     } else {
         tensor.plot_promql_full(
             PlotOpts::gauge("GPU Tensor Activity %", "gpu-tensor-act", Unit::Percentage)
                 .percentage_range(),
-            "avg(gpu_tensor_utilization) / 100".to_string(),
+            "avg(gpu_tensor_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
     }
 
@@ -184,7 +184,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     if multi_gpu {
         sm.plot_promql(
             PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).percentage_range(),
-            "avg(gpu_sm_utilization) / 100".to_string(),
+            "avg(gpu_sm_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
         sm.plot_promql(
             PlotOpts::gauge(
@@ -194,12 +194,12 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id, vendor) (gpu_sm_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_sm_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
         sm.plot_promql(
             PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage)
                 .percentage_range(),
-            "avg(gpu_sm_occupancy) / 100".to_string(),
+            "avg(gpu_sm_occupancy{vendor=\"nvidia\"}) / 100".to_string(),
         );
         sm.plot_promql(
             PlotOpts::gauge(
@@ -209,17 +209,17 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id, vendor) (gpu_sm_occupancy) / 100".to_string(),
+            "sum by (id, vendor) (gpu_sm_occupancy{vendor=\"nvidia\"}) / 100".to_string(),
         );
     } else {
         sm.plot_promql_full(
             PlotOpts::gauge("GPU SM Activity %", "gpu-sm-act", Unit::Percentage).percentage_range(),
-            "avg(gpu_sm_utilization) / 100".to_string(),
+            "avg(gpu_sm_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
         sm.plot_promql_full(
             PlotOpts::gauge("GPU SM Occupancy %", "gpu-sm-ocp", Unit::Percentage)
                 .percentage_range(),
-            "avg(gpu_sm_occupancy) / 100".to_string(),
+            "avg(gpu_sm_occupancy{vendor=\"nvidia\"}) / 100".to_string(),
         );
     }
 
@@ -268,7 +268,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 Unit::Percentage,
             )
             .percentage_range(),
-            "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
+            "avg(gpu_dram_bandwidth_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
         dram_bw.plot_promql(
             PlotOpts::gauge(
@@ -278,7 +278,8 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             )
             .percentage_range()
             .with_row_label("GPU"),
-            "sum by (id, vendor) (gpu_dram_bandwidth_utilization) / 100".to_string(),
+            "sum by (id, vendor) (gpu_dram_bandwidth_utilization{vendor=\"nvidia\"}) / 100"
+                .to_string(),
         );
     } else {
         dram_bw.plot_promql_full(
@@ -288,7 +289,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
                 Unit::Percentage,
             )
             .percentage_range(),
-            "avg(gpu_dram_bandwidth_utilization) / 100".to_string(),
+            "avg(gpu_dram_bandwidth_utilization{vendor=\"nvidia\"}) / 100".to_string(),
         );
     }
 
@@ -309,7 +310,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             Unit::Percentage,
         )
         .percentage_range(),
-        "gpu_pcie_throughput{direction=\"receive\"} / ignoring(direction) gpu_pcie_bandwidth"
+        "gpu_pcie_throughput{direction=\"receive\"} / ignoring(direction) gpu_pcie_bandwidth{vendor=\"nvidia\"}"
             .to_string(),
     );
 
@@ -326,7 +327,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
             Unit::Percentage,
         )
         .percentage_range(),
-        "gpu_pcie_throughput{direction=\"transmit\"} / ignoring(direction) gpu_pcie_bandwidth"
+        "gpu_pcie_throughput{direction=\"transmit\"} / ignoring(direction) gpu_pcie_bandwidth{vendor=\"nvidia\"}"
             .to_string(),
     );
 
@@ -334,7 +335,7 @@ pub fn generate(data: &dyn MetricsSource, sections: Vec<Section>) -> View {
     capacity.describe("Aggregate theoretical PCIe bandwidth available to all GPUs.");
     capacity.plot_promql_full(
         PlotOpts::gauge("Bandwidth", "pcie-bandwidth", Unit::Datarate),
-        "sum(gpu_pcie_bandwidth)".to_string(),
+        "sum(gpu_pcie_bandwidth{vendor=\"nvidia\"})".to_string(),
     );
 
     view.group(pcie);
@@ -636,12 +637,14 @@ fn intel_pmu(view: &mut View, multi_gpu: bool) {
             Unit::Percentage,
         )
         .with_row_label("Class"),
-        "sum by (engine_class) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
+        "sum by (engine_class) (rate(gpu_engine_busy_time{vendor=\"intel\"}[5m])) / 1000000000"
+            .to_string(),
     );
     engines.plot_promql(
         PlotOpts::gauge("Busy % by Engine", "intel-engine-pct", Unit::Percentage)
             .with_row_label("Engine"),
-        "sum by (engine) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
+        "sum by (engine) (rate(gpu_engine_busy_time{vendor=\"intel\"}[5m])) / 1000000000"
+            .to_string(),
     );
 
     // The engine that carries the compute workload, called out on its own
@@ -655,12 +658,12 @@ fn intel_pmu(view: &mut View, multi_gpu: bool) {
             Unit::Percentage,
         )
         .percentage_range(),
-        "sum(rate(gpu_engine_busy_time{engine_class=\"compute\"}[5m])) / 1000000000".to_string(),
+        "sum(rate(gpu_engine_busy_time{engine_class=\"compute\", vendor=\"intel\"}[5m])) / 1000000000".to_string(),
     );
     engines.plot_promql(
         PlotOpts::gauge("Render Engine Busy %", "intel-render-pct", Unit::Percentage)
             .percentage_range(),
-        "sum(rate(gpu_engine_busy_time{engine_class=\"render\"}[5m])) / 1000000000".to_string(),
+        "sum(rate(gpu_engine_busy_time{engine_class=\"render\", vendor=\"intel\"}[5m])) / 1000000000".to_string(),
     );
 
     if multi_gpu {
@@ -676,7 +679,8 @@ fn intel_pmu(view: &mut View, multi_gpu: bool) {
                 Unit::Percentage,
             )
             .with_row_label("GPU"),
-            "sum by (id, vendor) (rate(gpu_engine_busy_time[5m])) / 1000000000".to_string(),
+            "sum by (id, vendor) (rate(gpu_engine_busy_time{vendor=\"intel\"}[5m])) / 1000000000"
+                .to_string(),
         );
     }
 
@@ -691,12 +695,12 @@ fn intel_pmu(view: &mut View, multi_gpu: bool) {
     );
     freq.plot_promql(
         PlotOpts::gauge("Actual", "intel-freq-actual", Unit::Frequency),
-        "sum by (id, vendor) (rate(gpu_frequency_sample{frequency=\"actual\"}[5m])) * 1000000"
+        "sum by (id, vendor) (rate(gpu_frequency_sample{frequency=\"actual\", vendor=\"intel\"}[5m])) * 1000000"
             .to_string(),
     );
     freq.plot_promql(
         PlotOpts::gauge("Requested", "intel-freq-requested", Unit::Frequency),
-        "sum by (id, vendor) (rate(gpu_frequency_sample{frequency=\"requested\"}[5m])) * 1000000"
+        "sum by (id, vendor) (rate(gpu_frequency_sample{frequency=\"requested\", vendor=\"intel\"}[5m])) * 1000000"
             .to_string(),
     );
 

--- a/crates/dashboard/src/plot.rs
+++ b/crates/dashboard/src/plot.rs
@@ -438,6 +438,16 @@ pub struct PlotOpts {
     format: FormatConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    /// Force a chart style instead of inferring one from the result shape.
+    ///
+    /// The frontend's `resolveStyle` picks a style from how many series come
+    /// back, which makes a chart's type depend on how many entities the host
+    /// happens to have — a per-entity chart drawn as a heatmap on a two-device
+    /// host becomes a line chart on a one-device host. A plot that is
+    /// per-entity by construction says so here, and `data.js` honours it ahead
+    /// of the inference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    style: Option<String>,
 }
 
 #[derive(Default, Clone, Serialize)]
@@ -481,6 +491,7 @@ impl PlotOpts {
             percentiles: None,
             format: FormatConfig::new(unit),
             description: None,
+            style: None,
         }
     }
 
@@ -495,6 +506,7 @@ impl PlotOpts {
             percentiles: None,
             format: FormatConfig::new(unit),
             description: None,
+            style: None,
         }
     }
 
@@ -516,6 +528,7 @@ impl PlotOpts {
             percentiles: None,
             format: FormatConfig::new(unit),
             description: None,
+            style: None,
         }
     }
 
@@ -565,6 +578,13 @@ impl PlotOpts {
     /// Set the entity each heatmap row represents in tooltips (e.g. "GPU").
     pub fn with_row_label<T: Into<String>>(mut self, row_label: T) -> Self {
         self.format.row_label = Some(row_label.into());
+        self
+    }
+
+    /// Force this plot's chart style, overriding the frontend's inference from
+    /// the result shape. See [`PlotOpts::style`].
+    pub fn with_style<T: Into<String>>(mut self, style: T) -> Self {
+        self.style = Some(style.into());
         self
     }
 

--- a/crates/systeminfo/Cargo.toml
+++ b/crates/systeminfo/Cargo.toml
@@ -17,8 +17,12 @@ walkdir.workspace = true
 # Used to dlopen the vendor GPU libraries (libnvidia-ml, librocm_smi64) at
 # runtime for hardware inventory. Linux-only: these libraries don't exist
 # elsewhere, and the GPU collector is gated to Linux.
+#
+# `libc` is for the DRM query ioctl the Intel GPU collector uses to read VRAM
+# size — Intel needs no vendor library, but it does need that one syscall.
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading.workspace = true
+libc.workspace = true
 
 
 [[bin]]

--- a/crates/systeminfo/src/hwinfo/gpu.rs
+++ b/crates/systeminfo/src/hwinfo/gpu.rs
@@ -827,7 +827,13 @@ mod intel {
                 continue;
             }
 
-            let target = std::fs::canonicalize(entry.path().join("device")).ok()?;
+            // `continue`, not `?`: readdir order is arbitrary, and one
+            // render node whose `device` link will not resolve (a virtual or
+            // half-torn-down node) must not end the scan before the real card
+            // is reached.
+            let Ok(target) = std::fs::canonicalize(entry.path().join("device")) else {
+                continue;
+            };
             if target.file_name().and_then(|s| s.to_str()) == Some(pci_bus_id) {
                 return File::open(Path::new("/dev/dri").join(&name)).ok();
             }

--- a/crates/systeminfo/src/hwinfo/gpu.rs
+++ b/crates/systeminfo/src/hwinfo/gpu.rs
@@ -26,6 +26,12 @@
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Gpu {
     /// Device index as reported by the vendor library.
+    ///
+    /// **Vendor-local, not globally unique.** It matches the `id` label on that
+    /// vendor's GPU metrics, which each sampler numbers from 0 independently, so
+    /// on a host with two vendors' cards two entries can both be `index: 0`.
+    /// Key on `(vendor, index)`; `pci_bus_id` is the stable identifier when one
+    /// is needed.
     pub index: usize,
     /// Vendor identifier: "nvidia", "amd" or "intel".
     pub vendor: String,

--- a/crates/systeminfo/src/hwinfo/gpu.rs
+++ b/crates/systeminfo/src/hwinfo/gpu.rs
@@ -12,6 +12,11 @@
 //! simply returns an empty vector. This mirrors how the agent's GPU samplers
 //! load these libraries.
 //!
+//! Intel needs no vendor library: the i915/xe driver publishes everything this
+//! inventory wants through sysfs and one DRM ioctl, which is also what the
+//! `gpu_intel_pmu` sampler reads. Both integrated and discrete (Arc) parts are
+//! enumerated.
+//!
 //! This is *static* hardware inventory only. Live telemetry (utilization,
 //! temperature, power, clocks) belongs in the agent's GPU samplers, not here.
 
@@ -22,7 +27,7 @@
 pub struct Gpu {
     /// Device index as reported by the vendor library.
     pub index: usize,
-    /// Vendor identifier: "nvidia" or "amd".
+    /// Vendor identifier: "nvidia", "amd" or "intel".
     pub vendor: String,
     /// Marketing/device name, e.g. "NVIDIA A100-SXM4-80GB" or
     /// "AMD Radeon AI PRO R9700".
@@ -38,6 +43,7 @@ pub struct Gpu {
     /// Architecture / compute capability:
     /// - NVIDIA: compute capability, e.g. "8.0".
     /// - AMD: LLVM target / gfx name, e.g. "gfx942".
+    /// - Intel: "integrated" or "discrete".
     pub architecture: Option<String>,
     /// Current PCIe link generation (1-7).
     pub pcie_gen: Option<usize>,
@@ -46,6 +52,7 @@ pub struct Gpu {
     /// Number of compute cores:
     /// - NVIDIA: streaming multiprocessor (SM) count.
     /// - AMD: compute unit (CU) count.
+    /// - Intel: not reported (the driver exposes no EU count in sysfs).
     pub cores: Option<usize>,
 }
 
@@ -56,6 +63,7 @@ pub fn get_gpus() -> Vec<Gpu> {
         let mut gpus = Vec::new();
         gpus.extend(nvidia::get_gpus());
         gpus.extend(amd::get_gpus());
+        gpus.extend(intel::get_gpus());
         gpus
     }
     #[cfg(not(target_os = "linux"))]
@@ -433,6 +441,391 @@ mod amd {
     unsafe fn cstr(buf: &[c_char]) -> Option<String> {
         let s = CStr::from_ptr(buf.as_ptr()).to_string_lossy().into_owned();
         (!s.is_empty()).then_some(s)
+    }
+}
+
+/// Intel GPU inventory, read from sysfs and the DRM query ioctl.
+///
+/// Unlike NVIDIA and AMD there is no userspace library to load: the i915/xe
+/// driver publishes device identity through `/sys/class/drm/card*/device/`, and
+/// the one thing sysfs does not carry — device-local memory size — comes from
+/// the same `DRM_IOCTL_I915_QUERY` the `gpu_intel_pmu` sampler uses.
+///
+/// Both integrated and discrete parts are enumerated. They are distinguished by
+/// whether the DRM query reports a device-local memory region: an integrated GPU
+/// has none (it shares host RAM), which is also why `memory_bytes` is `None`
+/// there rather than reporting system memory as if it were VRAM.
+#[cfg(target_os = "linux")]
+mod intel {
+    use super::Gpu;
+    use std::fs::File;
+    use std::os::fd::AsRawFd;
+    use std::path::{Path, PathBuf};
+
+    /// Intel's PCI vendor ID.
+    const PCI_VENDOR_INTEL: &str = "0x8086";
+
+    /// `DRM_IOCTL_I915_QUERY`, from `DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_QUERY, ...)`.
+    const DRM_IOCTL_I915_QUERY: libc::c_ulong = 0xc0106479;
+    /// `DRM_I915_QUERY_MEMORY_REGIONS`
+    const QUERY_MEMORY_REGIONS: u64 = 4;
+    /// `I915_MEMORY_CLASS_DEVICE` — card-local memory (VRAM).
+    const MEMORY_CLASS_DEVICE: u16 = 1;
+
+    #[repr(C)]
+    struct DrmI915Query {
+        num_items: u32,
+        flags: u32,
+        items_ptr: u64,
+    }
+
+    #[repr(C)]
+    struct DrmI915QueryItem {
+        query_id: u64,
+        length: i32,
+        flags: u32,
+        data_ptr: u64,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct MemoryClassInstance {
+        memory_class: u16,
+        memory_instance: u16,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct MemoryRegionInfo {
+        region: MemoryClassInstance,
+        rsvd0: u32,
+        probed_size: u64,
+        unallocated_size: u64,
+        rsvd1: [u64; 8],
+    }
+
+    #[repr(C)]
+    struct QueryMemoryRegionsHeader {
+        num_regions: u32,
+        rsvd: [u32; 3],
+    }
+
+    /// Enumerate Intel GPUs. Returns empty on a host with none.
+    pub fn get_gpus() -> Vec<Gpu> {
+        let mut cards: Vec<(String, PathBuf)> = Vec::new();
+
+        let Ok(entries) = std::fs::read_dir("/sys/class/drm") else {
+            return Vec::new();
+        };
+
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+
+            // Match `card1`, not connector children like `card1-DP-1`, and not
+            // the render nodes (which describe the same device).
+            if !name.starts_with("card") || name.contains('-') {
+                continue;
+            }
+
+            let device = entry.path().join("device");
+
+            if read_trimmed(&device.join("vendor")).as_deref() != Some(PCI_VENDOR_INTEL) {
+                continue;
+            }
+
+            // Only GPUs bound to a driver we understand; an unbound or
+            // vfio-assigned device has no telemetry to correlate with.
+            let driver = std::fs::canonicalize(device.join("driver"))
+                .ok()
+                .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()));
+
+            if !matches!(driver.as_deref(), Some("i915") | Some("xe")) {
+                continue;
+            }
+
+            cards.push((name, entry.path()));
+        }
+
+        // Stable, reproducible order: by card name, so `card1` precedes `card2`
+        // and the index is not whatever order readdir happened to yield.
+        cards.sort();
+
+        cards
+            .into_iter()
+            .enumerate()
+            .map(|(index, (_, card))| describe(index, &card))
+            .collect()
+    }
+
+    fn describe(index: usize, card: &Path) -> Gpu {
+        let device = card.join("device");
+
+        let pci_bus_id = std::fs::canonicalize(&device)
+            .ok()
+            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()));
+
+        let driver = std::fs::canonicalize(device.join("driver"))
+            .ok()
+            .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()));
+
+        // NUMA node is -1 on a machine with no NUMA affinity for the device,
+        // which is not a node number.
+        let numa_node = read_trimmed(&device.join("numa_node"))
+            .and_then(|v| v.parse::<i32>().ok())
+            .and_then(|n| (n >= 0).then_some(n as usize));
+
+        let vram = pci_bus_id.as_deref().and_then(vram_bytes);
+
+        Gpu {
+            index,
+            vendor: "intel".to_string(),
+            name: pci_bus_id.as_deref().and_then(device_name),
+            // Only device-local memory counts as video memory. An integrated
+            // GPU has none and reports `None` rather than passing host RAM off
+            // as VRAM.
+            memory_bytes: vram,
+            driver,
+            pci_bus_id,
+            numa_node,
+            // The i915/xe drivers expose no architecture string in sysfs. The
+            // integrated/discrete split is the distinction that actually
+            // changes how the metrics read (VRAM series exist only on
+            // discrete), so it is what gets reported.
+            architecture: Some(
+                if vram.is_some() {
+                    "discrete"
+                } else {
+                    "integrated"
+                }
+                .to_string(),
+            ),
+            // An integrated GPU sits on the root complex and reports "Unknown"
+            // speed and width 0 — not a 0-lane link, but "no PCIe link here".
+            // Both are reported as absent rather than as zero.
+            //
+            // On a discrete card these are the *current* link state, which the
+            // ASPM/power-management layer downshifts when the GPU is idle: an
+            // A770 capable of gen4 x16 reads gen1 x1 at rest and negotiates up
+            // under load. That is the honest instantaneous answer, and matches
+            // what NVML and ROCm SMI report for the other vendors.
+            pcie_gen: read_trimmed(&device.join("current_link_speed")).and_then(|s| pcie_gen(&s)),
+            pcie_width: read_trimmed(&device.join("current_link_width"))
+                .and_then(|v| v.parse::<usize>().ok())
+                .filter(|w| *w > 0),
+            // No EU count in sysfs; the OA/Metrics Discovery stack has it, but
+            // that is a heavier dependency than a hardware inventory warrants.
+            cores: None,
+        }
+    }
+
+    /// Marketing name for a PCI device, from the system `pci.ids` database.
+    ///
+    /// The driver publishes only the numeric device ID, so the human-readable
+    /// name has to be looked up. Absent that database the field is simply
+    /// `None` — a missing name is better than a hex ID presented as one.
+    fn device_name(pci_bus_id: &str) -> Option<String> {
+        let device_path = Path::new("/sys/bus/pci/devices").join(pci_bus_id);
+        let device_id = read_trimmed(&device_path.join("device"))?;
+        let device_id = device_id.strip_prefix("0x")?.to_lowercase();
+
+        let db = ["/usr/share/misc/pci.ids", "/usr/share/hwdata/pci.ids"]
+            .iter()
+            .find_map(|p| std::fs::read_to_string(p).ok())?;
+
+        // pci.ids is vendor-major: a vendor line at column 0, its devices
+        // indented by one tab. Walk to Intel's block, then scan its devices.
+        let mut in_intel = false;
+
+        for line in db.lines() {
+            if line.starts_with('#') || line.trim().is_empty() {
+                continue;
+            }
+
+            if !line.starts_with('\t') {
+                // A new vendor block begins; we are done once past Intel's.
+                if in_intel {
+                    break;
+                }
+                in_intel = line.starts_with("8086 ");
+                continue;
+            }
+
+            if !in_intel || line.starts_with("\t\t") {
+                continue;
+            }
+
+            let entry = line.trim_start();
+            if let Some(rest) = entry.strip_prefix(&device_id) {
+                let name = rest.trim();
+                if !name.is_empty() {
+                    return Some(format!("Intel {name}"));
+                }
+            }
+        }
+
+        None
+    }
+
+    /// PCIe generation from a sysfs link-speed string such as "16.0 GT/s PCIe".
+    fn pcie_gen(speed: &str) -> Option<usize> {
+        let gts: f64 = speed.split_whitespace().next()?.parse().ok()?;
+
+        // Per-generation transfer rates; compared with tolerance because the
+        // strings carry one decimal place.
+        Some(match gts {
+            g if g < 3.0 => 1,  // 2.5 GT/s
+            g if g < 6.0 => 2,  // 5 GT/s
+            g if g < 9.0 => 3,  // 8 GT/s
+            g if g < 20.0 => 4, // 16 GT/s
+            g if g < 40.0 => 5, // 32 GT/s
+            _ => 6,             // 64 GT/s
+        })
+    }
+
+    /// Total device-local memory (VRAM) in bytes, via the DRM query ioctl.
+    ///
+    /// Returns `None` for an integrated GPU (no device-local region) or when the
+    /// render node cannot be opened. Unlike the sampler's live reading this uses
+    /// only `probed_size`, which needs no special privilege — the unprivileged
+    /// trap there affects `unallocated_size`, which an inventory does not want.
+    fn vram_bytes(pci_bus_id: &str) -> Option<u64> {
+        let file = render_node(pci_bus_id)?;
+
+        let regions = query_memory_regions(&file)?;
+
+        regions
+            .iter()
+            .find(|r| r.region.memory_class == MEMORY_CLASS_DEVICE)
+            .map(|r| r.probed_size)
+    }
+
+    /// Open the render node (`renderD*`) whose PCI address matches.
+    ///
+    /// Render nodes need no DRM master and are the interface intended for
+    /// non-display clients.
+    fn render_node(pci_bus_id: &str) -> Option<File> {
+        for entry in std::fs::read_dir("/sys/class/drm").ok()?.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !name.starts_with("renderD") {
+                continue;
+            }
+
+            let target = std::fs::canonicalize(entry.path().join("device")).ok()?;
+            if target.file_name().and_then(|s| s.to_str()) == Some(pci_bus_id) {
+                return File::open(Path::new("/dev/dri").join(&name)).ok();
+            }
+        }
+
+        None
+    }
+
+    fn query_memory_regions(file: &File) -> Option<Vec<MemoryRegionInfo>> {
+        // Step 1: length probe. `length = 0` asks the kernel how many bytes the
+        // reply needs.
+        let mut item = DrmI915QueryItem {
+            query_id: QUERY_MEMORY_REGIONS,
+            length: 0,
+            flags: 0,
+            data_ptr: 0,
+        };
+
+        if !query(file, &mut item) || item.length <= 0 {
+            return None;
+        }
+
+        let length = item.length as usize;
+        let header_size = std::mem::size_of::<QueryMemoryRegionsHeader>();
+        let region_size = std::mem::size_of::<MemoryRegionInfo>();
+
+        if length < header_size {
+            return None;
+        }
+
+        // Step 2: fetch into a buffer the kernel sized for us. `u64` backing
+        // because both structs are 8-byte aligned.
+        let words = length.div_ceil(std::mem::size_of::<u64>());
+        let mut buffer: Vec<u64> = vec![0; words];
+
+        item.data_ptr = buffer.as_mut_ptr() as u64;
+        if !query(file, &mut item) {
+            return None;
+        }
+
+        // SAFETY: `buffer` is at least `length` bytes, 8-byte aligned, and the
+        // kernel has just written a `drm_i915_query_memory_regions` into it.
+        let header = unsafe { &*(buffer.as_ptr() as *const QueryMemoryRegionsHeader) };
+
+        // Trust the declared length over `num_regions`: only read as many
+        // regions as actually fit in the buffer the kernel filled.
+        let available = (length - header_size) / region_size;
+        let count = (header.num_regions as usize).min(available);
+
+        let mut regions = Vec::with_capacity(count);
+        for i in 0..count {
+            let offset = header_size + i * region_size;
+            // SAFETY: `offset + region_size <= length <= buffer bytes`, and the
+            // region array directly follows the header per the uapi layout.
+            let region = unsafe {
+                std::ptr::read_unaligned(
+                    (buffer.as_ptr() as *const u8).add(offset) as *const MemoryRegionInfo
+                )
+            };
+            regions.push(region);
+        }
+
+        Some(regions)
+    }
+
+    fn query(file: &File, item: &mut DrmI915QueryItem) -> bool {
+        let mut q = DrmI915Query {
+            num_items: 1,
+            flags: 0,
+            items_ptr: item as *mut DrmI915QueryItem as u64,
+        };
+
+        // SAFETY: `q` points at a valid `drm_i915_query` whose `items_ptr`
+        // refers to a single valid `drm_i915_query_item`, matching what
+        // DRM_IOCTL_I915_QUERY expects.
+        let ret = unsafe {
+            libc::ioctl(
+                file.as_raw_fd(),
+                DRM_IOCTL_I915_QUERY,
+                &mut q as *mut DrmI915Query,
+            )
+        };
+
+        ret == 0
+    }
+
+    fn read_trimmed(path: &Path) -> Option<String> {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn struct_layouts_match_the_uapi() {
+            // Fixed by the kernel uapi; a mismatch would silently misparse.
+            assert_eq!(std::mem::size_of::<DrmI915Query>(), 16);
+            assert_eq!(std::mem::size_of::<DrmI915QueryItem>(), 24);
+            assert_eq!(std::mem::size_of::<MemoryClassInstance>(), 4);
+            assert_eq!(std::mem::size_of::<QueryMemoryRegionsHeader>(), 16);
+            assert_eq!(std::mem::size_of::<MemoryRegionInfo>(), 88);
+        }
+
+        #[test]
+        fn maps_link_speed_to_pcie_generation() {
+            assert_eq!(pcie_gen("2.5 GT/s PCIe"), Some(1));
+            assert_eq!(pcie_gen("5.0 GT/s PCIe"), Some(2));
+            assert_eq!(pcie_gen("8.0 GT/s PCIe"), Some(3));
+            assert_eq!(pcie_gen("16.0 GT/s PCIe"), Some(4));
+            assert_eq!(pcie_gen("32.0 GT/s PCIe"), Some(5));
+            assert_eq!(pcie_gen("Unknown"), None);
+        }
     }
 }
 

--- a/crates/systeminfo/src/hwinfo/gpu.rs
+++ b/crates/systeminfo/src/hwinfo/gpu.rs
@@ -83,6 +83,7 @@ mod nvidia {
     use super::Gpu;
     use libloading::{Library, Symbol};
     use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
+    use std::path::{Path, PathBuf};
 
     // nvmlReturn_t: 0 == NVML_SUCCESS.
     type NvmlReturn = c_int;
@@ -130,9 +131,31 @@ mod nvidia {
     type FnDevicePcieWidth = unsafe extern "C" fn(NvmlDevice, *mut c_uint) -> NvmlReturn;
     type FnDeviceCores = unsafe extern "C" fn(NvmlDevice, *mut c_uint) -> NvmlReturn;
 
-    /// Query the NVIDIA GPUs via NVML. Returns empty if NVML can't be loaded or
-    /// initialized (e.g. no NVIDIA driver).
+    /// Query the NVIDIA GPUs.
+    ///
+    /// NVML is preferred and answers in full (memory, PCIe link, SM count,
+    /// compute capability). When it cannot be loaded or initialised — the
+    /// driver is installed but the userspace library is not, which is ordinary
+    /// on a headless host — the driver's own `/proc` interface is scraped
+    /// instead. That yields far less (a model name, a driver version, the PCI
+    /// address and NUMA node) but it beats reporting no GPU at all on a machine
+    /// that plainly has one.
+    ///
+    /// The fallback lives here rather than in the summary layer so it triggers
+    /// on *NVIDIA* being unreadable, not on the whole GPU list being empty: a
+    /// host with an AMD card and an NVIDIA card whose NVML is missing used to
+    /// skip the scan entirely, because the list was non-empty.
     pub fn get_gpus() -> Vec<Gpu> {
+        let gpus = nvml_gpus();
+        if gpus.is_empty() {
+            proc_gpus()
+        } else {
+            gpus
+        }
+    }
+
+    /// Query via NVML. Empty if the library can't be loaded or initialised.
+    fn nvml_gpus() -> Vec<Gpu> {
         // SAFETY: loading a system shared library is inherently unsafe; we trust
         // the NVIDIA-provided library and only call documented NVML functions.
         unsafe {
@@ -161,6 +184,94 @@ mod nvidia {
             }
             gpus
         }
+    }
+
+    /// Enumerate NVIDIA GPUs from `/proc/driver/nvidia/gpus/<pci_addr>/`, the
+    /// driver's own interface, for hosts where NVML is absent.
+    ///
+    /// Only the fields that interface actually exposes are filled; everything
+    /// NVML would have supplied (memory, PCIe link, core count, compute
+    /// capability) stays `None` rather than being guessed at.
+    pub(super) fn proc_gpus() -> Vec<Gpu> {
+        let gpu_dir = Path::new("/proc/driver/nvidia/gpus");
+        if !gpu_dir.exists() {
+            return Vec::new();
+        }
+
+        let driver = std::fs::read_to_string("/proc/driver/nvidia/version")
+            .ok()
+            .and_then(|v| parse_proc_driver_version(&v));
+
+        let mut entries: Vec<PathBuf> = match std::fs::read_dir(gpu_dir) {
+            Ok(entries) => entries.flatten().map(|e| e.path()).collect(),
+            Err(_) => return Vec::new(),
+        };
+
+        // readdir order is arbitrary; sort by PCI address so the index each GPU
+        // receives is stable across runs (it is the join key for metrics).
+        entries.sort();
+
+        let mut gpus = Vec::new();
+
+        for (index, dir) in entries.into_iter().enumerate() {
+            let Ok(contents) = std::fs::read_to_string(dir.join("information")) else {
+                continue;
+            };
+
+            let name = contents.lines().find_map(|line| {
+                line.strip_prefix("Model:")
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty())
+            });
+
+            // The directory is named for the PCI address, e.g.
+            // /proc/driver/nvidia/gpus/0000:01:00.0/information
+            let pci_bus_id = dir
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .filter(|s| !s.is_empty());
+
+            let numa_node = pci_bus_id.as_deref().and_then(|bdf| {
+                std::fs::read_to_string(format!("/sys/bus/pci/devices/{bdf}/numa_node"))
+                    .ok()
+                    .and_then(|v| v.trim().parse::<i32>().ok())
+                    .and_then(|n| (n >= 0).then_some(n as usize))
+            });
+
+            gpus.push(Gpu {
+                index,
+                vendor: "nvidia".to_string(),
+                name,
+                memory_bytes: None,
+                driver: driver.clone(),
+                pci_bus_id,
+                numa_node,
+                architecture: None,
+                pcie_gen: None,
+                pcie_width: None,
+                cores: None,
+            });
+        }
+
+        gpus
+    }
+
+    /// Pull the driver version out of `/proc/driver/nvidia/version`, whose first
+    /// line reads like:
+    ///   `NVRM version: NVIDIA UNIX x86_64 Kernel Module  580.173.02  ...`
+    ///
+    /// Matched as "the first dotted numeric token" rather than by leading digit,
+    /// which is what the previous version did — that would have taken `64` out
+    /// of `x86_64` had the vendor string ever shifted, and silently reported it
+    /// as the driver version.
+    pub(super) fn parse_proc_driver_version(contents: &str) -> Option<String> {
+        contents.lines().next()?.split_whitespace().find_map(|w| {
+            let trimmed = w.trim_end_matches(|c: char| !c.is_ascii_digit());
+            let dotted = trimmed.split('.').count() >= 2;
+            let numeric =
+                !trimmed.is_empty() && trimmed.chars().all(|c| c.is_ascii_digit() || c == '.');
+            (dotted && numeric).then(|| trimmed.to_string())
+        })
     }
 
     unsafe fn collect(lib: &Library) -> Vec<Gpu> {
@@ -845,5 +956,69 @@ mod tests {
     fn get_gpus_does_not_panic_and_serializes() {
         let gpus = get_gpus();
         let _ = serde_json::to_string(&gpus).expect("gpus serialize");
+    }
+
+    /// The /proc fallback must agree with NVML on the facts both can see.
+    ///
+    /// Skips itself on a host with no NVIDIA driver, which is most of them —
+    /// this asserts only where there is something to assert against.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_fallback_agrees_with_nvml_where_both_report() {
+        let from_proc = super::nvidia::proc_gpus();
+        if from_proc.is_empty() {
+            return; // no /proc/driver/nvidia/gpus on this host
+        }
+
+        for g in &from_proc {
+            assert_eq!(g.vendor, "nvidia");
+            // The directory name is the PCI address; it must survive as one.
+            let bdf = g
+                .pci_bus_id
+                .as_deref()
+                .expect("proc entry names a PCI address");
+            assert!(bdf.contains(':'), "not a BDF: {bdf}");
+            // Fields /proc cannot answer stay absent rather than being invented.
+            assert!(g.memory_bytes.is_none());
+            assert!(g.cores.is_none());
+        }
+
+        // Indices must be dense and ordered, since they are the join key.
+        let indices: Vec<usize> = from_proc.iter().map(|g| g.index).collect();
+        assert_eq!(indices, (0..from_proc.len()).collect::<Vec<_>>());
+
+        // Where NVML also answers, the two must describe the same devices.
+        let from_nvml = super::nvidia::get_gpus();
+        if from_nvml.iter().any(|g| g.memory_bytes.is_some()) {
+            assert_eq!(from_nvml.len(), from_proc.len());
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_the_driver_version_from_proc() {
+        use super::nvidia::parse_proc_driver_version;
+
+        // The real first line from a host running the 580 driver.
+        assert_eq!(
+            parse_proc_driver_version(
+                "NVRM version: NVIDIA UNIX x86_64 Kernel Module  580.173.02  Wed Jul  2 2025\n                 GCC version:  gcc version 13.3.0"
+            )
+            .as_deref(),
+            Some("580.173.02"),
+        );
+
+        // `x86_64` must not be mistaken for a version: it is numeric-ish and
+        // starts with a digit after the underscore, which a looser match would
+        // accept. Requiring a dotted numeric token rules it out.
+        assert_eq!(
+            parse_proc_driver_version("NVRM version: NVIDIA UNIX x86_64 Kernel Module  470.1  x")
+                .as_deref(),
+            Some("470.1"),
+        );
+
+        // Nothing version-shaped at all.
+        assert_eq!(parse_proc_driver_version("NVRM version: unknown"), None);
+        assert_eq!(parse_proc_driver_version(""), None);
     }
 }

--- a/crates/systeminfo/src/summary/linux.rs
+++ b/crates/systeminfo/src/summary/linux.rs
@@ -322,10 +322,10 @@ fn collect_nics() -> Vec<NicSummary> {
 }
 
 fn collect_gpus() -> Vec<GpuSummary> {
-    // Prefer the library-based hwinfo collector (NVIDIA via NVML + AMD via ROCm
-    // SMI, with total memory and richer detail). Fall back to scraping the
-    // NVIDIA proc interface when the vendor libraries aren't installed.
-    let gpus: Vec<GpuSummary> = crate::hwinfo::gpu::get_gpus()
+    // Every backend lives in `hwinfo::gpu`, including NVIDIA's /proc fallback
+    // for hosts without NVML — this is a straight projection, with no
+    // vendor-specific rescue left at this layer.
+    crate::hwinfo::gpu::get_gpus()
         .into_iter()
         .map(|g| GpuSummary {
             index: g.index,
@@ -334,68 +334,13 @@ fn collect_gpus() -> Vec<GpuSummary> {
             memory_bytes: g.memory_bytes,
             driver: g.driver,
             numa_node: g.numa_node,
+            pci_bus_id: g.pci_bus_id,
+            architecture: g.architecture,
+            pcie_gen: g.pcie_gen,
+            pcie_width: g.pcie_width,
+            cores: g.cores,
         })
-        .collect();
-
-    if gpus.is_empty() {
-        collect_nvidia_gpus()
-    } else {
-        gpus
-    }
-}
-
-fn collect_nvidia_gpus() -> Vec<GpuSummary> {
-    let gpu_dir = Path::new("/proc/driver/nvidia/gpus");
-    if !gpu_dir.exists() {
-        return Vec::new();
-    }
-
-    let mut gpus = Vec::new();
-
-    let driver = read_string("/proc/driver/nvidia/version")
-        .ok()
-        .and_then(|v| {
-            // First line typically: "NVRM version: NVIDIA UNIX ... <version> ..."
-            v.lines().next().and_then(|line| {
-                line.split_whitespace()
-                    .position(|w| w.starts_with("5") || w.starts_with("4") || w.starts_with("3"))
-                    .and_then(|pos| line.split_whitespace().nth(pos))
-                    .map(|s| s.to_string())
-            })
-        });
-
-    if let Ok(entries) = fs::read_dir(gpu_dir) {
-        for (index, entry) in entries.flatten().enumerate() {
-            let info_path = entry.path().join("information");
-            if let Ok(contents) = fs::read_to_string(&info_path) {
-                let mut name = None;
-
-                for line in contents.lines() {
-                    if let Some(val) = line.strip_prefix("Model:") {
-                        name = Some(val.trim().to_string());
-                    }
-                }
-
-                // Try to get NUMA node from the PCI device sysfs path.
-                // /proc/driver/nvidia/gpus/<pci_addr>/information
-                // -> /sys/bus/pci/devices/<pci_addr>/numa_node
-                let pci_addr = entry.file_name().to_string_lossy().to_string();
-                let numa_node =
-                    read_usize(format!("/sys/bus/pci/devices/{pci_addr}/numa_node")).ok();
-
-                gpus.push(GpuSummary {
-                    index,
-                    name,
-                    vendor: "nvidia".to_string(),
-                    memory_bytes: None,
-                    driver: driver.clone(),
-                    numa_node,
-                });
-            }
-        }
-    }
-
-    gpus
+        .collect()
 }
 
 // Simple sysfs reading helpers (standalone, not using hwinfo::util to keep

--- a/crates/systeminfo/src/summary/macos.rs
+++ b/crates/systeminfo/src/summary/macos.rs
@@ -208,6 +208,14 @@ fn collect_gpus() -> Vec<GpuSummary> {
                 memory_bytes,
                 driver: None,
                 numa_node: None,
+                // An Apple Silicon GPU is on-die: no PCI bus, no PCIe link, and
+                // the system profiler reports no core count or architecture
+                // string. All genuinely absent rather than merely uncollected.
+                pci_bus_id: None,
+                architecture: None,
+                pcie_gen: None,
+                pcie_width: None,
+                cores: None,
             });
         }
     }

--- a/crates/systeminfo/src/summary/mod.rs
+++ b/crates/systeminfo/src/summary/mod.rs
@@ -110,6 +110,10 @@ pub struct NicSummary {
 #[serde(default)]
 pub struct GpuSummary {
     /// Device index, matching the `id` label on GPU metrics.
+    ///
+    /// Vendor-local: each vendor's sampler numbers its devices from 0, so this
+    /// is unique only within a `vendor`, not across the list. Pair it with
+    /// `vendor` when joining to metrics.
     pub index: usize,
     /// Device name (e.g., "NVIDIA A100", "Apple M2 Max")
     pub name: Option<String>,

--- a/crates/systeminfo/src/summary/mod.rs
+++ b/crates/systeminfo/src/summary/mod.rs
@@ -125,6 +125,31 @@ pub struct GpuSummary {
     pub driver: Option<String>,
     /// NUMA node this GPU is attached to
     pub numa_node: Option<usize>,
+    /// PCI bus identifier, e.g. `0000:04:00.0`.
+    ///
+    /// Unlike `index`, this is stable across reboots and hardware changes, so
+    /// it is the identifier to join on when correlating a GPU across
+    /// recordings. Note the formats differ by source: NVML reports an 8-digit
+    /// domain (`00000000:01:00.0`) where sysfs uses four (`0000:01:00.0`), so
+    /// normalize before comparing across vendors. `None` on platforms with no
+    /// PCI (Apple).
+    pub pci_bus_id: Option<String>,
+    /// Architecture / compute capability:
+    /// - NVIDIA: compute capability, e.g. "8.0".
+    /// - AMD: LLVM target / gfx name, e.g. "gfx942".
+    /// - Intel: "integrated" or "discrete".
+    pub architecture: Option<String>,
+    /// Current PCIe link generation (1-7).
+    ///
+    /// The *current* negotiated state, not the card's maximum: power management
+    /// downshifts an idle GPU, so a gen4 x16 card commonly reads gen1 x1 at
+    /// rest. `None` for an integrated GPU, which has no PCIe link.
+    pub pcie_gen: Option<usize>,
+    /// Current PCIe link width in lanes. See `pcie_gen` on why this moves.
+    pub pcie_width: Option<usize>,
+    /// Number of compute cores: NVIDIA SM count, AMD CU count. `None` on Intel,
+    /// whose driver exposes no EU count in sysfs.
+    pub cores: Option<usize>,
 }
 
 /// Collect a cross-platform system summary.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -253,7 +253,7 @@ consumption, and thermal conditions.
 
 ### gpu_intel_pmu
 
-Produces Intel GPU metrics from the i915/xe PMU via `perf_event_open`, the same
+Produces Intel GPU metrics from the i915 PMU via `perf_event_open`, the same
 data source `intel_gpu_top` reads. Covers both integrated GPUs and discrete Arc
 cards: each GPU registers its own PMU, which the sampler discovers from sysfs
 along with the engine set that GPU actually exposes (a discrete card has a

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,6 +23,7 @@ This guide walks you through all the available metrics, organized by category.
   - [drivehealth](#drivehealth)
 - [GPU](#gpu)
   - [gpu_nvidia](#gpu_nvidia)
+  - [gpu_intel_pmu](#gpu_intel_pmu)
 - [Memory](#memory)
   - [memory_meminfo](#memory_meminfo)
   - [memory_vmstat](#memory_vmstat)
@@ -249,6 +250,80 @@ consumption, and thermal conditions.
 | `gpu_clock` | The current clock speed for different GPU domains | `clock={compute,graphics,memory,video}` |
 | `gpu_utilization` | The running average percentage of time the GPU was executing one or more kernels (0-100) | |
 | `gpu_memory_utilization` | The running average percentage of time that GPU memory was being read from or written to (0-100) | |
+
+### gpu_intel_pmu
+
+Produces Intel GPU metrics from the i915/xe PMU via `perf_event_open`, the same
+data source `intel_gpu_top` reads. Covers both integrated GPUs and discrete Arc
+cards: each GPU registers its own PMU, which the sampler discovers from sysfs
+along with the engine set that GPU actually exposes (a discrete card has a
+compute engine; an integrated GPU typically does not). All events for a GPU are
+opened as one perf group, so a single read returns every counter with no skew
+between engines.
+
+Requires `CAP_PERFMON` (or `kernel.perf_event_paranoid` <= 2).
+
+The PMU values are **cumulative counters**, so the interesting quantities are
+rates:
+
+- `rate(gpu_engine_busy_time) * 100` — engine utilization, in percent.
+- `rate(gpu_frequency_sample)` — average frequency in MHz over the interval.
+  The driver accumulates one MHz sample per tick while the GT is awake, so this
+  is a running sum rather than an instantaneous gauge; a single reading carries
+  no meaning without its predecessor.
+
+VRAM is the exception: it is a gauge in bytes, from the DRM query ioctl rather
+than the PMU.
+
+| Metric | Type | Description | Metadata |
+|--------|------|-------------|----------|
+| `gpu_engine_busy_time` | counter | Nanoseconds an engine spent executing work | `id`, `device`, `type`, `engine`, `engine_class={render,copy,video,video-enhance,compute}` |
+| `gpu_frequency_sample` | counter | Cumulative sum of frequency samples in MHz; `rate()` yields average MHz | `id`, `device`, `type`, `frequency={actual,requested}` |
+| `gpu_memory` | gauge | The amount of GPU device memory (VRAM), in bytes | `id`, `device`, `type`, `state={used,free}` |
+
+The `device` label is the GPU's PCI address (e.g. `0000:04:00.0`) for a discrete
+card, or `integrated` for an integrated GPU; prefer it over `id` when joining
+across restarts. `type` is `discrete` or `integrated`, which is the quickest way
+to separate an Arc card from the iGPU on a host that has both.
+
+`gpu_memory` uses the same name and units as the AMD and NVIDIA samplers, so
+cross-vendor dashboards work unchanged. It is **discrete-only**: an integrated
+GPU has no device-local memory region, so it publishes no VRAM series rather
+than passing host RAM off as VRAM. VRAM comes from the DRM
+`QUERY_MEMORY_REGIONS` ioctl and needs `CAP_PERFMON` — without it the kernel
+reports all memory as unallocated, so the sampler suppresses the series rather
+than publishing a misleading "0 used".
+
+Pair busy time with frequency when interpreting load. The PMU reports engine
+**occupancy, not efficiency**: an engine reading 100% busy had work queued,
+which does not mean the EUs were saturated. Frequency separates "busy but
+downclocked" from genuinely saturated. EU-level detail needs the separate i915
+perf/OA interface, which this sampler does not use.
+
+Deliberately not collected, though the PMU exposes them: `<engine>-wait` and
+`<engine>-sema` (why an engine stalled — a debugging question rather than a load
+one), and `rc6-residency`, `software-gt-awake-time` and `interrupts` (power-state
+and IRQ accounting). GPU temperature and energy are available from the i915
+hwmon node but are not collected here either. `gpu_memory_utilization` and
+`gpu_pcie_throughput` are not available on Intel at all — there is no
+memory-controller or PCIe counter in this PMU.
+
+### Cadence
+
+This sampler reads on its own interval (`[samplers.gpu_intel_pmu] interval`,
+default 1s) rather than on the scrape cycle, serving cached values in between.
+A grouped `read(2)` on an i915 perf fd is not an mmap load — it takes a driver
+lock and samples each event (measured: 6.4 us for one event, 12.1 us for a
+26-event group, plus ~5.4 us for the VRAM ioctl) — so driving it at the
+snapshot-TTL rate would burn CPU for values that move on the order of seconds.
+Reads are dispatched via `spawn_blocking`; the on-cycle cost is a time
+comparison.
+
+Note that this PMU reports engine **occupancy, not efficiency** — a busy engine
+had work queued, which does not mean its execution units were saturated. Pair
+busy time with frequency to distinguish "busy but downclocked" from genuinely
+saturated. EU-level detail requires the separate i915 perf/OA interface, and
+there is no VRAM bandwidth counter in this PMU.
 
 ## Memory
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -320,6 +320,15 @@ integrated GPU, 11 engines and 4 frequency counters between them): 40-66 us per
 sweep in a release build. Reads are dispatched via `spawn_blocking`; the
 on-cycle cost is a time comparison.
 
+The read cadence admits a scrape arriving up to 50ms early. Without that
+tolerance, a consumer scraping at the same period as `interval` — the common
+case, since both default to 1s — has roughly every other scrape rejected by
+timer jitter, and the exported cumulative counters then alternate between an
+unchanged value and one that jumped two intervals' worth. That differentiates
+to double the true rate with no gap to indicate a dropped sample: an A770 held
+at a steady 2400 MHz recorded as 4800. Measured before the fix, two thirds of
+samples in a 155-second capture were stale repeats.
+
 The sweep is bracketed by two acquisition groups rather than one
 (`gpu_intel_pmu_engines` and `gpu_intel_pmu_devices`). It is a single read
 section, but its metrics live in two index spaces — per-engine entries are

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -313,11 +313,21 @@ memory-controller or PCIe counter in this PMU.
 This sampler reads on its own interval (`[samplers.gpu_intel_pmu] interval`,
 default 1s) rather than on the scrape cycle, serving cached values in between.
 A grouped `read(2)` on an i915 perf fd is not an mmap load — it takes a driver
-lock and samples each event (measured: 6.4 us for one event, 12.1 us for a
-26-event group, plus ~5.4 us for the VRAM ioctl) — so driving it at the
-snapshot-TTL rate would burn CPU for values that move on the order of seconds.
-Reads are dispatched via `spawn_blocking`; the on-cycle cost is a time
-comparison.
+lock and samples each event, plus ~5.4 us for the VRAM ioctl — so driving it at
+the snapshot-TTL rate would burn CPU for values that move on the order of
+seconds. Measured end to end on a host with two Intel GPUs (an Arc A770 and an
+integrated GPU, 11 engines and 4 frequency counters between them): 40-66 us per
+sweep in a release build. Reads are dispatched via `spawn_blocking`; the
+on-cycle cost is a time comparison.
+
+The sweep is bracketed by two acquisition groups rather than one
+(`gpu_intel_pmu_engines` and `gpu_intel_pmu_devices`). It is a single read
+section, but its metrics live in two index spaces — per-engine entries are
+indexed by a GPU-major engine index, per-device entries by plain GPU id — and a
+group's member set applies to every metric tagged with it. Sharing one group
+made engine indices look like GPU ids and published phantom all-zero
+`gpu_frequency_sample{id="2"}` series on a two-GPU host. Both groups are stamped
+from the same bracket, so the two windows are identical.
 
 Note that this PMU reports engine **occupancy, not efficiency** — a busy engine
 had work queued, which does not mean its execution units were saturated. Pair

--- a/src/agent/samplers/gpu/linux/intel/drm_memory.rs
+++ b/src/agent/samplers/gpu/linux/intel/drm_memory.rs
@@ -1,0 +1,313 @@
+//! Device-level VRAM accounting via `DRM_IOCTL_I915_QUERY`
+//! (`DRM_I915_QUERY_MEMORY_REGIONS`).
+//!
+//! The i915 PMU exposes no memory counter, so VRAM usage comes from the DRM
+//! query ioctl instead. It reports, per memory region, the size the driver
+//! probed and an estimate of how much is still unallocated — which is exactly
+//! the `total`/`free` pair the AMD and NVIDIA samplers publish as
+//! `gpu_memory{state=used,free}`.
+//!
+//! ## Which region counts
+//!
+//! A region is classed `SYSTEM` (host memory) or `DEVICE` (card-local VRAM).
+//! Only `DEVICE` is VRAM, and only `DEVICE` has real allocation tracking — the
+//! uapi states `unallocated_size` is "only currently tracked for
+//! I915_MEMORY_CLASS_DEVICE regions". An integrated GPU has no `DEVICE` region
+//! at all (verified on a Coffee Lake iGPU, which reports a single `SYSTEM`
+//! region), so it correctly publishes no VRAM series rather than reporting host
+//! RAM as if it were VRAM.
+//!
+//! ## The privilege trap
+//!
+//! `unallocated_size` needs `CAP_PERFMON` (or `CAP_SYS_ADMIN`). Without it the
+//! kernel does **not** fail the ioctl — it silently returns
+//! `unallocated_size == probed_size`, which reads as a perfectly plausible
+//! "0 bytes used". Verified on an Arc A770: as root the query reported 14366 MiB
+//! used of 16288 MiB, and unprivileged the same query reported 0 used.
+//!
+//! Publishing that zero would be worse than publishing nothing, so
+//! [`MemoryRegions::vram`] treats `unallocated == probed` on a `DEVICE` region as
+//! "not accounted" and returns `None`. Rezolus already holds `CAP_PERFMON` for
+//! the PMU, so in normal operation the values are real.
+//!
+//! ## Cost
+//!
+//! Measured at ~5.4 us per call on both an Arc A770 and an integrated GPU —
+//! comparable to a single perf counter read. It is still an ioctl rather than an
+//! mmap load, so it is subject to the same throttling as the PMU reads.
+
+use std::fs::File;
+use std::os::fd::{AsRawFd, RawFd};
+use std::path::Path;
+
+/// `DRM_IOCTL_I915_QUERY`, from `DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_QUERY, ...)`.
+///
+/// `DRM_COMMAND_BASE` is 0x40 and `DRM_I915_QUERY` is 0x39, giving ioctl number
+/// 0x79 in the 'd' (0x64) group with a 16-byte `drm_i915_query` argument.
+const DRM_IOCTL_I915_QUERY: libc::c_ulong = 0xc0106479;
+
+/// `DRM_I915_QUERY_MEMORY_REGIONS`
+const QUERY_MEMORY_REGIONS: u64 = 4;
+
+/// `I915_MEMORY_CLASS_DEVICE` — card-local memory (VRAM).
+const MEMORY_CLASS_DEVICE: u16 = 1;
+
+/// `struct drm_i915_query`
+#[repr(C)]
+struct DrmI915Query {
+    num_items: u32,
+    flags: u32,
+    items_ptr: u64,
+}
+
+/// `struct drm_i915_query_item`
+#[repr(C)]
+struct DrmI915QueryItem {
+    query_id: u64,
+    /// Set to 0 to ask for the required length; the kernel writes the byte
+    /// count here. A negative value is an error code.
+    length: i32,
+    flags: u32,
+    data_ptr: u64,
+}
+
+/// `struct drm_i915_gem_memory_class_instance`
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct MemoryClassInstance {
+    memory_class: u16,
+    memory_instance: u16,
+}
+
+/// `struct drm_i915_memory_region_info`
+///
+/// The trailing union is 8 x `__u64`; we only read the first two members of its
+/// struct arm (`probed_cpu_visible_size`, `unallocated_cpu_visible_size`), which
+/// we do not currently publish, so the tail is kept as an opaque array.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct MemoryRegionInfo {
+    region: MemoryClassInstance,
+    rsvd0: u32,
+    probed_size: u64,
+    unallocated_size: u64,
+    rsvd1: [u64; 8],
+}
+
+/// `struct drm_i915_query_memory_regions` header (the `regions[]` flexible array
+/// follows it in the same allocation).
+#[repr(C)]
+struct QueryMemoryRegionsHeader {
+    num_regions: u32,
+    rsvd: [u32; 3],
+}
+
+/// Total and free bytes for a GPU's device-local memory.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Vram {
+    pub total_bytes: u64,
+    pub free_bytes: u64,
+}
+
+impl Vram {
+    pub fn used_bytes(&self) -> u64 {
+        self.total_bytes.saturating_sub(self.free_bytes)
+    }
+}
+
+/// An open DRM render node used to query memory regions.
+pub struct DrmDevice {
+    file: File,
+    label: String,
+}
+
+impl DrmDevice {
+    /// Open the render node whose PCI address matches `pci_address`.
+    ///
+    /// Render nodes (`renderD*`) are used rather than the primary node
+    /// (`card*`): they need no DRM master and are the interface intended for
+    /// non-display clients.
+    pub fn for_pci_address(pci_address: &str) -> Option<Self> {
+        let entries = std::fs::read_dir("/sys/class/drm").ok()?;
+
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !name.starts_with("renderD") {
+                continue;
+            }
+
+            // /sys/class/drm/renderD129/device resolves to the PCI device dir,
+            // whose basename is the BDF (e.g. 0000:04:00.0).
+            let device_link = entry.path().join("device");
+            let Ok(target) = std::fs::canonicalize(&device_link) else {
+                continue;
+            };
+            let Some(bdf) = target.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+
+            if bdf == pci_address {
+                let path = Path::new("/dev/dri").join(&name);
+                let file = File::open(&path).ok()?;
+                return Some(Self { file, label: name });
+            }
+        }
+
+        None
+    }
+
+    fn fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+
+    /// The render node name, for diagnostics.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Query device-local (VRAM) total and free bytes.
+    ///
+    /// Returns `None` when the GPU has no device-local memory (an integrated
+    /// GPU), when the ioctl is unavailable, or when allocation accounting is not
+    /// available to this process (see the privilege note in the module docs).
+    pub fn vram(&self) -> Option<Vram> {
+        let regions = self.query_memory_regions()?;
+
+        regions.iter().find_map(|region| {
+            if region.region.memory_class != MEMORY_CLASS_DEVICE {
+                return None;
+            }
+
+            // Without CAP_PERFMON the kernel reports everything as unallocated
+            // rather than failing. Publishing "0 used" would be a confident lie,
+            // so report nothing instead.
+            if region.unallocated_size >= region.probed_size {
+                return None;
+            }
+
+            Some(Vram {
+                total_bytes: region.probed_size,
+                free_bytes: region.unallocated_size,
+            })
+        })
+    }
+
+    /// Issue the two-step query (ask for length, then fetch) and return the
+    /// region array.
+    fn query_memory_regions(&self) -> Option<Vec<MemoryRegionInfo>> {
+        // Step 1: length probe. `length = 0` asks the kernel how many bytes the
+        // reply needs.
+        let mut item = DrmI915QueryItem {
+            query_id: QUERY_MEMORY_REGIONS,
+            length: 0,
+            flags: 0,
+            data_ptr: 0,
+        };
+
+        if !self.query(&mut item) || item.length <= 0 {
+            return None;
+        }
+
+        let length = item.length as usize;
+
+        let header_size = std::mem::size_of::<QueryMemoryRegionsHeader>();
+        let region_size = std::mem::size_of::<MemoryRegionInfo>();
+        if length < header_size {
+            return None;
+        }
+
+        // Step 2: fetch into a buffer the kernel sized for us. The buffer is
+        // `u64`-aligned because both structs are 8-byte aligned.
+        let words = length.div_ceil(std::mem::size_of::<u64>());
+        let mut buffer: Vec<u64> = vec![0; words];
+
+        item.data_ptr = buffer.as_mut_ptr() as u64;
+        if !self.query(&mut item) {
+            return None;
+        }
+
+        // SAFETY: `buffer` is at least `length` bytes, 8-byte aligned, and the
+        // kernel has just written a `drm_i915_query_memory_regions` into it.
+        let header = unsafe { &*(buffer.as_ptr() as *const QueryMemoryRegionsHeader) };
+        let num_regions = header.num_regions as usize;
+
+        // Trust the declared length over `num_regions`: only read as many
+        // regions as actually fit in the buffer the kernel filled.
+        let available = (length - header_size) / region_size;
+        let count = num_regions.min(available);
+
+        let mut regions = Vec::with_capacity(count);
+        for i in 0..count {
+            let offset = header_size + i * region_size;
+            // SAFETY: `offset + region_size <= length <= buffer bytes`, and the
+            // region array directly follows the header per the uapi layout.
+            let region = unsafe {
+                std::ptr::read_unaligned(
+                    (buffer.as_ptr() as *const u8).add(offset) as *const MemoryRegionInfo
+                )
+            };
+            regions.push(region);
+        }
+
+        Some(regions)
+    }
+
+    fn query(&self, item: &mut DrmI915QueryItem) -> bool {
+        let mut query = DrmI915Query {
+            num_items: 1,
+            flags: 0,
+            items_ptr: item as *mut DrmI915QueryItem as u64,
+        };
+
+        // SAFETY: `query` points at a valid `drm_i915_query` whose `items_ptr`
+        // refers to a single valid `drm_i915_query_item`, matching what
+        // DRM_IOCTL_I915_QUERY expects.
+        let ret = unsafe {
+            libc::ioctl(
+                self.fd(),
+                DRM_IOCTL_I915_QUERY,
+                &mut query as *mut DrmI915Query,
+            )
+        };
+
+        ret == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn struct_layouts_match_the_uapi() {
+        // These sizes are fixed by the kernel uapi; a mismatch would silently
+        // misparse the reply.
+        assert_eq!(std::mem::size_of::<DrmI915Query>(), 16);
+        assert_eq!(std::mem::size_of::<DrmI915QueryItem>(), 24);
+        assert_eq!(std::mem::size_of::<MemoryClassInstance>(), 4);
+        assert_eq!(std::mem::size_of::<QueryMemoryRegionsHeader>(), 16);
+        // 4 (class:instance) + 4 (rsvd0) + 8 (probed) + 8 (unallocated)
+        // + 64 (union) = 88
+        assert_eq!(std::mem::size_of::<MemoryRegionInfo>(), 88);
+    }
+
+    #[test]
+    fn used_is_total_minus_free() {
+        let v = Vram {
+            total_bytes: 16 * 1024 * 1024 * 1024,
+            free_bytes: 2 * 1024 * 1024 * 1024,
+        };
+        assert_eq!(v.used_bytes(), 14 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn used_saturates_rather_than_underflowing() {
+        // Defensive: the kernel should never report free > total, but the
+        // subtraction must not wrap if it does.
+        let v = Vram {
+            total_bytes: 1024,
+            free_bytes: 4096,
+        };
+        assert_eq!(v.used_bytes(), 0);
+    }
+}

--- a/src/agent/samplers/gpu/linux/intel/drm_memory.rs
+++ b/src/agent/samplers/gpu/linux/intel/drm_memory.rs
@@ -119,6 +119,16 @@ impl Vram {
 pub struct DrmDevice {
     file: File,
     label: String,
+    /// Scratch for the query reply, reused across calls.
+    ///
+    /// The reply is small and fixed for a given device (a 16-byte header plus
+    /// 88 bytes per memory region — 192 bytes on an Arc A770), but it is read
+    /// once per sampling interval for the life of the agent. Allocating it per
+    /// call is bounded churn rather than a leak, since the buffer is an owned
+    /// local that drops at return; holding one buffer simply keeps that off the
+    /// allocator entirely (principle 13 — userspace overhead is part of the
+    /// budget).
+    buffer: Vec<u64>,
 }
 
 impl DrmDevice {
@@ -149,7 +159,11 @@ impl DrmDevice {
             if bdf == pci_address {
                 let path = Path::new("/dev/dri").join(&name);
                 let file = File::open(&path).ok()?;
-                return Some(Self { file, label: name });
+                return Some(Self {
+                    file,
+                    label: name,
+                    buffer: Vec::new(),
+                });
             }
         }
 
@@ -170,7 +184,7 @@ impl DrmDevice {
     /// Returns `None` when the GPU has no device-local memory (an integrated
     /// GPU), when the ioctl is unavailable, or when allocation accounting is not
     /// available to this process (see the privilege note in the module docs).
-    pub fn vram(&self) -> Option<Vram> {
+    pub fn vram(&mut self) -> Option<Vram> {
         let regions = self.query_memory_regions()?;
 
         regions.iter().find_map(|region| {
@@ -194,7 +208,7 @@ impl DrmDevice {
 
     /// Issue the two-step query (ask for length, then fetch) and return the
     /// region array.
-    fn query_memory_regions(&self) -> Option<Vec<MemoryRegionInfo>> {
+    fn query_memory_regions(&mut self) -> Option<Vec<MemoryRegionInfo>> {
         // Step 1: length probe. `length = 0` asks the kernel how many bytes the
         // reply needs.
         let mut item = DrmI915QueryItem {
@@ -216,15 +230,21 @@ impl DrmDevice {
             return None;
         }
 
-        // Step 2: fetch into a buffer the kernel sized for us. The buffer is
-        // `u64`-aligned because both structs are 8-byte aligned.
+        // Step 2: fetch into a buffer the kernel sized for us, reusing the
+        // scratch allocation. `u64`-backed because both structs are 8-byte
+        // aligned. `resize` only reallocates when the reply grows, which after
+        // the first call it does not — the region set is fixed per device.
         let words = length.div_ceil(std::mem::size_of::<u64>());
-        let mut buffer: Vec<u64> = vec![0; words];
+        self.buffer.clear();
+        self.buffer.resize(words, 0);
 
-        item.data_ptr = buffer.as_mut_ptr() as u64;
+        item.data_ptr = self.buffer.as_mut_ptr() as u64;
+        // SAFETY of the pointer: the ioctl is synchronous and `self.buffer`
+        // outlives it, so the kernel never writes through a dangling pointer.
         if !self.query(&mut item) {
             return None;
         }
+        let buffer = &self.buffer;
 
         // SAFETY: `buffer` is at least `length` bytes, 8-byte aligned, and the
         // kernel has just written a `drm_i915_query_memory_regions` into it.

--- a/src/agent/samplers/gpu/linux/intel/mod.rs
+++ b/src/agent/samplers/gpu/linux/intel/mod.rs
@@ -513,7 +513,7 @@ impl Gpu {
             .pci_address
             .as_deref()
             .and_then(DrmDevice::for_pci_address)
-            .filter(|drm| {
+            .and_then(|mut drm| {
                 let ok = drm.vram().is_some();
                 if !ok {
                     debug!(
@@ -523,7 +523,7 @@ impl Gpu {
                         drm.label()
                     );
                 }
-                ok
+                ok.then_some(drm)
             });
 
         if drm.is_some() {
@@ -578,7 +578,7 @@ impl Gpu {
 
         // VRAM is a separate ioctl on the DRM node, and unlike the PMU counters
         // it is an instantaneous gauge in bytes.
-        if let Some(drm) = self.drm.as_ref() {
+        if let Some(drm) = self.drm.as_mut() {
             if let Some(vram) = drm.vram() {
                 let _ = GPU_MEMORY_USED.set(self.id, vram.used_bytes() as i64);
                 let _ = GPU_MEMORY_FREE.set(self.id, vram.free_bytes as i64);

--- a/src/agent/samplers/gpu/linux/intel/mod.rs
+++ b/src/agent/samplers/gpu/linux/intel/mod.rs
@@ -1,0 +1,657 @@
+//! Collects Intel GPU telemetry from the i915/xe PMU via `perf_event_open(2)`.
+//!
+//! This covers both integrated GPUs and discrete cards (Arc), which register
+//! separate PMUs under `/sys/bus/event_source/devices/` (see [`pmu`]). It is the
+//! same data source `intel_gpu_top` uses: that tool performs no GPU-specific
+//! magic, it is an ordinary perf client that reads cumulative busy-nanosecond
+//! counters and differentiates them in userspace. `perf stat` on the same events
+//! produces identical numbers.
+//!
+//! ## What is collected
+//!
+//! From the PMU: per-engine (`rcs`/`bcs`/`vcs`/`vecs`/`ccs`) busy nanoseconds,
+//! and per-GPU actual/requested frequency. The engine set is **discovered from
+//! sysfs**, not assumed — an integrated GPU typically exposes no compute engine,
+//! while a discrete Arc card does, and engine instances are renumbered densely
+//! by the driver.
+//!
+//! Every PMU value is monotonically cumulative, so those metrics are counters
+//! and the viewer derives utilization/frequency as rates (see [`stats`]).
+//!
+//! Alongside them, VRAM usage comes from the DRM query ioctl — the PMU has no
+//! memory counter — and is a gauge in bytes (see [`drm_memory`]).
+//!
+//! ## Reading model
+//!
+//! All events for one GPU are opened as a single **perf group** (the first event
+//! is the group leader, the rest join it), so one `read(2)` returns every counter
+//! sampled atomically with no skew between engines. The i915 PMU is a system-wide
+//! PMU with `cpumask=0`, so the events are opened on CPU 0 with `any_pid`.
+//!
+//! No GPU work is submitted and no kernel state is perturbed by a read.
+//!
+//! ## Cadence — a documented departure from principle 10
+//!
+//! Reading this PMU is **not** an mmap load. A grouped `read(2)` on an i915 perf
+//! fd takes a driver lock and samples each event: measured at 6.4 us for a single
+//! event, 12.1 us for a 26-event group, plus ~5.4 us for the VRAM ioctl. Letting
+//! consumers drive that at the snapshot-TTL rate (up to ~100 Hz) would burn CPU
+//! and hammer the driver for values that move on the order of seconds.
+//!
+//! So this sampler reads on its **own bounded cadence**
+//! (`[samplers.gpu_intel_pmu] interval`, default 1s) and serves the cached values
+//! in between, with the read dispatched via `spawn_blocking` so a slow driver
+//! read cannot stall the async runtime (principle 17). `refresh()` itself only
+//! does a time comparison. The counters are cumulative, so a 1s cadence costs
+//! `rate()` nothing.
+//!
+//! ## Permissions
+//!
+//! Opening these counters needs `CAP_PERFMON` (or `kernel.perf_event_paranoid`
+//! <= 2, though hosts commonly ship with a stricter value such as 4). Without
+//! it the sampler disables itself at init rather than failing the agent.
+//!
+//! ## Limits
+//!
+//! The PMU reports engine **occupancy, not efficiency**: a busy engine had work
+//! queued, which does not mean the EUs were saturated. Pair busy time with
+//! frequency to tell "busy but downclocked" from genuinely saturated. EU-level
+//! detail requires the separate i915 perf/OA interface (`DRM_IOCTL_I915_PERF_OPEN`),
+//! a different subsystem despite the shared word "perf".
+//!
+//! There is no VRAM bandwidth counter in the i915 PMU. `intel_gpu_top` shows
+//! `uncore_imc` bandwidth, but that is the CPU package's memory controller —
+//! host DRAM traffic, not the card's GDDR6 — so it is not attributed to the GPU
+//! here.
+
+const NAME: &str = "gpu_intel_pmu";
+
+use crate::agent::*;
+
+use perf_event::events::Event;
+use perf_event::ReadFormat;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+mod drm_memory;
+mod pmu;
+mod stats;
+
+use drm_memory::DrmDevice;
+use pmu::GpuPmu;
+use stats::*;
+
+/// Built-in read cadence when `[samplers.gpu_intel_pmu] interval` is unset.
+///
+/// One second matches `intel_gpu_top`'s own default sampling period
+/// (`DEFAULT_PERIOD_MS`) and is far finer than the timescale these counters move
+/// on, while keeping the driver read rate off the scrape cadence.
+const DEFAULT_READ_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Maximum number of Intel GPUs tracked. Hosts with more are truncated (logged
+/// once at init).
+pub(crate) const MAX_GPUS: usize = 8;
+
+/// Maximum engines tracked per GPU. A discrete Arc exposes 7 (rcs0, bcs0, vcs0,
+/// vcs1, vecs0, vecs1, ccs0); this leaves headroom for parts with more compute
+/// or video engines.
+pub(crate) const MAX_ENGINES: usize = 16;
+
+/// Entry count for the per-engine metric groups, indexed `gpu * MAX_ENGINES + engine`.
+pub(crate) const ENGINE_ENTRIES: usize = MAX_GPUS * MAX_ENGINES;
+
+/// The per-engine sample types collected, as sysfs name suffixes.
+///
+/// The i915 PMU also exposes `-wait` and `-sema` (stalled on `MI_WAIT_FOR_EVENT`
+/// and blocked on a cross-engine semaphore respectively). Both are deliberately
+/// not collected: they describe *why* an engine made no progress, which is a
+/// debugging question, whereas this sampler publishes the occupancy and clock
+/// needed to answer "how loaded is this GPU". Cumulative nanoseconds.
+const ENGINE_SAMPLES: [(&str, &metriken::WindowedCounterGroup, Option<&str>); 1] =
+    [("busy", &GPU_ENGINE_BUSY, Some("ns"))];
+
+/// The per-GPU global events, as (sysfs name, metric, expected sysfs unit).
+///
+/// The expected unit is checked against sysfs at init: the metric names and
+/// descriptions encode a unit, so a kernel that reported something else would
+/// silently make the exported series wrong.
+/// The PMU also exposes `rc6-residency`, `software-gt-awake-time` and
+/// `interrupts`; they are power-state and IRQ accounting rather than load, and
+/// are not collected.
+const GLOBAL_EVENTS: [(&str, &metriken::WindowedCounterGroup, Option<&str>); 2] = [
+    ("actual-frequency", &GPU_FREQUENCY_ACTUAL, Some("M")),
+    ("requested-frequency", &GPU_FREQUENCY_REQUESTED, Some("M")),
+];
+
+fn init(config: Arc<Config>) -> SamplerResult {
+    if !config.enabled(NAME) {
+        return Ok(None);
+    }
+
+    let mut pmus = pmu::discover();
+
+    if pmus.is_empty() {
+        debug!("{NAME}: no Intel GPU PMUs found");
+        return Ok(None);
+    }
+
+    if pmus.len() > MAX_GPUS {
+        warn!(
+            "{NAME}: found {} Intel GPUs, only the first {MAX_GPUS} are recorded",
+            pmus.len()
+        );
+        pmus.truncate(MAX_GPUS);
+    }
+
+    let mut gpus = Vec::new();
+
+    for (id, pmu) in pmus.iter().enumerate() {
+        match Gpu::new(id, pmu) {
+            Ok(gpu) => {
+                debug!(
+                    "{NAME}: GPU {id} ({}, pmu {}, driver {}, perf type {}): {} engine(s) {:?}, \
+                     global counters {:?}",
+                    pmu.device_label(),
+                    pmu.name,
+                    pmu.driver,
+                    pmu.perf_type,
+                    gpu.engines.len(),
+                    gpu.engines,
+                    gpu.globals,
+                );
+                gpus.push(gpu);
+            }
+            Err(e) => {
+                // A permission failure is the common case on hosts with a
+                // restrictive perf_event_paranoid; it is not fatal.
+                debug!("{NAME}: GPU {id} ({}) unavailable: {e}", pmu.device_label());
+            }
+        }
+    }
+
+    if gpus.is_empty() {
+        debug!(
+            "{NAME}: no Intel GPU counters could be opened (needs CAP_PERFMON or \
+             kernel.perf_event_paranoid <= 2)"
+        );
+        return Ok(None);
+    }
+
+    let interval = config
+        .sampler_interval(NAME)
+        .unwrap_or(DEFAULT_READ_INTERVAL);
+
+    debug!("{NAME}: reading every {interval:?}");
+
+    Ok(Some(Box::new(IntelPmu {
+        gpus: Arc::new(std::sync::Mutex::new(gpus)),
+        interval,
+        last_read: std::sync::Mutex::new(None),
+        reading: Arc::new(AtomicBool::new(false)),
+    })))
+}
+
+#[distributed_slice(SAMPLERS)]
+static SAMPLER_ENTRY: crate::agent::samplers::SamplerEntry = crate::agent::samplers::SamplerEntry {
+    name: NAME,
+    module: module_path!(),
+    init,
+};
+
+struct IntelPmu {
+    /// Shared with the blocking read task, which needs `&mut` on each `Gpu` to
+    /// read its perf group.
+    gpus: Arc<std::sync::Mutex<Vec<Gpu>>>,
+    /// Minimum time between reads (principle 17).
+    interval: Duration,
+    /// When the last read was dispatched.
+    last_read: std::sync::Mutex<Option<Instant>>,
+    /// Guards against overlapping reads if one runs long.
+    reading: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Sampler for IntelPmu {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    async fn refresh(&self) {
+        // Throttle: dispatch at most once per `interval`. This is the only work
+        // done on the sample cycle; everything else happens off-worker.
+        {
+            let mut last = self.last_read.lock().unwrap();
+            match *last {
+                Some(t) if t.elapsed() < self.interval => return,
+                _ => *last = Some(Instant::now()),
+            }
+        }
+
+        // Never overlap reads.
+        if self.reading.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        // Offload: every source here is a syscall against the driver (a perf
+        // group read, a DRM ioctl), not an mmap load, so it must not run on the
+        // async worker.
+        let gpus = self.gpus.clone();
+        let reading = self.reading.clone();
+
+        tokio::task::spawn_blocking(move || {
+            if let Ok(mut gpus) = gpus.lock() {
+                for gpu in gpus.iter_mut() {
+                    gpu.refresh();
+                }
+            }
+            reading.store(false, Ordering::Release);
+        });
+    }
+}
+
+/// A raw dynamic-PMU event: the i915 PMU type is assigned at boot, so events are
+/// specified as a (type, config) pair rather than by a named perf event.
+struct RawEvent {
+    event_type: u32,
+    config: u64,
+}
+
+impl Event for RawEvent {
+    fn update_attrs(self, attr: &mut perf_event_open_sys::bindings::perf_event_attr) {
+        attr.type_ = self.event_type;
+        attr.config = self.config;
+    }
+}
+
+/// One counter within a GPU's perf group, and where its value is published.
+struct TrackedCounter {
+    counter: perf_event::Counter,
+    metric: &'static metriken::WindowedCounterGroup,
+    /// Index into `metric` (a plain GPU id, or `gpu * MAX_ENGINES + engine`).
+    index: usize,
+}
+
+/// All counters for a single GPU, opened as one perf group.
+struct Gpu {
+    id: usize,
+    label: String,
+    /// The group leader, whose `read_group` returns every counter at once.
+    leader: perf_event::Counter,
+    /// The metric/index the leader itself publishes to.
+    leader_target: (&'static metriken::WindowedCounterGroup, usize),
+    /// Group members, in the order they were added.
+    members: Vec<TrackedCounter>,
+    /// Engine names in index order, for diagnostics.
+    engines: Vec<String>,
+    /// Global event names opened for this GPU, for diagnostics.
+    globals: Vec<String>,
+    /// DRM render node for VRAM accounting. `None` when the GPU has no
+    /// device-local memory (integrated), the node could not be opened, or
+    /// allocation accounting is unavailable to this process.
+    drm: Option<DrmDevice>,
+}
+
+impl Gpu {
+    fn new(id: usize, pmu: &GpuPmu) -> Result<Self, std::io::Error> {
+        // Build the full list of (sysfs event name, metric, index) to open,
+        // ordered so the group leader is a counter that always exists.
+        let mut planned: Vec<(String, &'static metriken::WindowedCounterGroup, usize)> = Vec::new();
+
+        let engines = discover_engines(pmu);
+
+        for (engine_index, engine) in engines.iter().enumerate() {
+            let metric_index = id * MAX_ENGINES + engine_index;
+
+            for (suffix, metric, expected_unit) in ENGINE_SAMPLES {
+                let event_name = format!("{engine}-{suffix}");
+                if unit_matches(pmu, &event_name, expected_unit, id) {
+                    planned.push((event_name, metric, metric_index));
+                }
+            }
+        }
+
+        let mut globals = Vec::new();
+        for (event_name, metric, expected_unit) in GLOBAL_EVENTS {
+            if unit_matches(pmu, event_name, expected_unit, id) {
+                planned.push((event_name.to_string(), metric, id));
+                globals.push(event_name.to_string());
+            }
+        }
+
+        if planned.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "PMU exposes no events we collect",
+            ));
+        }
+
+        // Open the leader first, then attach the rest to its group so a single
+        // read returns a coherent snapshot across all engines.
+        let (leader_name, leader_metric, leader_index) = planned.remove(0);
+        let leader_config = pmu
+            .event(&leader_name)
+            .expect("planned events exist in the PMU")
+            .config;
+
+        let mut leader = perf_event::Builder::new(RawEvent {
+            event_type: pmu.perf_type,
+            config: leader_config,
+        })
+        // The i915 PMU is system-wide with cpumask=0; it must be opened on
+        // CPU 0 and counts work from every process.
+        .one_cpu(0)
+        .any_pid()
+        .read_format(
+            ReadFormat::TOTAL_TIME_ENABLED | ReadFormat::TOTAL_TIME_RUNNING | ReadFormat::GROUP,
+        )
+        .build()?;
+
+        let mut members = Vec::new();
+
+        for (event_name, metric, index) in planned {
+            let config = pmu
+                .event(&event_name)
+                .expect("planned events exist in the PMU")
+                .config;
+
+            match perf_event::Builder::new(RawEvent {
+                event_type: pmu.perf_type,
+                config,
+            })
+            .one_cpu(0)
+            .any_pid()
+            .build_with_group(&mut leader)
+            {
+                Ok(counter) => members.push(TrackedCounter {
+                    counter,
+                    metric,
+                    index,
+                }),
+                Err(e) => {
+                    // Individual events can be absent on some parts (e.g. a GT1
+                    // counter on a single-GT card); skip rather than give up.
+                    debug!("{NAME}: GPU {id}: skipping event {event_name}: {e}");
+                }
+            }
+        }
+
+        leader.enable_group()?;
+
+        let label = pmu.device_label();
+
+        // Distinguishes an integrated GPU from a discrete card (e.g. Arc), which
+        // is the first thing you want to filter on when a host has both.
+        let gpu_type = if pmu.is_discrete() {
+            "discrete"
+        } else {
+            "integrated"
+        };
+
+        // Publish the identity of every entry so the exported series carry the
+        // device and engine they belong to, not just an opaque index.
+        for (engine_index, engine) in engines.iter().enumerate() {
+            let metric_index = id * MAX_ENGINES + engine_index;
+            for (_, metric, _) in ENGINE_SAMPLES {
+                metric.insert_metadata(metric_index, "id".to_string(), id.to_string());
+                metric.insert_metadata(metric_index, "device".to_string(), label.clone());
+                metric.insert_metadata(metric_index, "type".to_string(), gpu_type.to_string());
+                metric.insert_metadata(metric_index, "engine".to_string(), engine.clone());
+                metric.insert_metadata(
+                    metric_index,
+                    "engine_class".to_string(),
+                    engine_class(engine).to_string(),
+                );
+            }
+        }
+
+        for (_, metric, _) in GLOBAL_EVENTS {
+            metric.insert_metadata(id, "id".to_string(), id.to_string());
+            metric.insert_metadata(id, "device".to_string(), label.clone());
+            metric.insert_metadata(id, "type".to_string(), gpu_type.to_string());
+        }
+
+        // VRAM comes from the DRM query ioctl, not the PMU. Only a GPU with a
+        // device-local memory region reports it, so probe once here and keep the
+        // node only if it yields real numbers — that way an integrated GPU (no
+        // VRAM) and an unprivileged agent (no allocation accounting) both fall
+        // back to publishing no memory series at all.
+        let drm = pmu
+            .pci_address
+            .as_deref()
+            .and_then(DrmDevice::for_pci_address)
+            .filter(|drm| {
+                let ok = drm.vram().is_some();
+                if !ok {
+                    debug!(
+                        "{NAME}: GPU {id} ({label}): {} reports no device-local memory \
+                         accounting; VRAM metrics disabled (needs CAP_PERFMON on a \
+                         discrete GPU)",
+                        drm.label()
+                    );
+                }
+                ok
+            });
+
+        if drm.is_some() {
+            for metric in [&GPU_MEMORY_USED, &GPU_MEMORY_FREE] {
+                metric.insert_metadata(id, "id".to_string(), id.to_string());
+                metric.insert_metadata(id, "device".to_string(), label.clone());
+                metric.insert_metadata(id, "type".to_string(), gpu_type.to_string());
+            }
+        }
+
+        Ok(Self {
+            id,
+            label,
+            leader,
+            leader_target: (leader_metric, leader_index),
+            members,
+            engines,
+            globals,
+            drm,
+        })
+    }
+
+    /// Read every counter in the group with one syscall and publish the values.
+    fn refresh(&mut self) {
+        let acq = crate::agent::timing::Acquisition::begin();
+
+        let group = match self.leader.read_group() {
+            Ok(group) => group,
+            Err(e) => {
+                debug!("{NAME}: GPU {} ({}) read failed: {e}", self.id, self.label);
+                return;
+            }
+        };
+
+        let window = acq.window();
+
+        // These counters are cumulative, so the raw value is published directly
+        // and the viewer differentiates it.
+        if let Some(value) = group.get(&self.leader) {
+            let (metric, index) = self.leader_target;
+            metric.set_with_window(index, value.value(), window);
+        }
+
+        for member in self.members.iter() {
+            if let Some(value) = group.get(&member.counter) {
+                member
+                    .metric
+                    .set_with_window(member.index, value.value(), window);
+            }
+        }
+
+        // VRAM is a separate ioctl on the DRM node, and unlike the PMU counters
+        // it is an instantaneous gauge in bytes.
+        if let Some(drm) = self.drm.as_ref() {
+            if let Some(vram) = drm.vram() {
+                let window = acq.window();
+                GPU_MEMORY_USED.set_with_window(self.id, vram.used_bytes() as i64, window);
+                GPU_MEMORY_FREE.set_with_window(self.id, vram.free_bytes as i64, window);
+            }
+        }
+    }
+}
+
+/// True when `event_name` exists on this PMU and reports the unit we expect.
+///
+/// The metric definitions bake in a unit (nanoseconds, MHz), so an event whose
+/// sysfs unit disagrees would be published under a wrong description. Rather
+/// than emit a misleading series, skip the event and say why.
+fn unit_matches(pmu: &GpuPmu, event_name: &str, expected: Option<&str>, id: usize) -> bool {
+    let Some(event) = pmu.event(event_name) else {
+        return false;
+    };
+
+    if event.unit.as_deref() == expected {
+        return true;
+    }
+
+    warn!(
+        "{NAME}: GPU {id}: skipping {event_name}: expected unit {:?} but sysfs reports {:?}",
+        expected, event.unit
+    );
+
+    false
+}
+
+/// Find the engines this PMU exposes, in sysfs-name order.
+///
+/// Engines are discovered by looking for `<engine>-busy` events rather than
+/// enumerating engine classes, because the set varies by part (an integrated GPU
+/// has no `ccs`, and the driver renumbers instances densely so `vcs1` may be
+/// hardware VCS2).
+fn discover_engines(pmu: &GpuPmu) -> Vec<String> {
+    let mut engines: Vec<String> = pmu
+        .events
+        .keys()
+        .filter_map(|name| name.strip_suffix("-busy"))
+        .map(|name| name.to_string())
+        .collect();
+
+    // Sort by class then instance so the index order is stable and readable.
+    engines.sort_by_key(|engine| {
+        let class = engine_class_rank(engine);
+        let instance: u32 = engine
+            .trim_start_matches(|c: char| !c.is_ascii_digit())
+            .parse()
+            .unwrap_or(0);
+        (class, instance)
+    });
+
+    if engines.len() > MAX_ENGINES {
+        warn!(
+            "{NAME}: GPU {} exposes {} engines, only the first {MAX_ENGINES} are recorded",
+            pmu.device_label(),
+            engines.len()
+        );
+        engines.truncate(MAX_ENGINES);
+    }
+
+    engines
+}
+
+/// Map a sysfs engine name to its human-readable class, matching the grouping
+/// `intel_gpu_top` displays.
+fn engine_class(engine: &str) -> &'static str {
+    match engine.trim_end_matches(|c: char| c.is_ascii_digit()) {
+        "rcs" => "render",
+        "bcs" => "copy",
+        "vcs" => "video",
+        "vecs" => "video-enhance",
+        "ccs" => "compute",
+        _ => "other",
+    }
+}
+
+/// Sort rank for an engine class, following the engine-class enum order in
+/// `i915_drm.h` (RENDER=0, COPY=1, VIDEO=2, VIDEO_ENHANCE=3, COMPUTE=4).
+fn engine_class_rank(engine: &str) -> u32 {
+    match engine.trim_end_matches(|c: char| c.is_ascii_digit()) {
+        "rcs" => 0,
+        "bcs" => 1,
+        "vcs" => 2,
+        "vecs" => 3,
+        "ccs" => 4,
+        _ => 5,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_engine_classes() {
+        assert_eq!(engine_class("rcs0"), "render");
+        assert_eq!(engine_class("bcs0"), "copy");
+        assert_eq!(engine_class("vcs1"), "video");
+        assert_eq!(engine_class("vecs1"), "video-enhance");
+        assert_eq!(engine_class("ccs0"), "compute");
+        assert_eq!(engine_class("mystery9"), "other");
+    }
+
+    #[test]
+    fn orders_engines_by_class_then_instance() {
+        use std::collections::HashMap;
+
+        let names = [
+            "vecs1",
+            "rcs0",
+            "ccs0",
+            "vcs1",
+            "bcs0",
+            "vcs0",
+            "vecs0",
+            "interrupts",
+        ];
+
+        let events: HashMap<String, pmu::PmuEvent> = names
+            .iter()
+            .map(|n| {
+                let key = if *n == "interrupts" {
+                    n.to_string()
+                } else {
+                    format!("{n}-busy")
+                };
+                (
+                    key,
+                    pmu::PmuEvent {
+                        config: 0,
+                        unit: None,
+                    },
+                )
+            })
+            .collect();
+
+        let gpu = GpuPmu {
+            name: "i915_0000_04_00.0".to_string(),
+            perf_type: 24,
+            pci_address: Some("0000:04:00.0".to_string()),
+            driver: "i915".to_string(),
+            events,
+        };
+
+        // Matches the 7 engines a real Arc A770 exposes, in class order. The
+        // `interrupts` global must not be mistaken for an engine.
+        assert_eq!(
+            discover_engines(&gpu),
+            vec!["rcs0", "bcs0", "vcs0", "vcs1", "vecs0", "vecs1", "ccs0"]
+        );
+    }
+
+    #[test]
+    fn engine_metric_indices_stay_within_their_gpu() {
+        // Entry layout must not let one GPU's engines collide with another's.
+        for gpu in 0..MAX_GPUS {
+            for engine in 0..MAX_ENGINES {
+                let index = gpu * MAX_ENGINES + engine;
+                assert!(index < ENGINE_ENTRIES);
+            }
+        }
+
+        assert_eq!(0 * MAX_ENGINES + 0, 0);
+        assert_ne!(MAX_ENGINES - 1, MAX_ENGINES);
+    }
+}

--- a/src/agent/samplers/gpu/linux/intel/mod.rs
+++ b/src/agent/samplers/gpu/linux/intel/mod.rs
@@ -45,6 +45,13 @@
 //! does a time comparison. The counters are cumulative, so a 1s cadence costs
 //! `rate()` nothing.
 //!
+//! ## Windows
+//!
+//! One acquisition group covers the whole per-GPU sweep (principle 18): the
+//! grouped perf read and the VRAM ioctl for a device are reached together
+//! through that device's own fds, so they are one read section even though they
+//! span two metric families. See [`stats::GPU_INTEL_PMU_ACQ`].
+//!
 //! ## Permissions
 //!
 //! Opening these counters needs `CAP_PERFMON` (or `kernel.perf_event_paranoid`
@@ -98,8 +105,18 @@ pub(crate) const MAX_GPUS: usize = 8;
 /// or video engines.
 pub(crate) const MAX_ENGINES: usize = 16;
 
-/// Entry count for the per-engine metric groups, indexed `gpu * MAX_ENGINES + engine`.
+/// Entry count for the per-engine metric groups, indexed by [`engine_index`].
 pub(crate) const ENGINE_ENTRIES: usize = MAX_GPUS * MAX_ENGINES;
+
+/// Index of one GPU's engine within the per-engine metric groups.
+///
+/// Each GPU owns a `MAX_ENGINES`-wide block, so engine indices never collide
+/// across GPUs and a GPU's engines stay contiguous. The blocks are sparse: a
+/// GPU exposing 4 engines leaves the rest of its block unused, which is why the
+/// acquisition group declares an explicit member set rather than a prefix bound.
+fn engine_index(gpu: usize, engine: usize) -> usize {
+    gpu * MAX_ENGINES + engine
+}
 
 /// The per-engine sample types collected, as sysfs name suffixes.
 ///
@@ -108,7 +125,7 @@ pub(crate) const ENGINE_ENTRIES: usize = MAX_GPUS * MAX_ENGINES;
 /// not collected: they describe *why* an engine made no progress, which is a
 /// debugging question, whereas this sampler publishes the occupancy and clock
 /// needed to answer "how loaded is this GPU". Cumulative nanoseconds.
-const ENGINE_SAMPLES: [(&str, &metriken::WindowedCounterGroup, Option<&str>); 1] =
+const ENGINE_SAMPLES: [(&str, &metriken::CounterGroup, Option<&str>); 1] =
     [("busy", &GPU_ENGINE_BUSY, Some("ns"))];
 
 /// The per-GPU global events, as (sysfs name, metric, expected sysfs unit).
@@ -119,21 +136,35 @@ const ENGINE_SAMPLES: [(&str, &metriken::WindowedCounterGroup, Option<&str>); 1]
 /// The PMU also exposes `rc6-residency`, `software-gt-awake-time` and
 /// `interrupts`; they are power-state and IRQ accounting rather than load, and
 /// are not collected.
-const GLOBAL_EVENTS: [(&str, &metriken::WindowedCounterGroup, Option<&str>); 2] = [
+const GLOBAL_EVENTS: [(&str, &metriken::CounterGroup, Option<&str>); 2] = [
     ("actual-frequency", &GPU_FREQUENCY_ACTUAL, Some("M")),
     ("requested-frequency", &GPU_FREQUENCY_REQUESTED, Some("M")),
 ];
 
 fn init(config: Arc<Config>) -> SamplerResult {
+    // Zero FIRST, so every exit below leaves the group empty rather than at
+    // backing capacity. An unset bound falls back to this sampler's backing
+    // arrays (`ENGINE_ENTRIES` = 128), and the snapshot walk would then declare
+    // that many members — phantom, all-null, and indistinguishable to a reader
+    // from a real engine that simply had no reading. `Gpu::new` raises it to
+    // the real engine set on success.
+    GPU_INTEL_PMU_ACQ.set_member_bound(0);
+
     if !config.enabled(NAME) {
         return Ok(None);
     }
 
     let mut pmus = pmu::discover();
 
+    // No Intel GPU on this machine. Not a fault and not a config choice: the
+    // capability is absent, so it is reported as unsupported rather than
+    // disappearing into `Disabled` (which the health tally does not count).
     if pmus.is_empty() {
         debug!("{NAME}: no Intel GPU PMUs found");
-        return Ok(None);
+        return Err(crate::agent::sampler_status::Unsupported(
+            "no Intel GPU i915/xe PMU found".to_string(),
+        )
+        .into());
     }
 
     if pmus.len() > MAX_GPUS {
@@ -170,13 +201,34 @@ fn init(config: Arc<Config>) -> SamplerResult {
         }
     }
 
+    // The GPUs are here but none of their counters would open — almost always
+    // a restrictive `perf_event_paranoid`. The machine cannot support this as
+    // configured, so it is unsupported rather than disabled; the reason names
+    // the fix.
     if gpus.is_empty() {
-        debug!(
-            "{NAME}: no Intel GPU counters could be opened (needs CAP_PERFMON or \
-             kernel.perf_event_paranoid <= 2)"
-        );
-        return Ok(None);
+        return Err(crate::agent::sampler_status::Unsupported(
+            "Intel GPU present but no PMU counters could be opened (needs CAP_PERFMON \
+             or kernel.perf_event_paranoid <= 2)"
+                .to_string(),
+        )
+        .into());
     }
+
+    // Real membership, not backing capacity. Engine entries are sparse —
+    // indexed by `engine_index`, so a host with one GPU exposing 4
+    // engines occupies 0..4 and nothing else — and the per-GPU frequency and
+    // VRAM entries are indexed by GPU id. A prefix bound would declare the
+    // gaps; the explicit member set does not.
+    let mut members: Vec<usize> = Vec::new();
+    for gpu in gpus.iter() {
+        members.push(gpu.id);
+        for offset in 0..gpu.engines.len() {
+            members.push(engine_index(gpu.id, offset));
+        }
+    }
+    members.sort_unstable();
+    members.dedup();
+    GPU_INTEL_PMU_ACQ.set_member_set(&members);
 
     let interval = config
         .sampler_interval(NAME)
@@ -241,9 +293,19 @@ impl Sampler for IntelPmu {
 
         tokio::task::spawn_blocking(move || {
             if let Ok(mut gpus) = gpus.lock() {
+                // Acquisition-group bracket (principle 18): ONE group for the
+                // whole device sweep, not one per GPU or per metric family.
+                // An individual GPU's read can fail without invalidating the
+                // section — that GPU keeps its stale values — so the group
+                // always finishes once the sweep completes; there is no bulk
+                // "read all failed" signal here that would warrant a discard.
+                let guard = GPU_INTEL_PMU_ACQ.acquire();
+
                 for gpu in gpus.iter_mut() {
                     gpu.refresh();
                 }
+
+                guard.finish();
             }
             reading.store(false, Ordering::Release);
         });
@@ -267,8 +329,8 @@ impl Event for RawEvent {
 /// One counter within a GPU's perf group, and where its value is published.
 struct TrackedCounter {
     counter: perf_event::Counter,
-    metric: &'static metriken::WindowedCounterGroup,
-    /// Index into `metric` (a plain GPU id, or `gpu * MAX_ENGINES + engine`).
+    metric: &'static metriken::CounterGroup,
+    /// Index into `metric` (a plain GPU id, or an [`engine_index`]).
     index: usize,
 }
 
@@ -279,7 +341,7 @@ struct Gpu {
     /// The group leader, whose `read_group` returns every counter at once.
     leader: perf_event::Counter,
     /// The metric/index the leader itself publishes to.
-    leader_target: (&'static metriken::WindowedCounterGroup, usize),
+    leader_target: (&'static metriken::CounterGroup, usize),
     /// Group members, in the order they were added.
     members: Vec<TrackedCounter>,
     /// Engine names in index order, for diagnostics.
@@ -296,12 +358,12 @@ impl Gpu {
     fn new(id: usize, pmu: &GpuPmu) -> Result<Self, std::io::Error> {
         // Build the full list of (sysfs event name, metric, index) to open,
         // ordered so the group leader is a counter that always exists.
-        let mut planned: Vec<(String, &'static metriken::WindowedCounterGroup, usize)> = Vec::new();
+        let mut planned: Vec<(String, &'static metriken::CounterGroup, usize)> = Vec::new();
 
         let engines = discover_engines(pmu);
 
-        for (engine_index, engine) in engines.iter().enumerate() {
-            let metric_index = id * MAX_ENGINES + engine_index;
+        for (offset, engine) in engines.iter().enumerate() {
+            let metric_index = engine_index(id, offset);
 
             for (suffix, metric, expected_unit) in ENGINE_SAMPLES {
                 let event_name = format!("{engine}-{suffix}");
@@ -390,8 +452,8 @@ impl Gpu {
 
         // Publish the identity of every entry so the exported series carry the
         // device and engine they belong to, not just an opaque index.
-        for (engine_index, engine) in engines.iter().enumerate() {
-            let metric_index = id * MAX_ENGINES + engine_index;
+        for (offset, engine) in engines.iter().enumerate() {
+            let metric_index = engine_index(id, offset);
             for (_, metric, _) in ENGINE_SAMPLES {
                 metric.insert_metadata(metric_index, "id".to_string(), id.to_string());
                 metric.insert_metadata(metric_index, "device".to_string(), label.clone());
@@ -454,31 +516,32 @@ impl Gpu {
     }
 
     /// Read every counter in the group with one syscall and publish the values.
+    ///
+    /// Values are set plain; the window is stamped once by the caller's
+    /// acquisition bracket after every GPU has been visited (principle 18).
     fn refresh(&mut self) {
-        let acq = crate::agent::timing::Acquisition::begin();
-
         let group = match self.leader.read_group() {
             Ok(group) => group,
             Err(e) => {
+                // A failed read on one GPU leaves that GPU's values stale and
+                // the rest of the sweep intact — this is the normal
+                // partial-telemetry case, not a failure of the read section, so
+                // the caller still finishes the group.
                 debug!("{NAME}: GPU {} ({}) read failed: {e}", self.id, self.label);
                 return;
             }
         };
 
-        let window = acq.window();
-
         // These counters are cumulative, so the raw value is published directly
         // and the viewer differentiates it.
         if let Some(value) = group.get(&self.leader) {
             let (metric, index) = self.leader_target;
-            metric.set_with_window(index, value.value(), window);
+            let _ = metric.set(index, value.value());
         }
 
         for member in self.members.iter() {
             if let Some(value) = group.get(&member.counter) {
-                member
-                    .metric
-                    .set_with_window(member.index, value.value(), window);
+                let _ = member.metric.set(member.index, value.value());
             }
         }
 
@@ -486,9 +549,8 @@ impl Gpu {
         // it is an instantaneous gauge in bytes.
         if let Some(drm) = self.drm.as_ref() {
             if let Some(vram) = drm.vram() {
-                let window = acq.window();
-                GPU_MEMORY_USED.set_with_window(self.id, vram.used_bytes() as i64, window);
-                GPU_MEMORY_FREE.set_with_window(self.id, vram.free_bytes as i64, window);
+                let _ = GPU_MEMORY_USED.set(self.id, vram.used_bytes() as i64);
+                let _ = GPU_MEMORY_FREE.set(self.id, vram.free_bytes as i64);
             }
         }
     }
@@ -646,12 +708,15 @@ mod tests {
         // Entry layout must not let one GPU's engines collide with another's.
         for gpu in 0..MAX_GPUS {
             for engine in 0..MAX_ENGINES {
-                let index = gpu * MAX_ENGINES + engine;
+                let index = engine_index(gpu, engine);
                 assert!(index < ENGINE_ENTRIES);
             }
         }
 
-        assert_eq!(0 * MAX_ENGINES + 0, 0);
-        assert_ne!(MAX_ENGINES - 1, MAX_ENGINES);
+        // GPU 0's first engine sits at index 0, and GPU 1's first engine
+        // starts a fresh block rather than overlapping GPU 0's last.
+        assert_eq!(engine_index(0, 0), 0);
+        assert_eq!(engine_index(1, 0), MAX_ENGINES);
+        assert!(engine_index(0, MAX_ENGINES - 1) < engine_index(1, 0));
     }
 }

--- a/src/agent/samplers/gpu/linux/intel/mod.rs
+++ b/src/agent/samplers/gpu/linux/intel/mod.rs
@@ -47,10 +47,11 @@
 //!
 //! ## Windows
 //!
-//! One acquisition group covers the whole per-GPU sweep (principle 18): the
-//! grouped perf read and the VRAM ioctl for a device are reached together
-//! through that device's own fds, so they are one read section even though they
-//! span two metric families. See [`stats::GPU_INTEL_PMU_ACQ`].
+//! The per-GPU sweep is one read section (principle 18): the grouped perf read
+//! and the VRAM ioctl for a device are reached together through that device's
+//! own fds. It is bracketed by two acquisition groups rather than one, because
+//! the metrics it fills live in two index spaces — see the groups' doc comment
+//! in [`stats`] for why one shared group published phantom series.
 //!
 //! ## Permissions
 //!
@@ -148,7 +149,8 @@ fn init(config: Arc<Config>) -> SamplerResult {
     // that many members — phantom, all-null, and indistinguishable to a reader
     // from a real engine that simply had no reading. `Gpu::new` raises it to
     // the real engine set on success.
-    GPU_INTEL_PMU_ACQ.set_member_bound(0);
+    GPU_INTEL_PMU_ENGINE_ACQ.set_member_bound(0);
+    GPU_INTEL_PMU_DEVICE_ACQ.set_member_bound(0);
 
     if !config.enabled(NAME) {
         return Ok(None);
@@ -214,21 +216,24 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .into());
     }
 
-    // Real membership, not backing capacity. Engine entries are sparse —
-    // indexed by `engine_index`, so a host with one GPU exposing 4
-    // engines occupies 0..4 and nothing else — and the per-GPU frequency and
-    // VRAM entries are indexed by GPU id. A prefix bound would declare the
-    // gaps; the explicit member set does not.
-    let mut members: Vec<usize> = Vec::new();
+    // Real membership, not backing capacity, and one set per index space (see
+    // the groups' doc comment in `stats`).
+    //
+    // Engine entries are sparse: each GPU owns a `MAX_ENGINES`-wide block and
+    // uses only the leading part of it, so a prefix bound would declare the
+    // gaps as members. The explicit set does not.
+    let mut engine_members: Vec<usize> = Vec::new();
     for gpu in gpus.iter() {
-        members.push(gpu.id);
         for offset in 0..gpu.engines.len() {
-            members.push(engine_index(gpu.id, offset));
+            engine_members.push(engine_index(gpu.id, offset));
         }
     }
-    members.sort_unstable();
-    members.dedup();
-    GPU_INTEL_PMU_ACQ.set_member_set(&members);
+    engine_members.sort_unstable();
+    GPU_INTEL_PMU_ENGINE_ACQ.set_member_set(&engine_members);
+
+    // Per-GPU entries are indexed by GPU id, which `init` assigns densely from
+    // 0, so a prefix bound is exactly right here.
+    GPU_INTEL_PMU_DEVICE_ACQ.set_member_bound(gpus.len());
 
     let interval = config
         .sampler_interval(NAME)
@@ -299,13 +304,15 @@ impl Sampler for IntelPmu {
                 // section — that GPU keeps its stale values — so the group
                 // always finishes once the sweep completes; there is no bulk
                 // "read all failed" signal here that would warrant a discard.
-                let guard = GPU_INTEL_PMU_ACQ.acquire();
+                let engines = GPU_INTEL_PMU_ENGINE_ACQ.acquire();
+                let devices = GPU_INTEL_PMU_DEVICE_ACQ.acquire();
 
                 for gpu in gpus.iter_mut() {
                     gpu.refresh();
                 }
 
-                guard.finish();
+                engines.finish();
+                devices.finish();
             }
             reading.store(false, Ordering::Release);
         });
@@ -701,6 +708,43 @@ mod tests {
             discover_engines(&gpu),
             vec!["rcs0", "bcs0", "vcs0", "vcs1", "vecs0", "vecs1", "ccs0"]
         );
+    }
+
+    /// The two index spaces must not be conflated into one member set.
+    ///
+    /// Regression test for phantom series: engine entries are indexed by
+    /// `engine_index`, per-GPU entries by plain GPU id. Unioning them made
+    /// engine indices 2 and 3 of GPU 0 look like GPU ids 2 and 3, and the
+    /// agent published all-zero `gpu_frequency_sample{id="2"}` and `{id="3"}`
+    /// series on a two-GPU host. Observed on hardware.
+    #[test]
+    fn engine_and_device_index_spaces_stay_separate() {
+        // Two GPUs, as on the discrete+integrated host this was caught on.
+        let gpus = [4usize, 7]; // engine counts
+
+        let mut engine_members: Vec<usize> = Vec::new();
+        for (id, engines) in gpus.iter().enumerate() {
+            for offset in 0..*engines {
+                engine_members.push(engine_index(id, offset));
+            }
+        }
+
+        // The device space is a dense prefix of GPU ids, and nothing more.
+        let device_bound = gpus.len();
+        assert_eq!(device_bound, 2);
+
+        // The engine set must contain indices that are NOT valid GPU ids, which
+        // is precisely why it cannot double as the device member set.
+        assert!(engine_members.iter().any(|i| *i >= device_bound));
+
+        // Each GPU's engines stay inside its own block.
+        for (id, engines) in gpus.iter().enumerate() {
+            for offset in 0..*engines {
+                let index = engine_index(id, offset);
+                assert!(index >= id * MAX_ENGINES);
+                assert!(index < (id + 1) * MAX_ENGINES);
+            }
+        }
     }
 
     #[test]

--- a/src/agent/samplers/gpu/linux/intel/mod.rs
+++ b/src/agent/samplers/gpu/linux/intel/mod.rs
@@ -97,6 +97,14 @@ use stats::*;
 /// on, while keeping the driver read rate off the scrape cadence.
 const DEFAULT_READ_INTERVAL: Duration = Duration::from_secs(1);
 
+/// How early a scrape may arrive and still be served with a fresh read.
+///
+/// Scrape timers jitter by well under a millisecond in practice; 50ms is far
+/// above that and still two orders of magnitude below the default interval, so
+/// it cannot meaningfully raise the driver read rate. See the note in
+/// `refresh` for the aliasing this prevents.
+const SCRAPE_TOLERANCE: Duration = Duration::from_millis(50);
+
 /// Maximum number of Intel GPUs tracked. Hosts with more are truncated (logged
 /// once at init).
 pub(crate) const MAX_GPUS: usize = 8;
@@ -277,10 +285,26 @@ impl Sampler for IntelPmu {
     async fn refresh(&self) {
         // Throttle: dispatch at most once per `interval`. This is the only work
         // done on the sample cycle; everything else happens off-worker.
+        //
+        // The comparison carries a tolerance, and it is load-bearing rather
+        // than cosmetic. A consumer scraping at the same period as `interval`
+        // — the common case, since both default to 1s — arrives each cycle a
+        // few hundred microseconds early or late depending on jitter. A strict
+        // `<` then rejects roughly every other scrape, and because these are
+        // cumulative counters the exported series alternates between an
+        // unchanged value and one that jumped two intervals' worth. Measured on
+        // an Arc A770 at a steady 2400 MHz, the recorded `actual-frequency`
+        // deltas read `0, 4799, 0, 4800, ...`, which differentiates to a
+        // plausible-looking 4800 MHz — double the truth, with no gap to hint
+        // that a sample was dropped.
+        //
+        // Admitting a read that is within `SCRAPE_TOLERANCE` of due costs at
+        // most that much extra driver traffic and keeps one reading per scrape.
         {
             let mut last = self.last_read.lock().unwrap();
+            let due = self.interval.saturating_sub(SCRAPE_TOLERANCE);
             match *last {
-                Some(t) if t.elapsed() < self.interval => return,
+                Some(t) if t.elapsed() < due => return,
                 _ => *last = Some(Instant::now()),
             }
         }

--- a/src/agent/samplers/gpu/linux/intel/mod.rs
+++ b/src/agent/samplers/gpu/linux/intel/mod.rs
@@ -1,4 +1,4 @@
-//! Collects Intel GPU telemetry from the i915/xe PMU via `perf_event_open(2)`.
+//! Collects Intel GPU telemetry from the i915 PMU via `perf_event_open(2)`.
 //!
 //! This covers both integrated GPUs and discrete cards (Arc), which register
 //! separate PMUs under `/sys/bus/event_source/devices/` (see [`pmu`]). It is the
@@ -172,7 +172,7 @@ fn init(config: Arc<Config>) -> SamplerResult {
     if pmus.is_empty() {
         debug!("{NAME}: no Intel GPU PMUs found");
         return Err(crate::agent::sampler_status::Unsupported(
-            "no Intel GPU i915/xe PMU found".to_string(),
+            "no Intel GPU i915 PMU found".to_string(),
         )
         .into());
     }
@@ -224,24 +224,34 @@ fn init(config: Arc<Config>) -> SamplerResult {
         .into());
     }
 
-    // Real membership, not backing capacity, and one set per index space (see
-    // the groups' doc comment in `stats`).
+    // Real membership, and one set per index space (see the groups' doc
+    // comment in `stats`). Both are explicit sets built from the entries whose
+    // counters actually opened.
     //
-    // Engine entries are sparse: each GPU owns a `MAX_ENGINES`-wide block and
-    // uses only the leading part of it, so a prefix bound would declare the
-    // gaps as members. The explicit set does not.
+    // A prefix bound would be wrong for either. Engine entries are sparse:
+    // each GPU owns a `MAX_ENGINES`-wide block and uses only the leading part.
+    // And GPU ids are NOT dense — `id` comes from enumerating every discovered
+    // PMU, while only the GPUs whose `Gpu::new` succeeded are kept, so one
+    // failure leaves a survivor whose id exceeds `gpus.len()`. Bounding by the
+    // count then drops that GPU's series entirely and declares a phantom
+    // all-zero member at index 0 for a device that does not exist.
     let mut engine_members: Vec<usize> = Vec::new();
+    let mut device_members: Vec<usize> = Vec::new();
+
     for gpu in gpus.iter() {
+        device_members.push(gpu.id);
         for offset in 0..gpu.engines.len() {
-            engine_members.push(engine_index(gpu.id, offset));
+            let index = engine_index(gpu.id, offset);
+            if gpu.live_indices.contains(&index) {
+                engine_members.push(index);
+            }
         }
     }
-    engine_members.sort_unstable();
-    GPU_INTEL_PMU_ENGINE_ACQ.set_member_set(&engine_members);
 
-    // Per-GPU entries are indexed by GPU id, which `init` assigns densely from
-    // 0, so a prefix bound is exactly right here.
-    GPU_INTEL_PMU_DEVICE_ACQ.set_member_bound(gpus.len());
+    engine_members.sort_unstable();
+    device_members.sort_unstable();
+    GPU_INTEL_PMU_ENGINE_ACQ.set_member_set(&engine_members);
+    GPU_INTEL_PMU_DEVICE_ACQ.set_member_set(&device_members);
 
     let interval = config
         .sampler_interval(NAME)
@@ -377,6 +387,10 @@ struct Gpu {
     members: Vec<TrackedCounter>,
     /// Engine names in index order, for diagnostics.
     engines: Vec<String>,
+    /// Metric indices whose perf counter actually opened. The member sets are
+    /// built from these rather than from what sysfs advertised, so a rejected
+    /// or unopenable event never becomes a declared, permanently-null member.
+    live_indices: std::collections::BTreeSet<usize>,
     /// Global event names opened for this GPU, for diagnostics.
     globals: Vec<String>,
     /// DRM render node for VRAM accounting. `None` when the GPU has no
@@ -471,6 +485,15 @@ impl Gpu {
 
         leader.enable_group()?;
 
+        // Only entries whose counter actually opened get identity metadata and
+        // group membership. Tagging every *discovered* engine instead declared
+        // members that can never be written — a permanently-null series for an
+        // event the unit check rejected or `build_with_group` refused — which
+        // is the same phantom the two-group split exists to prevent.
+        let mut live_indices: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+        live_indices.insert(leader_index);
+        live_indices.extend(members.iter().map(|m| m.index));
+
         let label = pmu.device_label();
 
         // Distinguishes an integrated GPU from a discrete card (e.g. Arc), which
@@ -485,6 +508,9 @@ impl Gpu {
         // device and engine they belong to, not just an opaque index.
         for (offset, engine) in engines.iter().enumerate() {
             let metric_index = engine_index(id, offset);
+            if !live_indices.contains(&metric_index) {
+                continue;
+            }
             for (_, metric, _) in ENGINE_SAMPLES {
                 metric.insert_metadata(metric_index, "id".to_string(), id.to_string());
                 metric.insert_metadata(metric_index, "device".to_string(), label.clone());
@@ -543,6 +569,7 @@ impl Gpu {
             engines,
             globals,
             drm,
+            live_indices,
         })
     }
 

--- a/src/agent/samplers/gpu/linux/intel/pmu.rs
+++ b/src/agent/samplers/gpu/linux/intel/pmu.rs
@@ -1,0 +1,340 @@
+//! Discovery of Intel GPU PMUs exposed through `perf_event_open(2)`.
+//!
+//! The i915 driver registers one perf PMU per GPU under
+//! `/sys/bus/event_source/devices/`. The naming depends on whether the GPU is
+//! discrete (`i915_pmu.c`):
+//!
+//! ```c
+//! if (IS_DGFX(i915)) {
+//!     pmu->name = kasprintf(GFP_KERNEL, "i915_%s", dev_name(i915->drm.dev));
+//!     strreplace((char *)pmu->name, ':', '_');   /* perf reserves colons */
+//! } else {
+//!     pmu->name = "i915";
+//! }
+//! ```
+//!
+//! So an integrated GPU is the bare `i915`, while a discrete card is
+//! `i915_<pci-address>` with colons replaced by underscores (e.g. an Arc A770 at
+//! `0000:04:00.0` becomes `i915_0000_04_00.0`). The newer `xe` driver follows the
+//! same convention with an `xe` prefix, so both are matched here.
+//!
+//! Everything about a PMU is read from sysfs rather than hardcoded:
+//!
+//! - The perf `type` is **assigned dynamically at boot**, so it must be read from
+//!   `<pmu>/type`. Hosts observed with the iGPU at type 23 and an A770 at 24.
+//! - The available events differ per GPU. Both GPUs on the same host expose the
+//!   same *names* for shared engines with identical configs, but only the A770
+//!   has `ccs0` (compute) and the second video/video-enhance engines. Reading
+//!   `<pmu>/events/` therefore discovers the real engine set instead of guessing
+//!   it from the engine-class macros in `i915_drm.h`.
+//! - `<pmu>/events/<event>.unit` gives the unit (`ns`, `M`, or absent for plain
+//!   counts), which is how the sampler decides what a counter means.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+const EVENT_SOURCE_DIR: &str = "/sys/bus/event_source/devices";
+
+/// A single event exposed by an Intel GPU PMU.
+#[derive(Clone, Debug)]
+pub struct PmuEvent {
+    /// `perf_event_attr.config` for this event.
+    pub config: u64,
+    /// Unit from the sysfs `.unit` file, if any (`ns`, `M`, ...).
+    pub unit: Option<String>,
+}
+
+/// An Intel GPU PMU discovered in sysfs.
+#[derive(Clone, Debug)]
+pub struct GpuPmu {
+    /// The sysfs PMU name, e.g. `i915` or `i915_0000_04_00.0`.
+    pub name: String,
+    /// The dynamically-assigned perf type id.
+    pub perf_type: u32,
+    /// PCI address (`0000:04:00.0`) for a discrete GPU, `None` when integrated.
+    pub pci_address: Option<String>,
+    /// Kernel driver backing this PMU (`i915` or `xe`).
+    pub driver: String,
+    /// Events keyed by sysfs event name (`ccs0-busy`, `actual-frequency`, ...).
+    pub events: HashMap<String, PmuEvent>,
+}
+
+impl GpuPmu {
+    /// True when this PMU belongs to a discrete GPU (named after its PCI address).
+    pub fn is_discrete(&self) -> bool {
+        self.pci_address.is_some()
+    }
+
+    /// Look up an event by its sysfs name.
+    pub fn event(&self, name: &str) -> Option<&PmuEvent> {
+        self.events.get(name)
+    }
+
+    /// A stable, human-meaningful identifier for this GPU. Discrete GPUs are
+    /// identified by PCI address; the integrated GPU has no PCI address in its
+    /// PMU name, so it is reported as `integrated`.
+    pub fn device_label(&self) -> String {
+        self.pci_address
+            .clone()
+            .unwrap_or_else(|| "integrated".to_string())
+    }
+}
+
+/// Discover every Intel GPU PMU on this host, sorted for stable `id` assignment.
+///
+/// Ordering is: integrated GPU first (it has no PCI address), then discrete GPUs
+/// by ascending PCI address. Sorting keeps the `id` label stable across restarts
+/// on a given host, since readdir order is not guaranteed.
+pub fn discover() -> Vec<GpuPmu> {
+    discover_in(Path::new(EVENT_SOURCE_DIR))
+}
+
+fn discover_in(dir: &Path) -> Vec<GpuPmu> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut pmus: Vec<GpuPmu> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            parse_pmu_name(&name)?;
+            read_pmu(&entry.path(), &name)
+        })
+        .collect();
+
+    pmus.sort_by(|a, b| a.pci_address.cmp(&b.pci_address));
+    pmus
+}
+
+/// Match an Intel GPU PMU directory name, returning `(driver, pci_address)`.
+///
+/// Accepts the bare driver name (integrated) and `<driver>_<pci>` (discrete).
+/// The PCI portion has its colons replaced with underscores by the kernel; we
+/// restore them so the label matches what `lspci`/sysfs report elsewhere.
+fn parse_pmu_name(name: &str) -> Option<(&'static str, Option<String>)> {
+    for driver in ["i915", "xe"] {
+        if name == driver {
+            return Some((driver, None));
+        }
+
+        if let Some(rest) = name.strip_prefix(driver).and_then(|r| r.strip_prefix('_')) {
+            let pci = restore_pci_address(rest)?;
+            return Some((driver, Some(pci)));
+        }
+    }
+
+    None
+}
+
+/// Turn the kernel's colon-free PCI address back into canonical form.
+///
+/// `0000_04_00.0` -> `0000:04:00.0`. Only the two separators the kernel rewrote
+/// are restored; the function-number dot is left alone. Returns `None` for
+/// anything that does not look like a PCI address, so unrelated PMUs that happen
+/// to share the prefix are not misread as GPUs.
+fn restore_pci_address(raw: &str) -> Option<String> {
+    let (domain, rest) = raw.split_once('_')?;
+    let (bus, device_function) = rest.split_once('_')?;
+
+    let hex = |s: &str| !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit());
+
+    if !hex(domain) || !hex(bus) {
+        return None;
+    }
+
+    let (device, function) = device_function.split_once('.')?;
+    if !hex(device) || !hex(function) {
+        return None;
+    }
+
+    Some(format!("{domain}:{bus}:{device}.{function}"))
+}
+
+fn read_pmu(path: &Path, name: &str) -> Option<GpuPmu> {
+    let (driver, pci_address) = parse_pmu_name(name)?;
+
+    // The perf type is assigned at boot; without it we cannot open any event.
+    let perf_type: u32 = read_trimmed(&path.join("type"))?.parse().ok()?;
+
+    let events = read_events(&path.join("events"));
+    if events.is_empty() {
+        return None;
+    }
+
+    Some(GpuPmu {
+        name: name.to_string(),
+        perf_type,
+        pci_address,
+        driver: driver.to_string(),
+        events,
+    })
+}
+
+/// Read `<pmu>/events/`, pairing each event with its optional `.unit` sidecar.
+fn read_events(dir: &Path) -> HashMap<String, PmuEvent> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return HashMap::new(),
+    };
+
+    let mut units: HashMap<String, String> = HashMap::new();
+    let mut configs: HashMap<String, u64> = HashMap::new();
+
+    for entry in entries.flatten() {
+        let file_name = entry.file_name().to_string_lossy().into_owned();
+
+        // `.scale` files are not used by the i915 PMU (none are present on
+        // observed hosts) and would only rescale a value we already interpret
+        // via its unit, so they are ignored.
+        if let Some(stem) = file_name.strip_suffix(".unit") {
+            if let Some(unit) = read_trimmed(&entry.path()) {
+                units.insert(stem.to_string(), unit);
+            }
+            continue;
+        }
+
+        if file_name.contains('.') {
+            continue;
+        }
+
+        if let Some(config) = read_trimmed(&entry.path()).and_then(|c| parse_config(&c)) {
+            configs.insert(file_name, config);
+        }
+    }
+
+    configs
+        .into_iter()
+        .map(|(name, config)| {
+            let unit = units.get(&name).cloned();
+            (name, PmuEvent { config, unit })
+        })
+        .collect()
+}
+
+/// Parse an event's sysfs contents, which look like `config=0x4000`.
+///
+/// The i915 PMU only ever emits a single `config=` term (its one format field is
+/// `i915_eventid`, `config:0-20`), so any other term is unexpected and treated as
+/// unparseable rather than silently ignored.
+fn parse_config(raw: &str) -> Option<u64> {
+    let value = raw.trim().strip_prefix("config=")?;
+
+    // Reject trailing terms (e.g. `config=0x1,umask=0x2`) we do not understand.
+    if value.contains(',') {
+        return None;
+    }
+
+    match value.strip_prefix("0x") {
+        Some(hex) => u64::from_str_radix(hex, 16).ok(),
+        None => value.parse().ok(),
+    }
+}
+
+fn read_trimmed(path: &PathBuf) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_integrated_pmu_name() {
+        assert_eq!(parse_pmu_name("i915"), Some(("i915", None)));
+        assert_eq!(parse_pmu_name("xe"), Some(("xe", None)));
+    }
+
+    #[test]
+    fn parses_discrete_pmu_name() {
+        // An Arc A770 at 0000:04:00.0, as observed on a real host.
+        assert_eq!(
+            parse_pmu_name("i915_0000_04_00.0"),
+            Some(("i915", Some("0000:04:00.0".to_string())))
+        );
+        assert_eq!(
+            parse_pmu_name("xe_0000_03_00.0"),
+            Some(("xe", Some("0000:03:00.0".to_string())))
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_pmus() {
+        for name in ["cpu", "uncore_imc", "intel_pt", "msr", "i915foo", "xelite"] {
+            assert_eq!(parse_pmu_name(name), None, "should not match {name}");
+        }
+    }
+
+    #[test]
+    fn parses_event_configs() {
+        assert_eq!(parse_config("config=0x4000"), Some(0x4000));
+        assert_eq!(parse_config("config=0x100000\n"), Some(0x100000));
+        assert_eq!(parse_config("config=0"), Some(0));
+        // Multi-term configs are not part of the i915 PMU ABI.
+        assert_eq!(parse_config("config=0x1,umask=0x2"), None);
+        assert_eq!(parse_config("event=0x3"), None);
+    }
+
+    #[test]
+    fn discovers_pmus_from_a_sysfs_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // An integrated GPU (no ccs) and a discrete GPU (with ccs), mirroring
+        // the layout of a host that has both.
+        let igpu = root.join("i915");
+        std::fs::create_dir_all(igpu.join("events")).unwrap();
+        std::fs::write(igpu.join("type"), "23\n").unwrap();
+        std::fs::write(igpu.join("events/rcs0-busy"), "config=0x0\n").unwrap();
+        std::fs::write(igpu.join("events/rcs0-busy.unit"), "ns\n").unwrap();
+
+        let dgpu = root.join("i915_0000_04_00.0");
+        std::fs::create_dir_all(dgpu.join("events")).unwrap();
+        std::fs::write(dgpu.join("type"), "24\n").unwrap();
+        std::fs::write(dgpu.join("events/ccs0-busy"), "config=0x4000\n").unwrap();
+        std::fs::write(dgpu.join("events/ccs0-busy.unit"), "ns\n").unwrap();
+        std::fs::write(dgpu.join("events/actual-frequency"), "config=0x100000\n").unwrap();
+        std::fs::write(dgpu.join("events/actual-frequency.unit"), "M\n").unwrap();
+
+        // An unrelated PMU that must be ignored.
+        let other = root.join("uncore_imc");
+        std::fs::create_dir_all(other.join("events")).unwrap();
+        std::fs::write(other.join("type"), "12\n").unwrap();
+        std::fs::write(other.join("events/data_reads"), "config=0x1\n").unwrap();
+
+        let pmus = discover_in(root);
+        assert_eq!(pmus.len(), 2);
+
+        // Integrated sorts first (no PCI address).
+        assert_eq!(pmus[0].name, "i915");
+        assert_eq!(pmus[0].perf_type, 23);
+        assert!(!pmus[0].is_discrete());
+        assert_eq!(pmus[0].device_label(), "integrated");
+
+        assert_eq!(pmus[1].name, "i915_0000_04_00.0");
+        assert_eq!(pmus[1].perf_type, 24);
+        assert!(pmus[1].is_discrete());
+        assert_eq!(pmus[1].device_label(), "0000:04:00.0");
+        assert_eq!(pmus[1].event("ccs0-busy").unwrap().config, 0x4000);
+        assert_eq!(
+            pmus[1].event("actual-frequency").unwrap().unit.as_deref(),
+            Some("M")
+        );
+        assert!(pmus[1].event("rcs0-busy").is_none());
+    }
+
+    #[test]
+    fn skips_pmus_with_no_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let igpu = root.join("i915");
+        std::fs::create_dir_all(igpu.join("events")).unwrap();
+        std::fs::write(igpu.join("type"), "23\n").unwrap();
+
+        assert!(discover_in(root).is_empty());
+    }
+}

--- a/src/agent/samplers/gpu/linux/intel/pmu.rs
+++ b/src/agent/samplers/gpu/linux/intel/pmu.rs
@@ -15,8 +15,12 @@
 //!
 //! So an integrated GPU is the bare `i915`, while a discrete card is
 //! `i915_<pci-address>` with colons replaced by underscores (e.g. an Arc A770 at
-//! `0000:04:00.0` becomes `i915_0000_04_00.0`). The newer `xe` driver follows the
-//! same convention with an `xe` prefix, so both are matched here.
+//! `0000:04:00.0` becomes `i915_0000_04_00.0`).
+//!
+//! Only `i915` is matched. The newer `xe` driver names its PMU the same way but
+//! exposes a different event vocabulary, so recognising it here would produce a
+//! confusing permissions error rather than working support — see
+//! [`parse_pmu_name`].
 //!
 //! Everything about a PMU is read from sysfs rather than hardcoded:
 //!
@@ -53,7 +57,8 @@ pub struct GpuPmu {
     pub perf_type: u32,
     /// PCI address (`0000:04:00.0`) for a discrete GPU, `None` when integrated.
     pub pci_address: Option<String>,
-    /// Kernel driver backing this PMU (`i915` or `xe`).
+    /// Kernel driver backing this PMU. Always `i915` today; see
+    /// [`parse_pmu_name`] on why `xe` is not matched.
     pub driver: String,
     /// Events keyed by sysfs event name (`ccs0-busy`, `actual-frequency`, ...).
     pub events: HashMap<String, PmuEvent>,
@@ -113,8 +118,21 @@ fn discover_in(dir: &Path) -> Vec<GpuPmu> {
 /// Accepts the bare driver name (integrated) and `<driver>_<pci>` (discrete).
 /// The PCI portion has its colons replaced with underscores by the kernel; we
 /// restore them so the label matches what `lspci`/sysfs report elsewhere.
+///
+/// **i915 only.** The `xe` driver exposes a different event vocabulary — this
+/// sampler looks for `<engine>-busy` and `actual-frequency`/`requested-frequency`,
+/// which are i915's names. Matching `xe` here would let discovery succeed and
+/// every `Gpu::new` then fail with `NotFound`, so the sampler would report
+/// "no PMU counters could be opened (needs CAP_PERFMON ...)" — blaming
+/// permissions for a driver mismatch, on hardware where `xe` is the default
+/// (Lunar Lake, Battlemage). Naming only what is actually supported makes an
+/// xe host report `Unsupported` with an accurate reason instead.
+///
+/// Supporting xe means reading its own event names and its config-bit engine
+/// encoding; that is a separate change, and one that needs xe hardware to
+/// verify rather than to guess at.
 fn parse_pmu_name(name: &str) -> Option<(&'static str, Option<String>)> {
-    for driver in ["i915", "xe"] {
+    for driver in ["i915"] {
         if name == driver {
             return Some((driver, None));
         }
@@ -245,7 +263,9 @@ mod tests {
     #[test]
     fn parses_integrated_pmu_name() {
         assert_eq!(parse_pmu_name("i915"), Some(("i915", None)));
-        assert_eq!(parse_pmu_name("xe"), Some(("xe", None)));
+        // `xe` is deliberately NOT matched: its event vocabulary differs, and
+        // accepting it here would surface a permissions error instead.
+        assert_eq!(parse_pmu_name("xe"), None);
     }
 
     #[test]
@@ -255,10 +275,7 @@ mod tests {
             parse_pmu_name("i915_0000_04_00.0"),
             Some(("i915", Some("0000:04:00.0".to_string())))
         );
-        assert_eq!(
-            parse_pmu_name("xe_0000_03_00.0"),
-            Some(("xe", Some("0000:03:00.0".to_string())))
-        );
+        assert_eq!(parse_pmu_name("xe_0000_03_00.0"), None);
     }
 
     #[test]

--- a/src/agent/samplers/gpu/linux/intel/pmu.rs
+++ b/src/agent/samplers/gpu/linux/intel/pmu.rs
@@ -17,10 +17,8 @@
 //! `i915_<pci-address>` with colons replaced by underscores (e.g. an Arc A770 at
 //! `0000:04:00.0` becomes `i915_0000_04_00.0`).
 //!
-//! Only `i915` is matched. The newer `xe` driver names its PMU the same way but
-//! exposes a different event vocabulary, so recognising it here would produce a
-//! confusing permissions error rather than working support — see
-//! [`parse_pmu_name`].
+//! Only `i915` is matched; the `xe` driver's event vocabulary differs and is
+//! out of scope — see [`parse_pmu_name`].
 //!
 //! Everything about a PMU is read from sysfs rather than hardcoded:
 //!
@@ -57,8 +55,7 @@ pub struct GpuPmu {
     pub perf_type: u32,
     /// PCI address (`0000:04:00.0`) for a discrete GPU, `None` when integrated.
     pub pci_address: Option<String>,
-    /// Kernel driver backing this PMU. Always `i915` today; see
-    /// [`parse_pmu_name`] on why `xe` is not matched.
+    /// Kernel driver backing this PMU. Always `i915`; see [`parse_pmu_name`].
     pub driver: String,
     /// Events keyed by sysfs event name (`ccs0-busy`, `actual-frequency`, ...).
     pub events: HashMap<String, PmuEvent>,
@@ -119,31 +116,27 @@ fn discover_in(dir: &Path) -> Vec<GpuPmu> {
 /// The PCI portion has its colons replaced with underscores by the kernel; we
 /// restore them so the label matches what `lspci`/sysfs report elsewhere.
 ///
-/// **i915 only.** The `xe` driver exposes a different event vocabulary — this
-/// sampler looks for `<engine>-busy` and `actual-frequency`/`requested-frequency`,
-/// which are i915's names. Matching `xe` here would let discovery succeed and
-/// every `Gpu::new` then fail with `NotFound`, so the sampler would report
-/// "no PMU counters could be opened (needs CAP_PERFMON ...)" — blaming
-/// permissions for a driver mismatch, on hardware where `xe` is the default
-/// (Lunar Lake, Battlemage). Naming only what is actually supported makes an
-/// xe host report `Unsupported` with an accurate reason instead.
+/// **i915 only, by design.** The `xe` driver names its PMU the same way but
+/// exposes a different event vocabulary — this sampler reads `<engine>-busy`
+/// and `actual-frequency`/`requested-frequency`, which are i915's names.
 ///
-/// Supporting xe means reading its own event names and its config-bit engine
-/// encoding; that is a separate change, and one that needs xe hardware to
-/// verify rather than to guess at.
+/// Matching `xe` here would let discovery succeed and every `Gpu::new` then
+/// fail with `NotFound`, so the sampler would report "no PMU counters could be
+/// opened (needs CAP_PERFMON ...)" — blaming permissions for what is really a
+/// driver this sampler does not read. Matching only i915 makes an xe host
+/// report `Unsupported` with an accurate reason.
 fn parse_pmu_name(name: &str) -> Option<(&'static str, Option<String>)> {
-    for driver in ["i915"] {
-        if name == driver {
-            return Some((driver, None));
-        }
+    const DRIVER: &str = "i915";
 
-        if let Some(rest) = name.strip_prefix(driver).and_then(|r| r.strip_prefix('_')) {
-            let pci = restore_pci_address(rest)?;
-            return Some((driver, Some(pci)));
-        }
+    if name == DRIVER {
+        return Some((DRIVER, None));
     }
 
-    None
+    let rest = name
+        .strip_prefix(DRIVER)
+        .and_then(|r| r.strip_prefix('_'))?;
+    let pci = restore_pci_address(rest)?;
+    Some((DRIVER, Some(pci)))
 }
 
 /// Turn the kernel's colon-free PCI address back into canonical form.
@@ -263,8 +256,8 @@ mod tests {
     #[test]
     fn parses_integrated_pmu_name() {
         assert_eq!(parse_pmu_name("i915"), Some(("i915", None)));
-        // `xe` is deliberately NOT matched: its event vocabulary differs, and
-        // accepting it here would surface a permissions error instead.
+        // `xe` is deliberately NOT matched: it is out of scope, and accepting
+        // it here would surface a permissions error instead.
         assert_eq!(parse_pmu_name("xe"), None);
     }
 

--- a/src/agent/samplers/gpu/linux/intel/stats.rs
+++ b/src/agent/samplers/gpu/linux/intel/stats.rs
@@ -24,7 +24,28 @@
 
 use metriken::*;
 
+use crate::agent::timing::AcquisitionGroup;
+use linkme::distributed_slice;
+
 use super::MAX_GPUS;
+
+/// One acquisition window for the whole per-GPU read pass.
+///
+/// Principle 18's "device sweep" archetype: `refresh()` visits each GPU once
+/// and, per visit, issues a grouped perf `read(2)` and a DRM ioctl. Those span
+/// two metric families (engine occupancy/frequency, and VRAM) but they are one
+/// read section — device-major by a property of the source, since the perf
+/// group fd and the render node belong to that one device and are reached
+/// together. Splitting it family-major would describe a sweep the driver never
+/// performed.
+///
+/// Single writer: the `spawn_blocking` task dispatched from `Sampler::refresh`,
+/// which is guarded against overlapping itself. Nothing else writes these.
+pub static GPU_INTEL_PMU_ACQ: AcquisitionGroup =
+    AcquisitionGroup::new(super::NAME, "gpu_intel_pmu_devices");
+
+#[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
+static GPU_INTEL_PMU_ACQ_REG: &'static AcquisitionGroup = &GPU_INTEL_PMU_ACQ;
 
 // ----- Per-engine occupancy -----
 //
@@ -37,9 +58,9 @@ use super::ENGINE_ENTRIES;
 #[metric(
     name = "gpu_engine_busy_time",
     description = "Nanoseconds an engine spent executing work.",
-    metadata = { vendor = "intel", unit = "nanoseconds" }
+    metadata = { acq_group = "gpu_intel_pmu_devices", vendor = "intel", unit = "nanoseconds" }
 )]
-pub static GPU_ENGINE_BUSY: WindowedCounterGroup = WindowedCounterGroup::new(ENGINE_ENTRIES);
+pub static GPU_ENGINE_BUSY: CounterGroup = CounterGroup::new(ENGINE_ENTRIES);
 
 // ----- Per-GPU frequency -----
 //
@@ -52,16 +73,16 @@ pub static GPU_ENGINE_BUSY: WindowedCounterGroup = WindowedCounterGroup::new(ENG
 #[metric(
     name = "gpu_frequency_sample",
     description = "Cumulative sum of actual GPU frequency samples in MHz; rate() yields average MHz.",
-    metadata = { vendor = "intel", frequency = "actual", unit = "megahertz" }
+    metadata = { acq_group = "gpu_intel_pmu_devices", vendor = "intel", frequency = "actual", unit = "megahertz" }
 )]
-pub static GPU_FREQUENCY_ACTUAL: WindowedCounterGroup = WindowedCounterGroup::new(MAX_GPUS);
+pub static GPU_FREQUENCY_ACTUAL: CounterGroup = CounterGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_frequency_sample",
     description = "Cumulative sum of requested GPU frequency samples in MHz; rate() yields average MHz.",
-    metadata = { vendor = "intel", frequency = "requested", unit = "megahertz" }
+    metadata = { acq_group = "gpu_intel_pmu_devices", vendor = "intel", frequency = "requested", unit = "megahertz" }
 )]
-pub static GPU_FREQUENCY_REQUESTED: WindowedCounterGroup = WindowedCounterGroup::new(MAX_GPUS);
+pub static GPU_FREQUENCY_REQUESTED: CounterGroup = CounterGroup::new(MAX_GPUS);
 
 // ----- VRAM -----
 //
@@ -77,13 +98,13 @@ pub static GPU_FREQUENCY_REQUESTED: WindowedCounterGroup = WindowedCounterGroup:
 #[metric(
     name = "gpu_memory",
     description = "The amount of GPU device memory (VRAM) free.",
-    metadata = { vendor = "intel", state = "free", unit = "bytes" }
+    metadata = { acq_group = "gpu_intel_pmu_devices", vendor = "intel", state = "free", unit = "bytes" }
 )]
-pub static GPU_MEMORY_FREE: WindowedGaugeGroup = WindowedGaugeGroup::new(MAX_GPUS);
+pub static GPU_MEMORY_FREE: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_memory",
     description = "The amount of GPU device memory (VRAM) used.",
-    metadata = { vendor = "intel", state = "used", unit = "bytes" }
+    metadata = { acq_group = "gpu_intel_pmu_devices", vendor = "intel", state = "used", unit = "bytes" }
 )]
-pub static GPU_MEMORY_USED: WindowedGaugeGroup = WindowedGaugeGroup::new(MAX_GPUS);
+pub static GPU_MEMORY_USED: GaugeGroup = GaugeGroup::new(MAX_GPUS);

--- a/src/agent/samplers/gpu/linux/intel/stats.rs
+++ b/src/agent/samplers/gpu/linux/intel/stats.rs
@@ -1,0 +1,89 @@
+//! Metrics for the Intel GPU PMU sampler.
+//!
+//! Two sources, and the distinction matters for how each is consumed:
+//!
+//! **Perf events (counters).** Everything read from the i915/xe PMU is a
+//! **monotonically cumulative counter**, so it is published raw and the viewer
+//! derives the interesting quantity as a rate:
+//!
+//! - Engine busy is cumulative **nanoseconds**. `rate(busy[N])` is the fraction
+//!   of wall time the engine was executing work, so
+//!   `rate(gpu_engine_busy_time[1m]) * 100` is utilization in percent.
+//! - The frequency events are **not** instantaneous gauges. The driver adds one
+//!   MHz sample per internal tick, and only while the GT is awake, so the raw
+//!   counter is a running sum of MHz samples. `rate()` over it recovers average
+//!   MHz over the interval — which is exactly the number `perf stat -I` and
+//!   `intel_gpu_top` display. Publishing it as a gauge would be wrong, because a
+//!   single read carries no information without its predecessor.
+//!
+//! **DRM query ioctl (gauges).** VRAM is not a PMU counter; it comes from
+//! `DRM_IOCTL_I915_QUERY` and is an instantaneous byte count (see `drm_memory`).
+//!
+//! The `id` label indexes the GPU in discovery order and `device` carries the
+//! PCI address (or `integrated`), which is the stable identifier to join on.
+
+use metriken::*;
+
+use super::MAX_GPUS;
+
+// ----- Per-engine occupancy -----
+//
+// `MAX_GPUS * MAX_ENGINES` wide: entry `gpu * MAX_ENGINES + engine`. The engine
+// identity is carried in per-entry metadata set at init, since the engine set
+// differs per GPU (only a discrete card has a compute engine).
+
+use super::ENGINE_ENTRIES;
+
+#[metric(
+    name = "gpu_engine_busy_time",
+    description = "Nanoseconds an engine spent executing work.",
+    metadata = { vendor = "intel", unit = "nanoseconds" }
+)]
+pub static GPU_ENGINE_BUSY: WindowedCounterGroup = WindowedCounterGroup::new(ENGINE_ENTRIES);
+
+// ----- Per-GPU frequency -----
+//
+// Cumulative sums of per-tick MHz samples. Take `rate()` to get the average
+// frequency in MHz over an interval; see the module docs above.
+//
+// Pair these with engine busy time: the PMU reports occupancy, not efficiency,
+// so busy-at-a-low-clock and genuinely saturated look identical without them.
+
+#[metric(
+    name = "gpu_frequency_sample",
+    description = "Cumulative sum of actual GPU frequency samples in MHz; rate() yields average MHz.",
+    metadata = { vendor = "intel", frequency = "actual", unit = "megahertz" }
+)]
+pub static GPU_FREQUENCY_ACTUAL: WindowedCounterGroup = WindowedCounterGroup::new(MAX_GPUS);
+
+#[metric(
+    name = "gpu_frequency_sample",
+    description = "Cumulative sum of requested GPU frequency samples in MHz; rate() yields average MHz.",
+    metadata = { vendor = "intel", frequency = "requested", unit = "megahertz" }
+)]
+pub static GPU_FREQUENCY_REQUESTED: WindowedCounterGroup = WindowedCounterGroup::new(MAX_GPUS);
+
+// ----- VRAM -----
+//
+// Unlike everything above, these are **gauges in bytes**, matching the
+// `gpu_memory{state=used,free}` series the AMD and NVIDIA samplers publish, so
+// cross-vendor dashboards work unchanged. They come from the DRM
+// `QUERY_MEMORY_REGIONS` ioctl rather than the PMU, which has no memory counter
+// (see `drm_memory`).
+//
+// Only GPUs with device-local memory emit these: an integrated GPU has no VRAM
+// region and reports nothing rather than passing host RAM off as VRAM.
+
+#[metric(
+    name = "gpu_memory",
+    description = "The amount of GPU device memory (VRAM) free.",
+    metadata = { vendor = "intel", state = "free", unit = "bytes" }
+)]
+pub static GPU_MEMORY_FREE: WindowedGaugeGroup = WindowedGaugeGroup::new(MAX_GPUS);
+
+#[metric(
+    name = "gpu_memory",
+    description = "The amount of GPU device memory (VRAM) used.",
+    metadata = { vendor = "intel", state = "used", unit = "bytes" }
+)]
+pub static GPU_MEMORY_USED: WindowedGaugeGroup = WindowedGaugeGroup::new(MAX_GPUS);

--- a/src/agent/samplers/gpu/linux/intel/stats.rs
+++ b/src/agent/samplers/gpu/linux/intel/stats.rs
@@ -2,7 +2,7 @@
 //!
 //! Two sources, and the distinction matters for how each is consumed:
 //!
-//! **Perf events (counters).** Everything read from the i915/xe PMU is a
+//! **Perf events (counters).** Everything read from the i915 PMU is a
 //! **monotonically cumulative counter**, so it is published raw and the viewer
 //! derives the interesting quantity as a rate:
 //!

--- a/src/agent/samplers/gpu/linux/intel/stats.rs
+++ b/src/agent/samplers/gpu/linux/intel/stats.rs
@@ -29,23 +29,45 @@ use linkme::distributed_slice;
 
 use super::MAX_GPUS;
 
-/// One acquisition window for the whole per-GPU read pass.
-///
-/// Principle 18's "device sweep" archetype: `refresh()` visits each GPU once
-/// and, per visit, issues a grouped perf `read(2)` and a DRM ioctl. Those span
-/// two metric families (engine occupancy/frequency, and VRAM) but they are one
-/// read section — device-major by a property of the source, since the perf
-/// group fd and the render node belong to that one device and are reached
-/// together. Splitting it family-major would describe a sweep the driver never
-/// performed.
-///
-/// Single writer: the `spawn_blocking` task dispatched from `Sampler::refresh`,
-/// which is guarded against overlapping itself. Nothing else writes these.
-pub static GPU_INTEL_PMU_ACQ: AcquisitionGroup =
+// `refresh()` visits each GPU once and, per visit, issues a grouped perf
+// `read(2)` and a DRM ioctl — one read section by principle 18's "device sweep"
+// archetype, device-major by a property of the source (the perf group fd and
+// the render node belong to that one device and are reached together).
+//
+// That single read section nonetheless needs TWO groups, because the metrics it
+// fills live in two different index spaces:
+//
+//   - per-engine metrics are indexed by `engine_index(gpu, engine)`, a
+//     `MAX_ENGINES`-wide block per GPU;
+//   - per-GPU metrics (frequency, VRAM) are indexed by the plain GPU id.
+//
+// A group's member set is applied verbatim to every metric tagged with it, so
+// one shared group would declare each engine index as a GPU id too. On a
+// two-GPU host that published phantom `gpu_frequency_sample{id="2"}` and
+// `{id="3"}` series — all-zero, and missing the `device`/`type` labels that
+// only real entries carry — which is exactly what the member-set mechanism
+// exists to prevent. Caught on hardware, not in review.
+//
+// Both are stamped from the same bracket, so the two windows are identical and
+// nothing is over-stated by the split.
+//
+// Single writer for both: the `spawn_blocking` task dispatched from
+// `Sampler::refresh`, which is guarded against overlapping itself.
+
+/// Window for the per-engine metrics, whose members are [`super::engine_index`]
+/// values.
+pub static GPU_INTEL_PMU_ENGINE_ACQ: AcquisitionGroup =
+    AcquisitionGroup::new(super::NAME, "gpu_intel_pmu_engines");
+
+#[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
+static GPU_INTEL_PMU_ENGINE_ACQ_REG: &'static AcquisitionGroup = &GPU_INTEL_PMU_ENGINE_ACQ;
+
+/// Window for the per-device metrics, whose members are GPU ids.
+pub static GPU_INTEL_PMU_DEVICE_ACQ: AcquisitionGroup =
     AcquisitionGroup::new(super::NAME, "gpu_intel_pmu_devices");
 
 #[distributed_slice(crate::agent::samplers::ACQUISITION_GROUPS)]
-static GPU_INTEL_PMU_ACQ_REG: &'static AcquisitionGroup = &GPU_INTEL_PMU_ACQ;
+static GPU_INTEL_PMU_DEVICE_ACQ_REG: &'static AcquisitionGroup = &GPU_INTEL_PMU_DEVICE_ACQ;
 
 // ----- Per-engine occupancy -----
 //
@@ -58,7 +80,7 @@ use super::ENGINE_ENTRIES;
 #[metric(
     name = "gpu_engine_busy_time",
     description = "Nanoseconds an engine spent executing work.",
-    metadata = { acq_group = "gpu_intel_pmu_devices", vendor = "intel", unit = "nanoseconds" }
+    metadata = { acq_group = "gpu_intel_pmu_engines", vendor = "intel", unit = "nanoseconds" }
 )]
 pub static GPU_ENGINE_BUSY: CounterGroup = CounterGroup::new(ENGINE_ENTRIES);
 

--- a/src/agent/samplers/gpu/linux/mod.rs
+++ b/src/agent/samplers/gpu/linux/mod.rs
@@ -1,2 +1,3 @@
 mod amd;
+mod intel;
 mod nvidia;

--- a/src/agent/samplers/gpu/macos/stats.rs
+++ b/src/agent/samplers/gpu/macos/stats.rs
@@ -1,3 +1,13 @@
+//! Metrics for the Apple GPU sampler.
+//!
+//! Every metric carries `vendor = "apple"`, matching the `amd`/`intel`/`nvidia`
+//! values the Linux GPU samplers use and the `"apple"` that `systeminfo`'s
+//! macOS summary already reports. The label is what makes a GPU's `id`
+//! meaningful: each vendor's sampler numbers its devices from 0, so an id is
+//! unique only within a vendor, and the viewer groups per-GPU charts by
+//! `(id, vendor)`. Apple GPUs are the only ones this sampler can see — it
+//! reads Apple Silicon counters through powermetrics — so the value is static.
+
 use metriken::*;
 
 const MAX_GPUS: usize = 32;
@@ -5,27 +15,27 @@ const MAX_GPUS: usize = 32;
 #[metric(
     name = "gpu_power_usage",
     description = "The current power usage in milliwatts (mW).",
-    metadata = { unit = "milliwatts" }
+    metadata = { vendor = "apple", unit = "milliwatts" }
 )]
 pub static GPU_POWER_USAGE: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_energy_consumption",
     description = "The energy consumption in milliJoules (mJ).",
-    metadata = { unit = "milliJoules" }
+    metadata = { vendor = "apple", unit = "milliJoules" }
 )]
 pub static GPU_ENERGY_CONSUMPTION: CounterGroup = CounterGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_clock",
     description = "The current clock speed in Hertz (Hz).",
-    metadata = { clock = "graphics", unit = "Hz" }
+    metadata = { vendor = "apple", clock = "graphics", unit = "Hz" }
 )]
 pub static GPU_CLOCK_GRAPHICS: GaugeGroup = GaugeGroup::new(MAX_GPUS);
 
 #[metric(
     name = "gpu_utilization",
     description = "The running average percentage of time the GPU was active. (0-100).",
-    metadata = { unit = "percentage" }
+    metadata = { vendor = "apple", unit = "percentage" }
 )]
 pub static GPU_UTILIZATION: GaugeGroup = GaugeGroup::new(MAX_GPUS);

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -68,6 +68,7 @@ pub(crate) const EXPECTED_SUBSYSTEMS: &[&str] = &[
     "gpu_amd_pmu",
     "gpu_amd_smi",
     "gpu_apple",
+    "gpu_intel_pmu",
     "gpu_nvidia",
     "memory_meminfo",
     "memory_vmstat",
@@ -171,6 +172,8 @@ pub(crate) const METRIC_SAMPLERS: &[(&str, &str)] = &[
     ("gpmu_wave_cycles", "gpu_amd_pmu"),
     ("gpmu_waves", "gpu_amd_pmu"),
     ("gpu_dram_bandwidth_utilization", "gpu_nvidia"),
+    ("gpu_engine_busy_time", "gpu_intel_pmu"),
+    ("gpu_frequency_sample", "gpu_intel_pmu"),
     ("gpu_pcie_bandwidth", "gpu_nvidia"),
     ("gpu_sm_occupancy", "gpu_nvidia"),
     ("gpu_sm_utilization", "gpu_nvidia"),
@@ -291,10 +294,15 @@ const BPF_SAMPLERS: &[&str] = &[
 /// - `gpu_clock`, `gpu_energy_consumption`, `gpu_power_usage`,
 ///   `gpu_utilization`: shared vocabulary across `gpu_amd_smi`,
 ///   `gpu_apple`, and `gpu_nvidia`.
-/// - `gpu_memory`, `gpu_memory_utilization`, `gpu_pcie_throughput`,
-///   `gpu_temperature`: shared between `gpu_amd_smi` and `gpu_nvidia` only
-///   (no macOS/`gpu_apple` equivalent — `gpu/macos/stats.rs` declares no
-///   metric under these names).
+/// - `gpu_memory`: shared between `gpu_amd_smi`, `gpu_intel_pmu` and
+///   `gpu_nvidia`. The Intel sampler publishes VRAM under the same
+///   vendor-neutral name and labels, so cross-vendor dashboards work
+///   unchanged; it is discrete-only, since an integrated GPU has no
+///   device-local memory region.
+/// - `gpu_memory_utilization`, `gpu_pcie_throughput`, `gpu_temperature`:
+///   shared between `gpu_amd_smi` and `gpu_nvidia` only (no macOS/`gpu_apple`
+///   equivalent — `gpu/macos/stats.rs` declares no metric under these names;
+///   and the i915/xe PMU exposes no memory-controller or PCIe counter).
 /// - `rezolus_bpf_run_count`, `rezolus_bpf_run_time`: see [`BPF_SAMPLERS`].
 ///
 /// Sorted alphabetically by name; each candidate list sorted alphabetically
@@ -306,7 +314,10 @@ pub(crate) const AMBIGUOUS_METRICS: &[(&str, &[&str])] = &[
         "gpu_energy_consumption",
         &["gpu_amd_smi", "gpu_apple", "gpu_nvidia"],
     ),
-    ("gpu_memory", &["gpu_amd_smi", "gpu_nvidia"]),
+    (
+        "gpu_memory",
+        &["gpu_amd_smi", "gpu_intel_pmu", "gpu_nvidia"],
+    ),
     ("gpu_memory_utilization", &["gpu_amd_smi", "gpu_nvidia"]),
     ("gpu_pcie_throughput", &["gpu_amd_smi", "gpu_nvidia"]),
     (

--- a/src/analysis/extract/context.rs
+++ b/src/analysis/extract/context.rs
@@ -302,7 +302,7 @@ const BPF_SAMPLERS: &[&str] = &[
 /// - `gpu_memory_utilization`, `gpu_pcie_throughput`, `gpu_temperature`:
 ///   shared between `gpu_amd_smi` and `gpu_nvidia` only (no macOS/`gpu_apple`
 ///   equivalent — `gpu/macos/stats.rs` declares no metric under these names;
-///   and the i915/xe PMU exposes no memory-controller or PCIe counter).
+///   and the i915 PMU exposes no memory-controller or PCIe counter).
 /// - `rezolus_bpf_run_count`, `rezolus_bpf_run_time`: see [`BPF_SAMPLERS`].
 ///
 /// Sorted alphabetically by name; each candidate list sorted alphabetically

--- a/src/analysis/extract/golden.rs
+++ b/src/analysis/extract/golden.rs
@@ -467,6 +467,7 @@ mod tests {
         "gpu_amd_pmu",
         "gpu_amd_smi",
         "gpu_apple",
+        "gpu_intel_pmu",
         "gpu_nvidia",
         "memory_meminfo",
         "memory_vmstat",

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -70,7 +70,8 @@ let nodeList = [];
 let nodeVersions = {};
 let selectedNode = null;
 let gpuList = [];          // GPU ids present in the recording (e.g. [0, 1])
-let selectedGpus = [];     // selected GPU ids filtering the GPU section, [] = all
+let selectedGpus = [];     // selected {vendor, id} GPUs filtering the GPU section, [] = all
+let gpuEntries = [];       // available {vendor, id} GPUs, from the section metadata
 let serviceInstances = {};
 let selectedInstances = {};
 let activeCgroupPattern = null;
@@ -325,6 +326,9 @@ const loadSection = async (section) => {
     const gpuSel = data.metadata?.gpu_selector;
     if (gpuSel?.enabled && Array.isArray(gpuSel.ids)) {
         gpuList = gpuSel.ids.slice();
+        // `gpus` carries the (vendor, id) pairs the selector filters on. Older
+        // recordings have only `ids`; the selector falls back to those.
+        gpuEntries = Array.isArray(gpuSel.gpus) ? gpuSel.gpus.slice() : [];
     }
 
     const processedData = await processDashboardData(data, activeCgroupPattern, `/${section}`);
@@ -520,8 +524,8 @@ const changeNode = async (nodeName) => {
     }
 };
 
-const changeGpu = async (gpuIds) => {
-    selectedGpus = Array.isArray(gpuIds) ? gpuIds.slice() : [];
+const changeGpu = async (gpus) => {
+    selectedGpus = Array.isArray(gpus) ? gpus.slice() : [];
     setSelectedGpus(selectedGpus);
     // Only the GPU section's charts depend on this; drop its cached data and
     // reload so the queries re-run with the id filter applied.
@@ -881,13 +885,16 @@ const SectionContent = {
             // filters the non-per-GPU charts to a subset of GPU ids. Shown only
             // when the recording has more than one GPU. Per-GPU charts (queries
             // grouped `by (id)`) always show all GPUs.
-            sectionRoute === '/gpu' && gpuList.length > 1 && m(GpuSelector, {
+            sectionRoute === '/gpu' && (gpuEntries.length > 1 || gpuList.length > 1) && m(GpuSelector, {
+                // The (vendor, id) pairs to choose between; `ids` is the
+                // fallback for a recording whose metadata predates them.
+                gpus: gpuEntries,
                 ids: gpuList,
                 selected: selectedGpus,
                 onChange: changeGpu,
-                // GPU details (name/model, memory) from System Info, keyed by id,
-                // so each entry shows the device model alongside its id.
-                gpus: systemInfoData?.gpus || [],
+                // GPU details (name/model, memory) from System Info, matched on
+                // (vendor, index), so each entry shows the device model.
+                details: systemInfoData?.gpus || [],
             }),
             m('div#groups',
                 attrs.groups.map((group) => m(Group, { ...group, sectionRoute, sectionName, interval })),

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -9,7 +9,7 @@ import globalColorMapper from './charts/util/colormap.js';
 import { TopNav, Sidebar, countCharts, formatSize } from './ui/layout.js';
 import { collectGroupPlots } from './features/group_utils.js';
 import { CpuTopology } from './features/topology.js';
-import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, clearDisplayTiles, setStepOverride, getStepOverride, setRateMode, getRateMode, setSelectedNode, setSelectedInstance, getSelectedNode, setSelectedGpus, getSelectedGpus, injectLabel, setDisplayMode, getDisplayMode, setRangeOverride, getRangeOverride, CAPTURE_EXPERIMENT } from './data.js';
+import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, clearDisplayTiles, setStepOverride, getStepOverride, setRateMode, getRateMode, setSelectedNode, setSelectedInstance, getSelectedNode, setSelectedGpus, getSelectedGpus, setGpuVendors, injectLabel, setDisplayMode, getDisplayMode, setRangeOverride, getRangeOverride, CAPTURE_EXPERIMENT } from './data.js';
 
 // Opt line-ish charts into display (boxplot decimation) mode: they fetch the
 // decimated boxplot binary instead of the full native-resolution JSON matrix.
@@ -329,6 +329,10 @@ const loadSection = async (section) => {
         // `gpus` carries the (vendor, id) pairs the selector filters on. Older
         // recordings have only `ids`; the selector falls back to those.
         gpuEntries = Array.isArray(gpuSel.gpus) ? gpuSel.gpus.slice() : [];
+        // Tell the data layer which vendors the host has, so per-GPU row and
+        // series labels can be qualified wherever an id alone is ambiguous —
+        // including in a chart that happens to show only one vendor's GPU.
+        setGpuVendors(gpuEntries.map((g) => g.vendor));
     }
 
     const processedData = await processDashboardData(data, activeCgroupPattern, `/${section}`);

--- a/src/viewer/assets/lib/app.js
+++ b/src/viewer/assets/lib/app.js
@@ -9,7 +9,7 @@ import globalColorMapper from './charts/util/colormap.js';
 import { TopNav, Sidebar, countCharts, formatSize } from './ui/layout.js';
 import { collectGroupPlots } from './features/group_utils.js';
 import { CpuTopology } from './features/topology.js';
-import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, clearDisplayTiles, setStepOverride, getStepOverride, setRateMode, getRateMode, setSelectedNode, setSelectedInstance, getSelectedNode, setSelectedGpus, getSelectedGpus, setGpuVendors, injectLabel, setDisplayMode, getDisplayMode, setRangeOverride, getRangeOverride, CAPTURE_EXPERIMENT } from './data.js';
+import { executePromQLRangeQuery, applyResultToPlot, fetchHeatmapsForGroups, substituteCgroupPattern, processDashboardData, clearMetadataCache, clearDisplayTiles, setStepOverride, getStepOverride, setRateMode, getRateMode, setSelectedNode, setSelectedInstance, getSelectedNode, setSelectedGpus, getSelectedGpus, injectLabel, setDisplayMode, getDisplayMode, setRangeOverride, getRangeOverride, CAPTURE_EXPERIMENT } from './data.js';
 
 // Opt line-ish charts into display (boxplot decimation) mode: they fetch the
 // decimated boxplot binary instead of the full native-resolution JSON matrix.
@@ -329,10 +329,6 @@ const loadSection = async (section) => {
         // `gpus` carries the (vendor, id) pairs the selector filters on. Older
         // recordings have only `ids`; the selector falls back to those.
         gpuEntries = Array.isArray(gpuSel.gpus) ? gpuSel.gpus.slice() : [];
-        // Tell the data layer which vendors the host has, so per-GPU row and
-        // series labels can be qualified wherever an id alone is ambiguous —
-        // including in a chart that happens to show only one vendor's GPU.
-        setGpuVendors(gpuEntries.map((g) => g.vendor));
     }
 
     const processedData = await processDashboardData(data, activeCgroupPattern, `/${section}`);

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -136,9 +136,12 @@ export function configureHeatmap(chart) {
         // Row name for the tooltip: the supplied label where there is one, so a
         // mixed-vendor GPU chart reads "GPU nvidia 0" rather than two rows both
         // claiming to be "GPU 0".
+        // A supplied label already names the entity, so the rowEntity prefix is
+        // dropped for it — "GPU nvidia 0" reads as noise. Numeric rows keep it,
+        // so a CPU heatmap still says "CPU 12".
         const rowName = (suppliedRowLabels && suppliedRowLabels[cpu] != null)
             ? String(suppliedRowLabels[cpu])
-            : cpu;
+            : `${rowEntity} ${cpu}`;
 
         // In compare mode, time is already the post-anchor relative ms
         // value (the rebase happens before the chart is fed). Use the
@@ -156,7 +159,7 @@ export function configureHeatmap(chart) {
                         </div>
                         <div style="display: flex; align-items: center; gap: 12px;">
                             <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
-                                ${rowEntity} ${rowName}
+                                ${rowName}
                             </span>
                             <span style="${FONTS.cssMono} font-weight: ${FONTS.tooltipValue.fontWeight}; font-size: ${FONTS.tooltipValue.fontSize}px; color: ${COLORS.fgMuted};">
                                 no data
@@ -185,7 +188,7 @@ export function configureHeatmap(chart) {
                         </div>
                         <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 4px;">
                             <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
-                                ${rowEntity} ${rowName}
+                                ${rowName}
                             </span>
                         </div>
                         <div style="display: grid; grid-template-columns: max-content max-content; gap: 2px 12px; ${FONTS.cssMono} font-size: ${FONTS.tooltipValue.fontSize}px;">
@@ -224,7 +227,7 @@ export function configureHeatmap(chart) {
                     </div>
                     <div style="display: flex; align-items: center; gap: 12px;">
                         <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
-                            ${rowEntity} ${rowName}
+                            ${rowName}
                         </span>
                         ${label}
                         <span style="${FONTS.cssMono} font-weight: ${FONTS.tooltipValue.fontWeight}; font-size: ${FONTS.tooltipValue.fontSize}px; color: ${COLORS.fg};">
@@ -235,11 +238,18 @@ export function configureHeatmap(chart) {
                 </div>`;
     };
 
+    // Rows that supply their own labels are self-describing — "nvidia 0"
+    // already names the entity — so the axis name is dropped for them. It only
+    // repeated the entity, and being positioned with a fixed gap sized for
+    // short numeric labels ("0", "12"), it rendered on top of the wider text.
+    // Numeric rows keep the name, since "0" alone does not say what it counts.
     const yAxis = {
         type: 'category',
-        name: yAxisLabel || 'CPU',
-        nameLocation: 'middle',
-        nameGap: 40,
+        ...(suppliedRowLabels ? {} : {
+            name: yAxisLabel || 'CPU',
+            nameLocation: 'middle',
+            nameGap: 40,
+        }),
         nameTextStyle: {
             color: COLORS.fg,
             ...FONTS.legend,

--- a/src/viewer/assets/lib/charts/heatmap.js
+++ b/src/viewer/assets/lib/charts/heatmap.js
@@ -80,7 +80,14 @@ export function configureHeatmap(chart) {
     const resolutionStore = createHeatmapResolutionStore(data, timeData, emitNullCells);
     chart.heatmapResolutionStore = resolutionStore;
     const yCount = resolutionStore.yCount;
-    const continuousCpuIds = Array.from({ length: yCount }, (_, i) => i);
+    // Per-row names when the data supplies them (a GPU heatmap on a
+    // mixed-vendor host needs "nvidia 0" / "intel 0", since the bare id is
+    // ambiguous); otherwise the row index, as before.
+    const suppliedRowLabels = chart.spec.row_labels;
+    const continuousCpuIds = Array.from({ length: yCount }, (_, i) =>
+        (suppliedRowLabels && suppliedRowLabels[i] != null)
+            ? String(suppliedRowLabels[i])
+            : i);
     if (continuousCpuIds.length !== resolutionStore.cpuIds.length) {
         console.error('CPU IDs are not continuous', resolutionStore.cpuIds);
     }
@@ -126,6 +133,12 @@ export function configureHeatmap(chart) {
         // If this is a downsampled data point, `value` is the max value.
         // Otherwise, it's just the value, with `minValue` being null.
         const [time, cpu, timeIndex, minVal, value] = params.data;
+        // Row name for the tooltip: the supplied label where there is one, so a
+        // mixed-vendor GPU chart reads "GPU nvidia 0" rather than two rows both
+        // claiming to be "GPU 0".
+        const rowName = (suppliedRowLabels && suppliedRowLabels[cpu] != null)
+            ? String(suppliedRowLabels[cpu])
+            : cpu;
 
         // In compare mode, time is already the post-anchor relative ms
         // value (the rebase happens before the chart is fed). Use the
@@ -143,7 +156,7 @@ export function configureHeatmap(chart) {
                         </div>
                         <div style="display: flex; align-items: center; gap: 12px;">
                             <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
-                                ${rowEntity} ${cpu}
+                                ${rowEntity} ${rowName}
                             </span>
                             <span style="${FONTS.cssMono} font-weight: ${FONTS.tooltipValue.fontWeight}; font-size: ${FONTS.tooltipValue.fontSize}px; color: ${COLORS.fgMuted};">
                                 no data
@@ -172,7 +185,7 @@ export function configureHeatmap(chart) {
                         </div>
                         <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 4px;">
                             <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
-                                ${rowEntity} ${cpu}
+                                ${rowEntity} ${rowName}
                             </span>
                         </div>
                         <div style="display: grid; grid-template-columns: max-content max-content; gap: 2px 12px; ${FONTS.cssMono} font-size: ${FONTS.tooltipValue.fontSize}px;">
@@ -211,7 +224,7 @@ export function configureHeatmap(chart) {
                     </div>
                     <div style="display: flex; align-items: center; gap: 12px;">
                         <span style="background: ${COLORS.accentSubtle}; padding: 3px 8px; border-radius: 4px; ${FONTS.cssMono} font-size: ${FONTS.tooltipTimestamp.fontSize}px; color: ${COLORS.accent};">
-                            ${rowEntity} ${cpu}
+                            ${rowEntity} ${rowName}
                         </span>
                         ${label}
                         <span style="${FONTS.cssMono} font-weight: ${FONTS.tooltipValue.fontWeight}; font-size: ${FONTS.tooltipValue.fontSize}px; color: ${COLORS.fg};">

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -54,13 +54,22 @@ export function resolveStyle(type_, subtype, result) {
         return 'scatter';
     }
 
-    // gauge or delta_counter: infer from result shape
-    if (result?.data?.result?.length > 1) {
-        const first = result.data.result[0];
+    // gauge or delta_counter: infer from result shape.
+    //
+    // A per-entity result (one series per CPU/GPU, carrying an `id`) renders as
+    // a heatmap — including when there is only ONE such entity. Requiring two
+    // made a chart's type depend on how many devices happened to be present:
+    // the same "Per-GPU" chart drew a heatmap on a two-GPU host and a line
+    // chart on a one-GPU host, and on a mixed-vendor host most per-GPU charts
+    // fell back to lines because only one vendor publishes each metric name.
+    // A one-row heatmap is the honest rendering of "per-entity, one entity".
+    const series = result?.data?.result;
+    if (series?.length >= 1) {
+        const first = series[0];
         if (first.metric && first.metric.id != null) {
             return 'heatmap';
         }
-        return 'multi';
+        if (series.length > 1) return 'multi';
     }
     return 'line';
 }

--- a/src/viewer/assets/lib/charts/metric_types.js
+++ b/src/viewer/assets/lib/charts/metric_types.js
@@ -56,20 +56,18 @@ export function resolveStyle(type_, subtype, result) {
 
     // gauge or delta_counter: infer from result shape.
     //
-    // A per-entity result (one series per CPU/GPU, carrying an `id`) renders as
-    // a heatmap — including when there is only ONE such entity. Requiring two
-    // made a chart's type depend on how many devices happened to be present:
-    // the same "Per-GPU" chart drew a heatmap on a two-GPU host and a line
-    // chart on a one-GPU host, and on a mixed-vendor host most per-GPU charts
-    // fell back to lines because only one vendor publishes each metric name.
-    // A one-row heatmap is the honest rendering of "per-entity, one entity".
-    const series = result?.data?.result;
-    if (series?.length >= 1) {
-        const first = series[0];
+    // A single series stays a LINE. A one-row heatmap encodes its value as
+    // colour and drops the y-axis, so it is strictly less readable than the
+    // line it would replace — and this function governs every gauge plot, not
+    // just GPU ones, so a 1-vCPU VM or a single-NIC host would lose its line
+    // charts too. A plot that wants a heatmap regardless declares it via
+    // `PlotOpts::style`, which `data.js` honours ahead of this inference.
+    if (result?.data?.result?.length > 1) {
+        const first = result.data.result[0];
         if (first.metric && first.metric.id != null) {
             return 'heatmap';
         }
-        if (series.length > 1) return 'multi';
+        return 'multi';
     }
     return 'line';
 }

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -698,20 +698,32 @@ const applyResultToPlot = (plot, result) => {
                 const seriesIntervals = [];
                 let timestamps = null;
 
+                // A GPU is identified by (vendor, id): every vendor's sampler
+                // numbers its devices from 0, so a host with an NVIDIA card and
+                // an Intel iGPU has two GPUs both labelled id="0". Naming a
+                // series by whichever label iterates first would render both as
+                // "0" — two indistinguishable lines.
+                //
+                // The vendor is only worth showing when the result actually
+                // spans vendors; on a single-vendor host "intel GPU 0" is noise
+                // where "GPU 0" says the same thing. Decided over the whole
+                // result set, so every line in one chart is named consistently.
+                const gpuVendors = new Set(
+                    result.data.result
+                        .map((item) => item.metric && item.metric.vendor)
+                        .filter(Boolean),
+                );
+                const qualifyGpuVendor = gpuVendors.size > 1;
+
                 result.data.result.forEach((item, idx) => {
                     if (item.values && Array.isArray(item.values)) {
                         let seriesName = 'Series ' + (idx + 1);
                         if (item.metric) {
-                            // A GPU is identified by (vendor, id): every
-                            // vendor's sampler numbers its devices from 0, so a
-                            // host with an NVIDIA card and an Intel iGPU has two
-                            // GPUs both labelled id="0". Taking whichever label
-                            // iterates first would name both series "0" — two
-                            // indistinguishable lines — or drop the id entirely
-                            // and name them by vendor. Qualify explicitly.
                             const { id, vendor } = item.metric;
                             if (id !== undefined && vendor !== undefined) {
-                                seriesName = `${vendor} ${id}`;
+                                seriesName = qualifyGpuVendor
+                                    ? `${vendor} GPU ${id}`
+                                    : `GPU ${id}`;
                             } else {
                                 for (const [key, value] of Object.entries(item.metric)) {
                                     if (key !== '__name__') {

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -594,6 +594,13 @@ export const promqlResultToHeatmapTriples = (results) => {
 
     // Indexed by ROW, not by result order: when ids are usable a row is the id
     // value itself, and rows for absent ids stay unlabelled.
+    //
+    // Only returned when a label actually differs from its row index. A CPU
+    // heatmap's labels are "0", "1", "2" — identical to the indices they sit
+    // at — and handing those to the renderer made it treat the rows as
+    // self-describing, dropping the "CPU" y-axis title and rendering tooltips
+    // as "2" instead of "CPU 2". That regressed every per-CPU, softirq and
+    // scheduler heatmap on every host, GPU or not.
     const rowLabels = [];
     results.forEach((item, idx) => {
         const m = item.metric || {};
@@ -616,8 +623,14 @@ export const promqlResultToHeatmapTriples = (results) => {
             triples.push([ti, y, v]);
         }
     });
+    // A label that equals its own row index tells the renderer nothing, so the
+    // whole array is withheld and the entity-titled default stands.
+    const rowLabelsAreInformative = rowLabels.some(
+        (label, row) => label != null && label !== String(row),
+    );
+
     return {
-        rowLabels,
+        rowLabels: rowLabelsAreInformative ? rowLabels : null,
         timestamps,
         triples,
         minValue: Number.isFinite(minValue) ? minValue : null,
@@ -715,7 +728,9 @@ const applyResultToPlot = (plot, result) => {
                 plot.data = triples;
                 plot.time_data = timestamps;
                 // Per-row names, so a GPU heatmap can say "nvidia 0" / "intel 0"
-                // where the bare id would be ambiguous.
+                // where the bare id would be ambiguous. `null` for rows that
+                // merely restate their index (a CPU heatmap), which leaves the
+                // renderer's entity title and "CPU 2" tooltips intact.
                 plot.row_labels = rowLabels;
                 plot.min_value = minValue != null ? minValue : Infinity;
                 plot.max_value = maxValue != null ? maxValue : -Infinity;

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -384,6 +384,21 @@ const applyDisplayToPlot = (plot, decoded) => {
             : (series.length > 1 ? 'multi' : 'line'));
 };
 
+// Vendors of every GPU in the recording, from the GPU section's metadata.
+// Whether a row label needs qualifying is a property of the HOST, not of one
+// query's result: on a host with an NVIDIA card and an Intel iGPU, a chart
+// showing only the NVIDIA GPU still needs to say "nvidia 0", because a bare
+// "0" does not tell the reader which of the host's two GPUs it is.
+let _gpuVendors = [];
+
+const setGpuVendors = (vendors) => {
+    _gpuVendors = Array.isArray(vendors) ? vendors.filter(Boolean) : [];
+};
+
+// True when the recording has GPUs from more than one vendor, so an id alone
+// is ambiguous anywhere it appears.
+const gpuVendorsAreAmbiguous = () => new Set(_gpuVendors).size > 1;
+
 let _selectedNode = null;
 let _selectedInstances = {};  // { serviceName: instanceId | null }
 // GPUs to filter the GPU section by; [] = all. Each entry is a
@@ -584,7 +599,11 @@ export const promqlResultToHeatmapTriples = (results) => {
     const vendors = new Set(
         results.map((item) => item.metric && item.metric.vendor).filter(Boolean),
     );
-    const qualifyVendor = vendors.size > 1;
+    // Qualify whenever the RECORDING spans vendors, not just this result: a
+    // chart holding only one vendor's GPU still needs to name it on a host
+    // where an id alone is ambiguous. Falls back to the result's own vendors
+    // when the recording-wide list has not been populated.
+    const qualifyVendor = gpuVendorsAreAmbiguous() || vendors.size > 1;
 
     // Indexed by ROW, not by result order: when ids are usable a row is the id
     // value itself, and rows for absent ids stay unlabelled.
@@ -743,7 +762,7 @@ const applyResultToPlot = (plot, result) => {
                         .map((item) => item.metric && item.metric.vendor)
                         .filter(Boolean),
                 );
-                const qualifyGpuVendor = gpuVendors.size > 1;
+                const qualifyGpuVendor = gpuVendorsAreAmbiguous() || gpuVendors.size > 1;
 
                 result.data.result.forEach((item, idx) => {
                     if (item.values && Array.isArray(item.values)) {
@@ -1271,6 +1290,8 @@ export {
     getSelectedNode,
     setSelectedGpus,
     getSelectedGpus,
+    setGpuVendors,
+    gpuVendorsAreAmbiguous,
     applyGpuSelection,
     setSelectedInstance,
     getSelectedInstance,

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -386,18 +386,73 @@ const applyDisplayToPlot = (plot, decoded) => {
 
 let _selectedNode = null;
 let _selectedInstances = {};  // { serviceName: instanceId | null }
-let _selectedGpus = [];        // GPU `id`s to filter the GPU section by; [] = all
+// GPUs to filter the GPU section by; [] = all. Each entry is a
+// {vendor, id} pair — see setSelectedGpus.
+let _selectedGpus = [];
 
 const setSelectedNode = (node) => { _selectedNode = node; };
 const getSelectedNode = () => _selectedNode;
 
 // When non-empty, the GPU section's non-per-GPU charts are filtered to these
-// GPU `id`s. Empty means show the aggregate (avg/sum across all GPUs). Per-GPU
+// GPUs. Empty means show the aggregate (avg/sum across all GPUs). Per-GPU
 // charts (those with `by (id)`) always show all GPUs and ignore this.
-const setSelectedGpus = (ids) => {
-    _selectedGpus = Array.isArray(ids) ? ids.map(String) : [];
+//
+// A GPU is identified by `(vendor, id)`, not `id` alone: every vendor's sampler
+// numbers its own devices from 0, so a host with an NVIDIA card and an Intel
+// iGPU has two different GPUs both labelled `id="0"`. Filtering on the id alone
+// would silently pull in the other vendor's series.
+//
+// Accepts either the {vendor, id} objects the selector passes, or bare ids
+// (older callers, and recordings whose sampler sets no vendor — the Apple GPU
+// sampler declares none). A bare id becomes {id} with no vendor, which filters
+// on the id alone exactly as before.
+const setSelectedGpus = (gpus) => {
+    _selectedGpus = Array.isArray(gpus)
+        ? gpus.map((g) => (g !== null && typeof g === 'object')
+            ? { vendor: g.vendor != null ? String(g.vendor) : null, id: String(g.id) }
+            : { vendor: null, id: String(g) })
+        : [];
 };
 const getSelectedGpus = () => _selectedGpus;
+
+/// Build the label selector for the current GPU selection and apply it to `q`.
+///
+/// Selections within one vendor collapse to a single `id=~"a|b"` matcher. A
+/// selection spanning vendors cannot: `vendor=~"a|b", id=~"0|1"` is a cross
+/// product that would also match (vendor a, id 1) — a GPU the user did not
+/// pick. PromQL has no OR over label matchers, so the query is instead widened
+/// per vendor only when that is exact, and otherwise left to the id matcher
+/// alone (the pre-existing behaviour, which over-matches rather than dropping
+/// data).
+const applyGpuSelection = (q, selected) => {
+    const vendors = new Set(selected.map((g) => g.vendor));
+    const ids = [...new Set(selected.map((g) => g.id))];
+
+    // One vendor (or none recorded): vendor pins the family, ids pick within it.
+    if (vendors.size === 1) {
+        const vendor = [...vendors][0];
+        if (vendor) q = injectLabel(q, 'vendor', vendor);
+        return ids.length === 1
+            ? injectLabel(q, 'id', ids[0])
+            : injectLabelRegex(q, 'id', ids.join('|'));
+    }
+
+    // Spanning vendors. If every selected vendor is fully represented at every
+    // selected id, the cross product is exactly the selection and both matchers
+    // are safe.
+    const known = [...vendors].filter(Boolean);
+    const exact = known.length === vendors.size
+        && known.every((v) => ids.every((id) =>
+            selected.some((g) => g.vendor === v && g.id === id)));
+
+    if (exact) {
+        q = injectLabelRegex(q, 'vendor', known.join('|'));
+    }
+
+    return ids.length === 1
+        ? injectLabel(q, 'id', ids[0])
+        : injectLabelRegex(q, 'id', ids.join('|'));
+};
 
 const setSelectedInstance = (serviceName, instanceId) => {
     _selectedInstances[serviceName] = instanceId;
@@ -793,12 +848,7 @@ const createDataApi = ({
         // `id`s. Per-GPU charts group `by (id)` to draw one line per GPU and
         // must always show all GPUs, so they are exempt. Empty selection = all.
         if (_selectedGpus.length > 0 && sectionRoute === '/gpu' && !/by\s*\(\s*id\s*\)/.test(q)) {
-            if (_selectedGpus.length === 1) {
-                q = injectLabel(q, 'id', _selectedGpus[0]);
-            } else {
-                // Match any of the selected ids via a regex label selector.
-                q = injectLabelRegex(q, 'id', _selectedGpus.join('|'));
-            }
+            q = applyGpuSelection(q, _selectedGpus);
         }
         if (injectTopologyLabels && serviceName) {
             const inst = _selectedInstances[serviceName];
@@ -1163,6 +1213,7 @@ export {
     getSelectedNode,
     setSelectedGpus,
     getSelectedGpus,
+    applyGpuSelection,
     setSelectedInstance,
     getSelectedInstance,
     injectLabel,

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -384,21 +384,6 @@ const applyDisplayToPlot = (plot, decoded) => {
             : (series.length > 1 ? 'multi' : 'line'));
 };
 
-// Vendors of every GPU in the recording, from the GPU section's metadata.
-// Whether a row label needs qualifying is a property of the HOST, not of one
-// query's result: on a host with an NVIDIA card and an Intel iGPU, a chart
-// showing only the NVIDIA GPU still needs to say "nvidia 0", because a bare
-// "0" does not tell the reader which of the host's two GPUs it is.
-let _gpuVendors = [];
-
-const setGpuVendors = (vendors) => {
-    _gpuVendors = Array.isArray(vendors) ? vendors.filter(Boolean) : [];
-};
-
-// True when the recording has GPUs from more than one vendor, so an id alone
-// is ambiguous anywhere it appears.
-const gpuVendorsAreAmbiguous = () => new Set(_gpuVendors).size > 1;
-
 let _selectedNode = null;
 let _selectedInstances = {};  // { serviceName: instanceId | null }
 // GPUs to filter the GPU section by; [] = all. Each entry is a
@@ -593,17 +578,19 @@ export const promqlResultToHeatmapTriples = (results) => {
     // identify the series, and each row carries its own label.
     const ids = results.map((item) => item.metric && item.metric.id);
     const numericIds = ids.map((v) => parseInt(v, 10));
+    // Ids index rows only when they are unique AND dense from 0. A sparse set
+    // leaves empty rows: sky publishes VRAM for its discrete GPU (id=1) and not
+    // its integrated one, so indexing by id drew a blank row 0 above the only
+    // real row. Falling back to result order packs the rows that exist.
     const idsUsable = numericIds.every((v) => !Number.isNaN(v))
-        && new Set(numericIds).size === numericIds.length;
+        && new Set(numericIds).size === numericIds.length
+        && Math.max(...numericIds) === numericIds.length - 1;
 
-    const vendors = new Set(
-        results.map((item) => item.metric && item.metric.vendor).filter(Boolean),
-    );
-    // Qualify whenever the RECORDING spans vendors, not just this result: a
-    // chart holding only one vendor's GPU still needs to name it on a host
-    // where an id alone is ambiguous. Falls back to the result's own vendors
-    // when the recording-wide list has not been populated.
-    const qualifyVendor = gpuVendorsAreAmbiguous() || vendors.size > 1;
+    // The vendor is always shown when a series carries one. An id is only
+    // meaningful within a vendor — every vendor's sampler numbers its devices
+    // from 0 — so "nvidia 0" identifies a GPU where "0" merely indexes one.
+    // Showing it unconditionally also keeps a chart's labels stable when the
+    // set of GPUs in a result changes.
 
     // Indexed by ROW, not by result order: when ids are usable a row is the id
     // value itself, and rows for absent ids stay unlabelled.
@@ -613,7 +600,7 @@ export const promqlResultToHeatmapTriples = (results) => {
         const row = idsUsable ? numericIds[idx] : idx;
         rowLabels[row] = m.id == null
             ? `${row}`
-            : (qualifyVendor && m.vendor ? `${m.vendor} ${m.id}` : `${m.id}`);
+            : (m.vendor ? `${m.vendor} ${m.id}` : `${m.id}`);
     });
 
     results.forEach((item, idx) => {
@@ -757,12 +744,6 @@ const applyResultToPlot = (plot, result) => {
                 // spans vendors; on a single-vendor host "intel GPU 0" is noise
                 // where "GPU 0" says the same thing. Decided over the whole
                 // result set, so every line in one chart is named consistently.
-                const gpuVendors = new Set(
-                    result.data.result
-                        .map((item) => item.metric && item.metric.vendor)
-                        .filter(Boolean),
-                );
-                const qualifyGpuVendor = gpuVendorsAreAmbiguous() || gpuVendors.size > 1;
 
                 result.data.result.forEach((item, idx) => {
                     if (item.values && Array.isArray(item.values)) {
@@ -770,9 +751,7 @@ const applyResultToPlot = (plot, result) => {
                         if (item.metric) {
                             const { id, vendor } = item.metric;
                             if (id !== undefined && vendor !== undefined) {
-                                seriesName = qualifyGpuVendor
-                                    ? `${vendor} GPU ${id}`
-                                    : `GPU ${id}`;
+                                seriesName = `${vendor} ${id}`;
                             } else {
                                 for (const [key, value] of Object.entries(item.metric)) {
                                     if (key !== '__name__') {
@@ -1290,8 +1269,6 @@ export {
     getSelectedNode,
     setSelectedGpus,
     getSelectedGpus,
-    setGpuVendors,
-    gpuVendorsAreAmbiguous,
     applyGpuSelection,
     setSelectedInstance,
     getSelectedInstance,

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -567,12 +567,38 @@ export const promqlResultToHeatmapTriples = (results) => {
     const triples = [];
     let minValue = Infinity;
     let maxValue = -Infinity;
+
+    // Row labels, parallel to the row indices below. An `id` alone does not
+    // identify a GPU — every vendor's sampler numbers its devices from 0, so a
+    // host with an NVIDIA card and an Intel iGPU has two series both at id=0.
+    // Indexing rows by parseInt(id) would stack them on the same row, one
+    // silently overwriting the other.
+    //
+    // So rows are laid out by result order whenever the ids do not uniquely
+    // identify the series, and each row carries its own label.
+    const ids = results.map((item) => item.metric && item.metric.id);
+    const numericIds = ids.map((v) => parseInt(v, 10));
+    const idsUsable = numericIds.every((v) => !Number.isNaN(v))
+        && new Set(numericIds).size === numericIds.length;
+
+    const vendors = new Set(
+        results.map((item) => item.metric && item.metric.vendor).filter(Boolean),
+    );
+    const qualifyVendor = vendors.size > 1;
+
+    // Indexed by ROW, not by result order: when ids are usable a row is the id
+    // value itself, and rows for absent ids stay unlabelled.
+    const rowLabels = [];
     results.forEach((item, idx) => {
-        let y = idx;
-        if (item.metric && item.metric.id != null) {
-            const parsed = parseInt(item.metric.id, 10);
-            if (!Number.isNaN(parsed)) y = parsed;
-        }
+        const m = item.metric || {};
+        const row = idsUsable ? numericIds[idx] : idx;
+        rowLabels[row] = m.id == null
+            ? `${row}`
+            : (qualifyVendor && m.vendor ? `${m.vendor} ${m.id}` : `${m.id}`);
+    });
+
+    results.forEach((item, idx) => {
+        const y = idsUsable ? numericIds[idx] : idx;
         for (const [ts, rawVal] of item.values || []) {
             const ti = timestampToIndex.get(ts);
             if (ti === undefined) continue;
@@ -585,6 +611,7 @@ export const promqlResultToHeatmapTriples = (results) => {
         }
     });
     return {
+        rowLabels,
         timestamps,
         triples,
         minValue: Number.isFinite(minValue) ? minValue : null,
@@ -677,10 +704,13 @@ const applyResultToPlot = (plot, result) => {
 
         if (hasMultipleSeries) {
             if (style === 'heatmap') {
-                const { timestamps, triples, minValue, maxValue } =
+                const { timestamps, triples, minValue, maxValue, rowLabels } =
                     promqlResultToHeatmapTriples(result.data.result);
                 plot.data = triples;
                 plot.time_data = timestamps;
+                // Per-row names, so a GPU heatmap can say "nvidia 0" / "intel 0"
+                // where the bare id would be ambiguous.
+                plot.row_labels = rowLabels;
                 plot.min_value = minValue != null ? minValue : Infinity;
                 plot.max_value = maxValue != null ? maxValue : -Infinity;
             } else {

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -702,10 +702,22 @@ const applyResultToPlot = (plot, result) => {
                     if (item.values && Array.isArray(item.values)) {
                         let seriesName = 'Series ' + (idx + 1);
                         if (item.metric) {
-                            for (const [key, value] of Object.entries(item.metric)) {
-                                if (key !== '__name__') {
-                                    seriesName = value;
-                                    break;
+                            // A GPU is identified by (vendor, id): every
+                            // vendor's sampler numbers its devices from 0, so a
+                            // host with an NVIDIA card and an Intel iGPU has two
+                            // GPUs both labelled id="0". Taking whichever label
+                            // iterates first would name both series "0" — two
+                            // indistinguishable lines — or drop the id entirely
+                            // and name them by vendor. Qualify explicitly.
+                            const { id, vendor } = item.metric;
+                            if (id !== undefined && vendor !== undefined) {
+                                seriesName = `${vendor} ${id}`;
+                            } else {
+                                for (const [key, value] of Object.entries(item.metric)) {
+                                    if (key !== '__name__') {
+                                        seriesName = value;
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -847,7 +859,11 @@ const createDataApi = ({
         // On the GPU section, filter the non-per-GPU charts to the selected GPU
         // `id`s. Per-GPU charts group `by (id)` to draw one line per GPU and
         // must always show all GPUs, so they are exempt. Empty selection = all.
-        if (_selectedGpus.length > 0 && sectionRoute === '/gpu' && !/by\s*\(\s*id\s*\)/.test(q)) {
+        // Per-GPU charts group by id (and by vendor, since an id is only
+        // unique within one vendor) to draw one line per GPU; they must show
+        // every GPU regardless of the selection, so they are exempt.
+        if (_selectedGpus.length > 0 && sectionRoute === '/gpu'
+            && !/by\s*\(\s*id\s*[,)]/.test(q)) {
             q = applyGpuSelection(q, _selectedGpus);
         }
         if (injectTopologyLabels && serviceName) {

--- a/src/viewer/assets/lib/features/gpu_selector.js
+++ b/src/viewer/assets/lib/features/gpu_selector.js
@@ -4,16 +4,35 @@
 // charts always show all GPUs and are unaffected (handled in data.js by
 // skipping queries that group `by (id)`).
 //
+// A GPU is identified by `(vendor, id)`, not `id` alone: every vendor's sampler
+// numbers its own devices from 0, so a host with an NVIDIA card and an Intel
+// iGPU has two distinct GPUs both labelled `id="0"`. The list is keyed on the
+// pair, and the pair is what `onChange` reports.
+//
 // Attrs:
-//   ids: number[]                  — available GPU ids (e.g. [0, 1])
-//   selected: (string|number)[]    — currently selected ids
-//   onChange: (ids: string[]) => void — called when the selection changes
-//   gpus: {index, name, vendor, memory_bytes}[] — System Info GPU details,
+//   gpus: {id, vendor?}[]          — available GPUs, from the section metadata
+//   ids: number[]                  — legacy id-only list, used when `gpus` is absent
+//   selected: {vendor, id}[]       — currently selected GPUs
+//   onChange: (gpus: {vendor, id}[]) => void — called when the selection changes
+//   details: {index, name, vendor, memory_bytes}[] — System Info GPU details,
 //         used to show each GPU's model name next to its id
 
 import globalColorMapper from '../charts/util/colormap.js';
 
-const gpuLabel = (id) => `GPU ${id}`;
+// Set key for one GPU. NUL cannot occur in a label value, so it cannot collide
+// with a vendor or id that merely contains the separator.
+const gpuKey = (g) => `${g.vendor ?? ''}\u0000${g.id}`;
+const parseKey = (key) => {
+    const [vendor, id] = key.split('\u0000');
+    return { vendor: vendor || null, id };
+};
+
+// Two GPUs can share an id, so the id alone is not a label. Name the vendor
+// whenever the recording has more than one.
+const gpuLabel = (key, showVendor) => {
+    const { vendor, id } = parseKey(key);
+    return showVendor && vendor ? `${vendor} GPU ${id}` : `GPU ${id}`;
+};
 
 // Compact byte formatter for the GPU memory shown in the selector (e.g. "32 GB").
 const formatBytes = (bytes) => {
@@ -27,8 +46,9 @@ const formatBytes = (bytes) => {
 
 /** Render one labeled multi-select column with a color swatch per GPU.
  *  Mirrors the cgroup selector's selectList (shift+click range select).
- *  `detailFn(id)` returns the model/details string shown under the id. */
-const selectList = (title, items, selectionSet, onToggle, emptyLabel, lastClicked, setLastClicked, detailFn) =>
+ *  Items are GPU keys (see `gpuKey`); `labelFn(key)` renders the display name
+ *  and `detailFn(key)` returns the model/details string shown under it. */
+const selectList = (title, items, selectionSet, onToggle, emptyLabel, lastClicked, setLastClicked, detailFn, labelFn) =>
     m('div.selector-column', [
         m('h4', title),
         m('ul.cgroup-select', {
@@ -42,7 +62,7 @@ const selectList = (title, items, selectionSet, onToggle, emptyLabel, lastClicke
                     role: 'option',
                     'aria-selected': selectionSet.has(item) ? 'true' : 'false',
                     class: selectionSet.has(item) ? 'selected' : '',
-                    title: detail ? `${gpuLabel(item)} — ${detail}` : gpuLabel(item),
+                    title: detail ? `${labelFn(item)} — ${detail}` : labelFn(item),
                     onclick: (e) => {
                         if (e.shiftKey && lastClicked != null) {
                             const from = items.indexOf(lastClicked);
@@ -59,10 +79,10 @@ const selectList = (title, items, selectionSet, onToggle, emptyLabel, lastClicke
                     },
                 }, [
                     m('span.cgroup-select-swatch', {
-                        style: { background: globalColorMapper.getColorByName(gpuLabel(item)) },
+                        style: { background: globalColorMapper.getColorByName(labelFn(item)) },
                     }),
                     m('span.cgroup-select-name', [
-                        m('span.gpu-select-id', gpuLabel(item)),
+                        m('span.gpu-select-id', labelFn(item)),
                         detail && m('span.gpu-select-detail', detail),
                     ]),
                 ]);
@@ -79,8 +99,14 @@ const transferBtn = (lrLabel, udLabel, title, disabled, onclick) =>
 
 export const GpuSelector = {
     oninit(vnode) {
-        // selectedGpus: the ids on the right (filtered). Seeded from attrs.
-        vnode.state.selectedGpus = new Set((vnode.attrs.selected || []).map(String));
+        // selectedGpus: the GPUs on the right (filtered), held as `gpuKey`
+        // strings so a Set can hold (vendor, id) pairs. Seeded from attrs,
+        // accepting either pairs or bare ids.
+        vnode.state.selectedGpus = new Set(
+            (vnode.attrs.selected || []).map((g) => (g !== null && typeof g === 'object')
+                ? gpuKey({ vendor: g.vendor ?? null, id: String(g.id) })
+                : gpuKey({ vendor: null, id: String(g) })),
+        );
         vnode.state.leftSelected = new Set();  // highlighted-but-not-transferred (left)
         vnode.state.rightSelected = new Set();
         vnode.state.lastClickedLeft = null;
@@ -88,7 +114,8 @@ export const GpuSelector = {
     },
 
     commit(vnode) {
-        vnode.attrs.onChange(Array.from(vnode.state.selectedGpus));
+        // Report {vendor, id} pairs, not the internal key strings.
+        vnode.attrs.onChange(Array.from(vnode.state.selectedGpus).map(parseKey));
     },
 
     transfer(vnode, items, action) {
@@ -104,21 +131,42 @@ export const GpuSelector = {
 
     view(vnode) {
         const st = vnode.state;
-        const all = (vnode.attrs.ids || []).map(String);
-        const available = all.filter((id) => !st.selectedGpus.has(id));
-        const selected = all.filter((id) => st.selectedGpus.has(id));
+
+        // Prefer the (vendor, id) pairs; fall back to the id-only list for a
+        // recording whose metadata predates them.
+        const entries = Array.isArray(vnode.attrs.gpus) && vnode.attrs.gpus.length > 0
+            ? vnode.attrs.gpus.map((g) => ({ vendor: g.vendor ?? null, id: String(g.id) }))
+            : (vnode.attrs.ids || []).map((id) => ({ vendor: null, id: String(id) }));
+
+        // Only qualify names with the vendor when more than one is present;
+        // "intel GPU 0" is noise on a single-vendor host.
+        const showVendor = new Set(entries.map((g) => g.vendor).filter(Boolean)).size > 1;
+        const labelFn = (key) => gpuLabel(key, showVendor);
+
+        const all = entries.map(gpuKey);
+        const available = all.filter((k) => !st.selectedGpus.has(k));
+        const selected = all.filter((k) => st.selectedGpus.has(k));
 
         const toggleMark = (set, item) => {
             if (set.has(item)) set.delete(item);
             else set.add(item);
         };
 
-        // Map GPU id -> details string ("AMD Radeon ... · 32 GB") from System Info.
-        const byIndex = new Map(
-            (vnode.attrs.gpus || []).map((g) => [String(g.index), g]),
+        // Map GPU -> details string ("AMD Radeon ... · 32 GB") from System Info.
+        // Keyed on (vendor, index): System Info's `index` is the same
+        // vendor-local number as the metric `id`, so on a mixed-vendor host the
+        // vendor is what keeps two `index: 0` entries apart. Fall back to a
+        // match on index alone when the entry carries no vendor.
+        const details = vnode.attrs.details || [];
+        const byPair = new Map(
+            details.map((g) => [gpuKey({ vendor: g.vendor ?? null, id: String(g.index) }), g]),
         );
-        const detailFn = (id) => {
-            const g = byIndex.get(String(id));
+        const byIndexOnly = new Map(details.map((g) => [String(g.index), g]));
+        const detailFn = (key) => {
+            const { vendor, id } = parseKey(key);
+            const g = byPair.get(key)
+                || (vendor ? undefined : byIndexOnly.get(id))
+                || byIndexOnly.get(id);
             if (!g) return '';
             const parts = [];
             if (g.name || g.vendor) parts.push(g.name || g.vendor);
@@ -138,6 +186,7 @@ export const GpuSelector = {
                     st.lastClickedLeft,
                     (item) => { st.lastClickedLeft = item; },
                     detailFn,
+                    labelFn,
                 ),
 
                 m('div.selector-controls', [
@@ -164,6 +213,7 @@ export const GpuSelector = {
                     st.lastClickedRight,
                     (item) => { st.lastClickedRight = item; },
                     detailFn,
+                    labelFn,
                 ),
             ]),
             m('div.selector-info', [

--- a/src/viewer/assets/lib/sections/section_views.js
+++ b/src/viewer/assets/lib/sections/section_views.js
@@ -105,12 +105,15 @@ const renderSingleNodeInfo = (info, CpuTopology, formatBytes) => {
                 m('table.sysinfo-table', m('tbody',
                     info.gpus.map((gpu) => m('tr', [
                         m('td.sysinfo-label', gpu.name || gpu.vendor),
-                        // An integrated GPU has no device-local memory, so the
-                        // memory figure is absent rather than zero. Say so
-                        // rather than rendering an empty cell next to a GPU
-                        // that is genuinely present.
+                        // Absent memory means UNKNOWN, not integrated. The
+                        // NVIDIA /proc fallback (used when the driver is
+                        // present but NVML is not) reports no memory at all,
+                        // and labelling those discrete cards "integrated" was
+                        // simply wrong. `architecture` says it when the
+                        // collector actually determined it.
                         m('td.sysinfo-value', [
-                            gpu.memory_bytes ? formatBytes(gpu.memory_bytes) : 'integrated',
+                            gpu.memory_bytes ? formatBytes(gpu.memory_bytes)
+                                : (gpu.architecture || ''),
                             gpu.driver ? ` (${gpu.driver})` : '',
                         ].join('')),
                     ])),

--- a/src/viewer/assets/lib/sections/section_views.js
+++ b/src/viewer/assets/lib/sections/section_views.js
@@ -105,8 +105,12 @@ const renderSingleNodeInfo = (info, CpuTopology, formatBytes) => {
                 m('table.sysinfo-table', m('tbody',
                     info.gpus.map((gpu) => m('tr', [
                         m('td.sysinfo-label', gpu.name || gpu.vendor),
+                        // An integrated GPU has no device-local memory, so the
+                        // memory figure is absent rather than zero. Say so
+                        // rather than rendering an empty cell next to a GPU
+                        // that is genuinely present.
                         m('td.sysinfo-value', [
-                            gpu.memory_bytes ? formatBytes(gpu.memory_bytes) : '',
+                            gpu.memory_bytes ? formatBytes(gpu.memory_bytes) : 'integrated',
                             gpu.driver ? ` (${gpu.driver})` : '',
                         ].join('')),
                     ])),

--- a/tests/gpu_selection.test.mjs
+++ b/tests/gpu_selection.test.mjs
@@ -160,3 +160,47 @@ test('heatmap rows: a single GPU still yields one labelled row', () => {
     // must label correctly rather than fall through to the index.
     assert.deepEqual(heatmapRowLabels([series('intel', '0')]), ['0']);
 });
+
+// Whether a row label needs its vendor is a property of the HOST, not of one
+// query's result. On hyb — an NVIDIA card plus an Intel iGPU — no metric name
+// is published by both vendors, so every per-GPU chart returns a single vendor.
+// Deciding per-result therefore left every row reading a bare "0", which does
+// not tell the reader which of the host's two GPUs it is.
+const rowLabelsFor = (results, recordingVendors) => {
+    const ids = results.map((i) => i.metric && i.metric.id);
+    const nums = ids.map((v) => parseInt(v, 10));
+    const usable = nums.every((v) => !Number.isNaN(v)) && new Set(nums).size === nums.length;
+    const own = new Set(results.map((i) => i.metric && i.metric.vendor).filter(Boolean));
+    const ambiguousHost = new Set(recordingVendors || []).size > 1;
+    const qualify = ambiguousHost || own.size > 1;
+    const out = [];
+    results.forEach((item, idx) => {
+        const m = item.metric || {};
+        const row = usable ? nums[idx] : idx;
+        out[row] = m.id == null
+            ? String(row)
+            : (qualify && m.vendor ? `${m.vendor} ${m.id}` : String(m.id));
+    });
+    return out;
+};
+
+test('a single-vendor result on a MIXED-vendor host is still qualified', () => {
+    // The reported case: hyb's "GPU % (Per-GPU)" holds only the NVIDIA GPU,
+    // because only NVIDIA publishes gpu_utilization there.
+    assert.deepEqual(
+        rowLabelsFor([series('nvidia', '0')], ['nvidia', 'intel']),
+        ['nvidia 0'],
+    );
+});
+
+test('a single-vendor host stays unqualified', () => {
+    assert.deepEqual(rowLabelsFor([series('amd', '0'), series('amd', '1')], ['amd', 'amd']),
+        ['0', '1']);
+});
+
+test('with no recording-wide vendors, the result decides', () => {
+    // Fallback path: metadata not yet loaded.
+    assert.deepEqual(rowLabelsFor([series('nvidia', '0'), series('intel', '0')], []),
+        ['nvidia 0', 'intel 0']);
+    assert.deepEqual(rowLabelsFor([series('intel', '0')], []), ['0']);
+});

--- a/tests/gpu_selection.test.mjs
+++ b/tests/gpu_selection.test.mjs
@@ -70,3 +70,19 @@ test('a partial cross product does not claim a vendor constraint it cannot expre
     assert.match(q, /id=~"0\|1"/);
     assert.doesNotMatch(q, /vendor=~/);
 });
+
+// Per-GPU charts group by (id, vendor) so two GPUs sharing an id draw as two
+// lines. They must stay exempt from the selector's filter, which is keyed on a
+// regex over that grouping — a regex that only matched the older `by (id)`
+// form would silently start filtering them.
+test('per-GPU groupings are exempt from the selection filter', () => {
+    const re = /by\s*\(\s*id\s*[,)]/;
+    assert.ok(re.test('sum by (id) (gpu_utilization) / 100'));
+    assert.ok(re.test('sum by (id, vendor) (gpu_utilization) / 100'));
+    assert.ok(re.test('max by (id, vendor) (gpu_temperature)'));
+    assert.ok(re.test('sum by ( id , vendor ) (gpu_clock)'));
+    // Aggregate charts are not exempt; they are what the selector filters.
+    assert.ok(!re.test('avg(gpu_utilization) / 100'));
+    assert.ok(!re.test('sum(gpu_memory{state="used"})'));
+    assert.ok(!re.test('sum by (vendor) (gpu_utilization)'));
+});

--- a/tests/gpu_selection.test.mjs
+++ b/tests/gpu_selection.test.mjs
@@ -5,7 +5,7 @@
 // silently plots the wrong device's data, which is why it is tested here.
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { applyGpuSelection } from '../src/viewer/assets/lib/data.js';
+import { applyGpuSelection, promqlResultToHeatmapTriples } from '../src/viewer/assets/lib/data.js';
 
 const Q = 'sum(gpu_memory{state="used"})';
 
@@ -89,64 +89,46 @@ test('per-GPU groupings are exempt from the selection filter', () => {
 
 // Per-GPU labels always carry the vendor. An id is only meaningful within a
 // vendor — every vendor's sampler numbers its devices from 0 — so "nvidia 0"
-// identifies a GPU where "0" merely indexes one. Showing it unconditionally
-// also keeps a chart's labels stable when the set of GPUs in a result changes.
-const series = (vendor, id) => ({ metric: { vendor, id } });
+// identifies a GPU where "0" merely indexes one.
+//
+// These exercise the SHIPPED `promqlResultToHeatmapTriples`, not a copy of it.
+// An earlier version of this file re-implemented the labelling locally, which
+// let a regression through: the real function returned labels for CPU-shaped
+// results too ("0", "1", "2"), and the renderer read that as "these rows name
+// themselves" and dropped the "CPU" y-axis title on every host. A local copy
+// cannot catch that; importing does.
+const series = (vendor, id) => ({ metric: { vendor, id }, values: [[0, '1']] });
+const rowsOf = (results) => promqlResultToHeatmapTriples(results).rowLabels;
 
-const seriesName = (item) => {
-    const { id, vendor } = item.metric;
-    if (id === undefined || vendor === undefined) return null;
-    return `${vendor} ${id}`;
-};
-
-const heatmapRowLabels = (results) => {
-    const ids = results.map((i) => i.metric && i.metric.id);
-    const nums = ids.map((v) => parseInt(v, 10));
-    const usable = nums.every((v) => !Number.isNaN(v))
-        && new Set(nums).size === nums.length
-        && Math.max(...nums) === nums.length - 1;
-    const out = [];
-    results.forEach((item, idx) => {
-        const m = item.metric || {};
-        const row = usable ? nums[idx] : idx;
-        out[row] = m.id == null ? String(row) : (m.vendor ? `${m.vendor} ${m.id}` : String(m.id));
-    });
-    return out;
-};
-
-test('series names carry the vendor on a single-vendor host too', () => {
-    assert.equal(seriesName(series('intel', '1')), 'intel 1');
-    assert.equal(seriesName(series('amd', '0')), 'amd 0');
-});
-
-test('heatmap rows carry the vendor on a single-vendor host too', () => {
-    // The reported case: sky is Intel-only, and its rows read "intel 0"/"intel 1"
-    // rather than a bare "0"/"1".
-    assert.deepEqual(heatmapRowLabels([series('intel', '0'), series('intel', '1')]),
+test('rows carry the vendor on a single-vendor host too', () => {
+    assert.deepEqual(rowsOf([series('intel', '0'), series('intel', '1')]),
         ['intel 0', 'intel 1']);
 });
 
-test('heatmap rows: two GPUs sharing an id get distinct rows', () => {
+test('two GPUs sharing an id get distinct rows', () => {
     // Rows were indexed by parseInt(id), so two GPUs both at id="0" landed on
     // the same row, one silently overwriting the other.
-    const rows = heatmapRowLabels([series('nvidia', '0'), series('intel', '0')]);
+    const rows = rowsOf([series('nvidia', '0'), series('intel', '0')]);
     assert.equal(rows.length, 2, 'both GPUs must occupy their own row');
     assert.deepEqual(rows, ['nvidia 0', 'intel 0']);
 });
 
-test('a series with no vendor label falls back rather than throwing', () => {
-    // The macOS GPU sampler sets no vendor on any of its metrics.
-    assert.equal(seriesName({ metric: { id: '0' } }), null);
-    assert.deepEqual(heatmapRowLabels([{ metric: { id: '0' } }]), ['0']);
-});
-
-test('a single GPU still yields one labelled row', () => {
-    assert.deepEqual(heatmapRowLabels([series('intel', '0')]), ['intel 0']);
-});
-
 test('a sparse id set packs its rows instead of leaving a gap', () => {
-    // sky publishes VRAM for its discrete GPU (id=1) but not its integrated
-    // one, so indexing rows by id drew a blank row 0 above the only real row.
-    assert.deepEqual(heatmapRowLabels([series('intel', '1')]), ['intel 1']);
-    assert.deepEqual(heatmapRowLabels([series('amd', '2')]), ['amd 2']);
+    // VRAM is discrete-only, so a host whose discrete GPU is id=1 yields only
+    // that series; indexing by id drew a blank row 0 above the real one.
+    assert.deepEqual(rowsOf([series('intel', '1')]), ['intel 1']);
+});
+
+test('a CPU-shaped result yields no labels, so the axis keeps its title', () => {
+    // The regression this file previously missed. Labels equal to their own row
+    // index tell the renderer nothing; handing them over made it drop the "CPU"
+    // y-axis title and render tooltips as "2" instead of "CPU 2".
+    const cpu = [{ metric: { id: '0' }, values: [[0, '1']] },
+                 { metric: { id: '1' }, values: [[0, '2']] },
+                 { metric: { id: '2' }, values: [[0, '3']] }];
+    assert.equal(rowsOf(cpu), null);
+});
+
+test('a series with no id at all is left to the renderer', () => {
+    assert.equal(rowsOf([{ metric: {}, values: [[0, '1']] }]), null);
 });

--- a/tests/gpu_selection.test.mjs
+++ b/tests/gpu_selection.test.mjs
@@ -87,120 +87,66 @@ test('per-GPU groupings are exempt from the selection filter', () => {
     assert.ok(!re.test('sum by (vendor) (gpu_utilization)'));
 });
 
-// Series naming for per-GPU charts. The vendor is shown only when the result
-// spans vendors: on a single-vendor host "intel GPU 0" is noise where "GPU 0"
-// says the same thing, but with two vendors both numbering from 0 the vendor
-// is the only thing telling the lines apart.
-//
-// Mirrors the logic in data.js; the vendor-spanning case cannot be produced by
-// any host available here (it needs a discrete Intel GPU alongside another
-// vendor publishing a shared metric name), so it is covered here instead.
-const nameSeries = (results) => {
-    const vendors = new Set(results.map((i) => i.metric && i.metric.vendor).filter(Boolean));
-    const qualify = vendors.size > 1;
-    return results.map((i) => {
-        const { id, vendor } = i.metric;
-        if (id !== undefined && vendor !== undefined) {
-            return qualify ? `${vendor} GPU ${id}` : `GPU ${id}`;
-        }
-        return null;
-    });
-};
-
+// Per-GPU labels always carry the vendor. An id is only meaningful within a
+// vendor — every vendor's sampler numbers its devices from 0 — so "nvidia 0"
+// identifies a GPU where "0" merely indexes one. Showing it unconditionally
+// also keeps a chart's labels stable when the set of GPUs in a result changes.
 const series = (vendor, id) => ({ metric: { vendor, id } });
 
-test('one vendor: series are named by id alone', () => {
-    assert.deepEqual(nameSeries([series('amd', '0'), series('amd', '1')]),
-        ['GPU 0', 'GPU 1']);
-});
+const seriesName = (item) => {
+    const { id, vendor } = item.metric;
+    if (id === undefined || vendor === undefined) return null;
+    return `${vendor} ${id}`;
+};
 
-test('two vendors sharing an id: the vendor disambiguates', () => {
-    assert.deepEqual(nameSeries([series('nvidia', '0'), series('intel', '0')]),
-        ['nvidia GPU 0', 'intel GPU 0']);
-});
-
-test('a series with no vendor label falls back rather than throwing', () => {
-    // The macOS GPU sampler sets no vendor on any of its metrics.
-    assert.deepEqual(nameSeries([{ metric: { id: '0' } }]), [null]);
-});
-
-// Heatmap row layout. Rows were indexed by parseInt(id), so two GPUs sharing an
-// id — an NVIDIA card and an Intel iGPU, both id="0" — landed on the same row,
-// one silently overwriting the other. Rows now fall back to result order when
-// the ids do not uniquely identify the series, and each row carries a label.
 const heatmapRowLabels = (results) => {
     const ids = results.map((i) => i.metric && i.metric.id);
     const nums = ids.map((v) => parseInt(v, 10));
-    const usable = nums.every((v) => !Number.isNaN(v)) && new Set(nums).size === nums.length;
-    const vendors = new Set(results.map((i) => i.metric && i.metric.vendor).filter(Boolean));
-    const qualify = vendors.size > 1;
+    const usable = nums.every((v) => !Number.isNaN(v))
+        && new Set(nums).size === nums.length
+        && Math.max(...nums) === nums.length - 1;
     const out = [];
     results.forEach((item, idx) => {
         const m = item.metric || {};
         const row = usable ? nums[idx] : idx;
-        out[row] = m.id == null
-            ? String(row)
-            : (qualify && m.vendor ? `${m.vendor} ${m.id}` : String(m.id));
+        out[row] = m.id == null ? String(row) : (m.vendor ? `${m.vendor} ${m.id}` : String(m.id));
     });
     return out;
 };
 
-test('heatmap rows: one vendor keeps bare ids', () => {
-    assert.deepEqual(heatmapRowLabels([series('amd', '0'), series('amd', '1')]), ['0', '1']);
+test('series names carry the vendor on a single-vendor host too', () => {
+    assert.equal(seriesName(series('intel', '1')), 'intel 1');
+    assert.equal(seriesName(series('amd', '0')), 'amd 0');
 });
 
-test('heatmap rows: two GPUs sharing an id get distinct rows, vendor-qualified', () => {
+test('heatmap rows carry the vendor on a single-vendor host too', () => {
+    // The reported case: sky is Intel-only, and its rows read "intel 0"/"intel 1"
+    // rather than a bare "0"/"1".
+    assert.deepEqual(heatmapRowLabels([series('intel', '0'), series('intel', '1')]),
+        ['intel 0', 'intel 1']);
+});
+
+test('heatmap rows: two GPUs sharing an id get distinct rows', () => {
+    // Rows were indexed by parseInt(id), so two GPUs both at id="0" landed on
+    // the same row, one silently overwriting the other.
     const rows = heatmapRowLabels([series('nvidia', '0'), series('intel', '0')]);
     assert.equal(rows.length, 2, 'both GPUs must occupy their own row');
     assert.deepEqual(rows, ['nvidia 0', 'intel 0']);
 });
 
-test('heatmap rows: a single GPU still yields one labelled row', () => {
-    // A per-entity chart is a heatmap even with one entity, so the one-row case
-    // must label correctly rather than fall through to the index.
-    assert.deepEqual(heatmapRowLabels([series('intel', '0')]), ['0']);
+test('a series with no vendor label falls back rather than throwing', () => {
+    // The macOS GPU sampler sets no vendor on any of its metrics.
+    assert.equal(seriesName({ metric: { id: '0' } }), null);
+    assert.deepEqual(heatmapRowLabels([{ metric: { id: '0' } }]), ['0']);
 });
 
-// Whether a row label needs its vendor is a property of the HOST, not of one
-// query's result. On hyb — an NVIDIA card plus an Intel iGPU — no metric name
-// is published by both vendors, so every per-GPU chart returns a single vendor.
-// Deciding per-result therefore left every row reading a bare "0", which does
-// not tell the reader which of the host's two GPUs it is.
-const rowLabelsFor = (results, recordingVendors) => {
-    const ids = results.map((i) => i.metric && i.metric.id);
-    const nums = ids.map((v) => parseInt(v, 10));
-    const usable = nums.every((v) => !Number.isNaN(v)) && new Set(nums).size === nums.length;
-    const own = new Set(results.map((i) => i.metric && i.metric.vendor).filter(Boolean));
-    const ambiguousHost = new Set(recordingVendors || []).size > 1;
-    const qualify = ambiguousHost || own.size > 1;
-    const out = [];
-    results.forEach((item, idx) => {
-        const m = item.metric || {};
-        const row = usable ? nums[idx] : idx;
-        out[row] = m.id == null
-            ? String(row)
-            : (qualify && m.vendor ? `${m.vendor} ${m.id}` : String(m.id));
-    });
-    return out;
-};
-
-test('a single-vendor result on a MIXED-vendor host is still qualified', () => {
-    // The reported case: hyb's "GPU % (Per-GPU)" holds only the NVIDIA GPU,
-    // because only NVIDIA publishes gpu_utilization there.
-    assert.deepEqual(
-        rowLabelsFor([series('nvidia', '0')], ['nvidia', 'intel']),
-        ['nvidia 0'],
-    );
+test('a single GPU still yields one labelled row', () => {
+    assert.deepEqual(heatmapRowLabels([series('intel', '0')]), ['intel 0']);
 });
 
-test('a single-vendor host stays unqualified', () => {
-    assert.deepEqual(rowLabelsFor([series('amd', '0'), series('amd', '1')], ['amd', 'amd']),
-        ['0', '1']);
-});
-
-test('with no recording-wide vendors, the result decides', () => {
-    // Fallback path: metadata not yet loaded.
-    assert.deepEqual(rowLabelsFor([series('nvidia', '0'), series('intel', '0')], []),
-        ['nvidia 0', 'intel 0']);
-    assert.deepEqual(rowLabelsFor([series('intel', '0')], []), ['0']);
+test('a sparse id set packs its rows instead of leaving a gap', () => {
+    // sky publishes VRAM for its discrete GPU (id=1) but not its integrated
+    // one, so indexing rows by id drew a blank row 0 above the only real row.
+    assert.deepEqual(heatmapRowLabels([series('intel', '1')]), ['intel 1']);
+    assert.deepEqual(heatmapRowLabels([series('amd', '2')]), ['amd 2']);
 });

--- a/tests/gpu_selection.test.mjs
+++ b/tests/gpu_selection.test.mjs
@@ -86,3 +86,40 @@ test('per-GPU groupings are exempt from the selection filter', () => {
     assert.ok(!re.test('sum(gpu_memory{state="used"})'));
     assert.ok(!re.test('sum by (vendor) (gpu_utilization)'));
 });
+
+// Series naming for per-GPU charts. The vendor is shown only when the result
+// spans vendors: on a single-vendor host "intel GPU 0" is noise where "GPU 0"
+// says the same thing, but with two vendors both numbering from 0 the vendor
+// is the only thing telling the lines apart.
+//
+// Mirrors the logic in data.js; the vendor-spanning case cannot be produced by
+// any host available here (it needs a discrete Intel GPU alongside another
+// vendor publishing a shared metric name), so it is covered here instead.
+const nameSeries = (results) => {
+    const vendors = new Set(results.map((i) => i.metric && i.metric.vendor).filter(Boolean));
+    const qualify = vendors.size > 1;
+    return results.map((i) => {
+        const { id, vendor } = i.metric;
+        if (id !== undefined && vendor !== undefined) {
+            return qualify ? `${vendor} GPU ${id}` : `GPU ${id}`;
+        }
+        return null;
+    });
+};
+
+const series = (vendor, id) => ({ metric: { vendor, id } });
+
+test('one vendor: series are named by id alone', () => {
+    assert.deepEqual(nameSeries([series('amd', '0'), series('amd', '1')]),
+        ['GPU 0', 'GPU 1']);
+});
+
+test('two vendors sharing an id: the vendor disambiguates', () => {
+    assert.deepEqual(nameSeries([series('nvidia', '0'), series('intel', '0')]),
+        ['nvidia GPU 0', 'intel GPU 0']);
+});
+
+test('a series with no vendor label falls back rather than throwing', () => {
+    // The macOS GPU sampler sets no vendor on any of its metrics.
+    assert.deepEqual(nameSeries([{ metric: { id: '0' } }]), [null]);
+});

--- a/tests/gpu_selection.test.mjs
+++ b/tests/gpu_selection.test.mjs
@@ -1,0 +1,72 @@
+// The GPU selector filters charts by rewriting each query's label matchers.
+// A GPU is (vendor, id), not id alone: every vendor's sampler numbers its own
+// devices from 0, so a host with an NVIDIA card and an Intel iGPU has two
+// different GPUs both labelled id="0". Getting this wrong does not error — it
+// silently plots the wrong device's data, which is why it is tested here.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { applyGpuSelection } from '../src/viewer/assets/lib/data.js';
+
+const Q = 'sum(gpu_memory{state="used"})';
+
+test('a single GPU pins both vendor and id', () => {
+    const q = applyGpuSelection(Q, [{ vendor: 'intel', id: '0' }]);
+    assert.match(q, /vendor="intel"/);
+    assert.match(q, /id="0"/);
+});
+
+test('same id under two vendors does not collapse to one id matcher', () => {
+    // The bug this guards: injecting id="0" alone matches the NVIDIA card AND
+    // the Intel iGPU, so selecting one plots the sum of both.
+    const nvidia = applyGpuSelection(Q, [{ vendor: 'nvidia', id: '0' }]);
+    const intel = applyGpuSelection(Q, [{ vendor: 'intel', id: '0' }]);
+    assert.notEqual(nvidia, intel);
+    assert.match(nvidia, /vendor="nvidia"/);
+    assert.match(intel, /vendor="intel"/);
+});
+
+test('several GPUs of one vendor collapse to a regex over ids', () => {
+    const q = applyGpuSelection(Q, [
+        { vendor: 'nvidia', id: '0' },
+        { vendor: 'nvidia', id: '1' },
+    ]);
+    assert.match(q, /vendor="nvidia"/);
+    assert.match(q, /id=~"0\|1"/);
+});
+
+test('a selection with no vendor recorded filters on id alone', () => {
+    // The Apple GPU sampler declares no vendor. Such a recording must keep
+    // working exactly as it did before vendors were considered.
+    const one = applyGpuSelection(Q, [{ vendor: null, id: '0' }]);
+    assert.match(one, /id="0"/);
+    assert.doesNotMatch(one, /vendor=/);
+
+    const two = applyGpuSelection(Q, [{ vendor: null, id: '0' }, { vendor: null, id: '1' }]);
+    assert.match(two, /id=~"0\|1"/);
+    assert.doesNotMatch(two, /vendor=/);
+});
+
+test('a full cross product across vendors constrains both labels', () => {
+    // Every selected vendor present at every selected id: the cross product is
+    // exactly the selection, so both matchers are safe.
+    const q = applyGpuSelection(Q, [
+        { vendor: 'nvidia', id: '0' },
+        { vendor: 'intel', id: '0' },
+    ]);
+    assert.match(q, /vendor=~"(intel\|nvidia|nvidia\|intel)"/);
+    assert.match(q, /id="0"/);
+});
+
+test('a partial cross product does not claim a vendor constraint it cannot express', () => {
+    // nvidia:0 and intel:1 only. Emitting vendor=~"nvidia|intel", id=~"0|1"
+    // would also match nvidia:1 and intel:0 — GPUs the user did not select.
+    // PromQL has no OR over matchers, so the vendor constraint is dropped
+    // rather than stated wrongly; the id matcher over-matches, which is the
+    // pre-existing behaviour and never drops selected data.
+    const q = applyGpuSelection(Q, [
+        { vendor: 'nvidia', id: '0' },
+        { vendor: 'intel', id: '1' },
+    ]);
+    assert.match(q, /id=~"0\|1"/);
+    assert.doesNotMatch(q, /vendor=~/);
+});

--- a/tests/gpu_selection.test.mjs
+++ b/tests/gpu_selection.test.mjs
@@ -123,3 +123,40 @@ test('a series with no vendor label falls back rather than throwing', () => {
     // The macOS GPU sampler sets no vendor on any of its metrics.
     assert.deepEqual(nameSeries([{ metric: { id: '0' } }]), [null]);
 });
+
+// Heatmap row layout. Rows were indexed by parseInt(id), so two GPUs sharing an
+// id — an NVIDIA card and an Intel iGPU, both id="0" — landed on the same row,
+// one silently overwriting the other. Rows now fall back to result order when
+// the ids do not uniquely identify the series, and each row carries a label.
+const heatmapRowLabels = (results) => {
+    const ids = results.map((i) => i.metric && i.metric.id);
+    const nums = ids.map((v) => parseInt(v, 10));
+    const usable = nums.every((v) => !Number.isNaN(v)) && new Set(nums).size === nums.length;
+    const vendors = new Set(results.map((i) => i.metric && i.metric.vendor).filter(Boolean));
+    const qualify = vendors.size > 1;
+    const out = [];
+    results.forEach((item, idx) => {
+        const m = item.metric || {};
+        const row = usable ? nums[idx] : idx;
+        out[row] = m.id == null
+            ? String(row)
+            : (qualify && m.vendor ? `${m.vendor} ${m.id}` : String(m.id));
+    });
+    return out;
+};
+
+test('heatmap rows: one vendor keeps bare ids', () => {
+    assert.deepEqual(heatmapRowLabels([series('amd', '0'), series('amd', '1')]), ['0', '1']);
+});
+
+test('heatmap rows: two GPUs sharing an id get distinct rows, vendor-qualified', () => {
+    const rows = heatmapRowLabels([series('nvidia', '0'), series('intel', '0')]);
+    assert.equal(rows.length, 2, 'both GPUs must occupy their own row');
+    assert.deepEqual(rows, ['nvidia 0', 'intel 0']);
+});
+
+test('heatmap rows: a single GPU still yields one labelled row', () => {
+    // A per-entity chart is a heatmap even with one entity, so the one-row case
+    // must label correctly rather than fall through to the index.
+    assert.deepEqual(heatmapRowLabels([series('intel', '0')]), ['0']);
+});

--- a/tests/resolve_style.test.mjs
+++ b/tests/resolve_style.test.mjs
@@ -1,0 +1,44 @@
+// `resolveStyle` decides the chart type for every gauge and delta_counter plot
+// in the viewer — CPU, network, disk, cgroup, GPU alike — from the shape of the
+// query result. It had no tests, and a GPU-motivated change to it silently
+// flipped single-entity charts across every subsystem from a line to a one-row
+// heatmap (a one-row heatmap encodes value as colour and drops the y-axis, so
+// it is strictly less readable than the line it replaced).
+//
+// These pin the inference so a change aimed at one subsystem cannot quietly
+// reshape the others. A plot that wants a specific style declares it via
+// PlotOpts::style, which data.js honours ahead of this function.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveStyle } from '../src/viewer/assets/lib/charts/metric_types.js';
+
+const result = (...metrics) => ({ data: { result: metrics.map((m) => ({ metric: m })) } });
+
+test('a single series is a line, even when it carries an id', () => {
+    // The regression case: a 1-vCPU VM, a single NIC, a single disk, one
+    // cgroup, or a one-GPU host must keep its line chart.
+    assert.equal(resolveStyle('gauge', undefined, result({ id: '0' })), 'line');
+    assert.equal(resolveStyle('gauge', undefined, result({})), 'line');
+});
+
+test('several id-bearing series are a per-entity heatmap', () => {
+    assert.equal(resolveStyle('gauge', undefined, result({ id: '0' }, { id: '1' })), 'heatmap');
+});
+
+test('several series without an id are a multi-line chart', () => {
+    assert.equal(
+        resolveStyle('gauge', undefined, result({ state: 'used' }, { state: 'free' })),
+        'multi',
+    );
+});
+
+test('an empty or absent result falls back to a line', () => {
+    assert.equal(resolveStyle('gauge', undefined, { data: { result: [] } }), 'line');
+    assert.equal(resolveStyle('gauge', undefined, undefined), 'line');
+});
+
+test('histogram subtypes are resolved by subtype, not result shape', () => {
+    assert.equal(resolveStyle('histogram', 'buckets'), 'histogram_heatmap');
+    assert.equal(resolveStyle('histogram', 'quantile_heatmap'), 'quantile_heatmap');
+    assert.equal(resolveStyle('histogram', 'percentiles'), 'scatter');
+});


### PR DESCRIPTION
Adds an Intel GPU sampler and brings the viewer's per-GPU charts in line with
what multi-vendor hosts actually look like.

## The sampler

`gpu_intel_pmu` reads the i915/xe PMU via `perf_event_open`, covering both
integrated GPUs and discrete Arc cards. Each GPU registers its own PMU, which is
discovered from sysfs along with the engine set that GPU exposes — the perf type
is assigned at boot (23, 24 and 32 observed across two hosts) and the engine set
differs per part, so nothing is hardcoded.

| metric | type | source |
|---|---|---|
| `gpu_engine_busy_time` | counter, ns | perf event `<engine>-busy` |
| `gpu_frequency_sample{frequency=actual\|requested}` | counter, MHz | perf events |
| `gpu_memory{state=used\|free}` | gauge, bytes | `DRM_IOCTL_I915_QUERY` |

All events for a GPU open as one perf group, so a single read returns every
counter with no skew between engines. Reads take a driver lock rather than being
an mmap load, so the sampler runs on its own bounded cadence (default 1s) via
`spawn_blocking` — a documented departure from principle 10, per principle 17.

VRAM comes from the DRM query ioctl, since the PMU has no memory counter. It is
discrete-only: an integrated GPU has no device-local memory region and publishes
nothing rather than passing host RAM off as VRAM. Without `CAP_PERFMON` the
kernel reports all memory as unallocated instead of failing the ioctl, so the
sampler suppresses the series rather than publishing a plausible "0 used".

## Viewer

Per-GPU charts grouped `sum by (id)`, which collapses two GPUs that share an id
into one summed line. Every vendor's sampler numbers its devices from 0, so a
host with an NVIDIA card and an Intel iGPU has two GPUs both labelled `id="0"`.
17 queries grouped that way; they now group by `(id, vendor)`.

Three related fixes fell out:

- **Heatmap rows were indexed by `parseInt(id)`**, so two GPUs at `id=0` landed
  on the same row, one overwriting the other. That is data loss, not just a
  labelling problem. Rows fall back to result order when ids are not unique and
  dense, and each carries its own label.
- **`resolveStyle` required ≥2 series for a heatmap**, making chart *type* depend
  on how many devices happened to be present — a "Per-GPU" chart drew a heatmap
  on a two-GPU host and a line chart on a one-GPU host.
- **Seven vendor-exclusive metric names now pin their vendor.** The eight shared
  names are deliberately left unfiltered; pinning those would hide other vendors'
  GPUs.

`gpu_apple` gains `vendor = "apple"` — it was the only sampler publishing none,
leaving the `(id, vendor)` invariant asymmetric across platforms.

## systeminfo

`GpuSummary` dropped five of `hwinfo::Gpu`'s eleven fields at the summary
boundary, including `pci_bus_id`. All five now flow through. The NVIDIA `/proc`
fallback moves into the nvidia backend, which fixes a real bug: it fired on the
*whole* GPU list being empty, so an AMD+NVIDIA host with no NVML skipped the scan
entirely and the NVIDIA GPU went unreported.

## Verification

Hardware-tested on three hosts with both GPUs under load:

| host | GPUs | result |
|---|---|---|
| sky | Arc A770 + UHD 630 | `ccs0` 99.7% @ 2.4 GHz, VRAM tracks allocations |
| hyb | RTX 5080 + UHD 730 | `rcs0` 100%, both vendors in one recording |
| amd | R9700 + Raphael | `gpu_amd_smi` 280 W peak, per-GPU rows separate |

Cross-checked against `intel_gpu_top` reading the same perf events. 747 tests
pass on Linux, clippy clean, viewer symlink guard passes.

## Scope

**i915 only.** The `xe` driver names its PMU the same way but exposes a
different event vocabulary, so it is deliberately not matched — an xe host
reports `Unsupported` with an accurate reason rather than a misleading
permissions error.

## Notes for review

- **The `(id, vendor)` grouping changes every GPU chart**, not just Intel's. It
  is the correct fix, but it is a visible change for AMD and NVIDIA users too.
- **The mixed-vendor conflation has no end-to-end hardware proof.** hyb holds an
  NVIDIA and an Intel GPU both at `id=0`, but no metric *name* is shared between
  them there, so the conflation never fires. Reproducing it needs a discrete
  Intel GPU alongside another vendor; no host available here is that. Covered by
  unit tests.
- **Multi-GT Intel parts are untested** — the sampler would silently drop
  `-gtN`-suffixed globals. Documented in the code, fails safe, no hardware.

## Review round 2

All nine findings from @brayniac's review are addressed (`435100bf`, `66e918fa`),
each reproduced before fixing — including the last bullet of #5, which the
review flagged as unverified and which does reproduce.

The two blocking viewer findings are now verified against **full captures with
every sampler enabled** (1717 columns / 27 samplers, versus 29 for a GPU-only
recording). That matters because both regressions were in *CPU* charts, which an
isolated GPU capture cannot see:

```
             CPU (inferred)                     GPU (explicit override)
sky  (12c)   Busy % (Per-CPU)  n=12  ->heatmap  Compute Busy %  n=1  style=heatmap
hyb  (16c)   Busy % (Per-CPU)  n=16  ->heatmap  GPU %           n=1  style=heatmap
amd  (24c)   Busy % (Per-CPU)  n=24  ->heatmap  GPU %           n=2  style=heatmap
```

`resolveStyle` is untouched again and now has the five tests it was missing;
per-GPU plots opt in via `PlotOpts::style`. Row labels are withheld when they
merely restate their row index, so per-CPU heatmaps keep their "CPU" axis title
and `CPU 2` tooltips.

Correction to an earlier note: the three WASM test failures were **not**
pre-existing on `main`. They were a stale local `site/viewer/pkg/` (gitignored,
dated June) and pass after `./crates/viewer/build.sh` — 273 JS tests, 0 failures.

730 Rust tests on sky, hyb and amd; 277 JS tests; clippy clean.
