### PR TITLE
fix(viewer): stranded measured points, and the interpolated flag in compare mode

### DIFF
--- a/src/viewer/assets/lib/charts/boxplot.js
+++ b/src/viewer/assets/lib/charts/boxplot.js
@@ -16,6 +16,23 @@ const zipMs = (t, col) => {
     return out;
 };
 
+// True when index `i` holds a MEASURED value whose neighbours are both missing
+// (interpolated, or off the end of the series).
+//
+// Such a point is why cutting interpolated values out of a line is not quite
+// free: a lone point on a `symbol: 'none'` line has no segment to draw, so the
+// one sample actually observed there renders as nothing (display path) or as a
+// stub dominated by its own uncertainty band (plain-line path, which uses
+// `step: 'start'`). Either way the chart de-emphasises the only real
+// measurement in the region — the exact inversion of what the interpolated
+// flag is for. Callers give these points their own symbol.
+export function isStranded(flags, i, n) {
+    if (!flags || flags[i]) return false;
+    const prevGone = i === 0 || flags[i - 1];
+    const nextGone = i === n - 1 || flags[i + 1];
+    return Boolean(prevGone && nextGone);
+}
+
 // Build the dashed, desaturated overlay that redraws the stretches of a series
 // the producer never observed, or `[]` when there are none.
 //
