### PR TITLE
ci: use current record flags and smoke-test the .rez default output

### DIFF
--- a/.claude/skills/document-feature/SKILL.md
+++ b/.claude/skills/document-feature/SKILL.md
@@ -35,12 +35,12 @@ the feature, each paired with the **exact correct invocation**. For example:
 
 ```
 Task: record from a Prometheus endpoint for 5 minutes, tagging the source as "llm-perf"
-Cmd:  rezolus record --metadata source=llm-perf --duration 5m http://host:9090/metrics out.parquet
+Cmd:  rezolus record --metadata source=llm-perf --duration 5m --url http://host:9090/metrics -o out.parquet
 ```
 
 **Cover the command's distinct modes, not just the happy path.** If the command
 has mutually-exclusive input modes, output formats, or a flag that changes the
-shape of the run (e.g. `record`'s positional-URL vs `--endpoint` vs `--config`,
+shape of the run (e.g. `record`'s `--url` vs `--endpoint` vs `--config`,
 or `--separate`), give each its own task. This matters because the blind sims in
 step 3 are your strongest signal, and a sim can only exercise a surface you wrote
 a task for — if every task is single-endpoint, the sims stay silent on the

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -327,7 +327,13 @@ jobs:
           cargo build ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }}
           sudo ./target/release/rezolus config/agent.toml & echo $! > agent.pid
           sleep 15
-          ./target/release/rezolus record --duration 30s http://127.0.0.1:4241 rezolus.parquet
+          ./target/release/rezolus record --duration 30s --url http://127.0.0.1:4241 -o rezolus.parquet
+          test -s rezolus.parquet
+          # default output format: no -o means rezolus.rez, which exercises the
+          # v3 SQLite writer, finalization, and reading the archive back
+          ./target/release/rezolus record --duration 10s --url http://127.0.0.1:4241
+          test -s rezolus.rez
+          ./target/release/rezolus recording metadata -i rezolus.rez
           # wrap mode: record a command against the live agent for its lifetime
           ./target/release/rezolus record --url http://127.0.0.1:4241 -o wrap.parquet -- sleep 3
           test -s wrap.parquet
@@ -348,7 +354,13 @@ jobs:
           cargo build ${{ env.FEATURE_FLAGS }} --locked ${{ env.FLAGS }}
           sudo ./target/debug/rezolus config/agent.toml & echo $! > agent.pid
           sleep 15
-          ./target/debug/rezolus record --duration 30s http://127.0.0.1:4241 rezolus.parquet
+          ./target/debug/rezolus record --duration 30s --url http://127.0.0.1:4241 -o rezolus.parquet
+          test -s rezolus.parquet
+          # default output format: no -o means rezolus.rez, which exercises the
+          # v3 SQLite writer, finalization, and reading the archive back
+          ./target/debug/rezolus record --duration 10s --url http://127.0.0.1:4241
+          test -s rezolus.rez
+          ./target/debug/rezolus recording metadata -i rezolus.rez
           # wrap mode: record a command against the live agent for its lifetime
           ./target/debug/rezolus record --url http://127.0.0.1:4241 -o wrap.parquet -- sleep 3
           test -s wrap.parquet

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ site/viewer/templates/manifest.json
 **/*.rs.bk
 .worktrees/
 results/
-# default `rezolus record` output file (repo root only)
+# default `rezolus record` output files (repo root only)
+/rezolus.rez
 /rezolus.parquet

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -78,7 +78,7 @@ class="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white/95 dar
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.1</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -78,7 +78,7 @@ class="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white/95 dar
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.1</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/cli.html
+++ b/site/docs/cli.html
@@ -78,7 +78,7 @@ class="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white/95 dar
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.1</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -78,7 +78,7 @@ class="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white/95 dar
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.1</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -80,7 +80,7 @@ class="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white/95 dar
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.1</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -78,7 +78,7 @@ class="lg:hidden border-t border-slate-200 dark:border-slate-800 bg-white/95 dar
 <!-- Sidebar -->
 <aside class="h-[calc(100vh-5rem)] w-56 sticky top-20 hidden lg:flex flex-col p-6 border-r border-slate-100 dark:border-slate-800 shrink-0">
 <div class="mb-8">
-<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.0</div>
+<div class="font-mono text-[10px] uppercase tracking-widest text-slate-400">v5.19.1</div>
 </div>
 <nav class="flex-1 space-y-6 overflow-y-auto text-sm">
 <div class="space-y-1">


### PR DESCRIPTION
## Summary

- The smoketest's first `record` call still used the deprecated positional URL/OUTPUT form and printed `note: the positional URL is deprecated, use --url` on every run. It predates those flags (#559); the calls added beside it in #981 already use the flag form. Unit coverage of the deprecated path is unaffected (`resolve_url_positional_is_deprecated`, `resolve_output_positional_is_deprecated`).
- The 30s recording was never checked — the longest step in the smoketest proved only that the process exited 0. Now `test -s`, matching how `wrap.parquet` is already verified.
- `.rez` is the default output format and CI never exercised it; every call passed an explicit `.parquet`. Adds a short run with no `-o` plus `recording metadata -i` to read the archive back, covering the v3 SQLite writer, finalization, and the reader end to end.
- `.gitignore` listed only `/rezolus.parquet` under a comment reading "default `rezolus record` output file". The default is `.rez` now, so a bare `record` in the repo root left an untracked archive behind.
- The `document-feature` skill's worked example — labelled "the exact correct invocation" — taught the deprecated positional form.

The new `.rez` run keeps `--url` explicit rather than relying on the default endpoint: the agent binds `0.0.0.0:4241` (IPv4 only) while `DEFAULT_URL` is `http://localhost:4241`, and `resolve_url(None, None)` already has unit coverage, so there's no reason to make a CI test depend on how the runner resolves `localhost`.

Noticed while looking into a smoketest log that also surfaced #1189 (`cpu_l3` reporting `failed` on a VM with no vPMU) — that one is a separate agent-side bug, not addressed here.

## Test plan

- [x] `cargo fmt --check` clean (no Rust changed)
- [x] Workflow YAML re-parses
- [x] `recording metadata -i out.rez` confirmed against the subcommand's own documented form (`src/parquet_tools/mod.rs`)
- [x] `tests/record_lifecycle.rs` already uses `--endpoint`/`-o`; CI and the skill file were the only stale callers
- [ ] CI green on this PR — the smoketest steps are the thing under test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiTCtTsw3AnNjAeHLj4Pyy