### PR TITLE
feat(viewer): draw unobserved stretches as a dashed, band-less segment

### DIFF
--- a/crates/dashboard/src/display_wire.rs
+++ b/crates/dashboard/src/display_wire.rs
@@ -84,13 +84,23 @@ pub fn display_query(
 /// each `n` little-endian f64. A series carrying a measurement-uncertainty band
 /// sets the header `unc` flag and appends two more columns (`uncLo,uncHi`,
 /// `NaN` for points without a band) after the six — so a mixed response stays
-/// self-describing. Padding keeps the first f64 8-byte aligned so the client can
-/// view columns as `Float64Array`s with zero copies.
+/// self-describing. A series with interpolated points then sets `interp` and
+/// appends one more (`1.0`/`0.0` per point). Order is fixed: the six, then the
+/// two `unc` columns if flagged, then the one `interp` column if flagged, so a
+/// decoder that reads the flags in that order stays aligned whichever
+/// combination a series has. Padding keeps the first f64 8-byte aligned so the
+/// client can view columns as `Float64Array`s with zero copies.
 pub fn encode_display_binary(series: &[DisplaySeries], budget: u32) -> Vec<u8> {
     // A series carries a band iff any of its points does (a decimated bucket with
     // no intervals yields None). The flag lets the decoder know to read the two
     // extra columns for this series.
     let has_unc = |s: &DisplaySeries| s.points.iter().any(|p| p.unc_lo.is_some());
+    // Likewise for the interpolated flag: a series that never crosses an
+    // unobserved stretch pays nothing for the feature. Sent as f64 rather than a
+    // packed bitmap so it decodes as one more zero-copy `Float64Array` like
+    // every other column — one byte per point saved is not worth a second
+    // decode path.
+    let has_interp = |s: &DisplaySeries| s.points.iter().any(|p| p.interpolated);
     let header = serde_json::json!({
         "resultType": "series",
         "budget": budget,
@@ -104,6 +114,7 @@ pub fn encode_display_binary(series: &[DisplaySeries], budget: u32) -> Vec<u8> {
                 "band": s.band,
                 "decimated": s.decimated,
                 "unc": has_unc(s),
+                "interp": has_interp(s),
                 "n": s.points.len(),
             }))
             .collect::<Vec<_>>(),
@@ -111,7 +122,7 @@ pub fn encode_display_binary(series: &[DisplaySeries], budget: u32) -> Vec<u8> {
     let header_bytes = serde_json::to_vec(&header).unwrap_or_default();
     let total_floats: usize = series
         .iter()
-        .map(|s| s.points.len() * if has_unc(s) { 8 } else { 6 })
+        .map(|s| s.points.len() * (6 + if has_unc(s) { 2 } else { 0 } + usize::from(has_interp(s))))
         .sum();
 
     let mut buf = Vec::with_capacity(4 + header_bytes.len() + 8 + total_floats * 8);
@@ -148,6 +159,13 @@ pub fn encode_display_binary(series: &[DisplaySeries], budget: u32) -> Vec<u8> {
             }
             for p in &s.points {
                 buf.extend_from_slice(&p.unc_hi.unwrap_or(f64::NAN).to_le_bytes());
+            }
+        }
+        // Interpolated column last, so it does not shift the `unc` columns for a
+        // series that has both.
+        if has_interp(s) {
+            for p in &s.points {
+                buf.extend_from_slice(&f64::from(u8::from(p.interpolated)).to_le_bytes());
             }
         }
     }
@@ -197,4 +215,131 @@ pub fn encode_heatmap_binary(hm: &HistogramHeatmapResult) -> Vec<u8> {
         buf.extend_from_slice(&(*bucket_idx as u32).to_le_bytes());
     }
     buf
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use metriken_query::display::{DisplaySeries, EnvPoint};
+
+    use super::*;
+
+    /// Decode a body back into (header, per-series f64 columns) the way the
+    /// browser does, so a test asserts against the bytes actually shipped
+    /// rather than against the encoder's own internals.
+    fn decode(buf: &[u8]) -> (serde_json::Value, Vec<Vec<f64>>) {
+        let header_len = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
+        let header: serde_json::Value = serde_json::from_slice(&buf[4..4 + header_len]).unwrap();
+        let mut off = (4 + header_len).div_ceil(8) * 8;
+        let mut cols = Vec::new();
+        for s in header["series"].as_array().unwrap() {
+            let n = s["n"].as_u64().unwrap() as usize;
+            let ncols = 6
+                + if s["unc"].as_bool().unwrap() { 2 } else { 0 }
+                + if s["interp"].as_bool().unwrap() { 1 } else { 0 };
+            for _ in 0..ncols {
+                let mut col = Vec::with_capacity(n);
+                for _ in 0..n {
+                    col.push(f64::from_le_bytes(buf[off..off + 8].try_into().unwrap()));
+                    off += 8;
+                }
+                cols.push(col);
+            }
+        }
+        // Every byte after the header must be accounted for by the flags; a
+        // leftover means the encoder wrote a column the header does not
+        // describe, which is exactly how a decoder silently misaligns.
+        assert_eq!(off, buf.len(), "trailing bytes the header did not describe");
+        (header, cols)
+    }
+
+    fn series(name: &str, points: Vec<EnvPoint>) -> DisplaySeries {
+        DisplaySeries {
+            metric: HashMap::from([("__name__".into(), name.into())]),
+            points,
+            native_interval: 1.0,
+            raw_points: 3,
+            reducer: Reducer::Boxplot,
+            band: [0.25, 0.75],
+            decimated: true,
+        }
+    }
+
+    fn pt(t: f64, v: f64) -> EnvPoint {
+        EnvPoint::new(t, v, v, v, v, v)
+    }
+
+    #[test]
+    fn a_series_with_no_interpolated_points_pays_nothing() {
+        let s = series("a", vec![pt(1.0, 5.0), pt(2.0, 6.0)]);
+        let (header, cols) = decode(&encode_display_binary(&[s], 500));
+        assert_eq!(header["series"][0]["interp"], serde_json::json!(false));
+        assert_eq!(cols.len(), 6, "six columns, no optional ones");
+    }
+
+    #[test]
+    fn the_interp_column_is_written_after_the_unc_pair() {
+        // Both optional column sets present. Distinct values throughout so a
+        // wrong ORDER shows up as wrong data rather than as plausible numbers —
+        // this is the property the hand-written JS mirror in
+        // tests/display_binary_decode.test.mjs depends on.
+        let s = series(
+            "a",
+            vec![
+                pt(1.0, 5.0)
+                    .with_band(Some((10.0, 11.0)))
+                    .with_interpolated(true),
+                pt(2.0, 6.0)
+                    .with_band(Some((20.0, 21.0)))
+                    .with_interpolated(false),
+            ],
+        );
+        let (header, cols) = decode(&encode_display_binary(&[s], 500));
+        assert_eq!(header["series"][0]["unc"], serde_json::json!(true));
+        assert_eq!(header["series"][0]["interp"], serde_json::json!(true));
+        assert_eq!(cols.len(), 9);
+        assert_eq!(cols[6], vec![10.0, 20.0], "uncLo");
+        assert_eq!(cols[7], vec![11.0, 21.0], "uncHi");
+        assert_eq!(cols[8], vec![1.0, 0.0], "interp, last");
+    }
+
+    #[test]
+    fn interp_without_a_band_still_lands_in_the_seventh_column() {
+        // The combination the renderer actually hits: rate() across a hole
+        // yields a value with NO band and the interpolated flag set. With `unc`
+        // false the interp column moves from index 8 to index 6, which is the
+        // whole reason the decoder must branch on both flags in order.
+        let s = series("a", vec![pt(1.0, 5.0).with_interpolated(true)]);
+        let (header, cols) = decode(&encode_display_binary(&[s], 500));
+        assert_eq!(header["series"][0]["unc"], serde_json::json!(false));
+        assert_eq!(cols.len(), 7);
+        assert_eq!(cols[6], vec![1.0]);
+    }
+
+    #[test]
+    fn mixed_series_each_declare_their_own_columns() {
+        // Three series with different flag combinations in one body. The decode
+        // helper's trailing-byte assertion is what makes this bite: mis-size any
+        // series and the later ones read into the wrong bytes.
+        let a = series("a", vec![pt(1.0, 1.0).with_interpolated(true)]);
+        let b = series("b", vec![pt(1.0, 2.0)]);
+        let c = series("c", vec![pt(1.0, 3.0).with_band(Some((7.0, 8.0)))]);
+        let (header, cols) = decode(&encode_display_binary(&[a, b, c], 500));
+        assert_eq!(header["series"][0]["interp"], serde_json::json!(true));
+        assert_eq!(header["series"][1]["interp"], serde_json::json!(false));
+        assert_eq!(header["series"][2]["interp"], serde_json::json!(false));
+        // 7 + 6 + 8
+        assert_eq!(cols.len(), 21);
+        assert_eq!(cols[6], vec![1.0], "a's interp column");
+        // a occupies 0..=6 (7 cols), b 7..=12 (6), so c starts at 13: its
+        // columns are t,min,lo,median,hi,max,uncLo,uncHi = 13..=20.
+        assert_eq!(cols[13], vec![1.0], "c's t");
+        assert_eq!(cols[16], vec![3.0], "c's median, still aligned");
+        assert_eq!(
+            cols[20],
+            vec![8.0],
+            "c's uncHi, the last column in the body"
+        );
+    }
 }

