### PR TITLE
test(viewer): a headless-browser harness for the layer nothing else tests

### DIFF
--- a/.claude/skills/viewer-render/SKILL.md
+++ b/.claude/skills/viewer-render/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: viewer-render
+description: Render the running viewer in a real headless browser and assert on what it drew — element geometry, computed colours, wrap points, truncated labels, console errors. Use when a change moves pixels (navbar/badge/chart layout, CSS, responsive behavior, theme), when a PR says it "needs a visual check", or when reviewing frontend work under src/viewer/assets/. Covers the gap viewer-smoke names: it asserts payload shape, this asserts rendering.
+---
+
+# Rendering the viewer for real
+
+## Why this exists
+
+Three layers of viewer testing already exist and none of them can see the page:
+
+- `tests/*.test.mjs` — pure frontend logic, no DOM by design (CLAUDE.md: "no
+  bundler, no jsdom").
+- `tests/viewer_smoke.sh` — API envelopes. Its own "what it does not cover"
+  section says *"Browser-rendered UI … visual regressions need eyeball
+  verification."*
+- CI — compiles both backends. Compilation is not rendering.
+
+So a change can be green everywhere and still ship a label at the disabled
+contrast tier, a chip strip that wraps out of the navbar, or a mithril keyed
+fragment that warns on every redraw. This renders the page in Chrome and
+reports what actually got drawn.
+
+## Two traps, both of which bite on the first run
+
+**1. Set `REZOLUS_NO_OPEN=1`.** A second after binding, `rezolus view` opens the
+dashboard in the user's real browser (`src/viewer/mod.rs`). It is an environment
+variable, not a CLI flag, so it is easy to miss — and a headless session that
+starts seven viewers across a review silently opens seven tabs on someone's
+desktop. Always set it.
+
+**2. Build with `--features developer-mode`.** The binary embeds
+`src/viewer/assets/` at *compile* time. A normal `cargo build` bakes in whatever
+the assets were when it last ran, so you screenshot the old frontend, see your
+change missing — or worse, see something plausible and conclude it works.
+
+```bash
+cargo build --bin rezolus --features developer-mode          # assets from disk
+REZOLUS_NO_OPEN=1 target/debug/rezolus view --listen 127.0.0.1:4299 /tmp/x.rez &
+```
+
+If the render disagrees with the source you are reading, it is trap 2.
+
+## Setup
+
+`puppeteer-core` plus a browser already on the machine. **Do not add either to
+the repo** — it deliberately carries no JS toolchain, and `puppeteer` (without
+`-core`) downloads ~150 MB of Chromium you do not need.
+
+```bash
+mkdir -p /tmp/viewer-render && (cd /tmp/viewer-render && npm i puppeteer-core)
+export PUPPETEER_CORE=/tmp/viewer-render/node_modules/puppeteer-core
+export CHROME_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+```
+
+`CHROME_PATH` is optional where Chrome sits in a standard location; the script
+probes the usual macOS and Linux paths.
+
+Plain `chrome --headless --screenshot=out.png <url>` **hangs** on this page —
+the dashboard never reaches the quiescent state that flag waits for. Use the
+script, which waits on `networkidle2` plus a selector.
+
+## Use it
+
+```bash
+# 1. Assets from disk, and no browser tab on the user's desktop.
+cargo build --bin rezolus --features developer-mode
+REZOLUS_NO_OPEN=1 target/debug/rezolus view --listen 127.0.0.1:4299 /tmp/three.rez &
+
+# 2. Render and inspect.
+node scripts/viewer_render.mjs \
+  --url http://127.0.0.1:4299 \
+  --selector '.compare-badge' \
+  --children '.compare-badge-label' \
+  --out /tmp/badge.png
+```
+
+Stdout is a JSON block: tag, classes, computed colours, box geometry, per-child
+text/title/colour/truncation, `rowTops`, `wrapped`, `consoleProblems`,
+`failedRequests`. Two PNGs land beside `--out`: the element, and the top band of
+the page for layout context.
+
+`--children` matters more than it looks. It defaults to *direct* children, and
+in this UI the node carrying the text, the tooltip and the truncation is usually
+a grandchild — a label inside a chip. Point it at that node or the interesting
+fields all read `null`.
+
+## Read the JSON, not just the picture
+
+The screenshot is for the human in the PR. The JSON is what you assert on:
+
+- **`wrapped` / `rowTops`** — distinct child row tops mean the content broke
+  onto more than one line. Sweep `--width 1440 1280 1100 1000 820` to find the
+  point where it happens; one screenshot at one width hides this entirely.
+- **`children[].truncated`** — `scrollWidth` past the painted width means an
+  ellipsis is eating text. If that child has no `title`, the text is
+  **unrecoverable** by the user. Truncation plus a missing tooltip is a finding.
+- **`children[].color`** — resolve the actual computed colour. `--fg-muted` is
+  the *disabled* tier (`#484f58` on dark); `--fg-secondary` (`#8b949e`) is
+  "dimmer but meant to be read". Picking the wrong one looks fine in the CSS and
+  wrong on screen.
+- **`consoleProblems`** — mithril keyed-fragment violations, exceptions in a
+  redraw. Silent in every other test layer.
+- **`failedRequests`** — a 404 on a newly added shared module means a missing
+  `site/viewer/lib` symlink (see the `viewer-parity` skill), which breaks the
+  static viewer completely.
+
+## Check both themes
+
+Colours are CSS custom properties overridden under `[data-theme="light"]`, and
+`--fg-muted` inverts between them. `--theme light` / `--theme dark` sets the
+attribute directly, so one run per theme covers both.
+
+## Where the script lives, and why not `tests/`
+
+`scripts/viewer_render.mjs`. CI runs `node --test tests/*.mjs`, and that glob
+takes **every** `.mjs` in the directory, not just `*.test.mjs` — a tool parked
+there gets executed as a test and fails the suite.
+
+## Fixtures
+
+`rez`'s fixture writer caps at four recordings:
+
+```bash
+cargo run -p rez --features test-support --example write_rez_fixture -- /tmp/four.rez 4
+```
+
+For more arms — worth doing, since layout problems only appear at scale —
+combine archives:
+
+```bash
+target/debug/rezolus recording combine /tmp/four.rez /tmp/three.rez -o /tmp/seven.rez
+```
+
+## Known noise
+
+A bare fixture has no systeminfo, so `/api/v1/systeminfo` and
+`/api/v1/selection` 404 and surface in `failedRequests`. Not your change.
+
+## What this still does not cover
+
+- **The WASM/static viewer.** This drives `rezolus view` (the axum server). The
+  frontend is symlinked and therefore identical, but the backend answering
+  `/api/v1/*` is not — see the `viewer-parity` skill. To render that side you
+  need `./crates/viewer/build.sh` and a static server over `site/`.
+- **Interaction.** Hover, click, drag, dropdown open/close. Puppeteer can do all
+  of it; the script just does not, yet.
+- **Pixel regression.** No baseline images are stored, deliberately — they rot.
+  The JSON facts are the durable assertion.

--- a/.claude/skills/viewer-smoke/SKILL.md
+++ b/.claude/skills/viewer-smoke/SKILL.md
@@ -51,10 +51,12 @@ in `src/viewer/` show up before review.
 - **Live mode** (`rezolus view <agent-url>`) — needs an actual rezolus
   agent listening, not reproducible without one.
 - **Browser-rendered UI** — the script only asserts on backend payload
-  shape. Visual regressions in the dashboard need eyeball verification.
+  shape. For the rendered page, use the `viewer-render` skill: it drives a
+  headless browser and asserts on geometry, computed colours, wrap points
+  and console errors.
 - **Compare-mode UI rendering** — the experiment attach/detach assertion
   only checks the API flag flip; the rendered side-by-side view isn't
-  exercised.
+  exercised. Again `viewer-render`.
 
 ## Requirements
 

--- a/scripts/viewer_render.mjs
+++ b/scripts/viewer_render.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+//
+// Render a running viewer in a real browser and report what it actually drew.
+//
+// `tests/` asserts on payload shape: `viewer_smoke.sh` checks API envelopes, and
+// the `.test.mjs` files exercise pure frontend logic with no DOM. Neither can
+// see a chip strip that wrapped out of the navbar, a label the theme rendered at
+// the disabled contrast tier, or a mithril keyed-fragment warning. This does.
+//
+// It lives in `scripts/` rather than `tests/` on purpose: CI runs
+// `node --test tests/*.mjs`, and that glob takes every `.mjs` in the directory,
+// not just `*.test.mjs` — a tool parked there is executed as a test and fails
+// the suite.
+//
+// It is deliberately NOT wired into CI: it needs a browser on the machine and a
+// puppeteer-core install that this repo does not carry (see the `viewer-render`
+// skill for why). Run it by hand when a change moves pixels.
+//
+//   node scripts/viewer_render.mjs --url http://127.0.0.1:4299 \
+//        --selector '.compare-badge' --out /tmp/badge.png
+//
+// Output is a JSON block on stdout plus two PNGs: the matched element, and the
+// top band of the page so the element is seen in the layout it shares.
+//
+// Requires PUPPETEER_CORE to point at a puppeteer-core install, or one to be
+// resolvable from the current directory. See `--help`.
+
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const USAGE = `
+Usage: node scripts/viewer_render.mjs --url <url> [options]
+
+  --url <url>          Viewer to load (required), e.g. http://127.0.0.1:4299
+  --selector <css>     Element to inspect and screenshot (default: body)
+  --children <css>     Descendants to enumerate (default: direct children).
+                       Use it to reach the node that actually carries the text
+                       or title, e.g. '.compare-badge-label'.
+  --out <path>         PNG path; a second "<name>-context.png" is also written
+  --width <px>         Viewport width (default 1440). Vary it to find wrap points.
+  --height <px>        Viewport height (default 900)
+  --theme <name>       Force 'light' or 'dark' via the data-theme attribute
+  --wait <css>         Extra selector to await before measuring
+  --timeout <ms>       Navigation/selector timeout (default 30000)
+
+Requires puppeteer-core and a Chrome/Chromium binary. Neither is a repo
+dependency — this repo carries no JS toolchain on purpose. Install into a
+scratch directory and point at it:
+
+  mkdir -p /tmp/viewer-render && cd /tmp/viewer-render && npm i puppeteer-core
+  PUPPETEER_CORE=/tmp/viewer-render/node_modules/puppeteer-core \\
+  CHROME_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \\
+  node scripts/viewer_render.mjs --url http://127.0.0.1:4299 --selector .compare-badge
+
+Two things to get right when starting the viewer you point this at:
+
+  REZOLUS_NO_OPEN=1   or every run pops a real browser tab on the desktop:
+                      "rezolus view" opens one a second after binding.
+  --features developer-mode
+                      or the binary serves the frontend assets embedded at
+                      COMPILE time and you screenshot a stale UI.
+
+  REZOLUS_NO_OPEN=1 target/debug/rezolus view --listen 127.0.0.1:4299 out.rez &
+`;
+
+const args = process.argv.slice(2);
+if (args.includes('--help') || args.includes('-h')) {
+    console.log(USAGE);
+    process.exit(0);
+}
+
+const arg = (name, fallback = undefined) => {
+    const i = args.indexOf(`--${name}`);
+    return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+
+const url = arg('url');
+if (!url) {
+    console.error(USAGE);
+    console.error('error: --url is required');
+    process.exit(2);
+}
+
+const selector = arg('selector', 'body');
+const childSelector = arg('children');
+const out = arg('out');
+const width = Number(arg('width', 1440));
+const height = Number(arg('height', 900));
+const theme = arg('theme');
+const waitFor = arg('wait');
+const timeout = Number(arg('timeout', 30000));
+
+// ── Locate puppeteer-core ────────────────────────────────────────────────────
+// Not a repo dependency, so resolve it from the environment first and fall back
+// to whatever the working directory can see.
+const resolvePuppeteer = () => {
+    const explicit = process.env.PUPPETEER_CORE;
+    if (explicit) {
+        const pkg = path.join(explicit, 'package.json');
+        try {
+            const require = createRequire(pathToFileURL(pkg));
+            const main = require(pkg).main || 'lib/puppeteer/puppeteer-core.js';
+            return pathToFileURL(path.join(explicit, main)).href;
+        } catch {
+            return pathToFileURL(path.join(explicit, 'lib/puppeteer/puppeteer-core.js')).href;
+        }
+    }
+    return 'puppeteer-core';
+};
+
+let puppeteer;
+try {
+    puppeteer = (await import(resolvePuppeteer())).default;
+} catch (e) {
+    console.error(USAGE);
+    console.error(`error: could not load puppeteer-core (${e.message})`);
+    process.exit(2);
+}
+
+// ── Locate a browser ─────────────────────────────────────────────────────────
+// puppeteer-core ships no browser by design; use one already on the machine.
+const CHROME_CANDIDATES = [
+    process.env.CHROME_PATH,
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+].filter(Boolean);
+
+const { existsSync } = await import('node:fs');
+const executablePath = CHROME_CANDIDATES.find((p) => existsSync(p));
+if (!executablePath) {
+    console.error(`error: no Chrome/Chromium found. Set CHROME_PATH.\ntried:\n  ${CHROME_CANDIDATES.join('\n  ')}`);
+    process.exit(2);
+}
+
+// ── Render ───────────────────────────────────────────────────────────────────
+const browser = await puppeteer.launch({
+    executablePath,
+    headless: true,
+    args: ['--no-sandbox', '--disable-gpu', '--hide-scrollbars'],
+});
+
+let exitCode = 0;
+try {
+    const page = await browser.newPage();
+    // deviceScaleFactor 2 so text in the PNG is legible when a human reads it.
+    await page.setViewport({ width, height, deviceScaleFactor: 2 });
+
+    // Console noise and failed requests are findings, not decoration: a mithril
+    // keyed-fragment violation or a 404 on a newly added module shows up here
+    // and nowhere else.
+    const consoleProblems = [];
+    const failedRequests = [];
+    page.on('console', (m) => {
+        if (m.type() === 'error' || m.type() === 'warning') {
+            consoleProblems.push(`${m.type()}: ${m.text()}`);
+        }
+    });
+    page.on('pageerror', (e) => consoleProblems.push(`pageerror: ${e.message}`));
+    page.on('response', (r) => {
+        if (r.status() >= 400) failedRequests.push(`${r.status()} ${r.url()}`);
+    });
+
+    await page.goto(url, { waitUntil: 'networkidle2', timeout });
+    if (waitFor) await page.waitForSelector(waitFor, { timeout });
+    await page.waitForSelector(selector, { timeout });
+
+    if (theme) {
+        await page.evaluate((t) => document.documentElement.setAttribute('data-theme', t), theme);
+        await new Promise((r) => setTimeout(r, 300));
+    }
+
+    const facts = await page.evaluate((sel, childSel) => {
+        const el = document.querySelector(sel);
+        const box = (n) => {
+            const r = n.getBoundingClientRect();
+            return { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) };
+        };
+        const cs = getComputedStyle(el);
+        // Direct children by default, but the node carrying the text and the
+        // title is often a grandchild (a label inside a chip) — and that is
+        // exactly the node whose truncation and tooltip matter.
+        const kids = childSel ? [...el.querySelectorAll(childSel)] : [...el.children];
+        return {
+            selector: sel,
+            tag: el.tagName.toLowerCase(),
+            classes: el.className,
+            title: el.getAttribute('title'),
+            box: box(el),
+            style: {
+                display: cs.display,
+                flexWrap: cs.flexWrap,
+                color: cs.color,
+                background: cs.backgroundColor,
+                fontSize: cs.fontSize,
+            },
+            // Distinct child row tops mean the content wrapped onto more than
+            // one line — the thing a single screenshot at one width hides.
+            rowTops: [...new Set(kids.map((k) => Math.round(k.getBoundingClientRect().top)))],
+            childCount: kids.length,
+            children: kids.slice(0, 24).map((k) => ({
+                tag: k.tagName.toLowerCase(),
+                classes: k.className,
+                text: (k.textContent || '').trim().slice(0, 40),
+                title: k.getAttribute('title'),
+                color: getComputedStyle(k).color,
+                box: box(k),
+                // scrollWidth past the painted width means an ellipsis is
+                // hiding text; if nothing carries a title, it is unrecoverable.
+                truncated: k.scrollWidth > Math.ceil(k.getBoundingClientRect().width) + 1,
+            })),
+        };
+    }, selector, childSelector);
+
+    facts.viewport = { width, height };
+    facts.theme = theme || (await page.evaluate(() => document.documentElement.getAttribute('data-theme') || 'dark'));
+    facts.wrapped = facts.rowTops.length > 1;
+    facts.consoleProblems = consoleProblems;
+    facts.failedRequests = failedRequests;
+
+    console.log(JSON.stringify(facts, null, 2));
+
+    if (out) {
+        const el = await page.$(selector);
+        await el.screenshot({ path: out });
+        // The band of page above and around the element, for layout context.
+        const contextHeight = Math.max(80, facts.box.y + facts.box.h + 30);
+        await page.screenshot({
+            path: out.replace(/(\.png)?$/, '-context.png'),
+            clip: { x: 0, y: 0, width, height: Math.min(contextHeight, height) },
+        });
+        console.error(`wrote ${out} and ${out.replace(/(\.png)?$/, '-context.png')}`);
+    }
+} catch (e) {
+    console.error(`error: ${e.message}`);
+    exitCode = 1;
+} finally {
+    await browser.close();
+}
+
+process.exit(exitCode);


### PR DESCRIPTION
## Summary

The rendered page is the one viewer layer with no harness. `viewer-smoke`'s own *"what it does not cover"* section says browser-rendered UI *"needs eyeball verification"*, and the `.test.mjs` files are pure logic with no DOM by design. So a change can be green everywhere and still ship a label at the disabled contrast tier, a chip strip that wrapped out of the navbar, or a mithril keyed-fragment warning on every redraw.

- `scripts/viewer_render.mjs` — drives the installed Chrome via `puppeteer-core` and reports what actually got drawn: element geometry, computed colours, per-child text/title/truncation, wrap points, console errors, failed requests. Plus two PNGs for whoever reads the PR.
- `.claude/skills/viewer-render/SKILL.md` — when to reach for it, and the traps.
- `viewer-smoke` now points at it from the gap it names.

**The JSON is the assertion; the screenshot is the illustration.** No baseline images — those rot.

## Why now

Written after using an ad-hoc version to review #1172. It caught a `+N` label set to `--fg-muted` — the *disabled* tier, `#484f58` on the dark badge ground — which reading the CSS had not. It also measured the wrap point across five viewport widths, which no single screenshot shows.

## The traps it records

Each of these cost real time on that review:

- **`REZOLUS_NO_OPEN=1`** — `rezolus view` opens a real browser tab a second after binding. It's an env var, not a CLI flag, so it's easy to miss. A headless session that starts seven viewers opens seven tabs on someone's desktop. (It did.)
- **`--features developer-mode`** — the binary embeds `src/viewer/assets/` at *compile* time, so a normal build screenshots a stale frontend. Nasty because the result looks plausible.
- **`--children`** — the node carrying the text, tooltip and truncation is usually a grandchild (a label inside a chip); the default direct-children walk reports `null` for exactly the fields that matter.

## Deliberate choices

- **Not in CI.** Needs a browser and a `puppeteer-core` install. This repo carries no JS toolchain on purpose — the skill installs into a scratch dir and points at it with `PUPPETEER_CORE`, so nothing lands in the repo. `puppeteer-core`, not `puppeteer`, so there's no ~150 MB Chromium download.
- **`scripts/`, not `tests/`.** CI runs `node --test tests/*.mjs`, and that glob takes every `.mjs`, not just `*.test.mjs` — a tool parked there is executed as a test and fails the suite. (Confirmed the hard way.)

## Test plan

- [x] Ran the documented flow start to finish against a 7-recording `.rez`: both themes, widths 1440/1280/1100/1000/820 (finds the wrap point at 820), titles and computed colours resolved, known-noise 404s reported
- [x] `node --test tests/*.mjs` — 249 pass, 0 fail with the script in `scripts/`
- [x] `node --check scripts/viewer_render.mjs`, `--help` exits 0
- [x] Graceful failure when `puppeteer-core` is absent and when no Chrome is found
- [x] `scripts/check-viewer-symlinks.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KheDzaD5bnVWcmdocmk2eW
