### PR TITLE
ci: pass RELEASE_TOKEN to the shared tag-release workflow by name

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,7 +9,12 @@ on:
 jobs:
   tag-release:
     uses: brayniac/rust-workflows/.github/workflows/tag-release.yml@v1
-    secrets: inherit
+    # By name, not `secrets: inherit`: GitHub only carries inherited secrets
+    # between repositories in the same organization, and the shared workflow
+    # lives under a different owner. With `inherit` the token arrives empty
+    # and checkout fails after the gate has already passed.
+    secrets:
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     with:
       # rezolus pushes the next development version straight to main rather
       # than opening a bump PR for it.


### PR DESCRIPTION
## Why

GitHub only honors `secrets: inherit` between repositories in the same organization or enterprise. `brayniac/rust-workflows` is under a different owner than `iopsystems/rezolus`, so `RELEASE_TOKEN` arrives empty. `ringline-rs/ringline` hit this on its first real release through the shared workflow today: the gate passed and `actions/checkout` failed with `Input required and not supplied: token`, leaving the release commit on main with no tag. Every rezolus tag-release run so far has stopped at the gate, so the same failure is latent here and would surface on the next `release:` commit.

## What

Replace `secrets: inherit` with an explicit `secrets: RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}`.

## Merge order

**Do not merge before brayniac/rust-workflows#2 is merged and `v1` re-pointed.** Passing a secret the called workflow does not declare is a validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDHdYwqsnPN4EkhRBvbDgE