--- a/src/viewer/assets/lib/charts/boxplot.js
+++ b/src/viewer/assets/lib/charts/boxplot.js
@@ -16,6 +16,52 @@ const zipMs = (t, col) => {
     return out;
 };
 
+// Build the dashed, desaturated overlay that redraws the stretches of a series
+// the producer never observed, or `[]` when there are none.
+//
+// Shared by both render paths on purpose: the matrix path (line.js, a plain
+// line) and the display path (buildBoxplotSeries, a median line over bands)
+// must draw a hole identically, or the same recording tells two different
+// visual stories depending on which path happened to fetch it. That is the bug
+// this whole feature exists to fix, so the styling lives in exactly one place.
+//
+// `t` is in seconds; the returned data is in ms like every other series here.
+// The run is extended one point either side so the segment joins the measured
+// line rather than floating detached.
+export function buildInterpolatedOverlay({ t, values, flags, name, color, z = 3 }) {
+    if (!Array.isArray(flags) || flags.length !== t.length) return [];
+    if (!flags.some(Boolean)) return [];
+
+    const pts = new Array(t.length);
+    let any = false;
+    for (let i = 0; i < t.length; i++) {
+        // A point is drawn when it is interpolated or neighbours one — the
+        // neighbour is the anchor; everything else is a null so echarts breaks
+        // the line rather than connecting across measured ground.
+        if (flags[i] || flags[i - 1] || flags[i + 1]) {
+            pts[i] = [t[i] * 1000, values[i]];
+            if (flags[i]) any = true;
+        } else {
+            pts[i] = [t[i] * 1000, null];
+        }
+    }
+    if (!any) return [];
+
+    return [{
+        type: 'line',
+        name,
+        data: pts,
+        showSymbol: false,
+        symbol: 'none',
+        silent: true,
+        z,
+        connectNulls: false,
+        tooltip: { show: false },
+        lineStyle: { color, width: 2, opacity: 0.35, type: 'dashed' },
+        areaStyle: undefined,
+    }];
+}
+
 const zipDiffMs = (t, base, top) => {
     const n = t.length;
     const out = new Array(n);
@@ -67,9 +113,19 @@ export function buildBoxplotSeries(s, opts = {}) {
         noMedian = false,
         // Draw-order offset so a caller with N series can stack them
         // consistently: a higher zBase draws on top. Series' internal levels
-        // span zBase+1..zBase+3, so callers should stride zBase by ≥4.
+        // span zBase+1..zBase+3, so callers should stride zBase by ≥4. (The
+        // interpolated overlay shares +3 with the median and relies on array
+        // order, precisely to keep that span three levels wide.)
         zBase = 0,
+        // Per-point flags marking values that span time nobody observed. When
+        // set, those points are cut out of the median line and redrawn as a
+        // dashed overlay, exactly as the plain-line path does.
+        interpolated = null,
     } = opts;
+
+    const interp = Array.isArray(interpolated) && interpolated.length === s.t.length
+        ? interpolated
+        : null;
 
     // Invisible baseline line that only establishes the stack floor. Hidden
     // from the tooltip so only the median row shows.
@@ -146,10 +202,33 @@ export function buildBoxplotSeries(s, opts = {}) {
     }
     // robust median line on top (skipped when the caller draws its own line)
     if (!noMedian) {
+        // Interpolated points are removed from the median line and left to the
+        // overlay. Drawing both put a 0.35-opacity dash directly over a solid
+        // line of the same colour, which reads as the solid line — the overlay
+        // was invisible until the nominal stopped covering it.
+        const median = zipMs(s.t, s.median);
+        if (interp) {
+            for (let i = 0; i < median.length; i++) {
+                if (interp[i]) median[i] = [median[i][0], null];
+            }
+            // Cutting points out can strand a MEASURED point between two holes,
+            // and a lone point on a `symbol: 'none'` line draws nothing at all —
+            // so the one sample that was actually observed there would vanish,
+            // which is the exact inversion of what this feature is for. Give
+            // just those points a visible dot.
+            for (let i = 0; i < median.length; i++) {
+                if (interp[i]) continue;
+                const prevGone = i === 0 || interp[i - 1];
+                const nextGone = i === median.length - 1 || interp[i + 1];
+                if (prevGone && nextGone) {
+                    median[i] = { value: median[i], symbol: 'circle', symbolSize: 4 };
+                }
+            }
+        }
         out.push({
             name,
             type: 'line',
-            data: zipMs(s.t, s.median),
+            data: median,
             symbol: 'none',
             lineStyle: { color: lineColor, width: 1.5 },
             // Legend/tooltip markers read `itemStyle.color`, NOT `lineStyle.color`
@@ -157,8 +236,25 @@ export function buildBoxplotSeries(s, opts = {}) {
             // so the legend swatch wouldn't match the drawn line.
             itemStyle: { color: lineColor },
             emphasis: { focus: 'series' },
+            // Explicit: the nulls punched above must render as breaks, not be
+            // bridged. echarts defaults this to false, but the median line is
+            // the one series here whose nulls now carry meaning.
+            connectNulls: false,
             z: zBase + 3,
         });
+        // ...and the dashed overlay redraws what was just cut. Same z as the
+        // median rather than zBase+4: the levels here are documented as
+        // zBase+1..+3 with callers striding zBase by 4, and +4 would sit inside
+        // the NEXT series' range. Equal z is enough — echarts draws later array
+        // entries on top, and this is pushed after the median.
+        out.push(...buildInterpolatedOverlay({
+            t: s.t,
+            values: s.median,
+            flags: interp,
+            name,
+            color: lineColor,
+            z: zBase + 3,
+        }));
     }
     return out;
 }

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -19,7 +19,12 @@ import {
     COLORS,
 } from './base.js';
 import { FONTS } from './util/fonts.js';
-import { buildBoxplotSeries, buildEnvelopeLines, buildDivergenceBand } from './boxplot.js';
+import {
+    buildBoxplotSeries,
+    buildEnvelopeLines,
+    buildDivergenceBand,
+    buildInterpolatedOverlay,
+} from './boxplot.js';
 import { chartSwatches, renderSwatchRow, SWATCH_ROW_HEIGHT } from './swatches.js';
 import { executePromQLRangeQuery, applyResultToPlot } from '../data.js';
 
@@ -56,6 +61,9 @@ export function configureLineChart(chart) {
                 // Optional rate() uncertainty band, parallel to valueData.
                 // Absent (undefined) for non-rate queries → no band drawn.
                 intervals: chart.spec.intervals,
+                // Which values span a stretch the producer never read; see
+                // buildInterpolatedSeries.
+                interpolated: chart.spec.interpolated,
             }]
             : []);
 
