### PR TITLE
ci: call the shared tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,90 +6,13 @@ on:
   push:
     branches: [main]
 
-env:
-  CARGO_TERM_COLOR: always
-
-# Required permissions for creating tags and pushing version bumps
-permissions:
-  contents: write
-
 jobs:
   tag-release:
-    name: Tag release and bump dev version
-    runs-on: ubuntu-latest
-    # Only run on the upstream repo when the commit message starts with "release: prepare v"
-    if: "${{ github.repository == 'iopsystems/rezolus' && startsWith(github.event.head_commit.message, 'release: prepare v') }}"
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          # Use PAT to allow pushing past branch protection
-          token: ${{ secrets.RELEASE_TOKEN }}
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Extract version
-        id: version
-        run: |
-          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Detected version: $VERSION"
-
-      - name: Check if tag exists
-        id: check_tag
-        run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.version.outputs.version }} already exists"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create and push tag
-        if: steps.check_tag.outputs.exists == 'false'
-        run: |
-          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
-          echo "Created and pushed tag v${{ steps.version.outputs.version }}"
-
-      - name: Install Rust
-        if: steps.check_tag.outputs.exists == 'false'
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-release
-        if: steps.check_tag.outputs.exists == 'false'
-        run: cargo install cargo-release --locked
-
-      - name: Bump to next dev version
-        if: steps.check_tag.outputs.exists == 'false'
-        run: |
-          # Calculate next dev version (patch bump + alpha.0)
-          VERSION="${{ steps.version.outputs.version }}"
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          NEXT_DEV="${MAJOR}.${MINOR}.$((PATCH + 1))-alpha.0"
-          echo "Bumping to next dev version: $NEXT_DEV"
-
-          # Update Cargo.toml and Cargo.lock
-          cargo release version "$NEXT_DEV" --execute --no-confirm
-
-          # Commit and push
-          git add -A
-          git commit -m "chore: begin next development iteration (${NEXT_DEV})"
-          git push origin main
-
-      - name: Summary
-        run: |
-          echo "## Release Tagged" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.check_tag.outputs.exists }}" == "true" ]; then
-            echo "Tag v${{ steps.version.outputs.version }} already existed, skipped." >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- Created tag: v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-            echo "- Bumped to next dev version" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The release workflow will now build packages, create the GitHub release, and update Homebrew." >> $GITHUB_STEP_SUMMARY
-          fi
+    uses: brayniac/rust-workflows/.github/workflows/tag-release.yml@v1
+    secrets: inherit
+    with:
+      # rezolus pushes the next development version straight to main rather
+      # than opening a bump PR for it.
+      dev-bump: direct
+      # A fork's main must not tag.
+      only-repository: iopsystems/rezolus


### PR DESCRIPTION
## Summary

- Replaces this repo's 93-line copy of `tag-release.yml` with an 8-line call to the shared workflow at [`brayniac/rust-workflows`](https://github.com/brayniac/rust-workflows), pinned at `@v1`.
- Behavior here is unchanged; the differences that had accumulated between repo copies were not decisions.
- rezolus is the first adopter, chosen because it releases often enough to exercise this quickly.

## Why

The same workflow was copied into 18 repositories and drifted into 11 distinct versions. What varied was accidental: `actions/checkout` at v4, v5 and v7; permissions at workflow or job level; the dev bump running through `sed` or `cargo-release`; the next dev version with or without an `-alpha.0` suffix; and three different commit prefixes counting as a release — `release: prepare v`, `release: v`, and `release: `.

That last one is the reason this matters. The prefix is coupled to its workflow by nothing but copy discipline, and a mismatch produces a release PR that merges cleanly, reports success, and never tags.

## What is unchanged

Verified against `upstream/main` rather than assumed:

| | Before | After |
| --- | --- | --- |
| Trigger | push to `main` | same |
| Fork gate | `github.repository == 'iopsystems/rezolus'` | `only-repository: iopsystems/rezolus` |
| Tag format | `vX.Y.Z` | same — `release.yml` still fires on `v*` |
| Dev bump | direct push to `main` via `cargo release version` | `dev-bump: direct`, same mechanism |
| Dev bump commit | `chore: begin next development iteration (${NEXT_DEV})` | byte-identical |
| Release commit prefix | `release: prepare v` | still accepted |
| `release.toml` | — | no change required |
| Version extraction | `5.19.2-alpha.0` | section-aware read gives the same on this manifest |

## What changes

Both toward being able to tell whether a release actually worked.

**The release check is a step, not a job-level `if:`.** An ordinary push to `main` now produces a run whose log says it was not a release, rather than no run at all. A skipped job leaves no trace, which makes "the release failed to tag" and "this commit was never a release" indistinguishable afterward.

**The commit must name the version the manifest holds.** A release PR that was retitled, or rebased onto a different bump, previously passed a prefix test while tagging whatever the manifest happened to say.

## Test plan

- [x] Shared workflow YAML parses; inputs, outputs and step order verified.
- [x] Gate logic exercised against 10 commit-message/version pairs, including the `v1.2.30`/`v1.2.3` boundary, prerelease versions, the merge-commit form, and a body that merely mentions a release string.
- [x] Section-aware version extraction agrees with the existing `grep` on this manifest and on nine others.
- [x] `RELEASE_TOKEN` present in repo secrets; `allowed_actions: "all"`, so calling a workflow outside the org is permitted.
- [ ] **After merge:** the next ordinary push to `main` should produce a `Tag Release` run that logs "not a release commit". That run appearing is the evidence the wiring is live — it does not require waiting for a release.
- [ ] **Next release:** confirm `v5.19.2` (or whichever version) is tagged and the dev bump lands on `main` as before.

If the post-merge run does not appear at all, the caller is not being triggered and this should be reverted rather than debugged in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KS512TGWtHvCMs1rcGz36