### PR TITLE
deps: metriken-query 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "metriken-query"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d7eb6704ca2d779622605a0323a318961cdd4c3e1c8f0192bde8d9646a59c3"
+checksum = "809a0fc88f20c965131bb856f7a93cf32d36f99ffddd1850260981cdbf26ca0e"
 dependencies = [
  "arrow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libloading = "0.8"
 log = "0.4.29"
 metriken = "0.11.0"
 metriken-exposition = "0.20.0"
-metriken-query = { version = "0.22.0", default-features = false }
+metriken-query = { version = "0.23.0", default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"


### PR DESCRIPTION
## Summary

Picks up `metriken-query` **0.23.0**, published today from iopsystems/metriken#147 and #148.

| crate | from | to |
|---|---|---|
| `metriken-query` | 0.22.0 | **0.23.0** |
| `metriken` | 0.11.0 | *unchanged* |
| `metriken-exposition` | 0.20.0 | *unchanged* |

One crate this time, not three. The last bump (#1188) moved all three together because a breaking change in `metriken` cascades down the chain — a tree cannot hold both 0.10 and 0.11 with the group types unifying. Nothing cascades here: #147 touched only `metriken-query`, so the lockfile moves exactly one package.

## No code changes — and that's a property of this tree, not luck

0.23.0 is breaking **twice over**, so a clean build deserves an explanation rather than a shrug. Both breaks structurally miss us:

- **`EnvPoint` is now `#[non_exhaustive]`** and gains `interpolated: bool`. We never name the type, let alone construct one. `display_wire.rs` only *receives* them through `DisplaySeries::points` and reads fields off them — and `#[non_exhaustive]` restricts construction and exhaustive matching, not field reads.
- **`Reducer::reduce` changed signature** from `(points, intervals, budget, band)` to `(points, bands, interpolated, budget, band)`. We use `Reducer` only as the `Boxplot` variant handed to `DisplayOptions`; the call itself is internal to metriken-query.

I checked both by grep rather than inferring them from a green build.

## Why this lands on its own

Deliberately ahead of the change that *consumes* 0.23, so everything depending on `metriken-query` can converge on one minor version instead of straddling 0.22 and 0.23 while the renderer work is still in flight.

What 0.23 actually unlocks, landing separately: display-mode decimation now carries the `interpolated` flag and reduces from the lossless per-point `bands` instead of the all-or-nothing `intervals`. That was the blocker — rezolus draws line charts through display mode **by default**, so an interpolated segment was correct on the matrix path and invisible on the path users actually see. The follow-up adds an `interp` header flag plus one f64 column in `display_wire.rs` (mirroring the existing `unc` flag's two) and the matching decoder in `data.js`.

## Verification

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --bins` — 690 pass, 0 fail
- [x] `node --test tests/*.mjs` — 261 tests, 0 fail
- [x] `cargo clippy --workspace --all-targets` — clean, no warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `scripts/check-viewer-symlinks.sh` — 57 modules resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KheDzaD5bnVWcmdocmk2eW
