### PR TITLE
deps: metriken 0.11, metriken-exposition 0.20, metriken-query 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "metriken"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674854d8e0c525f2630a859e4bfe6ca5f452d27e38592079950e3d396fa7f358"
+checksum = "e1a910ef0aa1172fc039d2d52c1e64d2343b16dd3f4d3f3ac9deb9adeb4c52f2"
 dependencies = [
  "histogram",
  "metriken-core",
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-exposition"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27254ab0c2cb71085b17be543db1970d11bde2144b78ed82ccdee0a35001d4eb"
+checksum = "33c17f43240c2b358eecd68ea26e5080d214987c309d8031526f971818df4eb5"
 dependencies = [
  "arrow",
  "chrono",
@@ -2249,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46a291ac1421b5992c6080fc9af6bcc6dd3a7fbb6e9e179ef41dd88762c4e8"
+checksum = "49d7eb6704ca2d779622605a0323a318961cdd4c3e1c8f0192bde8d9646a59c3"
 dependencies = [
  "arrow",
  "bytes",
@@ -2358,7 +2358,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3167,7 +3167,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3224,7 +3224,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3694,10 +3694,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4381,7 +4381,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ histogram = "1.3.1"
 libc = "0.2.186"
 libloading = "0.8"
 log = "0.4.29"
-metriken = "0.10.1"
-metriken-exposition = "0.19.0"
-metriken-query = { version = "0.21.0", default-features = false }
+metriken = "0.11.0"
+metriken-exposition = "0.20.0"
+metriken-query = { version = "0.22.0", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -652,17 +652,22 @@ recording (single iGPU, 55 min at 1 s).
   read per tick, so per principles 13/16/17 it needs a *measured* per-refresh
   number. Failing that, stamp the SoC `compatible` string into snapshot metadata
   so a consumer can at least tell which generation produced a zero.
-- **`GPU_ENERGY_CONSUMPTION` can publish a fabricated zero** — Open,
-  pre-existing, adjacent to #1108 and the same bug class. It is a `CounterGroup`
-  (`stats.rs`), and metriken's `CounterGroup::value()` has **no** sentinel: it
-  returns `Some(0)` for an unwritten slot as soon as *any* index in that group
-  has been written. So on a mixed multi-GPU host where `total_energy_consumption()`
-  succeeds for device 0 and fails for device 1, device 1 publishes a constant-zero
-  energy counter that reads as a real measurement. Cannot fire on a single-GPU
-  host (the group stays uninitialised and reads `None`), which is why #1108's
-  Tegra target does not hit it. Contrast `GaugeGroup`, which uses an `i64::MIN`
-  sentinel and correctly yields `None`. *Fix:* track written membership
-  explicitly, or move the metric to a gauge-like sentinel representation.
+- **`GPU_ENERGY_CONSUMPTION` can publish a fabricated zero** — **Closed** by
+  metriken 0.11. It is a `CounterGroup` (`stats.rs`), and `CounterGroup::value()`
+  used to have **no** sentinel: it returned `Some(0)` for an unwritten slot as
+  soon as *any* index in that group had been written. So on a mixed multi-GPU
+  host where `total_energy_consumption()` succeeds for device 0 and fails for
+  device 1, device 1 published a constant-zero energy counter that read as a real
+  measurement. `GaugeGroup` never had the problem — it has always used an
+  `i64::MIN` sentinel and correctly yielded `None` — and that asymmetry was the
+  trap: which group type a metric happened to use silently decided whether a
+  partially-populated group was a bug. metriken 0.11 gives an owned
+  `CounterGroup` the same treatment with `u64::MAX`
+  (iopsystems/metriken#143), so an unwritten entry now reads `None`.
+  *Still open for externally backed groups:* a BPF mmap is kernel zero-filled
+  and cannot hold a sentinel, so an unwritten slot there still reads `0`.
+  Membership for those comes from the map's registered entries rather than from
+  value presence, which is what `set_member_set` exists to declare.
 - **Per-device Tegra discrimination** — Open. `is_tegra_soc()` reads
   `/proc/device-tree/compatible`, a *host* property, but "no real PCIe link / no
   utilization counters" is a *device* property. A Tegra board carrying a discrete

--- a/src/agent/exposition/http/snapshot.rs
+++ b/src/agent/exposition/http/snapshot.rs
@@ -1141,10 +1141,16 @@ struct GroupDecision {
 /// a sampler allowed only part of the machine has — and that set is rarely a
 /// prefix.
 ///
-/// The distinction is not cosmetic. A registered `CounterGroup` slot that is
-/// never written reads as `0`, not as absent, so declaring a prefix that
-/// overstates the population publishes zeros for indices nothing measured — a
-/// wrong value where the honest answer is no value at all.
+/// The distinction is not cosmetic, though what it costs depends on the
+/// group's backing. metriken 0.11 gave an OWNED `CounterGroup` a `u64::MAX`
+/// unwritten sentinel, so an over-declared prefix there publishes `None` —
+/// honest, if noisy: columns that are always null. An EXTERNALLY backed group
+/// (a BPF mmap) cannot carry a sentinel, because the kernel zero-fills that
+/// memory, so an over-declared prefix still publishes `0` for indices nothing
+/// measured — a wrong value where the honest answer is no value at all. Those
+/// are exactly the per-CPU and per-cgroup groups a partial reservation
+/// under-populates, so declaring the real membership still matters most
+/// precisely where it always did.
 enum MemberIter<'a> {
     Prefix(std::ops::Range<usize>),
     Set(std::slice::Iter<'a, usize>),
@@ -3668,18 +3674,23 @@ mod tests {
     }
 
     // Same shape (2 entries), same write pattern (only index 0 touched) —
-    // one declared, one not. `CounterGroup`'s backing array zero-initializes
-    // eagerly across ALL entries the moment any one index is written, so
-    // index 1 reads `Some(0)` in both fixtures either way: the metriken
-    // group API gives no way to independently distinguish "a member that is
-    // genuinely present and reads zero" from "a phantom slot that merely
-    // exists because the backing array got initialized" once that's
-    // happened. What this test honestly pins is the observable CONTRACT
-    // difference the V3 design layers on top of that identical reading: a
-    // declared group reports index 1 as `Some(0)` (registration membership,
-    // no sentinel skip) while an otherwise-identical undeclared group
-    // suppresses it entirely (V2's transitional value-sentinel skip,
-    // default groups only).
+    // one declared, one not.
+    //
+    // metriken 0.11 gave `CounterGroup` the `u64::MAX` unwritten sentinel that
+    // `GaugeGroup` always had, so an untouched index now reads `None` rather
+    // than the `Some(0)` the eagerly zero-initialized array used to give. That
+    // removes the ambiguity this test used to work around: "a member that is
+    // genuinely present and reads zero" and "a phantom slot that merely exists
+    // because the backing array got initialized" are now distinguishable at the
+    // group API, so the V3 walk can report the second as absent instead of
+    // publishing a zero a consumer cannot tell from a measurement.
+    //
+    // The CONTRACT difference this pins is unchanged in shape: a declared group
+    // walks its registered membership and emits index 1 (now honestly `None`),
+    // while an otherwise-identical undeclared group suppresses the entry
+    // entirely (V2's transitional value-sentinel skip, default groups only).
+    // Registration membership is still what decides whether the entry appears
+    // at all — the sentinel only decides what it says.
     static V3_DECLARED_COUNTER_GROUP: AcquisitionGroup =
         AcquisitionGroup::new("unattributed", "counter_group_probe");
 
@@ -3735,9 +3746,9 @@ mod tests {
             "index 0 nonzero as written"
         );
         assert_eq!(
-            declared.counters[idx1],
-            Some(0),
-            "index 1 included as an honest Some(0), not suppressed"
+            declared.counters[idx1], None,
+            "index 1 is included by registration but reads as absent, not as a \
+             zero a consumer would take for a measurement (metriken 0.11 sentinel)"
         );
 
         let default_group = s
@@ -4663,10 +4674,13 @@ mod tests {
     /// This is what keeps a partially-allocated sampler honest. A group whose
     /// members are, say, CPUs 16-31 cannot say so with a bound — a bound means
     /// "the first N" — so it would have to declare 0..32 and let the CPUs it
-    /// never wrote publish `0`. An unwritten `CounterGroup` slot reads as zero,
-    /// not as absent, so that is a wrong value rather than missing data: a
-    /// consumer summing across the machine would understate it and see nothing
-    /// wrong.
+    /// never wrote speak for themselves. For the BPF-backed (externally backed)
+    /// groups this applies to, an untouched slot still reads `0`: the kernel
+    /// zero-fills that mmap and no sentinel can live in it. That is a wrong
+    /// value rather than missing data — a consumer summing across the machine
+    /// would understate it and see nothing wrong. (metriken 0.11 fixed the
+    /// OWNED case with a `u64::MAX` sentinel; externally backed groups are why
+    /// declaring the real member set still matters.)
     #[test]
     fn an_explicit_member_set_walks_only_its_own_indices() {
         // A bound: the dense prefix, as before.

--- a/src/agent/timing.rs
+++ b/src/agent/timing.rs
@@ -143,10 +143,14 @@ pub(crate) struct AcquisitionGroup {
     /// `member_bound` says "the first N indices"; some groups populate an
     /// arbitrary subset instead — a sampler allowed only part of the machine
     /// populates the CPUs it was allowed, which is rarely `0..n`. Declaring the
-    /// prefix anyway would leave the rest registered-but-never-written, and a
-    /// registered `CounterGroup` slot reads as `0`, not as absent. That is a
-    /// wrong value rather than missing data, which is the failure this whole
-    /// area exists to remove.
+    /// prefix anyway leaves the rest registered-but-never-written, and what
+    /// that publishes depends on the backing: an OWNED `CounterGroup` reads
+    /// `None` since metriken 0.11's `u64::MAX` sentinel, but an EXTERNALLY
+    /// backed one (a BPF mmap, which the kernel zero-fills and which therefore
+    /// cannot hold a sentinel) still reads `0`. That is a wrong value rather
+    /// than missing data, and BPF-backed per-CPU/per-cgroup groups are exactly
+    /// the ones a partial reservation under-populates — so this is the failure
+    /// this area exists to remove.
     member_set: OnceLock<Vec<usize>>,
     // Init-time flag: true means this group's acquisition IS the exposition
     // read itself (mmap-direct `PackedCounters`), not a sampler `refresh()`.


### PR DESCRIPTION
## Summary

Picks up the three crates published today:

| crate | from | to |
|---|---|---|
| `metriken` | 0.10.1 | 0.11.0 |
| `metriken-exposition` | 0.19.0 | 0.20.0 |
| `metriken-query` | 0.21.0 | 0.22.0 |

They move together by necessity — `metriken` 0.11 is breaking, and a tree cannot hold both 0.10 and 0.11 with the group types unifying.

## What actually changed here

The version edit is three lines. The rest is absorbing one semantic change.

**`metriken` 0.11 gives an owned `CounterGroup` the `u64::MAX` unwritten sentinel that `GaugeGroup` always had** (iopsystems/metriken#143), so an entry nobody wrote now reads `None` instead of `Some(0)`.

### The test that changes meaning, not just its expected value

`declared_group_includes_zero_counter_entries_default_group_skips_them` asserted `Some(0)` for an unwritten declared member. Its comment explained at length that the metriken API

> gives no way to independently distinguish "a member that is genuinely present and reads zero" from "a phantom slot that merely exists because the backing array got initialized"

metriken 0.11 gives exactly that way. So the assertion becomes `None`, and the comment now says what the test pins today. **The contract itself is unchanged in shape**: registration membership still decides whether the entry appears at all; the sentinel only decides what it says.

### Three doc comments rewritten, not deleted

`timing.rs:147`, `snapshot.rs:1145` and the `an_explicit_member_set_walks_only_its_own_indices` doc all justified `set_member_set` on the grounds that an unwritten `CounterGroup` slot reads as zero.

**That is still true — for externally backed groups.** A BPF mmap is memory the kernel zero-fills, so it cannot carry a sentinel, and an untouched slot there still reads `0`. Since BPF-backed per-CPU and per-cgroup groups are precisely the ones a partial PMU reservation under-populates (the #1096 failure: `cpu_cycles = [0, 0, 0, 0]` on skipped CPUs), the reasoning holds exactly where it always mattered. It just needed scoping to the backing rather than stated as universal.

That owned-vs-external split is the thing most likely to trip up the next reader, so it is now written down in all three places.

### Backlog

`docs/backlog.md`'s **"`GPU_ENERGY_CONSUMPTION` can publish a fabricated zero"** is closed for owned groups, and left open — scoped — for externally backed ones.

## Verification

- [x] `cargo test --bins` — 690 pass, 0 fail
- [x] `node --test tests/*.mjs` — 261 tests, 0 fail
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `scripts/check-viewer-symlinks.sh` — 57 modules resolve

Exactly one test failed on the bare version bump, and it was the one predicted before the bump was made, with the predicted message:

```
assertion `left == right` failed: index 1 included as an honest Some(0), not suppressed
  left: None
 right: Some(0)
```

## Follow-on

`metriken-query` 0.22 also ships `MatrixSample::bands` and `MatrixSample::interpolated`. Nothing here consumes them yet — the branch that does is `wip/interpolated-renderer`, which is waiting on the decimated display path (`crates/dashboard/src/display_wire.rs`) to carry the flag, since line charts default to that path and would otherwise never show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KheDzaD5bnVWcmdocmk2eW
