### PR TITLE
ci: drop the unused Chrome apt source before updating

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -27,7 +27,16 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sudo apt update
+          # The runner image ships a Google Chrome apt source we do not use.
+          # While Google republishes, its Packages index and Release file
+          # disagree, and `apt-get update` exits non-zero on ANY failed index --
+          # failing the job even though it already ignored the bad one and every
+          # package we install comes from the Ubuntu archive. Drop the source we
+          # do not need rather than ignore all failures, which would hide a real
+          # archive outage as a confusing "package not found" later.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/google-chrome.sources
+          sudo apt-get update
           sudo apt-get -y install libelf-dev
       - name: cargo check
         run: |
@@ -46,7 +55,10 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sudo apt update
+          # Drop the unused Chrome apt source; see the note in `check`.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/google-chrome.sources
+          sudo apt-get update
           sudo apt-get -y install libelf-dev
       # Reporting, not gating: this feeds GitHub code scanning, and its exit
       # status is `sarif-fmt`'s rather than clippy's because of the pipe. Left
@@ -85,7 +97,10 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sudo apt update
+          # Drop the unused Chrome apt source; see the note in `check`.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/google-chrome.sources
+          sudo apt-get update
           sudo apt-get -y install libelf-dev
       - name: clippy (deny warnings)
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -159,7 +174,12 @@ jobs:
       - name: Install wasm-pack
         run: cargo install wasm-pack --version ^0.14 --locked
       - name: Install wabt
-        run: sudo apt-get update && sudo apt-get -y install wabt
+        run: |
+          # Drop the unused Chrome apt source; see the note in `check`.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/google-chrome.sources
+          sudo apt-get update
+          sudo apt-get -y install wabt
       # The `.rez` reader has to keep compiling for the browser. Its default
       # feature set does NOT: the ingest half pulls `metriken`, whose registry
       # declares a `linkme` distributed slice, and `linkme` has no wasm32
@@ -267,7 +287,10 @@ jobs:
         if: ${{ matrix.os != 'macos-latest' }}
         shell: bash
         run: |
-          sudo apt update
+          # Drop the unused Chrome apt source; see the note in `check`.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/google-chrome.sources
+          sudo apt-get update
           sudo apt-get -y install libelf-dev
           rustup component add rustfmt
 


### PR DESCRIPTION
## The failure

Every job that installs a package failed today in `Install dependencies`, having compiled nothing:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
   Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

The runner image ships a Google Chrome apt source. While Google republishes, the `Packages.gz` it serves does not match the hashes in its own `Release` file — here, a `Release` created at 17:16:59 against an index last modified at 09:41:12. That window is easily long enough to catch a CI run, and it caught several: `check`, `clippy`, `clippy-deny`, `build-ubuntu-*`, `wasm-viewer`, plus the `verify all tests pass` gate. A re-run 20 minutes later failed identically.

## Why it takes the whole job down

Read the second error line: apt **had already ignored** the bad index and carried on, and the Ubuntu archive fetched fine (`Fetched 9436 kB in 1s`). Every package these jobs install — `libelf-dev` and `wabt` — comes from that archive, so the update was functionally complete.

What failed was the **exit code**. `apt-get update` returns non-zero if *any* configured index fails, including one nothing in this repository needs. The result is that an unrelated third party can block every merge here, which is what happened.

## The fix, and the one not taken

Drop the source we do not use, then update:

```yaml
sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
           /etc/apt/sources.list.d/google-chrome.sources
sudo apt-get update
```

`apt-get update || true` would also go green, and it is the tempting one-character fix. It is worse: it swallows a genuine archive outage as well, which then re-emerges from the install step as a confusing "package not found" with the actual cause scrolled off. Removing the single source we do not need keeps a real failure fatal.

Both filenames are removed because runner images have been migrating from the one-line `.list` format to deb822 `.sources`; `rm -f` on an absent path is a no-op, so this is correct on either image.

## Scope

Five sites in `cargo.yml` — four installing `libelf-dev` (`check`, `clippy`, `clippy-deny`, `build`) and one installing `wabt` (`wasm-viewer`). Exactly the set that failed. The rationale is stated once at the first site; the rest reference it.

No behaviour change beyond the exit code: the same packages are installed from the same archive.

## Verification

The workflow parses (`yaml.safe_load`), and the five patched steps are confirmed to be precisely the five that failed. This PR's own run is the real test — it exercises the patched workflow on the same runner images while Google's mirror is still inconsistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)