@@ -91,6 +99,12 @@ export function configureLineChart(chart) {
             stackId: `bp${i}`,
             lineColor: seriesList[i]?.color || COLORS.accent,
             zBase: (boxplotCols.length - 1 - i) * 4,
+            // Single-series only, mirroring `intervals` vs `series_intervals`:
+            // data.js sets `interpolated` for one series and null for many, and
+            // multi-series bands here are already a stated follow-up. Without
+            // this the display path — the DEFAULT for line charts — renders a
+            // hole in the same ink as measured data, which is the whole bug.
+            interpolated: boxplotCols.length === 1 ? chart.spec.interpolated : null,
         }))
         : seriesList.flatMap((s, idx) => {
         // Compare-mode entry carrying a decimated boxplot (median + min/max):
@@ -106,7 +120,19 @@ export function configureLineChart(chart) {
             });
         }
 
+        // Interpolated points are cut OUT of the nominal and left to the dashed
+        // overlay, rather than drawn by both. Drawing them twice made the
+        // overlay invisible — same colour, same path, and a 0.35-opacity dash
+        // over a solid line of the same hue reads as the solid line. Removing
+        // them means the only thing rendered across a hole is the dashed
+        // segment, which is the point: the chart should not show an unobserved
+        // stretch in the same ink as a measured one.
+        const interp = Array.isArray(s.interpolated)
+            && s.interpolated.length === s.timeData.length
+            ? s.interpolated
+            : null;
         const zippedRaw = s.timeData.map((t, i) => {
+            if (interp && interp[i]) return [t * 1000, null, null];
             const [v, raw] = clampToRange(s.valueData[i], range);
             return [t * 1000, v, raw];
         });