@@ -211,16 +228,9 @@ export function buildBoxplotSeries(s, opts = {}) {
             for (let i = 0; i < median.length; i++) {
                 if (interp[i]) median[i] = [median[i][0], null];
             }
-            // Cutting points out can strand a MEASURED point between two holes,
-            // and a lone point on a `symbol: 'none'` line draws nothing at all —
-            // so the one sample that was actually observed there would vanish,
-            // which is the exact inversion of what this feature is for. Give
-            // just those points a visible dot.
+            // Stranded measured points get their own dot; see isStranded.
             for (let i = 0; i < median.length; i++) {
-                if (interp[i]) continue;
-                const prevGone = i === 0 || interp[i - 1];
-                const nextGone = i === median.length - 1 || interp[i + 1];
-                if (prevGone && nextGone) {
+                if (isStranded(interp, i, median.length)) {
                     median[i] = { value: median[i], symbol: 'circle', symbolSize: 4 };
                 }
             }

--- a/src/viewer/assets/lib/charts/compare.js
+++ b/src/viewer/assets/lib/charts/compare.js
@@ -285,6 +285,12 @@ const overlayLine = ({ spec, captures, anchors, captureLabels }) => {
                 // Value band rides parallel to valueData (time-independent), so
                 // the time rebase leaves it untouched. Undefined for non-rate.
                 intervals: cap.intervals,
+                // Also parallel to valueData and time-independent, so the
+                // rebase above leaves it alone. Per-capture on purpose: two
+                // recordings have holes at different times, which is precisely
+                // why a shaded time region can't express this and a per-series
+                // overlay can.
+                interpolated: cap.interpolated,
                 fill: false,
             };
         }

--- a/src/viewer/assets/lib/charts/line.js
+++ b/src/viewer/assets/lib/charts/line.js
@@ -24,6 +24,7 @@ import {
     buildEnvelopeLines,
     buildDivergenceBand,
     buildInterpolatedOverlay,
+    isStranded,
 } from './boxplot.js';
 import { chartSwatches, renderSwatchRow, SWATCH_ROW_HEIGHT } from './swatches.js';
 import { executePromQLRangeQuery, applyResultToPlot } from '../data.js';
@@ -134,7 +135,28 @@ export function configureLineChart(chart) {
         const zippedRaw = s.timeData.map((t, i) => {
             if (interp && interp[i]) return [t * 1000, null, null];
             const [v, raw] = clampToRange(s.valueData[i], range);
-            return [t * 1000, v, raw];
+            const point = [t * 1000, v, raw];
+            // A measured point with holes on both sides has no segment to draw.
+            // Under `step: 'start'` it survives as a stub, but its uncertainty
+            // band renders a narrow vertical sliver that outshouts it — the
+            // chart ends up drawing most attention to the interval at the one
+            // x-position where there IS a measurement. Give it a dot so the
+            // sample reads as a sample. (insertGapNulls handles object-form
+            // items, so this stays compatible with the gap pass below.)
+            // Sized and outlined to read OVER its own uncertainty band. A
+            // single-point band is drawn by echarts as a filled column (an area
+            // series with one non-null point), and a 4px dot disappears inside
+            // it — leaving the interval louder than the measurement at the one
+            // x-position that actually has data. The band is real and stays;
+            // the dot just has to win.
+            return isStranded(interp, i, s.timeData.length)
+                ? {
+                    value: point,
+                    symbol: 'circle',
+                    symbolSize: 7,
+                    itemStyle: { color: s.color, borderColor: COLORS.bgCard, borderWidth: 1.5 },
+                }
+                : point;
         });
 
         // Scatter-mode series: faded connecting line underneath + crisp
@@ -170,11 +192,20 @@ export function configureLineChart(chart) {
         }
 
         const zipped = insertGapNulls(zippedRaw, chart.interval);
+        // `showSymbol: false` suppresses symbols for the WHOLE series, so a
+        // per-item `symbol` on a stranded point is ignored under it. Switching
+        // to `symbol: 'none'` keeps every ordinary point unmarked while letting
+        // an item override — but only bother when a stranded point exists, so
+        // no other chart's symbol behaviour changes.
+        const hasStranded = Boolean(interp)
+            && zippedRaw.some((d) => d && !Array.isArray(d) && d.symbol);
         const base = {
             data: zipped,
             type: 'line',
             name: s.name,
-            showSymbol: false,
+            ...(hasStranded
+                ? { showSymbol: true, symbol: 'none' }
+                : { showSymbol: false }),
             sampling: 'lttb',
             emphasis: { focus: 'series' },
             step: 'start',

--- a/src/viewer/assets/lib/data.js
+++ b/src/viewer/assets/lib/data.js
@@ -629,6 +629,12 @@ export const promqlResultToLinePair = (results) => {
         // Optional rate()/histogram value band, parallel to valueData; null
         // for non-rate queries. Lets compare/experiment captures carry a band.
         intervals: parseIntervals(first),
+        // Likewise the interpolated flags. This function rebuilds a series from
+        // a hand-picked field list, so anything not named here is dropped even
+        // though the wire carried it — and the drop is invisible to every check
+        // except rendering the chart. That is exactly how compare mode ended up
+        // with no dashed overlay while the response was perfectly correct.
+        interpolated: parseInterpolated(first),
     };
 };
 

--- a/src/viewer/assets/lib/viewer_core.js
+++ b/src/viewer/assets/lib/viewer_core.js
@@ -33,6 +33,9 @@ const extractBaselineCapture = (spec, options = {}) => {
             // rate()/histogram value band (parallel to valueData), populated by
             // applyResultToPlot's single-series path; null for non-rate queries.
             cap.intervals = spec.intervals || null;
+            // Parallel to valueData like intervals; drives the dashed overlay
+            // for this capture.
+            cap.interpolated = spec.interpolated || null;
         } else {
             cap.timeData = [];
             cap.valueData = [];
@@ -109,6 +112,7 @@ const extractExperimentCapture = (spec, promqlResult, options = {}) => {
         cap.timeData = pair.timeData;
         cap.valueData = pair.valueData;
         cap.intervals = pair.intervals || null;
+        cap.interpolated = pair.interpolated || null;
         // Decimated boxplot columns (fetched separately via display mode) for
         // the compare envelope — null when the fetch failed or is pending.
         cap.boxplot = Array.isArray(options.boxplot) ? (options.boxplot[0] || null) : null;

--- a/tests/interpolated_points.test.mjs
+++ b/tests/interpolated_points.test.mjs
@@ -184,3 +184,72 @@ test('both render paths style a hole identically', () => {
     assert.deepEqual(viaMatrix.lineStyle, viaDisplay.lineStyle);
     assert.equal(viaMatrix.silent, viaDisplay.silent);
 });
+
+// --- stranded measured points, and the compare-mode path ------------------
+//
+// Both found by systemslab-e3 rendering the feature against its own chart
+// stack, after I shipped it. The shared theme: a hole adjacent to another hole
+// (or to the series edge) is the case a single-gap fixture never produces, and
+// a hand-picked field list drops data that the wire carried correctly.
+
+const { isStranded } = await import('../src/viewer/assets/lib/charts/boxplot.js');
+const { promqlResultToLinePair } = await import('../src/viewer/assets/lib/data.js');
+
+test('isStranded finds measured points with holes on both sides', () => {
+    //            0      1     2      3     4      5
+    const f = [false, true, false, true, false, false];
+    assert.equal(isStranded(f, 2, 6), true, 'index 2 sits between two holes');
+    assert.equal(isStranded(f, 4, 6), false, 'index 4 has a measured neighbour');
+    assert.equal(isStranded(f, 1, 6), false, 'an interpolated point is never stranded');
+});
+
+test('isStranded treats the series edges as missing neighbours', () => {
+    assert.equal(isStranded([false, true, true], 0, 3), true, 'first point, hole after');
+    assert.equal(isStranded([true, true, false], 2, 3), true, 'last point, hole before');
+    assert.equal(isStranded([false, false, true], 0, 3), false, 'first point, measured after');
+    assert.equal(isStranded(null, 0, 3), false, 'no flags at all');
+});
+
+test('the two-hole case: one observed sample between two holes keeps a symbol', () => {
+    // The exact shape that produced the bug: 22..29 and 31..37 unobserved,
+    // leaving index 30 as the ONLY measured sample in the region. A single
+    // contiguous hole never exercises this, which is why it shipped.
+    const n = 60;
+    const flags = Array.from({ length: n }, (_, i) =>
+        (i >= 22 && i < 30) || (i >= 31 && i < 38));
+    assert.equal(flags[30], false, 'index 30 is the observed sample');
+    assert.equal(isStranded(flags, 30, n), true);
+    // and its neighbours are not, so exactly one dot appears here
+    assert.equal(isStranded(flags, 29, n), false);
+    assert.equal(isStranded(flags, 38, n), false);
+    assert.equal(flags.filter((_, i) => isStranded(flags, i, n)).length, 1);
+});
+
+test('a single contiguous hole strands nothing — the control case', () => {
+    // Renders correctly today, and is the reference the failing case is read
+    // against. Kept so a future change can't "fix" the two-hole case by
+    // sprinkling dots everywhere.
+    const n = 60;
+    const flags = Array.from({ length: n }, (_, i) => i >= 24 && i < 36);
+    assert.equal(flags.filter((_, i) => isStranded(flags, i, n)).length, 0);
+});
+
+test('promqlResultToLinePair carries interpolated, not just intervals', () => {
+    // The compare-mode drop: this function rebuilds a series from a hand-picked
+    // field list, so a field absent from that list vanishes despite arriving on
+    // the wire — with a green build and a correct response.
+    const pair = promqlResultToLinePair([{
+        values: [[1, '10'], [2, '20'], [3, '30']],
+        bands: [[9, 11], null, [29, 31]],
+        interpolated: [false, true, false],
+    }]);
+    assert.deepEqual(pair.interpolated, [false, true, false]);
+    assert.equal(pair.intervals.length, 3);
+    assert.equal(pair.intervals[1], null, 'no band where interpolated');
+});
+
+test('promqlResultToLinePair leaves interpolated null for a plain series', () => {
+    const pair = promqlResultToLinePair([{ values: [[1, '10'], [2, '20']] }]);
+    assert.equal(pair.interpolated, null);
+    assert.equal(pair.intervals, null);
+});


### PR DESCRIPTION
## Summary

Two defects in #1193, both found by **systemslab-e3** rendering the feature against its own chart stack after I shipped it. Neither is a regression — compare mode never had the overlay, and the plain-line path always had the stranded case — but both are wrong today.

## 1. A measured sample between two holes

Cutting interpolated points out of a line can strand a **measured** point with holes on both sides. It then has no segment to draw: on the display path it vanished outright; on the plain-line path `step: 'start'` left a stub dominated by its own uncertainty band. The chart drew most attention to the *interval* at the one x-position that actually had data — the inversion of what the flag is for.

#1193 fixed this for the display path only (`boxplot.js`) and I called it a follow-up. The rule now lives once, as `isStranded`, and both paths call it.

**Two things the fix needed that no unit test could have told me:**

- **`showSymbol: false` suppresses symbols for the whole series**, so a per-item `symbol` is silently ignored under it. `boxplot.js` works only because it uses `symbol: 'none'`, which an item *can* override. The base line series now switches to that form — but only when a stranded point exists, so no other chart's symbol behaviour changes. My first attempt set the per-item symbol, reported `symbols: 1` in the series data, and drew nothing.
- **A 4px dot disappears inside its own band.** A single-point band renders as a filled column — an area series with one non-null point, measured here as baseline `110.8` + delta `16` at the stranded index with nulls either side. The band is real data and stays; the dot is sized and outlined to win.

## 2. `interpolated` dropped in compare mode

`promqlResultToLinePair` rebuilds a series from a hand-picked field list — `{timeData, valueData, intervals}` — so the flag died there despite arriving correctly on the wire: green build, correct response, no overlay.

Its only non-test caller is the per-capture builder for **A/B compare** — precisely the case `buildInterpolatedSeries`' own comment argues the overlay exists for:

> a shaded time region cannot say WHICH series has the hole, which matters in compare mode where captures have holes at different times

Compare mode is the case I wrote that justification about, and the one place the flag never arrived. Now carried through both `cap` builders and onto the compare series.

## Verification — rendered, then read back

Using systemslab's two-hole repro, asserting on the echarts series structurally rather than eyeballing a screenshot:

| case | result |
|---|---|
| two holes, one observed sample between (22..29, 31..37) | median 15 nulls, **symbols=1**, dashed overlay 18 non-null (15 + 3 anchors) |
| one contiguous hole (24..35) — the control | **symbols=0** on every series, overlay still present |

The control matters as much as the failing case: it proves the fix is targeted rather than sprinkling dots everywhere. **A single-gap fixture never produces a stranded point, which is exactly why this shipped** — I tested one contiguous hole and one at the series edge.

## Testing

Seven new tests: the `isStranded` rule, its edge-of-series behaviour, the two-hole case, the contiguous control, and `promqlResultToLinePair` carrying the flag (present and absent).

- [x] `node --test tests/*.mjs` — 287 tests, 0 fail
- [x] `cargo test --bins` — 690 pass
- [x] `cargo test -p dashboard` — 85 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `scripts/check-viewer-symlinks.sh` — 57 modules resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KheDzaD5bnVWcmdocmk2eW
