### PR TITLE
release: prepare v5.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [5.19.1] - 2026-09-09
+
 ### Added
 
 - Agent: block IO latency is now split into its three phases, each a histogram
@@ -24,6 +26,21 @@
   rendering unchanged. External consumers that query `blockio_latency` by name
   — Prometheus rules, Grafana dashboards, saved PromQL — need updating.
   (#1054, #1124)
+
+### Fixed
+
+- Exporter: `/metrics/binary` served zero bytes when the agent could not be
+  reached. To a scraper that only reads the body that is the same as an empty
+  snapshot, but not to a consumer that probes the endpoint to decide what it
+  speaks: zero bytes are not a msgpack document, so the probe concluded the
+  endpoint was Prometheus and fell through to the text route. `rezolus record`
+  probes exactly that way, so pointed at an exporter whose source had not come
+  up yet it reported `detected Prometheus`, refused with `.rez requires a
+  rezolus (msgpack) endpoint`, and recorded nothing for the whole run — even
+  when the source appeared seconds later. It now serves a valid msgpack
+  document carrying no metrics, which is both true and recoverable: the
+  consumer keeps its connection and picks up real data the moment the agent
+  appears. An empty body *from* the agent is normalized the same way. (#1176)
 
 ## [5.19.0] - 2026-08-31
 
@@ -1171,7 +1188,8 @@
 - Rewritten implementation of Rezolus using libbpf-rs and perf-event2 to provide
   a more modern approach to BPF and Perf Event instrumentation. 
 
-[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.19.0...HEAD
+[unreleased]: https://github.com/iopsystems/rezolus/compare/v5.19.1...HEAD
+[5.19.1]: https://github.com/iopsystems/rezolus/compare/v5.19.0...v5.19.1
 [5.19.0]: https://github.com/iopsystems/rezolus/compare/v5.18.0...v5.19.0
 [5.18.0]: https://github.com/iopsystems/rezolus/compare/v5.17.0...v5.18.0
 [5.17.0]: https://github.com/iopsystems/rezolus/compare/v5.16.2...v5.17.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "rezolus"
-version = "5.19.1-alpha.2"
+version = "5.19.1"
 dependencies = [
  "allan",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ wasm-bindgen = "0.2.120"
 
 [package]
 name = "rezolus"
-version = "5.19.1-alpha.2"
+version = "5.19.1"
 description = "High resolution systems performance telemetry agent"
 edition = "2021"
 license.workspace = true


### PR DESCRIPTION
## Release v5.19.1

Prepares the release of v5.19.1, cutting the `5.19.1-alpha` line.

### Changes

- Version: `5.19.1-alpha.2` → `5.19.1`
- `CHANGELOG.md`: `[Unreleased]` closed as `[5.19.1]`, fresh empty `[Unreleased]` opened, comparison links updated

### Why now

The headline fix is #1176, added to the changelog under **Fixed** as part of this PR.

The exporter served **zero bytes** from `/metrics/binary` whenever its agent was unreachable. To a scraper that only reads bodies that is the same as an empty snapshot; to a consumer that *probes* the endpoint to decide what protocol it speaks, it is not — zero bytes are not a msgpack document, so the probe concluded Prometheus and fell through to the text route.

`rezolus record` probes exactly that way. Pointed at an exporter whose source had not yet come up it reported `detected Prometheus`, refused with `` .rez requires a rezolus (msgpack) endpoint ``, and recorded **nothing for the whole run** — even when the source appeared seconds later. One unavailable moment at startup cost the entire recording, and the error named the wrong cause.

This matters for consumers that cannot pass endpoint modifiers to work around it. SystemsLab's job runner invokes `rezolus record --url <url>` with no way to specify `protocol=msgpack`, so the bug is a silent whole-job metrics loss there.

Verified end to end on a real host before and after, with a stock 5.19.0 recorder and a plain `--url`:

| | before | after |
|---|---|---|
| `/metrics/binary`, source down | HTTP 200, **0 bytes** | HTTP 200, **19 bytes** |
| recorder verdict | `detected Prometheus` → refused | **`detected Msgpack`** |
| result | no archive at all | **6,094,848-byte archive** |

The archive is correct rather than merely present: recording begins at the instant the source appeared, with the dead seconds absent rather than fabricated.

### Also in this release

Everything else already on `main` since v5.19.0 — the block IO latency phase split and `blockio_latency` → `blockio_device_latency` rename (#1054, #1124), the `.rez` format extraction and viewer work, and the dashboard template embedding (#1175). See the changelog section for the full list.

### Checks

`cargo clippy --all-targets -- -D warnings` clean and `cargo test` green locally, per the release procedure.

### After merge

`tag-release.yml` tags `v5.19.1` and bumps to the next dev version; `release.yml` builds and publishes the deb/rpm packages and the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)