@@ -174,7 +200,13 @@ export function configureLineChart(chart) {
         // series carries rate() acquisition-window bounds. Implemented as a
         // two-series stack: an invisible `lo` baseline plus a `hi-lo` delta
         // whose filled area spans lo→hi. z:1 keeps it under the line (z:2).
-        return [...buildBandSeries(s, idx, range, chart.interval), base];
+        // The interpolated overlay goes on top (z:3) so a drained, dashed
+        // segment reads over the solid nominal rather than under it.
+        return [
+            ...buildBandSeries(s, idx, range, chart.interval),
+            base,
+            ...buildInterpolatedSeries(s, range),
+        ];
     });
 
     // Compare-mode line overlays want relative-time labels (+Xs) on
@@ -252,6 +284,40 @@ export function configureLineChart(chart) {
     }
 
     ensureTotalToggle(chart);
+}
+
+// Build the echarts series that redraws the interpolated stretches of `s` in a
+// desaturated colour, or `[]` when the series has none.
+//
+// A point flagged `interpolated` was not observed: the series was null across
+// that stretch and rate() spanned it, because the total across a hole is known
+// even though its distribution inside is not. It carries no uncertainty band,
+// because an unobserved interval's honest bound is not a number — so without
+// this the point is indistinguishable from a measured one.
+//
+// Drawn as an overlay rather than by restyling the main line: echarts has no
+// per-segment lineStyle, and the alternatives are worse. Splitting the nominal
+// into observed/interpolated series doubles the legend and the tooltip
+// handling; a shaded time region cannot say WHICH series has the hole, which
+// matters in compare mode where captures have holes at different times. The
+// overlay keeps the series' identity and colour, just drained.
+//
+// The run is extended one point either side so the desaturated segment joins
+// the solid line rather than floating detached.
+export function buildInterpolatedSeries(s, range) {
+    const flags = s.interpolated;
+    if (!Array.isArray(flags) || flags.length !== s.timeData.length) return [];
+    // Clamp first so the overlay tracks the same clipped values the nominal
+    // line draws; the shared builder handles run detection and styling.
+    const values = s.valueData.map((v) => clampToRange(v, range)[0]);
+    return buildInterpolatedOverlay({
+        t: s.timeData,
+        values,
+        flags,
+        name: s.name,
+        color: s.color || COLORS.accent,
+        z: 3,
+    });
 }
 
 // Build the echarts series pair that renders a series' uncertainty band,

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -116,6 +116,14 @@ export const decodeDisplayBinary = (buf) => {
             out.uncHi = new Float64Array(buf, off, s.n);
             off += s.n * 8;
         }
+        // Then, if flagged, one more column marking the points that span a
+        // stretch the producer never read. Read AFTER the unc columns because
+        // the encoder writes it last; reading it earlier would silently
+        // misalign every series that carries both.
+        if (s.interp) {
+            out.interpCol = new Float64Array(buf, off, s.n);
+            off += s.n * 8;
+        }
         return out;
     });
     return { resultType: header.resultType, budget: header.budget, series };
@@ -339,6 +347,26 @@ export const displayIntervals = (s) => {
     return any ? out : null;
 };
 
+// Convert a decoded display series' interpolated column into the boolean array
+// parseInterpolated produces on the matrix path, so line.js consumes one shape
+// regardless of which path fetched the data. Returns null when the series has
+// no interpolated points — the renderer treats null and all-false alike, but
+// returning null keeps `plot.interpolated` falsy so nothing downstream has to
+// distinguish "no flag sent" from "flag sent, all clear".
+export const displayInterpolated = (s) => {
+    if (!s || !s.interpCol) return null;
+    let any = false;
+    const out = new Array(s.interpCol.length);
+    for (let i = 0; i < s.interpCol.length; i++) {
+        // The encoder writes exactly 1.0 or 0.0, but decimation upstream could
+        // in principle produce a fraction; treat anything non-zero as set
+        // rather than testing equality against 1.
+        out[i] = s.interpCol[i] !== 0;
+        if (out[i]) any = true;
+    }
+    return any ? out : null;
+};
+
 // Store a decoded display response on the plot. `data` carries the median
 // line(s) so all existing chart machinery (axis extent, zoom, no-data
 // detection, change-detection) works unchanged; `boxplot` carries the
@@ -352,6 +380,10 @@ const applyDisplayToPlot = (plot, decoded) => {
         plot.series_metrics = [];
         plot.intervals = null;
         plot.series_intervals = [];
+        // Cleared with the rest: an empty response after a series that had a
+        // hole would otherwise leave the flag set, and line.js would index a
+        // stale array against the next render's timestamps.
+        plot.interpolated = null;
         return;
     }
     const timestamps = Array.from(series[0].t);
@@ -376,6 +408,11 @@ const applyDisplayToPlot = (plot, decoded) => {
         plot.intervals = displayIntervals(series[0]);
         plot.series_intervals = [];
     }
+    // The dashed interpolated overlay is a single-series line affordance, the
+    // same as `intervals` above: line.js reads `plot.interpolated`, and multi
+    // and scatter have no overlay to draw. Cleared in the multi case so a
+    // previous single-series render cannot leave a stale flag behind.
+    plot.interpolated = series.length > 1 ? null : displayInterpolated(series[0]);
     // Resolve the render style the same way the JSON path does: percentile
     // histograms → scatter, single line-ish → line, multi line-ish → multi.
     plot._resolvedStyle = plot.opts?.style
