### PR TITLE
ci: stop publishing Debian 11 packages, which is EOL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # debian
-          - { distro: debian, release: bullseye, arch: x86_64 }
-          - { distro: debian, release: bullseye, arch: arm64 }
+          # debian -- bullseye dropped, EOL (see CHANGELOG 5.19.1)
           - { distro: debian, release: bookworm, arch: x86_64 }
           - { distro: debian, release: bookworm, arch: arm64 }
           - { distro: debian, release: trixie, arch: x86_64 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@
   consumer keeps its connection and picks up real data the moment the agent
   appears. An empty body *from* the agent is normalized the same way. (#1176)
 
+### Removed
+
+- **Debian 11 (bullseye) packages are no longer published.** Debian 11 has
+  reached end of life: `bullseye-security` was last signed on 2026-08-31 and
+  its `Release` file expired on 2026-09-07. apt refuses an expired `Release`,
+  so `apt-get update` fails inside the build container and cannot be made to
+  succeed without disabling the freshness check — which would mean shipping
+  packages built against an archive that receives no further security updates.
+  Debian 11 users should stay on 5.19.0 or upgrade to bookworm or trixie. The
+  install script and the supported-distribution list are updated to match, so
+  it reports the release as unsupported rather than adding a repository that
+  has no packages for it.
+
 ## [5.19.0] - 2026-08-31
 
 ### Changed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ The install script will add our repositories and install Rezolus using your
 package manager.
 
 **Supported distributions:**
-- Debian: 13 (trixie/stable), 12 (bookworm/oldstable), 11 (bullseye/oldoldstable)
+- Debian: 13 (trixie/stable), 12 (bookworm/oldstable)
 - Ubuntu: 20.04 (focal), 22.04 (jammy), 24.04 (noble)
 - Enterprise Linux 9 and 10 (Rocky Linux, AlmaLinux, RHEL, CentOS Stream, Oracle Linux)
 - Amazon Linux: 2023

--- a/install.sh
+++ b/install.sh
@@ -146,12 +146,12 @@ if command -v apt &> /dev/null; then
     case "$DISTRO" in
         debian)
             case "$CODENAME" in
-                trixie|bookworm|bullseye)
+                trixie|bookworm)
                     REPO_NAME="debian-${CODENAME}"
                     ;;
                 *)
                     echo "Error: Unsupported Debian release: $CODENAME" >&2
-                    echo "Supported releases: trixie, bookworm, bullseye" >&2
+                    echo "Supported releases: trixie, bookworm" >&2
                     exit 1
                     ;;
             esac


### PR DESCRIPTION
## The failure

The v5.19.1 release build failed in **both** bullseye legs, 14 s in, having compiled nothing:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 1d 20h 47min 20s). Updates for this repository will not be applied.
```

Debian 11 has reached end of life. `bullseye-security` was last signed **2026-08-31** with `Valid-Until: 2026-09-07`, and nothing will refresh it. apt refuses an expired `Release` file, so `apt-get -q update` inside the container exits 100.

This is permanent, not a flake — it will fail identically on every future release.

## Why it blocks the whole release, not just Debian 11

`publish` has `needs: build-deb`. `fail-fast: false` lets the other legs finish, but a failed matrix job still fails the `needs`, so **`publish` is skipped entirely** — no GitHub release, no packages to Artifact Registry, no Homebrew, no crates.io. v5.19.1 tagged successfully and then shipped nothing.

## Why drop rather than work around

`-o Acquire::Check-Valid-Until=false` would go green. It would also mean building release packages against an archive that receives no further security updates, while `install.sh` continued to advertise Debian 11 as supported. Dropping the platform says the same thing honestly.

## Scope

- `release.yml`: the two bullseye matrix legs removed (deb matrix goes 11 → 9; bookworm and trixie remain)
- `install.sh`: no longer accepts `bullseye`, so a Debian 11 user gets "unsupported release" rather than a repository with no packages in it for them
- `docs/installation.md`: supported-distribution list updated to match
- `CHANGELOG.md`: documented under **Removed** in 5.19.1

Updating the installer alongside the matrix is the part that matters — dropping only the build would leave the script adding an apt repo that is empty for that release, which fails later and more confusingly.

Debian 11 users stay on 5.19.0, or upgrade to bookworm or trixie.

## Verification

Workflow YAML parses and the deb matrix now contains exactly bookworm and trixie for both architectures; `bash -n install.sh` clean.

## Follow-up

`v5.19.1` currently points at a commit without this fix and published nothing. Once this lands the tag will be repointed at the release commit plus this change, so the release is cut properly rather than leaving a stillborn tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)