@@ -545,7 +582,14 @@ export const promqlResultToHeatmapTriples = (results) => {
 // and drop malformed pairs to null. Returns null when nothing is usable
 // so callers can treat "has a band" as a simple truthiness check.
 export const parseIntervals = (sample) => {
-    const iv = sample && sample.intervals;
+    // `bands` is the lossless form: present when ANY value has a band, with a
+    // null entry where one does not (a point interpolated across a stretch the
+    // producer never read). `intervals` is all-or-nothing and goes absent for
+    // the whole series as soon as one point lacks a band, so prefer `bands`
+    // where the producer offers it and fall back for older responses. Per-entry
+    // nulls need no special handling — the loop below already maps a malformed
+    // or missing pair to null, and `buildBandSeries` already draws a gap there.
+    const iv = (sample && (sample.bands || sample.intervals)) || null;
     if (!Array.isArray(iv) || iv.length === 0) return null;
     const out = iv.map((pair) => {
         if (!Array.isArray(pair) || pair.length < 2) return null;
@@ -555,6 +599,22 @@ export const parseIntervals = (sample) => {
         return lo <= hi ? [lo, hi] : [hi, lo];
     });
     return out.some((p) => p !== null) ? out : null;
+};
+
+// Parse a series' optional `interpolated` field into a boolean array parallel
+// to `values`, or `null` when absent.
+//
+// A true entry marks a value the producer did not observe the interval of: the
+// series was null across a stretch, and rate() spanned it because the total is
+// known even though its distribution inside is not. Such a point carries no
+// band — an uncertainty interval answers "how precisely do we know the average
+// over THIS interval", and for an interval nobody watched that is not a number
+// — so this is the only thing distinguishing it from a measured point. Charts
+// render it differently rather than letting it pass as observed.
+export const parseInterpolated = (sample) => {
+    const flags = sample && sample.interpolated;
+    if (!Array.isArray(flags) || flags.length === 0) return null;
+    return flags.some(Boolean) ? flags.map(Boolean) : null;
 };
 
 // Convert the first series in a PromQL range-query result into a pair
@@ -691,8 +751,12 @@ const applyResultToPlot = (plot, result) => {
                 plot.data = [timestamps, values];
                 // Optional rate() uncertainty band, parallel to values.
                 plot.intervals = parseIntervals(sample);
+                // Which of those values the producer never observed the
+                // interval of; see parseInterpolated.
+                plot.interpolated = parseInterpolated(sample);
             } else {
                 plot.data = [];
+                plot.interpolated = null;
             }
             // Line-style plots have no series legend; clear any stale entries
             // from a prior multi-series render so legends don't "ghost".

--- a/tests/display_binary_decode.test.mjs
+++ b/tests/display_binary_decode.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { decodeDisplayBinary } from '../src/viewer/assets/lib/data.js';
+import { decodeDisplayBinary, displayInterpolated } from '../src/viewer/assets/lib/data.js';
 
 // Build a display-mode binary buffer exactly as routes.rs
 // `encode_display_binary` does: [u32 LE headerLen][JSON header][pad to 8B]
@@ -10,6 +10,9 @@ function encode(series, budget = 500) {
     // columns; the header `unc` flag tells the decoder to read the two extra
     // columns after the six boxplot columns.
     const hasUnc = (s) => Array.isArray(s.uncLo) && Array.isArray(s.uncHi);
+    // ...and one more column when the series has interpolated points. Written
+    // AFTER the unc pair, matching the Rust encoder's fixed order.
+    const hasInterp = (s) => Array.isArray(s.interpCol);
     const header = {
         resultType: 'series',
         budget,
@@ -21,13 +24,14 @@ function encode(series, budget = 500) {
             band: s.band,
             decimated: s.decimated,
             unc: hasUnc(s),
+            interp: hasInterp(s),
             n: s.t.length,
         })),
     };
     const headerBytes = new TextEncoder().encode(JSON.stringify(header));
     const padded = Math.ceil((4 + headerBytes.length) / 8) * 8;
     const totalFloats = series.reduce(
-        (a, s) => a + s.t.length * (hasUnc(s) ? 8 : 6),
+        (a, s) => a + s.t.length * (6 + (hasUnc(s) ? 2 : 0) + (hasInterp(s) ? 1 : 0)),
         0,
     );
     const buf = new ArrayBuffer(padded + totalFloats * 8);
@@ -36,9 +40,11 @@ function encode(series, budget = 500) {
     new Uint8Array(buf, 4, headerBytes.length).set(headerBytes);
     let off = padded;
     for (const s of series) {
-        const cols = hasUnc(s)
-            ? ['t', 'min', 'lo', 'median', 'hi', 'max', 'uncLo', 'uncHi']
-            : ['t', 'min', 'lo', 'median', 'hi', 'max'];
+        const cols = [
+            't', 'min', 'lo', 'median', 'hi', 'max',
+            ...(hasUnc(s) ? ['uncLo', 'uncHi'] : []),
+            ...(hasInterp(s) ? ['interpCol'] : []),
+        ];
         for (const name of cols) {
             for (const v of s[name]) {
                 dv.setFloat64(off, v, true);
@@ -184,4 +190,88 @@ test('decodeDisplayBinary: odd-length header still 8-byte aligns the floats', ()
     const out = decodeDisplayBinary(encode([s]));
     assert.equal(out.series[0].median[0], 7);
     assert.equal(out.series[0].nativeInterval, 0.5);
+});
+
+// --- interpolated column -------------------------------------------------
+//
+// The column is optional and written LAST, after the optional unc pair. The
+// ordering is the whole risk: a decoder that reads `interp` before `unc`, or
+// that reads it for a series that didn't flag it, misaligns every subsequent
+// series in the buffer rather than failing loudly. So the cases below cover
+// each combination of the two flags, and a mixed multi-series buffer.
+
+const base = (over = {}) => ({
+    metric: { __name__: 'cpu_usage' },
+    nativeInterval: 1,
+    rawPoints: 10,
+    reducer: 'boxplot',
+    band: [0.25, 0.75],
+    decimated: true,
+    t: [100, 101, 102],
+    min: [1, 2, 3],
+    lo: [1, 2, 3],
+    median: [1, 2, 3],
+    hi: [1, 2, 3],
+    max: [1, 2, 3],
+    ...over,
+});
+
+test('interp column decodes when present without an unc pair', () => {
+    const out = decodeDisplayBinary(encode([base({ interpCol: [0, 1, 0] })]));
+    assert.deepEqual(Array.from(out.series[0].interpCol), [0, 1, 0]);
+    assert.deepEqual(displayInterpolated(out.series[0]), [false, true, false]);
+});
+
+test('interp column is read after unc, not before it', () => {
+    // The case that catches a decoder reading the columns in the wrong order:
+    // both flags set, and every column holds a distinct value so a swap shows up
+    // as wrong data rather than as a plausible-looking array.
+    const s = base({
+        uncLo: [10, 20, 30],
+        uncHi: [11, 21, 31],
+        interpCol: [1, 0, 1],
+    });
+    const got = decodeDisplayBinary(encode([s])).series[0];
+    assert.deepEqual(Array.from(got.uncLo), [10, 20, 30]);
+    assert.deepEqual(Array.from(got.uncHi), [11, 21, 31]);
+    assert.deepEqual(Array.from(got.interpCol), [1, 0, 1]);
+    assert.deepEqual(displayInterpolated(got), [true, false, true]);
+});
+
+test('a series without the flag exposes no interp column and no flags', () => {
+    const got = decodeDisplayBinary(encode([base()])).series[0];
+    assert.equal(got.interp, false);
+    assert.equal(got.interpCol, undefined);
+    assert.equal(displayInterpolated(got), null);
+});
+
+test('displayInterpolated returns null when the column is present but all clear', () => {
+    // Distinct from "no column": the encoder only sets the flag when some point
+    // is interpolated, but a decimated bucket could in principle clear them all.
+    // Both must read as falsy so the renderer draws no overlay.
+    const got = decodeDisplayBinary(encode([base({ interpCol: [0, 0, 0] })])).series[0];
+    assert.equal(displayInterpolated(got), null);
+});
+
+test('mixed series stay aligned when only some carry the extra columns', () => {
+    // The alignment case that matters in practice: three series in one buffer
+    // with different flag combinations. If the decoder mis-sizes any of them,
+    // the LATER series read garbage — so assert the last one hardest.
+    const a = base({ metric: { __name__: 'a' }, interpCol: [1, 1, 0] });
+    const b = base({ metric: { __name__: 'b' }, t: [200, 201, 202], median: [4, 5, 6] });
+    const c = base({
+        metric: { __name__: 'c' },
+        t: [300, 301, 302],
+        median: [7, 8, 9],
+        uncLo: [1, 1, 1],
+        uncHi: [2, 2, 2],
+        interpCol: [0, 0, 1],
+    });
+    const out = decodeDisplayBinary(encode([a, b, c])).series;
+    assert.deepEqual(displayInterpolated(out[0]), [true, true, false]);
+    assert.equal(displayInterpolated(out[1]), null);
+    assert.deepEqual(Array.from(out[2].t), [300, 301, 302]);
+    assert.deepEqual(Array.from(out[2].median), [7, 8, 9]);
+    assert.deepEqual(Array.from(out[2].uncHi), [2, 2, 2]);
+    assert.deepEqual(displayInterpolated(out[2]), [false, false, true]);
 });

--- a/tests/interpolated_points.test.mjs
+++ b/tests/interpolated_points.test.mjs
@@ -1,0 +1,186 @@
+// Points a producer never observed the interval of.
+//
+// `rate()` spans a hole in a series — the total across it is known even though
+// its distribution inside is not — but such a point carries no uncertainty
+// band, because the honest bound on an unobserved interval is not a number.
+// The `interpolated` flag is the only thing distinguishing it from a measured
+// point, and these cover the path from the wire response to the echarts series
+// that draws it differently.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// The chart modules read CSS custom properties at load; stub the DOM so their
+// palettes fall back to literals (same shim the other chart tests use).
+globalThis.document = globalThis.document || { documentElement: {} };
+globalThis.getComputedStyle =
+    globalThis.getComputedStyle || (() => ({ getPropertyValue: () => '' }));
+
+const { parseIntervals, parseInterpolated } = await import('../src/viewer/assets/lib/data.js');
+
+// The engine's response for a counter that reads at 3s/4s/5s, goes null, and
+// returns at 8s/9s. `bands` is null exactly where nobody observed the interval.
+const gapped = {
+    values: [[4, 100], [5, 100], [6, 133.33], [7, 133.33], [8, 133.33], [9, 100]],
+    bands: [[95.24, 105.26], [95.24, 105.26], null, null, null, [95.24, 105.26]],
+    interpolated: [false, false, true, true, true, false],
+};
+
+test('bands survive the points that have them when others do not', () => {
+    const iv = parseIntervals(gapped);
+    assert.equal(iv.length, 6, 'parallel to values');
+    assert.deepEqual(
+        iv.map((p) => p !== null),
+        [true, true, false, false, false, true],
+        'a hole nulls its own entry and leaves the rest alone',
+    );
+    assert.deepEqual(iv[0], [95.24, 105.26]);
+});
+
+test('bands is preferred over the all-or-nothing intervals field', () => {
+    // A response carrying both: `intervals` is the lossy legacy view and goes
+    // absent for the whole series as soon as one point lacks a band, so a
+    // reader that trusts it loses bands it could have drawn.
+    const both = { ...gapped, intervals: undefined };
+    assert.ok(parseIntervals(both), 'bands alone is enough');
+
+    // And an older response with only `intervals` still parses, unchanged.
+    const legacy = {
+        values: [[1, 5], [2, 6]],
+        intervals: [[4, 6], [5, 7]],
+    };
+    assert.deepEqual(parseIntervals(legacy), [[4, 6], [5, 7]]);
+});
+
+test('interpolated parses to a boolean array, or null when nothing is', () => {
+    assert.deepEqual(parseInterpolated(gapped), [false, false, true, true, true, false]);
+    assert.equal(
+        parseInterpolated({ interpolated: [false, false] }),
+        null,
+        'all-false is the same as absent — nothing to draw',
+    );
+    assert.equal(parseInterpolated({}), null, 'absent for non-rate queries');
+    assert.equal(parseInterpolated({ interpolated: 'nope' }), null, 'malformed');
+});
+
+const { buildInterpolatedSeries } = await import('../src/viewer/assets/lib/charts/line.js');
+
+const series = (flags) => ({
+    name: 'probe',
+    color: '#2E5BFF',
+    timeData: [4, 5, 6, 7, 8, 9],
+    valueData: [100, 100, 133.33, 133.33, 133.33, 100],
+    interpolated: flags,
+});
+
+test('the overlay covers the hole and anchors to the measured line', () => {
+    const [s] = buildInterpolatedSeries(series(gapped.interpolated), null);
+    assert.ok(s, 'an overlay is produced');
+
+    const drawn = s.data.map(([, v]) => v !== null);
+    // Indices 2,3,4 are interpolated; 1 and 5 are their measured neighbours and
+    // must be drawn too, or the dashed segment floats detached from the line.
+    assert.deepEqual(drawn, [false, true, true, true, true, true]);
+    assert.equal(s.lineStyle.type, 'dashed');
+    assert.ok(s.lineStyle.opacity < 1, 'desaturated relative to the nominal');
+    assert.equal(s.silent, true, 'the nominal line owns the tooltip');
+    assert.equal(s.color ?? s.lineStyle.color, '#2E5BFF', 'keeps the series identity');
+});
+
+test('no overlay when nothing is interpolated', () => {
+    assert.deepEqual(buildInterpolatedSeries(series([false, false, false, false, false, false]), null), []);
+    assert.deepEqual(buildInterpolatedSeries(series(null), null), []);
+    assert.deepEqual(
+        buildInterpolatedSeries(series([true, true]), null),
+        [],
+        'a flags array that does not match the data length is ignored',
+    );
+});
+
+// --- the display path -----------------------------------------------------
+//
+// These exist because the feature shipped broken on this path once already:
+// line.js draws a plain line ONLY when the plot carries no boxplot columns, and
+// the display path always carries them. So the overlay was wired into the
+// branch users never hit, and every unit test above still passed. The default
+// path needs its own coverage.
+
+const { buildBoxplotSeries, buildInterpolatedOverlay } =
+    await import('../src/viewer/assets/lib/charts/boxplot.js');
+
+// One decimated series: measured at 4s/5s, unobserved across 6s/7s/8s, measured
+// again at 9s — the same shape as `gapped` above, in decoded-column form.
+const cols = {
+    t: [4, 5, 6, 7, 8, 9],
+    min: [100, 100, 133, 133, 133, 100],
+    lo: [100, 100, 133, 133, 133, 100],
+    median: [100, 100, 133, 133, 133, 100],
+    hi: [100, 100, 133, 133, 133, 100],
+    max: [100, 100, 133, 133, 133, 100],
+    uncLo: [95, 95, NaN, NaN, NaN, 95],
+    uncHi: [105, 105, NaN, NaN, NaN, 105],
+};
+const FLAGS = [false, false, true, true, true, false];
+
+const medianOf = (out) => out.find((s) => s.name && s.lineStyle?.type !== 'dashed');
+const overlayOf = (out) => out.find((s) => s.lineStyle?.type === 'dashed');
+const yOf = (d) => (d && d.value ? d.value[1] : d ? d[1] : null);
+
+test('the display path draws a dashed overlay, not just the plain-line path', () => {
+    const out = buildBoxplotSeries(cols, { name: 'cpu_gap', interpolated: FLAGS });
+    const overlay = overlayOf(out);
+    assert.ok(overlay, 'boxplot render must emit the interpolated overlay');
+    assert.equal(overlay.lineStyle.opacity, 0.35);
+    assert.equal(overlay.silent, true);
+});
+
+test('interpolated points are cut out of the median line', () => {
+    const out = buildBoxplotSeries(cols, { name: 'cpu_gap', interpolated: FLAGS });
+    const ys = medianOf(out).data.map(yOf);
+    assert.deepEqual(ys, [100, 100, null, null, null, 100]);
+});
+
+test('a measured point stranded between holes stays visible', () => {
+    // Index 5 is measured but both neighbours are gone, and a lone point on a
+    // `symbol: 'none'` line draws nothing — so it must carry its own symbol or
+    // the only observed sample there disappears.
+    const out = buildBoxplotSeries(cols, { name: 'cpu_gap', interpolated: FLAGS });
+    const last = medianOf(out).data[5];
+    assert.equal(last.symbol, 'circle', 'stranded measured point needs a symbol');
+    assert.equal(yOf(last), 100);
+    // A point with a measured neighbour must NOT get one, or every series
+    // sprouts dots.
+    assert.equal(medianOf(out).data[0].symbol, undefined);
+});
+
+test('no flags means the median is untouched and no overlay appears', () => {
+    const out = buildBoxplotSeries(cols, { name: 'cpu_gap' });
+    assert.equal(overlayOf(out), undefined);
+    assert.deepEqual(medianOf(out).data.map(yOf), [100, 100, 133, 133, 133, 100]);
+});
+
+test('a flags array of the wrong length is ignored rather than misapplied', () => {
+    // Defensive: mis-indexing flags against values would mislabel which points
+    // were observed, which is worse than showing no overlay at all.
+    const out = buildBoxplotSeries(cols, { name: 'cpu_gap', interpolated: [true, false] });
+    assert.equal(overlayOf(out), undefined);
+    assert.deepEqual(medianOf(out).data.map(yOf), [100, 100, 133, 133, 133, 100]);
+});
+
+test('the overlay anchors one point either side of the run', () => {
+    const overlay = buildInterpolatedOverlay({
+        t: cols.t, values: cols.median, flags: FLAGS, name: 'x', color: '#fff',
+    })[0];
+    // index 0 is two steps from the run → null; 1 and 5 are the anchors.
+    assert.deepEqual(overlay.data.map((d) => d[1]), [null, 100, 133, 133, 133, 100]);
+});
+
+test('both render paths style a hole identically', () => {
+    // The point of sharing the builder: one recording must not look different
+    // depending on which path fetched it.
+    const viaDisplay = overlayOf(buildBoxplotSeries(cols, { name: 'x', interpolated: FLAGS }));
+    const viaMatrix = buildInterpolatedOverlay({
+        t: cols.t, values: cols.median, flags: FLAGS, name: 'x', color: viaDisplay.lineStyle.color,
+    })[0];
+    assert.deepEqual(viaMatrix.lineStyle, viaDisplay.lineStyle);
+    assert.equal(viaMatrix.silent, viaDisplay.silent);
+});


### PR DESCRIPTION
## Summary

`rate()` over a hole in a series carries a value but **no uncertainty band** — the total across the hole is known, its distribution inside is not, and the honest bound on an unobserved interval is not a number. metriken-query 0.23 marks those points `interpolated`. Until now nothing downstream could tell them from measured ones, so the chart drew a hole in the same ink as data.

Now it doesn't:

- **solid line + band** where the producer actually read
- **dashed, desaturated, band-less** across the stretch it never read

## Three parts

**The wire.** `encode_display_binary` gains an `interp` header flag and one f64 column, mirroring the existing `unc` flag's two. Column order is fixed — the six, then `unc` if flagged, then `interp` if flagged — so a decoder reading the flags in that order stays aligned whatever combination a series has. Sent as f64 rather than a packed bitmap so it decodes as one more zero-copy `Float64Array`; one byte per point isn't worth a second decode path.

**The decode.** `displayInterpolated` beside `displayIntervals`, producing the same boolean array the matrix path's `parseInterpolated` does, so the renderer consumes one shape regardless of which path fetched the data.

**The render.** Interpolated points are cut out of the nominal and redrawn as a dashed overlay anchored one point either side. Drawn *on top of* the solid line instead, a 0.35-opacity dash in the same hue just reads as the solid line — so the points have to leave the nominal for the overlay to be visible at all.

## The bug this nearly shipped with

`line.js` draws a plain line **only when the plot carries no boxplot columns** — and the display path always carries them. So the overlay was wired into the branch users never hit, while **every unit test passed**. That is the same failure this feature exists to fix, one level up: correct on the path nobody looks at, invisible on the default.

Found by rendering the chart in a real browser and reading the echarts series back — not by testing. The overlay builder now lives in `boxplot.js` and both paths call it, so one recording cannot look different depending on which path fetched it. A test pins that the two produce identical styling.

Cutting points out has a second-order effect worth naming: it can strand a **measured** point between two holes, and a lone point on a `symbol: 'none'` line draws nothing — so the one sample actually observed there vanished. Those points now carry their own dot. Visible at the right-hand edge of the screenshot below.

## Verified end-to-end, not just unit-tested

Against a real `.rez` archive with a genuine hole, through the running server:

```
wire header:  n=6 unc=true interp=true
interp col:   [0, 0, 1, 1, 1, 0]     ← matches the matrix path exactly
uncLo:        [95.2, 95.2, NaN, NaN, NaN, 95.2]   ← band absent precisely where interpolated
all bytes consumed: true
```

and in the browser, the rendered chart's echarts series:

```
z=3 name=cpu_gap solid  nulls=3   ← median, interpolated points cut out
z=3 name=cpu_gap dashed nulls=1   ← overlay, opacity 0.35, silent
```

## Testing

- `tests/interpolated_points.test.mjs` — 12 tests: `bands` preferred over the all-or-nothing `intervals`, flag parsing, overlay anchoring, **the display path specifically** (dashed overlay emitted, median cut, stranded point gets a symbol, wrong-length flags ignored rather than misapplied, and both paths styling a hole identically)
- `tests/display_binary_decode.test.mjs` — 5 new: the column read after `unc` not before it, interp-without-band landing in column 7, and a mixed multi-series buffer where mis-sizing any series corrupts the later ones
- `crates/dashboard/src/display_wire.rs` — **4 new Rust tests, where there were none.** The JS test hand-mirrors this encoder, which is exactly how the two drift; these pin the layout from the Rust side, including a decode helper that asserts no trailing bytes the header didn't describe

- [x] `node --test tests/*.mjs` — 278 tests, 0 fail
- [x] `cargo test --bins` — 690 pass
- [x] `cargo test -p dashboard` — 84 pass
- [x] `cargo clippy --workspace --all-targets` — clean, zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] `scripts/check-viewer-symlinks.sh` — 57 modules resolve

## Parity

The encoder is in the shared `dashboard` crate and `data.js` / `line.js` / `boxplot.js` are symlinked into `site/viewer/lib/`, so both backends get this by construction — no hand-mirroring, nothing for the WASM side to miss.

## Known follow-up

The stranded-measured-point fix is applied on the display (boxplot) path. The matrix path nulls interpolated points the same way and has the same edge; it is far rarer there (charts default to display mode) and the fix is the same shape when someone wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KheDzaD5bnVWcmdocmk2eW
